### PR TITLE
fix(cli): verify engine start on join; don't advertise loopback as LAN

### DIFF
--- a/grid/cli/provider.py
+++ b/grid/cli/provider.py
@@ -141,14 +141,58 @@ def _spawn_engine(
     record["pid"] = proc.pid
     _write_record(grid_id, engine_id, record)
 
+    status = _await_engine_start(runtime.network_url(cfg), record["node_id"], proc)
+    if status == "died":
+        _record_path(grid_id, engine_id).unlink(missing_ok=True)
+        raise SystemExit(
+            f"Engine {engine_id} exited before it registered. See {log_path}:\n{_log_tail(log_path)}"
+        )
+
     print(f"Joined engine {engine_id} to {cfg['name']} (pid={proc.pid})")
     if endpoint_url:
         print(f"endpoint_url={endpoint_url}")
     if models:
         print(f"models={','.join(models)}")
     print(f"log={log_path}")
+    if status == "starting":
+        print("(still starting — run `grid models` shortly to confirm it is live)")
     print(f"Check `grid models {cfg['name']}`; stop with `grid leave {cfg['name']} --engine {engine_id}`.")
     return 0
+
+
+def _await_engine_start(grid_url: str, node_id: str, proc, grace: float = 3.0) -> str:
+    """Block briefly to tell whether a freshly-spawned engine actually came up.
+
+    Returns "registered" once the grid sees it, "died" if the process exited,
+    or "starting" if it is still alive but not yet registered (e.g. a `--serve`
+    engine still loading its model). Uses ``proc.poll()`` rather than a bare
+    pid signal so an exited-but-unreaped child (a zombie) is detected.
+    """
+    deadline = time.time() + grace
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            return "died"
+        if _is_registered(grid_url, node_id):
+            return "registered"
+        time.sleep(0.2)
+    return "starting" if proc.poll() is None else "died"
+
+
+def _is_registered(grid_url: str, node_id: str) -> bool:
+    try:
+        resp = httpx.get(f"{grid_url}/nodes/discover", timeout=2)
+        resp.raise_for_status()
+    except httpx.HTTPError:
+        return False
+    return any(p.get("node_id") == node_id for p in resp.json().get("providers", []))
+
+
+def _log_tail(path, lines: int = 12) -> str:
+    try:
+        text = path.read_text(errors="replace")
+    except OSError:
+        return ""
+    return "\n".join(text.strip().splitlines()[-lines:])
 
 
 # ---------------------------------------------------------------------------

--- a/grid/system/detect.py
+++ b/grid/system/detect.py
@@ -38,37 +38,50 @@ _PROBES: tuple[tuple[str, int, str], ...] = (
 
 def detect_engines(*, advertise_host: str | None = None, timeout: float = 0.75) -> list[DetectedEngine]:
     """Probe localhost for running engines and return the ones that answer."""
+    lan_host = advertise_host or runtime.detect_lan_ip()
     found: list[DetectedEngine] = []
     for label, port, kind in _PROBES:
         if kind == "comfyui":
-            if _comfyui_reachable(port, timeout):
-                # Advertise media by this box's LAN host; the media bundle is
-                # selected at join time, so no model list here.
-                url = runtime.provider_endpoint_url(None, port, advertise_host).removesuffix("/v1")
-                found.append(DetectedEngine(label=label, endpoint_url=url, models=[], media=True))
+            if _comfyui_reachable("127.0.0.1", port, timeout):
+                host = _reachable_host(lan_host, advertise_host, port, kind, timeout)
+                found.append(DetectedEngine(label=label, endpoint_url=f"http://{host}:{port}", models=[], media=True))
             continue
-        models = _probe(port, kind, timeout)
+        models = _probe("127.0.0.1", port, kind, timeout)
         if models is None:
             continue
-        # Advertise the engine by this box's LAN IP, not localhost, so other
-        # machines on the grid can reach it.
-        endpoint_url = runtime.provider_endpoint_url(None, port, advertise_host)
-        found.append(DetectedEngine(label=label, endpoint_url=endpoint_url, models=models))
+        host = _reachable_host(lan_host, advertise_host, port, kind, timeout)
+        found.append(DetectedEngine(label=label, endpoint_url=f"http://{host}:{port}/v1", models=models))
     return found
 
 
-def _probe(port: int, kind: str, timeout: float) -> list[str] | None:
+def _reachable_host(lan_host: str, advertise_host: str | None, port: int, kind: str, timeout: float) -> str:
+    """Pick the host to advertise.
+
+    Prefer the LAN address so other machines can reach the engine, but only if
+    the engine is actually bound there — many engines default to loopback. When
+    it is not, keep `127.0.0.1` (correct when the grid runs on this same box).
+    An explicit --advertise-host is always trusted.
+    """
+    if advertise_host:
+        return lan_host
+    if lan_host == "127.0.0.1":
+        return "127.0.0.1"
+    reachable = _comfyui_reachable(lan_host, port, timeout) if kind == "comfyui" else _probe(lan_host, port, kind, timeout) is not None
+    return lan_host if reachable else "127.0.0.1"
+
+
+def _probe(host: str, port: int, kind: str, timeout: float) -> list[str] | None:
     if kind == "ollama":
-        models = _read_json_list(f"http://127.0.0.1:{port}/api/tags", "models", "name", timeout)
+        models = _read_json_list(f"http://{host}:{port}/api/tags", "models", "name", timeout)
         if models is not None:
             return models
         # Newer Ollama also speaks the OpenAI API; fall through to that shape.
-    return _read_json_list(f"http://127.0.0.1:{port}/v1/models", "data", "id", timeout)
+    return _read_json_list(f"http://{host}:{port}/v1/models", "data", "id", timeout)
 
 
-def _comfyui_reachable(port: int, timeout: float) -> bool:
+def _comfyui_reachable(host: str, port: int, timeout: float) -> bool:
     try:
-        resp = httpx.get(f"http://127.0.0.1:{port}/system_stats", timeout=timeout)
+        resp = httpx.get(f"http://{host}:{port}/system_stats", timeout=timeout)
         return resp.status_code == 200
     except httpx.HTTPError:
         return False

--- a/tests/test_lan_cli.py
+++ b/tests/test_lan_cli.py
@@ -6,6 +6,7 @@ import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 
+import httpx
 import pytest
 from fastapi.testclient import TestClient
 
@@ -566,6 +567,7 @@ def test_join_at_writes_record_and_spawns_detached(monkeypatch, tmp_path):
             self.pid = 4321
 
     monkeypatch.setattr(cli.provider.subprocess, "Popen", FakePopen)
+    monkeypatch.setattr(cli.provider, "_await_engine_start", lambda *a, **k: "registered")
 
     args = cli.build_parser().parse_args([
         "join",
@@ -597,6 +599,7 @@ def test_join_no_flags_single_detected_engine_joins_it(monkeypatch, tmp_path):
         lambda host: [detect.DetectedEngine(label="ollama", endpoint_url="http://192.168.1.50:11434/v1", models=["llama3"])],
     )
     monkeypatch.setattr(cli.provider.subprocess, "Popen", lambda cmd, **kw: type("P", (), {"pid": 1})())
+    monkeypatch.setattr(cli.provider, "_await_engine_start", lambda *a, **k: "registered")
 
     args = cli.build_parser().parse_args(["join", "home"])
     assert cli.cmd_join(args) == 0
@@ -634,11 +637,94 @@ def test_join_all_joins_every_detected_engine(monkeypatch, tmp_path):
         ],
     )
     monkeypatch.setattr(cli.provider.subprocess, "Popen", lambda cmd, **kw: type("P", (), {"pid": 1})())
+    monkeypatch.setattr(cli.provider, "_await_engine_start", lambda *a, **k: "registered")
 
     args = cli.build_parser().parse_args(["join", "home", "--all"])
     assert cli.cmd_join(args) == 0
     records = cli.provider._read_records(config.select_grid("home")["network_id"])
     assert set(records) == {"ollama", "vllm"}
+
+
+def test_join_cleans_up_record_when_engine_dies(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    cfg = runtime.init_network_config(name="home", port=8090)
+    monkeypatch.setattr(cli.provider.subprocess, "Popen", lambda cmd, **kw: type("P", (), {"pid": 999_999})())
+    monkeypatch.setattr(cli.provider, "_await_engine_start", lambda *a, **k: "died")
+
+    args = cli.build_parser().parse_args([
+        "join", "home", "--at", "http://192.168.1.10:11434/v1", "-m", "llama3", "--name", "bad",
+    ])
+    with pytest.raises(SystemExit):
+        cli.cmd_join(args)
+    # The stale record must not survive a failed start.
+    assert cli.provider._read_records(cfg["network_id"]) == {}
+
+
+def test_await_engine_start_distinguishes_died_registered_starting(monkeypatch):
+    monkeypatch.setattr(cli.provider, "_is_registered", lambda url, node: node == "live")
+
+    class _Proc:
+        def __init__(self, code):
+            self._code = code
+
+        def poll(self):
+            return self._code
+
+    assert cli.provider._await_engine_start("http://x", "live", _Proc(None), grace=1.0) == "registered"
+    assert cli.provider._await_engine_start("http://x", "n", _Proc(1), grace=1.0) == "died"
+    assert cli.provider._await_engine_start("http://x", "n", _Proc(None), grace=0.3) == "starting"
+
+
+def test_detect_keeps_loopback_when_lan_not_bound(monkeypatch):
+    monkeypatch.setattr(detect.runtime, "detect_lan_ip", lambda: "10.0.0.5")
+
+    class FakeResp:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._payload
+
+    def fake_get(url, timeout=None):
+        # Engine answers on loopback only; the LAN IP is not bound.
+        if "10.0.0.5" in url:
+            raise httpx.ConnectError("refused")
+        if url.endswith("/api/tags"):
+            return FakeResp({"models": [{"name": "llama3"}]})
+        if url.endswith("/v1/models"):
+            return FakeResp({"data": [{"id": "llama3"}]})
+        raise httpx.ConnectError("refused")  # no comfyui
+
+    monkeypatch.setattr(detect.httpx, "get", fake_get)
+
+    engines = detect.detect_engines()
+    assert engines
+    assert all(e.endpoint_url.startswith("http://127.0.0.1:") for e in engines)
+
+
+def test_detect_prefers_lan_when_bound(monkeypatch):
+    monkeypatch.setattr(detect.runtime, "detect_lan_ip", lambda: "10.0.0.5")
+
+    class FakeResp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"data": [{"id": "llama3"}], "models": [{"name": "llama3"}]}
+
+    def fake_get(url, timeout=None):
+        if "system_stats" in url:
+            raise httpx.ConnectError("no comfyui")
+        return FakeResp()  # reachable on both loopback and LAN
+
+    monkeypatch.setattr(detect.httpx, "get", fake_get)
+
+    engines = detect.detect_engines()
+    assert engines
+    assert all(e.endpoint_url.startswith("http://10.0.0.5:") for e in engines)
 
 
 def test_leave_all_removes_records(monkeypatch, tmp_path):


### PR DESCRIPTION
Addresses two issues from code review:

- grid join reported success even when the detached provider died immediately (bad --serve model, missing llama-server, port in use). Now wait briefly for the child to register; if it exits first, print the log tail, delete the stale record, and exit non-zero. Uses proc.poll() so an exited-but-unreaped child (zombie) is detected rather than read as alive.
- engine auto-detection advertised loopback-only engines (Ollama/LM Studio defaults) at the box's LAN IP, which the proxy then couldn't reach. Probe the LAN address first and fall back to 127.0.0.1 when the engine isn't bound there; an explicit --advertise-host is still trusted.

Tests: join cleanup on death, _await_engine_start states, detection loopback/LAN selection. ruff + pytest green (39 passing).