### PR TITLE
fix: detect Ollama tool support and rewrite --advertise-as aliases (remote + local)

### DIFF
--- a/cli/provider.py
+++ b/cli/provider.py
@@ -421,6 +421,14 @@ def _run_engine(args: SimpleNamespace) -> int:
             print(f"llama-server is ready on :{args.endpoint_port}")
 
         advertised_models = list(text_advertised_models)
+        # Map each advertised (possibly `--advertise-as` alias) text model to the name the engine
+        # answers to, so the local proxy can rewrite the model before forwarding: the real model for
+        # an external `--at` engine, the alias itself for a built-in (llama-server is launched with
+        # `--alias`, so it *is* the alias). Media models keep their fixed `comfyui:*` names — no rewrite.
+        if args.endpoint_url:
+            upstream = dict(zip(text_advertised_models, args.models))
+        else:
+            upstream = {name: name for name in text_advertised_models}
         if args.enable_media:
             prepared = _prepare_media_engine(args)
             advertised_models.extend(prepared["models"])
@@ -437,6 +445,7 @@ def _run_engine(args: SimpleNamespace) -> int:
             "pricing": {},
             "capabilities": _media_capabilities(advertised_models) if args.enable_media else {},
             "load": {"active_tasks": 0},
+            "upstream": upstream,
         }
         _register_engine(grid_url, node_id, payload)
         registered = True

--- a/local/server.py
+++ b/local/server.py
@@ -34,6 +34,9 @@ class NodeUpdateRequest(BaseModel):
     capabilities: dict[str, Any] = Field(default_factory=dict)
     load: dict[str, Any] = Field(default_factory=dict)
     name: str | None = None
+    # advertised model → the name the engine answers to (`--advertise-as` maps a consumer-facing alias
+    # back to the engine's real model name). Empty means identity; only external `--at` aliases differ.
+    upstream: dict[str, str] = Field(default_factory=dict)
 
 
 class HeartbeatRequest(BaseModel):
@@ -52,6 +55,7 @@ class Node:
     capabilities: dict[str, Any] = field(default_factory=dict)
     load: dict[str, Any] = field(default_factory=dict)
     name: str | None = None
+    upstream: dict[str, str] = field(default_factory=dict)
     first_seen_at: str = field(default_factory=lambda: _utc_now_iso())
     last_heartbeat: float = field(default_factory=time.time)
 
@@ -119,6 +123,7 @@ def create_app(*, grid_id: str, grid_name: str) -> FastAPI:
         node.capabilities = dict(req.capabilities)
         node.load = dict(req.load)
         node.name = req.name
+        node.upstream = dict(req.upstream)
         node.last_heartbeat = time.time()
         _nodes(app)[node_id] = node
         return {"status": "updated", "node": node.public_dict()}
@@ -194,6 +199,13 @@ async def _proxy_openai(app: FastAPI, endpoint_path: str, request: Request) -> R
     engine = _choose_engine(app, model)
     if not engine:
         return _openai_error(503, f"No active local engine for model {model!r}", "engine_unavailable")
+
+    # An external engine advertised under `--advertise-as` only knows its real model name; rewrite the
+    # body's model alias→real before forwarding. Re-serialise only when it differs — otherwise forward
+    # the original bytes untouched (no mapping / built-in / no alias, where advertised == real).
+    upstream_model = engine.upstream.get(model)
+    if upstream_model and upstream_model != model:
+        raw_body = json.dumps({**body, "model": upstream_model}).encode()
 
     url = f"{engine.endpoint_url.rstrip('/')}/{endpoint_path}"
     headers = {"content-type": request.headers.get("content-type", "application/json")}

--- a/remote/probe.py
+++ b/remote/probe.py
@@ -21,12 +21,19 @@ import httpx
 
 _PROBE_TIMEOUT = 15.0
 _PROPS_TIMEOUT = 5.0
+_SHOW_TIMEOUT = 5.0
 _BENCHMARK_TIMEOUT = 60.0
 
 
-def capabilities(llm_url: str, model: str) -> dict[str, Any]:
-    """One-call public API: live-probe ``llm_url`` for ``model`` and return the register envelope."""
-    return envelope(model, probe_llama_capabilities(llm_url, model))
+def capabilities(llm_url: str, model: str, *, advertise_as: str | None = None) -> dict[str, Any]:
+    """One-call public API: live-probe ``llm_url`` for ``model`` and return the register envelope.
+
+    ``advertise_as`` keys the envelope under the *advertised* name when the engine serves ``model``
+    under a different alias (``--advertise-as``). The relay drops caps whose model keys don't match
+    the advertised list, so an aliased external engine must probe by its real name (what the engine
+    answers to) yet register under the alias (what consumers ask for).
+    """
+    return envelope(advertise_as or model, probe_llama_capabilities(llm_url, model))
 
 
 # --- HTTP (routed through httpx.Client so tests can inject a MockTransport) ---
@@ -51,6 +58,23 @@ def _post_chat(llm_url: str, payload: dict[str, Any], *, timeout: float = _PROBE
         return resp.json()
     except ValueError:
         return None
+
+
+def _post_json(url: str, payload: dict[str, Any], *, timeout: float) -> dict[str, Any] | None:
+    """POST ``payload`` to an arbitrary URL and return the parsed JSON object, or ``None`` on any
+    transport / non-200 / non-JSON response (used for Ollama's native ``/api/show``)."""
+    try:
+        with httpx.Client(timeout=timeout) as client:
+            resp = client.post(url, json=payload)
+    except httpx.HTTPError:
+        return None
+    if resp.status_code != 200:
+        return None
+    try:
+        data = resp.json()
+    except ValueError:
+        return None
+    return data if isinstance(data, dict) else None
 
 
 # --- response parsing ---
@@ -131,6 +155,30 @@ def _probe_props(llm_url: str, timeout: float = _PROPS_TIMEOUT) -> dict[str, boo
     }
 
 
+def _ollama_base(llm_url: str) -> str:
+    """Ollama's native API (``/api/...``) lives at the server root, not under ``/v1``."""
+    base = llm_url.rstrip("/")
+    if base.endswith("/v1"):
+        base = base[:-3]
+    return base.rstrip("/")
+
+
+def _probe_ollama_caps(llm_url: str, model: str, timeout: float = _SHOW_TIMEOUT) -> dict[str, bool]:
+    """Read Ollama's declared model capabilities from ``POST /api/show`` (``capabilities: [...]``).
+
+    Authoritative where a live forced-tool probe stays silent: Ollama serves no ``/props``, and its
+    OpenAI endpoint may ignore a forced ``tool_choice`` so a small model emits no tool call — yet
+    Ollama still *knows* the template supports tools. Best-effort: a non-Ollama engine (llama.cpp,
+    vLLM, …) 404s here and we return ``{}``, leaving the live probe + ``/props`` to decide.
+    """
+    payload = _post_json(f"{_ollama_base(llm_url)}/api/show", {"model": model}, timeout=timeout)
+    caps = (payload or {}).get("capabilities")
+    if not isinstance(caps, list):
+        return {}
+    names = {str(c).lower() for c in caps}
+    return {"vision": "vision" in names, "tools": "tools" in names}
+
+
 def _probe_models(llm_url: str, llm_model: str, timeout: float = _PROPS_TIMEOUT) -> set[str]:
     resp = _get(f"{llm_url.rstrip('/')}/models", timeout=timeout)
     if resp is None or resp.status_code != 200:
@@ -174,9 +222,11 @@ def probe_llama_capabilities(llm_url: str, llm_model: str) -> dict[str, bool]:
     }
 
     props_caps = _probe_props(llm_url)
+    ollama_caps = _probe_ollama_caps(llm_url, llm_model)
     probed["vision"] = bool(
         (_probe_models(llm_url, llm_model) & {"image", "multimodal", "vision"})
         or props_caps.get("vision")
+        or ollama_caps.get("vision")
     )
 
     json_object_resp = _post_chat(llm_url, {
@@ -228,6 +278,7 @@ def probe_llama_capabilities(llm_url: str, llm_model: str) -> dict[str, bool]:
     probed["tools"] = bool(
         (isinstance(tools_resp, dict) and _probe_has_tool_calls(tools_resp))
         or (props_caps.get("tools") and props_caps.get("tool_calls"))
+        or ollama_caps.get("tools")
     )
     probed["parallel_tool_calls"] = bool(probed["tools"] and props_caps.get("parallel_tool_calls"))
     return probed

--- a/remote/serve.py
+++ b/remote/serve.py
@@ -69,7 +69,7 @@ def run_remote_engine_from_record(grid_id: str, engine_id: str) -> int:
     rc = 0
     try:
         engine_results, launched, launcher = _bring_up_engines(record)
-        routes, union_models, capabilities, warnings = _build_routing(engine_results)
+        routes, upstream, union_models, capabilities, warnings = _build_routing(engine_results)
         for line in warnings:  # surface shadowed-duplicate models so routing isn't a silent surprise
             print(line, file=sys.stderr)
         state = _ServeState(
@@ -85,6 +85,7 @@ def run_remote_engine_from_record(grid_id: str, engine_id: str) -> int:
             pricing=_pricing(record),
             max_concurrency=int(record.get("max_concurrency") or 1),
             routes=routes,
+            upstream=upstream,
         )
         register(state)
         print(f"Engine {state.node_id} serving {union_models} via the relay at {signaling_url}")
@@ -120,31 +121,36 @@ def run_remote_engine_from_record(grid_id: str, engine_id: str) -> int:
 
 def _bring_up_engines(
     record: dict[str, Any],
-) -> tuple[list[tuple[str, list[str], dict[str, Any]]], list[Any], Any]:
+) -> tuple[list[tuple[str, list[str], list[str], dict[str, Any]]], list[Any], Any]:
     """Bring up every engine the record lists and probe each (mirrors cli/provider._run_engine).
 
     Returns ``(engine_results, launched, launcher_module)`` where ``engine_results`` is
-    ``[(llm_url, advertised_models, caps_envelope), ...]`` in record order — fed to ``_build_routing``.
-    ``launched`` collects the built-in llama-servers to stop on teardown (empty when every engine is
-    external). Only a built-in ``--serve`` launches, and only as the **sole** engine: ``grid join
-    --all`` gathers already-running engines, so a multi-engine record is all external URLs.
+    ``[(llm_url, advertised_models, upstream_models, caps_envelope), ...]`` in record order — fed to
+    ``_build_routing``. ``upstream_models`` is what the *local engine answers to* (the real model name
+    for an external ``--at`` engine; the ``--advertise-as`` alias for a built-in llama-server launched
+    with ``--alias``), so a job's advertised model can be rewritten to it before forwarding. Each engine
+    is probed by its upstream name (Ollama/vLLM only know that) but the caps envelope is keyed by the
+    advertised name (what consumers ask for). ``launched`` collects the built-in llama-servers to stop
+    on teardown (empty when every engine is external). Only a built-in ``--serve`` launches, and only as
+    the **sole** engine: ``grid join --all`` gathers already-running engines, so a multi-engine record
+    is all external URLs.
     """
     specs = record.get("engines") or [_flat_spec(record)]
     aliases = list(record.get("advertise_as") or [])
     if len(specs) > 1 and any(not spec.get("endpoint_url") for spec in specs):
         raise SystemExit("Serving several engines needs external endpoints; the built-in engine serves one model.")
 
-    results: list[tuple[str, list[str], dict[str, Any]]] = []
+    results: list[tuple[str, list[str], list[str], dict[str, Any]]] = []
     launched: list[Any] = []
     launcher_mod = None
     try:
         for spec in specs:
-            llm_url, proc, mod, advertised = _bring_up_one(spec, record, aliases)
+            llm_url, proc, mod, advertised, upstream = _bring_up_one(spec, record, aliases)
             if proc is not None:
                 launched.append(proc)
                 launcher_mod = mod
-            caps = probe.capabilities(llm_url, advertised[0]) if advertised else {}
-            results.append((llm_url, advertised, caps))
+            caps = probe.capabilities(llm_url, upstream[0], advertise_as=advertised[0]) if upstream else {}
+            results.append((llm_url, advertised, upstream, caps))
     except BaseException:  # a later spec failed — don't orphan a server an earlier spec already launched
         if launcher_mod is not None:
             for proc in launched:
@@ -164,18 +170,21 @@ def _flat_spec(record: dict[str, Any]) -> dict[str, Any]:
 
 def _bring_up_one(
     spec: dict[str, Any], record: dict[str, Any], aliases: list[str]
-) -> tuple[str, Any, Any, list[str]]:
+) -> tuple[str, Any, Any, list[str], list[str]]:
     """Resolve one engine's URL, launching the built-in llama-server for ``--serve``.
 
-    Returns ``(llm_url, launched, launcher_module, advertised_models)``. For an external engine
-    nothing is launched (``launched``/``launcher`` are ``None``). Launch tuning (port, ctx, …) comes
-    from the record's top-level fields — only the single built-in path consumes them.
+    Returns ``(llm_url, launched, launcher_module, advertised_models, upstream_models)``. ``upstream``
+    is what the engine itself answers to: the **real** model names for an external ``--at`` engine
+    (Ollama/vLLM don't know the ``--advertise-as`` alias), but the **alias** for a built-in llama-server
+    — it is launched with ``--alias advertised``, so that alias *is* its model name. For an external
+    engine nothing is launched (``launched``/``launcher`` are ``None``). Launch tuning (port, ctx, …)
+    comes from the record's top-level fields — only the single built-in path consumes them.
     """
     models = list(spec.get("models") or [])
     advertised = _advertised_models(models, aliases)
     endpoint_url = spec.get("endpoint_url")
-    if endpoint_url:  # external engine: forward to it, launch nothing
-        return endpoint_url.rstrip("/"), None, None, advertised
+    if endpoint_url:  # external engine: forward to it (by its real model name), launch nothing
+        return endpoint_url.rstrip("/"), None, None, advertised, list(models)
     if not models:
         raise SystemExit("Provide a model to serve (--serve <model>) or point at one (--at <url> -m <model>).")
     if len(models) != 1:
@@ -205,8 +214,9 @@ def _bring_up_one(
         # Don't orphan the llama-server if it never became ready (load failure / timeout / SIGTERM).
         launcher_mod.stop(launched)
         raise
-    # The relay forwards to the engine on *this* box, so the loop reaches it on loopback.
-    return f"http://127.0.0.1:{port}/v1", launched, launcher_mod, advertised
+    # The relay forwards to the engine on *this* box, so the loop reaches it on loopback. The built-in
+    # llama-server is launched with ``--alias advertised[0]``, so it answers to the alias: upstream == advertised.
+    return f"http://127.0.0.1:{port}/v1", launched, launcher_mod, advertised, list(advertised)
 
 
 def _advertised_models(models: list[str], aliases: list[str]) -> list[str]:
@@ -223,14 +233,17 @@ def _advertised_models(models: list[str], aliases: list[str]) -> list[str]:
 
 
 def _build_routing(
-    engine_results: list[tuple[str, list[str], dict[str, Any]]],
-) -> tuple[dict[str, str], list[str], dict[str, Any], list[str]]:
+    engine_results: list[tuple[str, list[str], list[str], dict[str, Any]]],
+) -> tuple[dict[str, str], dict[str, str], list[str], dict[str, Any], list[str]]:
     """Merge several local engines into one remote identity's routing state (DECISIONS D9).
 
-    ``engine_results`` is ``[(llm_url, models, caps_envelope), ...]`` in detect order. Returns
-    ``(routes, union_models, merged_caps, warnings)``:
+    ``engine_results`` is ``[(llm_url, advertised, upstream, caps_envelope), ...]`` in detect order —
+    ``advertised`` and ``upstream`` are parallel per-engine lists (the advertised name and the name the
+    engine itself answers to). Returns ``(routes, upstream_routes, union_models, merged_caps, warnings)``:
 
-    - ``routes`` — ``{model: llm_url}``; the **first** engine to advertise a model wins (deterministic).
+    - ``routes`` — ``{advertised_model: llm_url}``; the **first** engine to advertise a model wins.
+    - ``upstream_routes`` — ``{advertised_model: upstream_model}``; how a forwarded job's model is
+      rewritten to what the local engine expects (identity unless ``--advertise-as`` aliased it).
     - ``union_models`` — every advertised model once, in first-seen order (what the identity registers).
     - ``merged_caps`` — one ``{"schema_version": 1, "models": {...}}`` envelope, first-wins per model;
       ``{}`` when nothing probed (registers text-only, like the single-engine path).
@@ -241,12 +254,13 @@ def _build_routing(
     ``env.get("models") or {}`` and never KeyErrors the whole table on one bad engine.
     """
     routes: dict[str, str] = {}
+    upstream_routes: dict[str, str] = {}
     union_models: list[str] = []
     merged_models: dict[str, Any] = {}
     warnings: list[str] = []
-    for llm_url, models, caps in engine_results:
+    for llm_url, advertised, upstream, caps in engine_results:
         caps_models = (caps or {}).get("models") or {}
-        for model in models:
+        for model, upstream_model in zip(advertised, upstream):
             if model in routes:
                 warnings.append(
                     f"Two engines serve model {model!r}; routing it to the first ({routes[model]!r}) "
@@ -254,11 +268,12 @@ def _build_routing(
                 )
                 continue
             routes[model] = llm_url
+            upstream_routes[model] = upstream_model
             union_models.append(model)
             if model in caps_models:
                 merged_models[model] = caps_models[model]
     merged_caps = {"schema_version": 1, "models": merged_models} if merged_models else {}
-    return routes, union_models, merged_caps, warnings
+    return routes, upstream_routes, union_models, merged_caps, warnings
 
 
 def _meta(record: dict[str, Any], engine_id: str) -> dict[str, Any]:
@@ -331,6 +346,7 @@ class _ServeState:
         pricing: dict[str, float],
         max_concurrency: int,
         routes: dict[str, str] | None = None,
+        upstream: dict[str, str] | None = None,
     ) -> None:
         self.signaling_url = signaling_url
         self.node_id = node_id
@@ -343,6 +359,9 @@ class _ServeState:
             self._routes = {model: url.rstrip("/") for model, url in routes.items()}
         else:
             self._routes = {model: self.llm_url for model in self.models}
+        # advertised model → the name the local engine answers to (``--advertise-as`` maps the
+        # consumer-facing alias back to the engine's real model name). Empty means identity.
+        self._upstream = dict(upstream or {})
         self.capabilities = dict(capabilities or {})
         self.meta = dict(meta or {})
         self.pricing = dict(pricing or {})
@@ -368,6 +387,15 @@ class _ServeState:
         distinct = set(self._routes.values())
         if len(distinct) == 1:
             return next(iter(distinct))
+        return None
+
+    def upstream_model(self, model: str | None) -> str | None:
+        """The name the local engine answers to for an advertised ``model`` (``--advertise-as`` maps the
+        consumer-facing alias back to the engine's real model name). ``None`` when unmapped — the caller
+        then forwards the body's model unchanged (single-engine fallback / built-in, where they match).
+        """
+        if model and model in self._upstream:
+            return self._upstream[model]
         return None
 
     def token(self) -> str:
@@ -504,12 +532,18 @@ def handle_job(state: _ServeState, job: dict[str, Any]) -> None:
         _try_submit_error(state, txn, f"no engine serves model {model!r}")
         return
 
+    # Consumers address the model by its advertised name; an external engine behind ``--advertise-as``
+    # only knows its real name, so rewrite the body's model before forwarding (a new dict — never
+    # mutate the job). No mapping / already-equal → forward unchanged (built-in + single-engine paths).
+    upstream_model = state.upstream_model(model)
+    forward_body = {**body, "model": upstream_model} if upstream_model and upstream_model != model else body
+
     state.enter_inference()
     try:
         if is_stream:
-            _forward_stream(state, txn, endpoint, body, read_timeout, target)
+            _forward_stream(state, txn, endpoint, forward_body, read_timeout, target)
         else:
-            _forward_whole(state, txn, endpoint, body, read_timeout, target)
+            _forward_whole(state, txn, endpoint, forward_body, read_timeout, target)
     except Exception as exc:  # one bad job must not kill the loop
         print(f"\nJob {txn} failed: {exc!r}", file=sys.stderr)
         _try_submit_error(state, txn, str(exc))

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -1973,6 +1973,82 @@ def test_probe_capabilities_degrades_to_text_only_on_probe_failure(monkeypatch, 
     assert entry["features"]["json_object"] is False
 
 
+def _ollama_handler(caps):
+    """An Ollama-shaped engine: no /props, /v1/models without capabilities, /api/show declares `caps`,
+    and its OpenAI endpoint ignores a forced tool_choice (replies with content, never tool_calls)."""
+    def handler(request):
+        path = request.url.path
+        if path == "/props":
+            return httpx.Response(404)  # Ollama serves no llama-server /props
+        if path == "/api/show":
+            return httpx.Response(200, json={"capabilities": caps})
+        if path.endswith("/models"):
+            return httpx.Response(200, json={"data": [{"id": "m"}]})  # no per-model capabilities
+        if path.endswith("/chat/completions"):
+            return httpx.Response(200, json={"choices": [{"message": {"content": "hi"}}]})
+        return httpx.Response(404)
+    return handler
+
+
+def test_probe_tools_from_ollama_show_when_live_probe_silent(monkeypatch, tmp_path):
+    """Ollama declares tool support via /api/show even though the forced-tool_choice probe stays
+    silent and there is no /props — the node must still advertise tools (else the relay 400s tool calls)."""
+    from remote import probe
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    _mock_engine(monkeypatch, _ollama_handler(["completion", "tools"]))
+
+    env = probe.capabilities("http://h:11434/v1", "deepseek-r1:1.5b")
+
+    assert env["models"]["deepseek-r1:1.5b"]["features"]["tools"] is True
+
+
+def test_probe_vision_from_ollama_show_capabilities(monkeypatch, tmp_path):
+    from remote import probe
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    _mock_engine(monkeypatch, _ollama_handler(["completion", "vision"]))
+
+    env = probe.capabilities("http://h:11434/v1", "llava")
+    entry = env["models"]["llava"]
+    assert entry["features"]["vision"] is True and entry["input_modalities"] == ["text", "image"]
+
+
+def test_probe_ollama_show_without_tools_stays_text_only(monkeypatch, tmp_path):
+    """/api/show that omits `tools` must not fabricate tool support — a non-tool model stays tools=False."""
+    from remote import probe
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    _mock_engine(monkeypatch, _ollama_handler(["completion"]))
+
+    env = probe.capabilities("http://h:11434/v1", "gemma")
+    assert env["models"]["gemma"]["features"]["tools"] is False
+
+
+def test_probe_tools_from_live_probe_without_props_or_show(monkeypatch, tmp_path):
+    """An OpenAI engine with no /props and no /api/show (LM Studio / MLX / vLLM shape) still detects
+    tools via the live forced-tool_choice probe when the engine honors it and emits a tool_call."""
+    from remote import probe
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+
+    def handler(request):
+        path = request.url.path
+        if path in ("/props", "/api/show"):
+            return httpx.Response(404)  # neither llama.cpp nor Ollama metadata
+        if path.endswith("/models"):
+            return httpx.Response(200, json={"data": [{"id": "m"}]})
+        if path.endswith("/chat/completions"):
+            if json.loads(request.content).get("tools"):
+                return httpx.Response(200, json={"choices": [{"message": {"tool_calls": [{"id": "1"}]}}]})
+            return httpx.Response(200, json={"choices": [{"message": {"content": "x"}}]})
+        return httpx.Response(404)
+
+    _mock_engine(monkeypatch, handler)
+    env = probe.capabilities("http://h:1234/v1", "m")
+    assert env["models"]["m"]["features"]["tools"] is True  # live probe carries LM Studio/MLX/vLLM
+
+
 def test_probe_benchmark_tok_s_prefers_predicted_per_second(monkeypatch, tmp_path):
     from remote import probe
 
@@ -2296,6 +2372,33 @@ def test_serve_handle_job_single_engine_forwards_unknown_model(monkeypatch, tmp_
     assert "error" not in captured  # forwarded to the sole engine, not rejected
 
 
+def test_serve_handle_job_rewrites_alias_to_upstream_model(monkeypatch, tmp_path):
+    """The consumer addresses the model by its advertised alias; the external engine only knows its
+    real name. handle_job must rewrite body['model'] alias→real before forwarding (Issue 1: 404)."""
+    from remote import relay, serve
+
+    state = _serve_state(
+        monkeypatch, tmp_path, models=["ollama-model"],
+        routes={"ollama-model": "http://sole.local/v1"},
+        upstream={"ollama-model": "qwen3.5:0.8b"},
+    )
+    captured = {}
+    monkeypatch.setattr(relay, "submit_response",
+                        lambda url, tok, txn, *, content, stream: captured.update(content=content))
+    monkeypatch.setattr(relay, "submit_error",
+                        lambda url, tok, txn, *, message, tokens_delivered=0: captured.update(error=message))
+
+    def engine(request):
+        # the LOCAL engine must receive its real model name, not the advertised alias
+        assert json.loads(request.content)["model"] == "qwen3.5:0.8b"
+        return httpx.Response(200, json={"ok": True})
+
+    _mock_serve_engine(monkeypatch, engine)
+    serve.handle_job(state, {"transaction_id": "t1", "endpoint_path": "chat/completions",
+                             "body": {"model": "ollama-model", "messages": []}, "is_stream": False})
+    assert "error" not in captured and b'"ok"' in captured["content"]
+
+
 def test_serve_heartbeat_loop_stops_when_auth_exhausted(monkeypatch, tmp_path):
     from remote import relay, serve
 
@@ -2316,10 +2419,11 @@ def test_serve_heartbeat_loop_stops_when_auth_exhausted(monkeypatch, tmp_path):
 def test_build_routing_single_engine_maps_each_model(monkeypatch, tmp_path):
     from remote import serve
 
-    routes, union, caps, warns = serve._build_routing([
-        ("http://127.0.0.1:8081/v1", ["m1", "m2"], {"schema_version": 1, "models": {"m1": {"x": 1}}}),
+    routes, upstream, union, caps, warns = serve._build_routing([
+        ("http://127.0.0.1:8081/v1", ["m1", "m2"], ["m1", "m2"], {"schema_version": 1, "models": {"m1": {"x": 1}}}),
     ])
     assert routes == {"m1": "http://127.0.0.1:8081/v1", "m2": "http://127.0.0.1:8081/v1"}
+    assert upstream == {"m1": "m1", "m2": "m2"}  # no alias → identity
     assert union == ["m1", "m2"]  # both advertised; only the probed first model carries caps
     assert caps == {"schema_version": 1, "models": {"m1": {"x": 1}}}
     assert warns == []
@@ -2328,11 +2432,12 @@ def test_build_routing_single_engine_maps_each_model(monkeypatch, tmp_path):
 def test_build_routing_disjoint_engines_union_and_merge(monkeypatch, tmp_path):
     from remote import serve
 
-    routes, union, caps, warns = serve._build_routing([
-        ("http://127.0.0.1:8081/v1", ["a"], {"schema_version": 1, "models": {"a": {"f": "A"}}}),
-        ("http://127.0.0.1:8000/v1", ["b"], {"schema_version": 1, "models": {"b": {"f": "B"}}}),
+    routes, upstream, union, caps, warns = serve._build_routing([
+        ("http://127.0.0.1:8081/v1", ["a"], ["a"], {"schema_version": 1, "models": {"a": {"f": "A"}}}),
+        ("http://127.0.0.1:8000/v1", ["b"], ["b"], {"schema_version": 1, "models": {"b": {"f": "B"}}}),
     ])
     assert routes == {"a": "http://127.0.0.1:8081/v1", "b": "http://127.0.0.1:8000/v1"}
+    assert upstream == {"a": "a", "b": "b"}
     assert union == ["a", "b"]
     assert caps == {"schema_version": 1, "models": {"a": {"f": "A"}, "b": {"f": "B"}}}
     assert warns == []
@@ -2341,11 +2446,12 @@ def test_build_routing_disjoint_engines_union_and_merge(monkeypatch, tmp_path):
 def test_build_routing_duplicate_model_first_wins_with_warning(monkeypatch, tmp_path):
     from remote import serve
 
-    routes, union, caps, warns = serve._build_routing([
-        ("http://127.0.0.1:8081/v1", ["dup"], {"schema_version": 1, "models": {"dup": {"f": "first"}}}),
-        ("http://127.0.0.1:8000/v1", ["dup"], {"schema_version": 1, "models": {"dup": {"f": "second"}}}),
+    routes, upstream, union, caps, warns = serve._build_routing([
+        ("http://127.0.0.1:8081/v1", ["dup"], ["dup"], {"schema_version": 1, "models": {"dup": {"f": "first"}}}),
+        ("http://127.0.0.1:8000/v1", ["dup"], ["dup"], {"schema_version": 1, "models": {"dup": {"f": "second"}}}),
     ])
     assert routes == {"dup": "http://127.0.0.1:8081/v1"}  # first detected wins
+    assert upstream == {"dup": "dup"}  # winner's upstream, shadowed duplicate ignored
     assert union == ["dup"]  # advertised once
     assert caps == {"schema_version": 1, "models": {"dup": {"f": "first"}}}  # caps follow the winner
     assert len(warns) == 1 and "dup" in warns[0]
@@ -2355,11 +2461,28 @@ def test_build_routing_tolerates_failed_probe_empty_caps(monkeypatch, tmp_path):
     from remote import serve
 
     # A failed probe degrades to {} upstream — the merge must still route, not KeyError.
-    routes, union, caps, warns = serve._build_routing([
-        ("http://127.0.0.1:8081/v1", ["m"], {}),
+    routes, upstream, union, caps, warns = serve._build_routing([
+        ("http://127.0.0.1:8081/v1", ["m"], ["m"], {}),
     ])
     assert routes == {"m": "http://127.0.0.1:8081/v1"} and union == ["m"]
+    assert upstream == {"m": "m"}
     assert caps == {}  # no capabilities → registers text-only
+    assert warns == []
+
+
+def test_build_routing_maps_alias_to_upstream_real_name(monkeypatch, tmp_path):
+    """A `--advertise-as` alias routes + registers under the alias, but upstream carries the engine's
+    real model name so a forwarded job can be rewritten to what the engine actually serves."""
+    from remote import serve
+
+    routes, upstream, union, caps, warns = serve._build_routing([
+        ("http://h:11434/v1", ["ollama-model"], ["qwen3.5:0.8b"],
+         {"schema_version": 1, "models": {"ollama-model": {"x": 1}}}),
+    ])
+    assert routes == {"ollama-model": "http://h:11434/v1"}
+    assert upstream == {"ollama-model": "qwen3.5:0.8b"}  # alias → real, the crux of the forward fix
+    assert union == ["ollama-model"]
+    assert caps == {"schema_version": 1, "models": {"ollama-model": {"x": 1}}}
     assert warns == []
 
 
@@ -2374,16 +2497,42 @@ def test_bring_up_engines_external_multi_probes_each(monkeypatch, tmp_path):
         "advertise_as": [],
     }
     seen = []
-    monkeypatch.setattr(probe, "capabilities", lambda url, model: seen.append((url, model))
-                        or {"schema_version": 1, "models": {model: {"f": model}}})
+    monkeypatch.setattr(probe, "capabilities", lambda url, model, *, advertise_as=None: seen.append((url, model))
+                        or {"schema_version": 1, "models": {advertise_as or model: {"f": model}}})
 
     results, launched, launcher = serve._bring_up_engines(record)
     assert launched == [] and launcher is None  # external engines: nothing launched/owned
     assert results == [
-        ("http://h:11434/v1", ["llama3"], {"schema_version": 1, "models": {"llama3": {"f": "llama3"}}}),
-        ("http://h:8000/v1", ["mistral"], {"schema_version": 1, "models": {"mistral": {"f": "mistral"}}}),
+        ("http://h:11434/v1", ["llama3"], ["llama3"], {"schema_version": 1, "models": {"llama3": {"f": "llama3"}}}),
+        ("http://h:8000/v1", ["mistral"], ["mistral"], {"schema_version": 1, "models": {"mistral": {"f": "mistral"}}}),
     ]
-    assert seen == [("http://h:11434/v1", "llama3"), ("http://h:8000/v1", "mistral")]  # each probed once
+    assert seen == [("http://h:11434/v1", "llama3"), ("http://h:8000/v1", "mistral")]  # each probed by real name
+
+
+def test_bring_up_engines_external_alias_probes_real_name_keys_alias(monkeypatch, tmp_path):
+    """`--advertise-as` on an external engine: probe by the engine's REAL model name (Ollama/vLLM
+    don't know the alias) but return caps + upstream so the loop registers/forwards under the alias."""
+    from remote import probe, serve
+
+    record = {
+        "engines": [{"endpoint_url": "http://h:11434/v1", "models": ["qwen3.5:0.8b"], "engine_label": "ollama"}],
+        "advertise_as": ["ollama-model"],
+    }
+    seen = {}
+
+    def fake_caps(url, model, *, advertise_as=None):
+        seen.update(url=url, model=model, advertise_as=advertise_as)
+        return {"schema_version": 1, "models": {advertise_as or model: {"f": model}}}
+
+    monkeypatch.setattr(probe, "capabilities", fake_caps)
+
+    results, launched, _ = serve._bring_up_engines(record)
+    assert launched == []
+    assert seen["model"] == "qwen3.5:0.8b"  # probed by the real name the engine answers to
+    assert seen["advertise_as"] == "ollama-model"  # caps keyed by the advertised alias
+    llm_url, advertised, upstream, caps = results[0]
+    assert advertised == ["ollama-model"] and upstream == ["qwen3.5:0.8b"]
+    assert set(caps["models"]) == {"ollama-model"}  # relay registers under the advertised name
 
 
 def test_bring_up_engines_falls_back_to_flat_record(monkeypatch, tmp_path):
@@ -2391,12 +2540,14 @@ def test_bring_up_engines_falls_back_to_flat_record(monkeypatch, tmp_path):
 
     # A record written before multi-engine has no `engines` list — synthesise one spec from flat fields.
     record = {"endpoint_url": "http://h:11434/v1", "models": ["llama3"], "advertise_as": []}
-    monkeypatch.setattr(probe, "capabilities", lambda url, model: {"schema_version": 1, "models": {model: {}}})
+    monkeypatch.setattr(probe, "capabilities",
+                        lambda url, model, *, advertise_as=None: {"schema_version": 1, "models": {advertise_as or model: {}}})
 
     results, launched, _ = serve._bring_up_engines(record)
     assert launched == []  # external engine: nothing launched
     assert results[0][0] == "http://h:11434/v1"
     assert results[0][1] == ["llama3"]
+    assert results[0][2] == ["llama3"]  # upstream == advertised when no alias
 
 
 def test_bring_up_engines_rejects_multi_without_endpoints(monkeypatch, tmp_path):

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -584,6 +584,8 @@ def test_run_engine_advertise_as_routes_alias_and_sets_llama_alias(monkeypatch, 
     assert calls["kwargs"]["alias"] == "your-model"
     assert calls["payload"]["models"] == ["your-model"]
     assert calls["payload"]["endpoint_url"] == "http://192.168.1.50:8081/v1"
+    # built-in llama-server answers to its --alias, so upstream is identity (no forward rewrite)
+    assert calls["payload"]["upstream"] == {"your-model": "your-model"}
 
 
 def test_run_engine_endpoint_url_skips_local_llama_server(monkeypatch, tmp_path):
@@ -599,6 +601,55 @@ def test_run_engine_endpoint_url_skips_local_llama_server(monkeypatch, tmp_path)
 
     assert cli.provider._run_engine(args) == 0
     assert calls["payload"]["endpoint_url"] == "http://192.168.1.50:8081/v1"
+
+
+def test_run_engine_external_advertise_as_maps_upstream(monkeypatch, tmp_path):
+    """External `--at` engine under `--advertise-as`: upstream maps the alias to the engine's REAL
+    model name so the local proxy can rewrite it before forwarding (mirrors the remote serve fix)."""
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    calls = {}
+    monkeypatch.setattr(launcher, "start_llm", lambda *a, **k: pytest.fail("start_llm should not be called"))
+    monkeypatch.setattr(cli.provider, "_register_engine", lambda url, node_id, payload: calls.setdefault("payload", payload))
+    monkeypatch.setattr(cli.httpx, "delete", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli.time, "sleep", lambda seconds: (_ for _ in ()).throw(KeyboardInterrupt()))
+
+    args = _engine_args(models=["qwen3:0.6b"], advertise_as=["ollama-model"],
+                        endpoint_url="http://192.168.1.9:11434/v1")
+    assert cli.provider._run_engine(args) == 0
+    assert calls["payload"]["models"] == ["ollama-model"]  # consumers see the alias
+    assert calls["payload"]["upstream"] == {"ollama-model": "qwen3:0.6b"}  # engine gets the real name
+
+
+def test_local_proxy_rewrites_alias_to_upstream_model(monkeypatch):
+    """The local grid proxy must forward the engine's REAL model name, not the advertised alias the
+    consumer used — else an external engine (Ollama/vLLM) 404s on the unknown alias (Issue 1, local)."""
+    from local import server as local_server
+
+    app = create_app(grid_id="ag-test", grid_name="test")
+    client = TestClient(app)
+    reg = client.put("/nodes/node-ext", json={
+        "role": "engine",
+        "models": ["ollama-model"],
+        "endpoint_url": "http://192.168.1.9:11434/v1",
+        "upstream": {"ollama-model": "qwen3:0.6b"},
+    })
+    assert reg.status_code == 200
+
+    seen = {}
+
+    def engine(request):
+        seen["path"] = request.url.path
+        seen["model"] = json.loads(request.content)["model"]
+        return httpx.Response(200, json={"choices": [{"message": {"content": "hi"}}]})
+
+    real = httpx.AsyncClient
+    monkeypatch.setattr(local_server.httpx, "AsyncClient",
+                        lambda *a, **k: real(*a, **{**k, "transport": httpx.MockTransport(engine)}))
+
+    resp = client.post("/v1/chat/completions", json={"model": "ollama-model", "messages": []})
+    assert resp.status_code == 200
+    assert seen["path"].endswith("/chat/completions")
+    assert seen["model"] == "qwen3:0.6b"  # alias rewritten to the engine's real model name
 
 
 def test_run_engine_enable_media_advertises_media_models(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Fixes two bugs hit when serving an Ollama `--at` engine through a grid — one per mode:

- **Tools under-detected for Ollama (remote).** Ollama serves no llama-server `/props` and silently ignores a forced `tool_choice` (a tool-capable model like `qwen3:0.6b` returns HTTP 200 with *no* `tool_calls`), so the capability probe reported `tools=false` and the relay rejected tool requests with `HTTP 400 "No active provider for this model supports tools"`. The probe now reads Ollama's declared capabilities from `POST /api/show` as an authoritative source for `tools` + `vision`. This also fixes Ollama **vision** detection, previously impossible (no `/props`, no capabilities in `/v1/models`).

- **`--advertise-as` 404 on external engines (remote + local).** The alias is only the relay/consumer-facing name, but both the remote serve loop and the local proxy probed/forwarded using it while the engine only knows its real model name → `404 model not found`. Each now carries an `advertised → real` upstream map: probe by the real name (register caps under the alias) and rewrite `body["model"]` alias→real before forwarding. Built-in llama-server is unaffected (it's launched with `--alias`, so advertised == real).

## Verified live against Ollama

- `qwen3:0.6b` (`/api/show` caps `[completion, tools, thinking]`) → probe now reports `tools=true`; the old forced-`tool_choice` probe returned 200 with no `tool_calls` → `false`.
- `gemma3` (`/api/show` caps `[completion, vision]`) → `tools=false` (correct), `vision=true` (newly detected).
- Real `grid --remote join` bring-up path + a full `handle_job` round-trip through an `--advertise-as ollama-model` alias: rewrites to `qwen3:0.6b` and returns a genuine `get_weather({"city":"Hanoi"})` tool call.

## Coverage note

Declarative capability sources are `/props` (llama.cpp) and `/api/show` (Ollama), both 404 harmlessly on other engines. LM Studio and MLX have no capability-metadata endpoint, so they rely on the live forced-`tool_choice` probe (covered by a test).

## Test plan

- [x] `pytest tests/test_local_cli.py` — 276 passed
- [x] `ruff check` — clean
- [x] Live Ollama: probe, remote-join code path, and forward round-trip (above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
