### PR TITLE
feat(remote): serve media (ComfyUI) engines over the relay

### DIFF
--- a/cli/provider.py
+++ b/cli/provider.py
@@ -540,71 +540,16 @@ def _advertised_text_models(models: list[str], aliases: list[str]) -> list[str]:
 
 
 def _prepare_media_engine(args: SimpleNamespace) -> dict[str, Any]:
-    from local import media_runtime
-    from shared.engine import comfyui
-    from shared.models import media_bundles
-    from shared.media import media_gating
-    from shared.system import gpu as gpu_probe
-    from shared.system import host as host_probe
+    # The bring-up itself lives in `local/media_engine.py` so the remote serve loop can reuse it
+    # without a `remote → cli` back-dependency (ADR 0004 §2). This wrapper adapts the local `args`.
+    from local import media_engine
 
-    if not comfyui.comfyui_dir().exists():
-        raise SystemExit(
-            "ComfyUI is not installed. Run `grid engine install comfyui` first, then "
-            "`grid engine pull <bundle>` for each bundle you want to serve."
-        )
-
-    requested = list(args.media_bundles) if args.media_bundles else None
-    if media_gating.is_apple_silicon():
-        host_info = host_probe.gather()
-        memory_mb = [host_info.memory_total_gb * 1024]
-        memory_label = f"unified memory = {host_info.memory_total_gb:.1f} GB"
-    else:
-        gpus = gpu_probe.enumerate_gpus()
-        memory_mb = [item.memory_total_mb for item in gpus]
-        memory_label = f"VRAM = {[round(value / 1024, 1) for value in memory_mb] or 'none'} GB"
-
-    gates = media_gating.select_bundles(memory_mb, requested=requested)
-    if not gates:
-        raise SystemExit(
-            "No media bundles meet the memory threshold for this host "
-            f"(detected {memory_label}). Either skip --media or run on a larger GPU/system."
-        )
-
-    missing: list[str] = []
-    for gate in gates:
-        for spec in media_bundles.BUNDLES[gate.bundle]:
-            if not media_bundles.target_path(spec).exists():
-                missing.append(f"{gate.bundle}/{spec.hf_path}")
-    if missing:
-        raise SystemExit(
-            "ComfyUI bundles are missing files. Run `grid engine pull <bundle>` "
-            "for each enabled bundle. Missing:\n  " + "\n  ".join(missing[:10])
-        )
-
-    comfyui_started = False
-    if not comfyui.is_running(args.comfyui_port):
-        cp = comfyui.start(args.comfyui_port)
-        comfyui_started = True
-        print(f"Spawned ComfyUI pid={cp.proc.pid}, log={cp.log}")
-        comfyui.wait_for_ready(args.comfyui_port)
-        print(f"ComfyUI ready on http://localhost:{args.comfyui_port}")
-
-    comfyui_url = f"http://localhost:{args.comfyui_port}/api"
-    proc = media_runtime.start_media_server(port=args.media_port, comfyui_url=comfyui_url)
-    media_url = runtime.engine_endpoint_url(
-        None,
-        args.media_port,
-        args.advertise_host,
-    ).removesuffix("/v1")
-    print(f"Spawned engine media server pid={proc.pid}, url={media_url}")
-    advertised = [gate.advertise_as for gate in gates]
-    print(f"Media enabled: advertising {advertised}")
-    return {
-        "models": advertised,
-        "proc": proc,
-        "media_url": media_url,
-        "comfyui_started": comfyui_started,
-    }
+    return media_engine.prepare_media_engine(
+        media_bundles=list(args.media_bundles) if args.media_bundles else None,
+        comfyui_port=args.comfyui_port,
+        media_port=args.media_port,
+        advertise_host=args.advertise_host,
+    )
 
 
 def _media_capabilities(models: list[str]) -> dict[str, Any]:

--- a/cli/remote_provider.py
+++ b/cli/remote_provider.py
@@ -24,16 +24,14 @@ from shared import paths, run_records
 
 
 def _reject_local_only_flags(args: argparse.Namespace) -> None:
-    """local-only `grid join` flags have no meaning in remote mode (DECISIONS D8): a remote engine polls
-    the relay outbound, so there is no inbound endpoint to advertise, and media serving is later."""
-    if getattr(args, "media", False):
-        raise SystemExit("Remote media serving isn't available yet; it lands in a later release.")
+    """local-only `grid join` flags have no meaning in remote mode (DECISIONS D8): a remote engine
+    polls the relay outbound, so there is no inbound endpoint to advertise. (`--media` IS supported —
+    a remote media engine's server is reached by the serve loop on loopback, not advertised.)"""
     if getattr(args, "advertise_host", None) is not None:
         raise SystemExit(
             "--advertise-host is local-only. A remote engine polls the relay outbound, so there is "
             "no inbound endpoint to advertise."
         )
-    # --media-port carries a non-None default but only matters with --media, already rejected above.
 
 
 def cmd_remote_join(args: argparse.Namespace) -> int:
@@ -64,8 +62,9 @@ def cmd_remote_join(args: argparse.Namespace) -> int:
     # member can't pre-check fails later at register). See remote_grid.resolve_relay_base.
     signaling_url, _status = remote_grid.resolve_relay_base(session, rec, network_id, label)
 
-    specs = _resolve_serve_targets(args)
-    if not specs:  # several engines detected and the operator declined to join them all
+    specs, media_detected = _resolve_serve_targets(args)
+    media = bool(getattr(args, "media", False)) or media_detected
+    if not specs and not media:  # engines detected and the operator declined, or nothing to serve
         print("Nothing joined.")
         return 0
     if len(specs) > 1 and (getattr(args, "advertise_as", []) or []):
@@ -77,7 +76,7 @@ def cmd_remote_join(args: argparse.Namespace) -> int:
     if existing and run_records.pid_alive(int(existing.get("pid") or 0)):
         raise SystemExit(f"Engine {engine_id!r} is already joined to {label}. Use a different --name.")
 
-    record = _build_record(args, network_id, engine_id, signaling_url, specs)
+    record = _build_record(args, network_id, engine_id, signaling_url, specs, media=media)
     run_records.write_record(network_id, engine_id, record)
 
     proc = _spawn_remote_engine(network_id, engine_id)
@@ -100,31 +99,40 @@ def cmd_remote_join(args: argparse.Namespace) -> int:
         print(f"endpoint_url={record['endpoint_url']}")
     if record["models"]:
         print(f"models={','.join(record['models'])}")
+    if media:  # the comfyui:* models are resolved from bundle gating at serve time, not here
+        print("media=on (serving comfyui:* workflows via the relay)")
     print(f"log={log_path}")
     # The relay isn't locally pollable, so we can't confirm "registered" here — report starting.
     print(f"(starting — stop with `grid leave {label} --engine {engine_id}`)")
     return 0
 
 
-def _resolve_serve_targets(args: argparse.Namespace) -> list[dict[str, object]]:
-    """What to serve, as a list of engine specs `{endpoint_url, models, engine_label}`.
+def _resolve_serve_targets(args: argparse.Namespace) -> tuple[list[dict[str, object]], bool]:
+    """What to serve: `(text_engine_specs, media_detected)`.
 
-    External `--at` and built-in `--serve` resolve to one spec. A bare `grid join` auto-detects: with
-    `--all` (or after an interactive confirm) it returns *every* detected engine so one identity serves
-    their union (DECISIONS D9); otherwise several detected engines are ambiguous and it asks for
-    `--all`/`--engine`. Returns `[]` only when the operator declines the interactive "join all" prompt.
-    Mirrors local `cli/provider.cmd_join`, but remote registers ONE identity instead of one per engine.
+    Text specs are `{endpoint_url, models, engine_label}`. `media_detected` is True when auto-detect
+    finds a media (ComfyUI) engine, so the caller brings the media engine up alongside the text ones.
+    External `--at` and built-in `--serve` each resolve to one text spec (media comes only from an
+    explicit `--media`). An explicit `--media` with no text engine is media-only: return `([], False)`
+    and let `args.media` carry it. A bare `grid join` auto-detects: text engines join under one
+    identity (DECISIONS D9) — `--all` (or an interactive confirm) accepts several, otherwise it asks —
+    and any detected media engine flips `media_detected`. Returns `([], False)` when the operator
+    declines the "join all" prompt. Mirrors local `cli/provider.cmd_join` (remote → ONE identity).
     """
     from . import provider
 
     if args.at:
         if not args.models:
             raise SystemExit("--at requires at least one -m/--model naming what that engine serves.")
-        return [{"endpoint_url": args.at, "models": list(args.models), "engine_label": None}]
+        return [{"endpoint_url": args.at, "models": list(args.models), "engine_label": None}], False
     if args.serve:
-        return [{"endpoint_url": None, "models": [args.serve], "engine_label": None}]
+        return [{"endpoint_url": None, "models": [args.serve], "engine_label": None}], False
     if args.models:
         raise SystemExit("-m/--model names models for an engine; pair it with --at <url>, or use --serve <model>.")
+    if getattr(args, "media", False):
+        # Explicit `--media` with no text engine → media-only. Skip detection; the serve loop brings up
+        # the media engine from the bundle gating.
+        return [], False
 
     detected = provider._detect(None)  # advertise_host is local-only; remote always probes loopback
     if not detected:
@@ -137,24 +145,19 @@ def _resolve_serve_targets(args: argparse.Namespace) -> list[dict[str, object]]:
         if not detected:
             raise SystemExit(f"No detected engine named {args.engine!r}. Run `grid join` to list them.")
 
-    # Remote can't serve media engines yet: drop them from a multi-join, reject a lone one.
+    media_detected = any(engine.media for engine in detected)
     text = [engine for engine in detected if not engine.media]
-    if not text:
-        raise SystemExit("Remote media serving isn't available yet; it lands in a later release.")
     if len(text) > 1 and not args.all:
         provider._print_plan(text)
         if provider._interactive():
             if not provider._confirm("Join all detected engines?"):
-                return []
+                return [], False
         else:
             raise SystemExit("Multiple engines detected; pass --all, --engine <kind>, or --at <url>.")
-    for engine in detected:
-        if engine.media:
-            print(f"Skipping {engine.label!r}: remote media serving isn't available yet.", file=sys.stderr)
     return [
         {"endpoint_url": engine.endpoint_url, "models": list(engine.models), "engine_label": engine.label}
         for engine in text
-    ]
+    ], media_detected
 
 
 def _warn_shadowed_models(specs: list[dict[str, object]]) -> None:
@@ -179,12 +182,15 @@ def _build_record(
     engine_id: str,
     signaling_url: str,
     specs: list[dict[str, object]],
+    media: bool = False,
 ) -> dict[str, object]:
     """The remote engine's run record — non-secret routing only; the token stays in credentials.toml.
 
     Several engines can serve under one identity (DECISIONS D9): `engines` carries each local engine
     so the serve loop can build the model→engine table. Top-level `models` is their union and
     `endpoint_url` is the single engine's URL (None when several) — kept for display + back-compat.
+    `media` (+ bundles/ports) mirror the local record fields so the serve loop brings up ComfyUI + the
+    media server; a media-only join has empty `specs`/`models` and derives `comfyui:*` at serve time.
     """
     from local import runtime
 
@@ -200,6 +206,10 @@ def _build_record(
         "endpoint_url": single_endpoint,
         "models": union,
         "engines": specs,
+        "media": bool(media),
+        "media_bundles": list(getattr(args, "bundles", []) or []),
+        "comfyui_port": getattr(args, "comfyui_port", 8188),
+        "media_port": getattr(args, "media_port", 8190),
         "advertise_as": list(getattr(args, "advertise_as", []) or []),
         "engine_label": getattr(args, "engine_label", None),
         "pricing_input": getattr(args, "pricing_input", None),

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -197,7 +197,11 @@ of `__engine`. That subprocess (`remote/serve.py:run_remote_engine_from_record`)
 4. `grid join --all` serves several local engines under **one** identity: it registers the union
    of their models and routes each polled job to the engine serving the requested `body["model"]`
    (first-detected wins on a duplicate). See [ADR 0007](adr/0007-remote-multi-engine-routing.md).
-5. `grid leave` SIGTERMs the subprocess, which flips the node back to `consumer` so the relay
+5. `grid join --media` also brings up ComfyUI + the media server, registers the `comfyui:*`
+   workflows the host's VRAM gates in, and forwards `media/*` jobs to the media server on loopback
+   (always streamed SSE) — media-only or alongside a text engine. See
+   [ADR 0008](adr/0008-remote-media-serve.md).
+6. `grid leave` SIGTERMs the subprocess, which flips the node back to `consumer` so the relay
    drains queued work, and stops anything it launched. See
    [ADR 0004](adr/0004-remote-provider-serve.md).
 

--- a/docs/adr/0008-remote-media-serve.md
+++ b/docs/adr/0008-remote-media-serve.md
@@ -1,0 +1,71 @@
+# ADR 0008 — Remote provider media serve (ComfyUI over the relay)
+
+Status: accepted (2026-07-02)
+
+## Context
+
+ADR 0004 landed `grid join` in remote mode for **text** engines and deferred media: `--media` was
+rejected at the join boundary, the serve loop's endpoint allowlist was text-only, and `handle_job`
+dropped any `media/*` job with "isn't available in remote mode yet". ADR 0005 (remote consume) and
+`cli/remote_request.py` already ship the **consumer** half — `grid image` / `edit` / `video` POST
+`media/*` to `{relay}/relay/v1/...` and consume the SSE via the shared `cli/media_io.py` — and the
+relay wire layer (`remote/relay.py`) already streams SSE both ways (`submit_response(stream=True)`).
+So the only missing half was the **provider**: bringing ComfyUI up on a remote-joined box and
+forwarding relay `media/*` jobs to it. This slice fills that half. It mirrors local media serving
+(`cli/provider._run_engine` + `local/server._proxy_media`); the consumer side and relay contract are
+unchanged.
+
+Hard invariant (unchanged from 0004): local `grid join` behaviour and the whole existing suite stay
+green; no `remote → cli` back-dependency; the relay's poll response stays untrusted input.
+
+## Decisions
+
+1. **ComfyUI bring-up moves to `local/media_engine.py`.** The bring-up (memory-gate the bundles,
+   verify files, start ComfyUI + the media server) was inline in `cli/provider._prepare_media_engine`.
+   It moves verbatim into `local/media_engine.prepare_media_engine(...)`; `cli/provider` keeps
+   `_prepare_media_engine(args)` as a thin adapter (so the local test/monkeypatch surface is
+   byte-identical). The serve loop (`remote/serve.py`) calls the shared function directly — it lives in
+   `local/` **not** `cli/` precisely so remote reuses it without a `remote → cli` import (ADR 0004 §2);
+   the serve loop already imports `local.runtime`.
+
+2. **One serve loop, media brought up alongside text.** `run_remote_engine_from_record` brings up text
+   engines only when the record names them (`has_text`), so a media-only join (empty text spec) never
+   hits `_bring_up_engines`. When `record["media"]`, it calls `prepare_media_engine`, merges the
+   `comfyui:*` models into the identity's `union_models` and their `media` caps
+   (`shared.media.media_gating.capability_entry`) into the register envelope, and passes the media
+   server's **loopback** URL (`http://127.0.0.1:<media_port>`) to `_ServeState`. Media therefore
+   coexists with a text engine under one identity (DECISIONS D9): `grid join --serve <m> --media`
+   registers `[<m>, comfyui:image_generation, …]`. Teardown stops the media server we launched and
+   only stops ComfyUI if **we** started it (never one the operator was already running).
+
+3. **`media/*` jobs forward to the media server, always streamed.** `handle_job` routes an endpoint on
+   the fixed media allowlist (`media/image/generate`, `media/image/edit`, `media/video/i2v`) to
+   `state.media_url` via the existing `_forward_stream` — a media response is always SSE, so `is_stream`
+   is ignored. The media allowlist is **separate** from `_ALLOWED_ENDPOINTS` (text) because the two
+   route to different local URLs; a `media/*` path outside the allowlist is refused (never blind-
+   forwarded), preserving the 0004 §6 guarantee that the relay's untrusted `endpoint_path` can't reach
+   an arbitrary local path. A job for a media endpoint on a text-only identity (no `media_url`) is
+   reported as an error, not crashed.
+
+4. **The record carries media, mirroring local.** `cli/remote_provider._build_record` gains
+   `media` / `media_bundles` / `comfyui_port` / `media_port` (same fields, same defaults as the local
+   record in `cli/provider._spawn_engine`). `_reject_local_only_flags` no longer rejects `--media`
+   (only `--advertise-host` stays local-only — a remote engine polls outbound, so a media server needs
+   no advertised address; the loop reaches it on loopback). `_resolve_serve_targets` returns
+   `(text_specs, media_detected)`: an explicit `--media` with no text engine is media-only, and a
+   detected ComfyUI engine flips `media_detected` so a bare `grid join` picks it up.
+
+## Consequences
+
+- Remote media serving works end-to-end **on the provider side**: `grid join --media --bundle
+  image_generation` now registers `comfyui:*` and serves relay `media/*` jobs. Whether the hosted
+  relay actually enqueues media jobs and accepts the streamed media response is server-side and must
+  be confirmed in a 2-host E2E — the provider now does exactly what the consumer + relay expect.
+- The media read budget reuses the job's `inference_timeout_seconds` (per-chunk read timeout); media
+  handlers emit progress frequently, so a long video generation won't idle it out. If the hosted relay
+  tunes that value only for text, a future slice can carry a media-specific budget.
+- `--all` mixing several text engines **and** a detected media engine under one identity falls out of
+  the design (text specs + one media server), but the tested paths are media-only and media + a single
+  text engine; the broad union is exercised less and may need follow-up polish.
+- The detached seam stays the one plug-in point; the classification + flag-gating tests still keep a
+  command from running the wrong mode's code.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -217,22 +217,29 @@ join --all` serves several detected engines under **one** identity: it advertise
 models and routes each job to the engine that serves the requested model (first-detected wins when
 two engines share a model name).
 
+`grid join --media [--bundle <bundle>]...` serves this box's built-in media (ComfyUI) engine to the
+relay — media-only, or alongside a text engine (`--serve`/`--at` + `--media`). The serve loop brings
+up ComfyUI + the media server, registers the `comfyui:*` workflows the host's VRAM gates in, and the
+relay forwards `media/*` jobs to the media server on loopback; the SSE (progress + base64 result
+files) streams back exactly as in local mode.
+
 The `grid join` flag set is the union of both modes, gated by mode:
 
 - **Both modes:** `--at` / `--serve` / `-m,--model` / `--engine <kind>` / `--name` / `--all`,
-  `--advertise-as`, `--endpoint-port` (alias `--llama-port`), `--comfyui-port`, and the llama
-  tuning flags (`--ctx-size --n-predict --parallel --flash-attn --temp --reasoning-budget`).
-- **local-only:** `--advertise-host`, `--media-port` (a remote engine polls outbound — no inbound
+  `--advertise-as`, `--endpoint-port` (alias `--llama-port`), the llama tuning flags
+  (`--ctx-size --n-predict --parallel --flash-attn --temp --reasoning-budget`), and the media flags
+  `--media` / `--bundle <bundle>` / `--comfyui-port` / `--media-port`.
+- **local-only:** `--advertise-host` (a remote engine polls the relay outbound — there is no inbound
   endpoint to advertise).
 - **Remote-only:** `--engine-label` (the engine kind shown on the grid page), `--max-concurrency`.
 - **Deprecated:** `--pricing-input` / `--pricing-output` — kept so old invocations don't hard-error,
   but they no longer advertise a price. Set your authoritative per-model price with `grid price set`
   (see [Price](#price)) instead.
 
-A flag used in the wrong mode fails with a clear message. (`--media` serving in remote mode is a later
-slice; `--advertise-as` is single-engine only and is rejected with `--all`.) See
-[ADR 0004](./adr/0004-remote-provider-serve.md) and
-[ADR 0007](./adr/0007-remote-multi-engine-routing.md).
+A flag used in the wrong mode fails with a clear message. (`--advertise-as` is single-engine only and
+is rejected with `--all`.) See [ADR 0004](./adr/0004-remote-provider-serve.md),
+[ADR 0007](./adr/0007-remote-multi-engine-routing.md), and
+[ADR 0008](./adr/0008-remote-media-serve.md).
 
 ## Models
 

--- a/local/media_engine.py
+++ b/local/media_engine.py
@@ -1,0 +1,93 @@
+"""Bring up the local media (ComfyUI) engine + the provider media server.
+
+Shared by both modes so neither owns the ComfyUI bring-up: local (`cli/provider._run_engine`)
+advertises the media server to the LAN grid proxy; remote (`remote/serve.py`) forwards relay media
+jobs to it on loopback. It lives in `local/` (not `cli/`) precisely so `remote/serve.py` can reuse it
+without a `remote → cli` back-dependency (ADR 0004 §2) — the serve loop already imports `local.runtime`.
+
+Memory gating (`shared.media.media_gating`) picks which `comfyui:*` bundles this host has enough
+VRAM / unified memory to advertise; a missing ComfyUI install or un-pulled bundle is a clean
+`SystemExit` at bring-up, never a half-started engine.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from local import media_runtime, runtime
+
+
+def prepare_media_engine(
+    *,
+    media_bundles: list[str] | None,
+    comfyui_port: int,
+    media_port: int,
+    advertise_host: str | None,
+) -> dict[str, Any]:
+    """Start ComfyUI (if needed) + the provider media server, and report what it advertises.
+
+    Returns ``{"models": [comfyui:* ...], "proc": <media server Popen>, "media_url": <advertised
+    base>, "comfyui_started": bool}``. ``media_url`` is the URL the media server is *advertised* at
+    (LAN-facing via ``advertise_host`` for local); the remote serve loop ignores it and forwards on
+    loopback. ``comfyui_started`` tells the caller whether IT launched ComfyUI (so teardown only stops
+    a ComfyUI it started, never one the operator was already running).
+    """
+    from shared.engine import comfyui
+    from shared.media import media_gating
+    from shared.models import media_bundles as bundles_mod
+    from shared.system import gpu as gpu_probe
+    from shared.system import host as host_probe
+
+    if not comfyui.comfyui_dir().exists():
+        raise SystemExit(
+            "ComfyUI is not installed. Run `grid engine install comfyui` first, then "
+            "`grid engine pull <bundle>` for each bundle you want to serve."
+        )
+
+    requested = list(media_bundles) if media_bundles else None
+    if media_gating.is_apple_silicon():
+        host_info = host_probe.gather()
+        memory_mb = [host_info.memory_total_gb * 1024]
+        memory_label = f"unified memory = {host_info.memory_total_gb:.1f} GB"
+    else:
+        gpus = gpu_probe.enumerate_gpus()
+        memory_mb = [item.memory_total_mb for item in gpus]
+        memory_label = f"VRAM = {[round(value / 1024, 1) for value in memory_mb] or 'none'} GB"
+
+    gates = media_gating.select_bundles(memory_mb, requested=requested)
+    if not gates:
+        raise SystemExit(
+            "No media bundles meet the memory threshold for this host "
+            f"(detected {memory_label}). Either skip --media or run on a larger GPU/system."
+        )
+
+    missing: list[str] = []
+    for gate in gates:
+        for spec in bundles_mod.BUNDLES[gate.bundle]:
+            if not bundles_mod.target_path(spec).exists():
+                missing.append(f"{gate.bundle}/{spec.hf_path}")
+    if missing:
+        raise SystemExit(
+            "ComfyUI bundles are missing files. Run `grid engine pull <bundle>` "
+            "for each enabled bundle. Missing:\n  " + "\n  ".join(missing[:10])
+        )
+
+    comfyui_started = False
+    if not comfyui.is_running(comfyui_port):
+        cp = comfyui.start(comfyui_port)
+        comfyui_started = True
+        print(f"Spawned ComfyUI pid={cp.proc.pid}, log={cp.log}")
+        comfyui.wait_for_ready(comfyui_port)
+        print(f"ComfyUI ready on http://localhost:{comfyui_port}")
+
+    comfyui_url = f"http://localhost:{comfyui_port}/api"
+    proc = media_runtime.start_media_server(port=media_port, comfyui_url=comfyui_url)
+    media_url = runtime.engine_endpoint_url(None, media_port, advertise_host).removesuffix("/v1")
+    print(f"Spawned engine media server pid={proc.pid}, url={media_url}")
+    advertised = [gate.advertise_as for gate in gates]
+    print(f"Media enabled: advertising {advertised}")
+    return {
+        "models": advertised,
+        "proc": proc,
+        "media_url": media_url,
+        "comfyui_started": comfyui_started,
+    }

--- a/remote/serve.py
+++ b/remote/serve.py
@@ -27,10 +27,12 @@ from shared import run_records
 # Engine read budget when the relay doesn't advertise one (older relay); matches its default.
 _DEFAULT_INFERENCE_TIMEOUT = 600.0
 
-# The relay-supplied endpoint is interpolated into the local engine URL, so only forward known text
+# The relay-supplied endpoint is interpolated into a local engine URL, so only forward known
 # endpoints — this stops a buggy or compromised relay from probing other local paths via `../`.
-# (Media is a later slice and is rejected with its own message.)
+# Text goes to the LLM engine; media goes to this box's media server, each with its own fixed
+# allowlist (the media paths are NOT under `_ALLOWED_ENDPOINTS` — they route to a different URL).
 _ALLOWED_ENDPOINTS = frozenset({"chat/completions", "completions"})
+_MEDIA_ENDPOINTS = frozenset({"media/image/generate", "media/image/edit", "media/video/i2v"})
 
 
 # ---------------------------------------------------------------------------
@@ -65,13 +67,47 @@ def run_remote_engine_from_record(grid_id: str, engine_id: str) -> int:
 
     launched: list[Any] = []
     launcher = None
+    media_proc = None
+    comfyui_started = False
     state = None
     rc = 0
     try:
-        engine_results, launched, launcher = _bring_up_engines(record)
+        # Bring up text engines only when the record names some — a media-only join (`grid join
+        # --media`) has no text spec, and `_bring_up_engines` would otherwise error on the empty spec.
+        has_text = bool(record.get("engines")) or bool(record.get("models")) or bool(record.get("endpoint_url"))
+        if has_text:
+            engine_results, launched, launcher = _bring_up_engines(record)
+        else:
+            engine_results = []
         routes, upstream, union_models, capabilities, warnings = _build_routing(engine_results)
         for line in warnings:  # surface shadowed-duplicate models so routing isn't a silent surprise
             print(line, file=sys.stderr)
+
+        # Media engine (ComfyUI + the provider media server) — brought up on this same box and
+        # reached by the poll loop on loopback (the relay forwards `media/*` jobs to us like text).
+        # Its `comfyui:*` models + caps merge into the one identity we register (DECISIONS D9).
+        media_url = None
+        if record.get("media"):
+            from local import media_engine
+            from shared.media import media_gating
+
+            media_port = int(record.get("media_port") or 8190)
+            prepared = media_engine.prepare_media_engine(
+                media_bundles=list(record.get("media_bundles") or []) or None,
+                comfyui_port=int(record.get("comfyui_port") or 8188),
+                media_port=media_port,
+                advertise_host=None,  # loopback forward — no LAN-facing URL needed in remote mode
+            )
+            media_proc = prepared["proc"]
+            comfyui_started = bool(prepared["comfyui_started"])
+            media_url = f"http://127.0.0.1:{media_port}"
+            caps_models = dict((capabilities or {}).get("models") or {})
+            for model in prepared["models"]:
+                if model not in union_models:
+                    union_models.append(model)
+                caps_models[model] = media_gating.capability_entry()
+            capabilities = {"schema_version": 1, "models": caps_models} if caps_models else {}
+
         state = _ServeState(
             signaling_url=signaling_url,
             node_id=node_id,
@@ -86,6 +122,7 @@ def run_remote_engine_from_record(grid_id: str, engine_id: str) -> int:
             max_concurrency=int(record.get("max_concurrency") or 1),
             routes=routes,
             upstream=upstream,
+            media_url=media_url,
         )
         register(state)
         print(f"Engine {state.node_id} serving {union_models} via the relay at {signaling_url}")
@@ -112,6 +149,22 @@ def run_remote_engine_from_record(grid_id: str, engine_id: str) -> int:
                     print(f"Stopped llama-server (pid={proc.proc.pid}).")
                 except Exception as exc:  # best-effort teardown; never mask the real exit
                     print(f"Stopping llama-server failed (ignoring): {exc}", file=sys.stderr)
+        if media_proc is not None:  # stop the media server we launched
+            from local import media_runtime
+
+            try:
+                media_runtime.stop_media_server(media_proc)
+                print("Stopped engine media server.")
+            except Exception as exc:  # best-effort teardown; never mask the real exit
+                print(f"Stopping media server failed (ignoring): {exc}", file=sys.stderr)
+        if comfyui_started:  # only stop ComfyUI if WE started it (not one the operator was running)
+            from shared.engine import comfyui
+
+            try:
+                comfyui.stop()
+                print("Stopped ComfyUI.")
+            except Exception as exc:  # best-effort teardown; never mask the real exit
+                print(f"Stopping ComfyUI failed (ignoring): {exc}", file=sys.stderr)
     return rc
 
 
@@ -289,7 +342,16 @@ def _meta(record: dict[str, Any], engine_id: str) -> dict[str, Any]:
         kinds = [e.get("engine_label") for e in (record.get("engines") or []) if e.get("engine_label")]
         if kinds:
             label = "+".join(dict.fromkeys(kinds))
-    return {"name": engine_id, "engine": label or ("external" if record.get("endpoint_url") else "llama.cpp")}
+    if not label:
+        if record.get("endpoint_url"):
+            label = "external"
+        elif record.get("models") or record.get("engines"):
+            label = "llama.cpp"
+        elif record.get("media"):  # a media-only identity has no text engine to name
+            label = "comfyui"
+        else:
+            label = "llama.cpp"
+    return {"name": engine_id, "engine": label}
 
 
 def _pricing(record: dict[str, Any]) -> dict[str, float]:
@@ -347,12 +409,17 @@ class _ServeState:
         max_concurrency: int,
         routes: dict[str, str] | None = None,
         upstream: dict[str, str] | None = None,
+        media_url: str | None = None,
     ) -> None:
         self.signaling_url = signaling_url
         self.node_id = node_id
         self.network_id = network_id
         self.llm_url = llm_url.rstrip("/")
         self.models = list(models)
+        # This box's media server base (`http://127.0.0.1:<media_port>`) when the identity serves
+        # media, else None. `media/*` jobs forward here instead of an LLM engine; all media models
+        # share the one server, so a single URL (not a per-model route) is enough.
+        self.media_url = media_url.rstrip("/") if media_url else None
         # model → local engine URL. Several engines may serve under one identity (DECISIONS D9); for
         # the single-engine case the map is derived so every advertised model points at the one engine.
         if routes is not None:
@@ -519,8 +586,21 @@ def handle_job(state: _ServeState, job: dict[str, Any]) -> None:
     is_stream = bool(job.get("is_stream", False))
     read_timeout = float(job.get("inference_timeout_seconds") or _DEFAULT_INFERENCE_TIMEOUT)
 
-    if endpoint.startswith("media/"):  # remote media serving is a later slice
-        _try_submit_error(state, txn, "media serving isn't available in remote mode yet")
+    if endpoint in _MEDIA_ENDPOINTS:  # media → this box's media server; always SSE, so always stream
+        if not state.media_url:
+            _try_submit_error(state, txn, f"this engine does not serve media (endpoint {endpoint!r})")
+            return
+        state.enter_inference()
+        try:
+            _forward_stream(state, txn, endpoint, body, read_timeout, state.media_url)
+        except Exception as exc:  # one bad media job must not kill the loop
+            print(f"\nMedia job {txn} failed: {exc!r}", file=sys.stderr)
+            _try_submit_error(state, txn, str(exc))
+        finally:
+            state.exit_inference()
+        return
+    if endpoint.startswith("media/"):  # a media path we don't serve — never blind-forward it
+        _try_submit_error(state, txn, f"unsupported media endpoint: {endpoint!r}")
         return
     if endpoint not in _ALLOWED_ENDPOINTS:  # don't forward an unknown path to the local engine
         _try_submit_error(state, txn, f"unsupported endpoint: {endpoint!r}")

--- a/shared/engine/comfyui.py
+++ b/shared/engine/comfyui.py
@@ -44,9 +44,13 @@ COMFYUI_PORT_DEFAULT = 8188
 COMFYUI_PINNED_COMMIT = "47ccecaee009cce148e8c2a5bdc2ecb302cc52ee"
 COMFYUI_GGUF_PINNED_COMMIT = "6ea2651e7df66d7585f6ffee804b20e92fb38b8a"
 GGUF_PINNED_VERSION = "gguf==0.18.0"
-TORCH_PINNED = "torch==2.13.0.dev20260423"
-TORCHVISION_PINNED = "torchvision==0.27.0.dev20260423"
-TORCHAUDIO_PINNED = "torchaudio==2.11.0"
+# PyTorch nightly (CPU/MPS index below). Bumped 2026-07-02: the prior dev20260423 pins aged out of
+# the nightly index (it keeps only ~recent dates), and torchaudio==2.11.0 only exists as a nightly —
+# dev20260504 is the earliest date with matching torch/torchvision/torchaudio cp311 arm64 wheels on
+# the same 2.13.0 line as the original pin.
+TORCH_PINNED = "torch==2.13.0.dev20260504"
+TORCHVISION_PINNED = "torchvision==0.27.0.dev20260504"
+TORCHAUDIO_PINNED = "torchaudio==2.11.0.dev20260504"
 TORCH_NIGHTLY_INDEX = "https://download.pytorch.org/whl/nightly/cpu"
 MACOS_MEDIA_PACKAGE_LOCK = "comfyui_macos_package_lock.txt"
 

--- a/shared/engine/comfyui_macos_package_lock.txt
+++ b/shared/engine/comfyui_macos_package_lock.txt
@@ -91,10 +91,10 @@ spandrel==0.4.2
 starlette==0.27.0
 sympy==1.14.0
 tokenizers==0.22.2
-torch==2.13.0.dev20260423
-torchaudio==2.11.0
+torch==2.13.0.dev20260504
+torchaudio==2.11.0.dev20260504
 torchsde==0.2.6
-torchvision==0.27.0.dev20260423
+torchvision==0.27.0.dev20260504
 tqdm==4.67.3
 trampoline==0.1.2
 transformers==5.8.1

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -1346,12 +1346,32 @@ def test_remote_join_all_rejects_advertise_as(monkeypatch, tmp_path):
     assert "advertise-as" in str(exc.value).lower()
 
 
-def test_remote_join_rejects_media(monkeypatch, tmp_path):
+def test_remote_join_media_only_writes_media_record_and_spawns(monkeypatch, tmp_path):
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    spawned = _mock_remote_spawn(monkeypatch)
+
+    assert cli.main(["join", "--media", "--bundle", "image_generation"]) == 0
+
+    records = cli.provider._read_records("n1")
+    (engine_id, record), = records.items()
+    assert record["media"] is True
+    assert record["media_bundles"] == ["image_generation"]
+    # A media-only join carries no text engine; the comfyui:* models are resolved from bundle gating
+    # at serve time, so the record's models/endpoint stay empty.
+    assert record["models"] == [] and record["endpoint_url"] is None and record["engines"] == []
+    assert record["comfyui_port"] == 8188 and record["media_port"] == 8190
+    assert spawned["cmd"][-3:] == ["__remote-engine", "n1", engine_id]
+
+
+def test_remote_join_media_with_serve_carries_both(monkeypatch, tmp_path):
     _seed_running_remote_grid(monkeypatch, tmp_path)
     _mock_remote_spawn(monkeypatch)
-    with pytest.raises(SystemExit) as exc:
-        cli.main(["join", "--media"])
-    assert "media" in str(exc.value).lower()
+
+    assert cli.main(["join", "--serve", "m", "--media"]) == 0
+
+    record = next(iter(cli.provider._read_records("n1").values()))
+    assert record["media"] is True  # media coexists with a built-in text engine under one identity
+    assert record["models"] == ["m"] and record["engines"][0]["models"] == ["m"]
 
 
 def test_remote_join_rejects_advertise_host(monkeypatch, tmp_path):
@@ -2231,15 +2251,98 @@ def test_serve_handle_job_engine_error_submits_error(monkeypatch, tmp_path):
     assert "500" in captured["error"] and "submitted" not in captured
 
 
-def test_serve_handle_job_rejects_media(monkeypatch, tmp_path):
+def test_serve_handle_job_media_without_media_url_submits_error(monkeypatch, tmp_path):
+    """A text-only identity that gets a media job (mis-routed by the relay) reports it, never crashes."""
     from remote import relay, serve
 
-    state = _serve_state(monkeypatch, tmp_path)
+    state = _serve_state(monkeypatch, tmp_path)  # no media_url → this engine serves no media
     captured = {}
     monkeypatch.setattr(relay, "submit_error", lambda url, tok, txn, *, message, tokens_delivered=0: captured.update(error=message))
 
     serve.handle_job(state, {"transaction_id": "t1", "endpoint_path": "media/image/generate", "body": {}})
     assert "media" in captured["error"].lower()
+
+
+def test_serve_handle_job_forwards_media_to_media_server(monkeypatch, tmp_path):
+    """A media identity forwards the job to its local media server and streams the SSE back — always
+    streamed (media responses are SSE), regardless of the job's is_stream flag."""
+    from remote import relay, serve
+
+    state = _serve_state(monkeypatch, tmp_path, media_url="http://127.0.0.1:8190")
+    captured = {}
+
+    def cap_submit(url, tok, txn, *, content, stream):
+        captured.update(stream=stream, txn=txn, body=b"".join(content))  # drain the generator while open
+
+    monkeypatch.setattr(relay, "submit_response", cap_submit)
+    monkeypatch.setattr(relay, "submit_error", lambda url, tok, txn, *, message, tokens_delivered=0: captured.update(error=message))
+
+    def media_server(request):
+        assert request.url.path == "/media/image/generate"  # forwarded to the media server, not /v1
+        assert json.loads(request.content)["prompt"] == "a cat"
+        return httpx.Response(200, content=b'data: {"type":"result"}\n\ndata: [DONE]\n\n')
+
+    _mock_serve_engine(monkeypatch, media_server)
+    serve.handle_job(state, {"transaction_id": "t1", "endpoint_path": "media/image/generate",
+                             "body": {"prompt": "a cat"}, "is_stream": False})
+    assert captured["stream"] is True and captured["txn"] == "t1"
+    assert b"[DONE]" in captured["body"] and "error" not in captured
+
+
+def test_serve_handle_job_rejects_unknown_media_endpoint(monkeypatch, tmp_path):
+    """The relay's endpoint_path is untrusted: a media path outside the fixed allowlist is refused even
+    on a media engine, so a traversal like `media/../` can never reach the media server (ADR 0004 §6)."""
+    from remote import relay, serve
+
+    state = _serve_state(monkeypatch, tmp_path, media_url="http://127.0.0.1:8190")
+    captured = {}
+    monkeypatch.setattr(relay, "submit_error", lambda url, tok, txn, *, message, tokens_delivered=0: captured.update(error=message))
+
+    serve.handle_job(state, {"transaction_id": "t1", "endpoint_path": "media/bogus", "body": {}})
+    assert "unsupported media endpoint" in captured["error"].lower()
+
+
+def test_run_remote_engine_media_only_registers_comfyui_models(monkeypatch, tmp_path):
+    """A media-only record: bring up the media engine (no text engine), register the comfyui:* models
+    + media caps, and pass the loopback media_url to the serve state. Guards the has_text skip so the
+    empty text spec never reaches `_bring_up_engines`."""
+    import base64
+    import json as _json
+
+    from shared import run_records
+    from local import media_engine, media_runtime
+    from remote import relay, serve
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    run_records.write_record("n1", "media1", {
+        "engine_id": "media1", "node_id": "ignored", "grid_id": "n1", "pid": 0,
+        "signaling_url": "https://relay.example", "endpoint_url": None, "models": [], "engines": [],
+        "media": True, "media_bundles": ["image_generation"], "comfyui_port": 8188, "media_port": 8190,
+    })
+    # A per-grid token whose JWT carries the node_id claim (register addresses the token's own node).
+    claims = base64.urlsafe_b64encode(_json.dumps({"node_id": "node-xyz"}).encode()).decode().rstrip("=")
+    monkeypatch.setattr(serve, "_load_tokens", lambda net: (f"h.{claims}.s", "RT"))
+
+    class _Proc:
+        pid = 1234
+
+    monkeypatch.setattr(media_engine, "prepare_media_engine", lambda **kw: {
+        "models": ["comfyui:image_generation"], "proc": _Proc(), "media_url": "unused", "comfyui_started": False,
+    })
+    monkeypatch.setattr(serve, "_bring_up_engines",
+                        lambda rec: pytest.fail("media-only join must not bring up a text engine"))
+    captured = {}
+    monkeypatch.setattr(relay, "register_node", lambda url, tok, node, **kw: captured.update(node=node, **kw))
+    monkeypatch.setattr(serve, "_poll_loop", lambda state: (captured.update(media_url=state.media_url), state.stop.set()))
+    monkeypatch.setattr(relay, "heartbeat", lambda *a, **k: "ok")
+    monkeypatch.setattr(relay, "unregister_node", lambda *a, **k: None)
+    monkeypatch.setattr(media_runtime, "stop_media_server", lambda proc, **k: None)
+
+    assert serve.run_remote_engine_from_record("n1", "media1") == 0
+    assert captured["node"] == "node-xyz"
+    assert captured["models"] == ["comfyui:image_generation"]
+    assert captured["capabilities"]["models"]["comfyui:image_generation"]["endpoints"] == ["media"]
+    assert captured["media_url"] == "http://127.0.0.1:8190"  # loopback forward target for the poll loop
 
 
 def test_serve_poll_once_returns_none_when_no_work(monkeypatch, tmp_path):

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -324,7 +324,7 @@ def test_media_pinned_engine_versions_and_bundles_are_ported():
     assert comfyui.COMFYUI_PINNED_COMMIT == "47ccecaee009cce148e8c2a5bdc2ecb302cc52ee"
     assert comfyui.COMFYUI_GGUF_PINNED_COMMIT == "6ea2651e7df66d7585f6ffee804b20e92fb38b8a"
     assert comfyui.GGUF_PINNED_VERSION == "gguf==0.18.0"
-    assert comfyui.TORCH_PINNED == "torch==2.13.0.dev20260423"
+    assert comfyui.TORCH_PINNED == "torch==2.13.0.dev20260504"
     assert comfyui.COMFYUI_REQUIREMENT_PINS == (
         "comfyui_frontend_package==1.42.14",
         "comfyui_workflow_templates==0.9.62",


### PR DESCRIPTION
## Summary

Makes remote-mode `grid join --media` work. Remote media serving was hard-rejected
("Remote media serving isn't available yet"); the **provider** half was the only missing
piece — the consumer side (`grid image`/`edit`/`video`) and the relay SSE transport already
shipped (ADR 0005). This brings the media engine up in the remote serve loop and forwards
media jobs to it, media-only or alongside a text engine.

## Changes

**`feat(remote)`: serve media (ComfyUI) engines over the relay**
- `local/media_engine.py` (new): extract the ComfyUI + media-server bring-up out of
  `cli/provider` so `remote/serve.py` reuses it without a `remote→cli` import (ADR 0004 §2);
  `cli/provider._prepare_media_engine` stays a thin wrapper (local behaviour byte-identical).
- `remote/serve.py`: bring media up when the record asks, merge the `comfyui:*` models + caps
  into the one registered identity, add `media_url` to `_ServeState`, forward `media/*`
  (fixed allowlist) to the loopback media server as streamed SSE, and tear it down on exit.
- `cli/remote_provider.py`: accept `--media`, carry media/bundle/port fields into the run
  record, stop dropping detected media engines.
- Docs: ADR 0008 + `cli.md` / `ARCHITECTURE.md`.

**`fix(comfyui)`: bump stale PyTorch nightly pin** (pre-existing, unrelated bug)
- `grid engine install comfyui` failed: pinned `torch==2.13.0.dev20260423` had aged out of
  PyTorch's nightly index, and `torchaudio==2.11.0` only exists as a nightly. Bumped
  torch/torchvision/torchaudio to `dev20260504` in `comfyui.py` + the macOS package lock.

## Test plan
- [x] `pytest` — 293 pass (media forwarding, `comfyui:*` registration, endpoint allowlist,
  media-only serve loop, CLI record; plus the existing suite incl. v0.1.6 pricing).
- [x] `ruff check .` clean.
- [x] Rebased onto `main` (v0.1.6); auto-merged with the pricing feature, suite re-verified.
- [ ] Live end-to-end generation deferred — needs grid's ComfyUI (installs cleanly after the
  torch fix) + a ~19 GB bundle download (bandwidth-bound). The hosted relay routing `media/*`
  jobs is the remaining server-side unknown (noted in ADR 0008).
