### PR TITLE
fix(comfyui): harden media install, startup, and teardown

### DIFF
--- a/cli/engine.py
+++ b/cli/engine.py
@@ -48,7 +48,7 @@ def cmd_engine_start(args: argparse.Namespace) -> int:
 
     cp = comfyui.start(args.port)
     print(f"Spawned ComfyUI pid={cp.proc.pid}, log={cp.log}")
-    comfyui.wait_for_ready(args.port)
+    comfyui.wait_for_ready(args.port, proc=cp.proc)
     print(f"ComfyUI ready on http://localhost:{args.port}")
     if args.detach:
         return 0

--- a/cli/provider.py
+++ b/cli/provider.py
@@ -249,6 +249,18 @@ def cmd_leave(args: argparse.Namespace) -> int:
 
 def _stop_engine(grid_id: str, engine_id: str, record: dict[str, Any]) -> None:
     run_records.stop_engine(grid_id, engine_id, record)
+    # Reap ONLY a ComfyUI this engine itself started (`comfyui_started` persisted at bring-up) — never one
+    # shared with another media engine or started by the operator — and target its specific port so a
+    # co-resident engine's ComfyUI is untouched. Covers the case where the engine's own teardown was
+    # SIGKILLed mid-stop or the media server restarted ComfyUI in a separate session.
+    if record.get("media") and record.get("comfyui_started"):
+        from shared.engine import comfyui
+
+        port = record.get("comfyui_port", comfyui.COMFYUI_PORT_DEFAULT)
+        try:
+            comfyui.stop_running(port)
+        except OSError as exc:  # best-effort: one media engine's reap must not abort a `leave --all`
+            print(f"Reaping ComfyUI on :{port} failed (ignoring): {exc}", file=sys.stderr)
 
 
 # ---------------------------------------------------------------------------
@@ -435,6 +447,10 @@ def _run_engine(args: SimpleNamespace) -> int:
             media_proc = prepared["proc"]
             media_url = prepared["media_url"]
             comfyui_started = bool(prepared["comfyui_started"])
+            if comfyui_started:
+                # Persist ownership so `grid leave` reaps only a ComfyUI THIS engine started — never one
+                # shared with another media engine or already running when we joined.
+                run_records.update_record(args.grid, args.name, comfyui_started=True)
 
         payload = {
             "role": "engine",
@@ -484,6 +500,11 @@ def _run_engine(args: SimpleNamespace) -> int:
 
             comfyui.stop()
             print(f"Stopped ComfyUI on :{args.comfyui_port}")
+        if not registered:
+            # An engine that exited before registering (e.g. a media engine whose ComfyUI never became
+            # ready — it slips past the 3s spawn grace, so nothing else reaps it) must not leave a stale
+            # record, or `grid leave --all` is needed just to clear the ghost.
+            run_records.record_path(args.grid, args.name).unlink(missing_ok=True)
 
 
 # ---------------------------------------------------------------------------

--- a/cli/remote_provider.py
+++ b/cli/remote_provider.py
@@ -147,8 +147,11 @@ def _resolve_serve_targets(args: argparse.Namespace) -> tuple[list[dict[str, obj
 
     media_detected = any(engine.media for engine in detected)
     text = [engine for engine in detected if not engine.media]
-    if len(text) > 1 and not args.all:
-        provider._print_plan(text)
+    # Gate on ALL detected engines (incl. a media/ComfyUI one) and show them in the plan, so a
+    # detected media engine is never silently joined without confirmation, nor silently dropped on
+    # decline (mirrors local `cli/provider.cmd_join`, which counts + prints the full detected list).
+    if len(detected) > 1 and not args.all:
+        provider._print_plan(detected)
         if provider._interactive():
             if not provider._confirm("Join all detected engines?"):
                 return [], False

--- a/cli/remote_provider.py
+++ b/cli/remote_provider.py
@@ -284,7 +284,9 @@ def cmd_remote_leave(args: argparse.Namespace) -> int:
         names = ", ".join(sorted(records))
         raise SystemExit(f"Several engines joined ({names}); pass --engine <id> or --all.")
 
+    from . import provider  # shared teardown: stops the engine + reaps a media engine's ComfyUI
+
     for engine_id in targets:
-        run_records.stop_engine(network_id, engine_id, records[engine_id])
+        provider._stop_engine(network_id, engine_id, records[engine_id])
         print(f"Left engine {engine_id} on {label}.")
     return 0

--- a/local/media_engine.py
+++ b/local/media_engine.py
@@ -71,16 +71,29 @@ def prepare_media_engine(
             "for each enabled bundle. Missing:\n  " + "\n  ".join(missing[:10])
         )
 
-    comfyui_started = False
-    if not comfyui.is_running(comfyui_port):
-        cp = comfyui.start(comfyui_port)
-        comfyui_started = True
-        print(f"Spawned ComfyUI pid={cp.proc.pid}, log={cp.log}")
-        comfyui.wait_for_ready(comfyui_port)
-        print(f"ComfyUI ready on http://localhost:{comfyui_port}")
+    if comfyui_port == media_port:
+        raise SystemExit(
+            f"--comfyui-port and --media-port must differ (both are {comfyui_port}); ComfyUI and the "
+            "provider media server cannot share a port."
+        )
 
-    comfyui_url = f"http://localhost:{comfyui_port}/api"
-    proc = media_runtime.start_media_server(port=media_port, comfyui_url=comfyui_url)
+    comfyui_started = False
+    try:
+        if not comfyui.is_running(comfyui_port):
+            cp = comfyui.start(comfyui_port)
+            comfyui_started = True
+            print(f"Spawned ComfyUI pid={cp.proc.pid}, log={cp.log}")
+            comfyui.wait_for_ready(comfyui_port)
+            print(f"ComfyUI ready on http://localhost:{comfyui_port}")
+
+        comfyui_url = f"http://localhost:{comfyui_port}/api"
+        proc = media_runtime.start_media_server(port=media_port, comfyui_url=comfyui_url)
+    except BaseException:
+        # Never orphan a ComfyUI *we* started: if readiness or the media-server launch fails after
+        # start(), stop it before propagating (mirrors _bring_up_one's launched-server cleanup).
+        if comfyui_started:
+            comfyui.stop()
+        raise
     media_url = runtime.engine_endpoint_url(None, media_port, advertise_host).removesuffix("/v1")
     print(f"Spawned engine media server pid={proc.pid}, url={media_url}")
     advertised = [gate.advertise_as for gate in gates]

--- a/local/media_engine.py
+++ b/local/media_engine.py
@@ -43,7 +43,18 @@ def prepare_media_engine(
             "`grid engine pull <bundle>` for each bundle you want to serve."
         )
 
+    # No explicit --bundle: default to what's actually pulled, so `pull image_generation` → `join
+    # --media` just works instead of hard-failing on the un-pulled image_editing/i2v bundles. An
+    # explicit --bundle stays strict (the missing-files check below still errors if it isn't pulled).
     requested = list(media_bundles) if media_bundles else None
+    if requested is None:
+        requested = bundles_mod.present_bundles()
+        if not requested:
+            raise SystemExit(
+                "No media bundles are pulled yet. Run `grid engine pull <bundle>` "
+                "(image_generation | image_editing | i2v) before joining with --media, "
+                "or pass --bundle <name> to name one explicitly."
+            )
     if media_gating.is_apple_silicon():
         host_info = host_probe.gather()
         memory_mb = [host_info.memory_total_gb * 1024]
@@ -83,7 +94,7 @@ def prepare_media_engine(
             cp = comfyui.start(comfyui_port)
             comfyui_started = True
             print(f"Spawned ComfyUI pid={cp.proc.pid}, log={cp.log}")
-            comfyui.wait_for_ready(comfyui_port)
+            comfyui.wait_for_ready(comfyui_port, proc=cp.proc)
             print(f"ComfyUI ready on http://localhost:{comfyui_port}")
 
         comfyui_url = f"http://localhost:{comfyui_port}/api"

--- a/remote/serve.py
+++ b/remote/serve.py
@@ -70,6 +70,7 @@ def run_remote_engine_from_record(grid_id: str, engine_id: str) -> int:
     media_proc = None
     comfyui_started = False
     state = None
+    registered = False
     rc = 0
     try:
         # Bring up text engines only when the record names some — a media-only join (`grid join
@@ -100,6 +101,9 @@ def run_remote_engine_from_record(grid_id: str, engine_id: str) -> int:
             )
             media_proc = prepared["proc"]
             comfyui_started = bool(prepared["comfyui_started"])
+            if comfyui_started:
+                # Persist ownership so `grid leave` reaps only a ComfyUI THIS engine started.
+                run_records.update_record(grid_id, engine_id, comfyui_started=True)
             media_url = f"http://127.0.0.1:{media_port}"
             caps_models = dict((capabilities or {}).get("models") or {})
             for model in prepared["models"]:
@@ -125,6 +129,7 @@ def run_remote_engine_from_record(grid_id: str, engine_id: str) -> int:
             media_url=media_url,
         )
         register(state)
+        registered = True
         print(f"Engine {state.node_id} serving {union_models} via the relay at {signaling_url}")
         print("Send SIGTERM (grid leave) to unregister.")
         heartbeat = threading.Thread(target=_heartbeat_loop, args=(state,), daemon=True)
@@ -165,6 +170,13 @@ def run_remote_engine_from_record(grid_id: str, engine_id: str) -> int:
                 print("Stopped ComfyUI.")
             except Exception as exc:  # best-effort teardown; never mask the real exit
                 print(f"Stopping ComfyUI failed (ignoring): {exc}", file=sys.stderr)
+        if not registered:
+            # Reap the on-disk record for an engine that died before registering (e.g. a media engine
+            # whose ComfyUI never became ready), so it doesn't linger and force a `grid leave --all`.
+            try:
+                run_records.record_path(grid_id, engine_id).unlink(missing_ok=True)
+            except OSError as exc:  # best-effort teardown; never mask the real exit
+                print(f"Reaping stale record failed (ignoring): {exc}", file=sys.stderr)
     return rc
 
 

--- a/remote/serve.py
+++ b/remote/serve.py
@@ -282,6 +282,10 @@ def _advertised_models(models: list[str], aliases: list[str]) -> list[str]:
     cleaned = [alias.strip() for alias in aliases]
     if any(not alias for alias in cleaned):
         raise SystemExit("--advertise-as values cannot be empty.")
+    if any(alias.startswith("comfyui:") for alias in cleaned):
+        # `comfyui:*` is the reserved media namespace; aliasing a text model into it would clobber a
+        # media capability entry at register time (matches the guard in cli/provider._advertised_text_models).
+        raise SystemExit("--advertise-as is only for text models; media models use fixed comfyui:* names.")
     if len(set(cleaned)) != len(cleaned):
         raise SystemExit("--advertise-as values must be unique.")
     return cleaned
@@ -632,11 +636,36 @@ def handle_job(state: _ServeState, job: dict[str, Any]) -> None:
 
 
 def _try_submit_error(state: _ServeState, txn: str, message: str) -> None:
-    """Report a job failure to the relay, best-effort — a failed report is logged, never raised."""
+    """Report a job failure to the relay, best-effort. Refresh the token once on a 401 — otherwise a
+    job whose token expired mid-run gets NO terminal signal and the consumer hangs. A still-failed
+    report is logged, never raised (one bad job must not kill the loop)."""
+    for attempt in (1, 2):
+        token = state.token()
+        try:
+            relay.submit_error(state.signaling_url, token, txn, message=message)
+            return
+        except relay.RelayUnauthorized:
+            if attempt == 2 or not state.refresh(stale_token=token):
+                print(f"\nCouldn't report job {txn} failure: relay rejected the token.", file=sys.stderr)
+                return
+            # refreshed — loop retries once with the new token
+        except relay.RelayError as exc:
+            print(f"\nCouldn't report job {txn} failure to the relay: {exc}", file=sys.stderr)
+            return
+
+
+def _submit_response(state: _ServeState, txn: str, *, content: Any, stream: bool) -> None:
+    """Post a result to the relay, refreshing the token once on a 401 (mirrors poll_once/heartbeat_once
+    — without this, a completed job whose token expired mid-run is silently discarded). A streamed body
+    is a single-use iterator that can't be replayed, so a 401 there re-raises; `handle_job` then reports
+    it via `_try_submit_error` (which also refreshes), so the consumer gets a terminal signal."""
+    token = state.token()
     try:
-        relay.submit_error(state.signaling_url, state.token(), txn, message=message)
-    except (relay.RelayError, relay.RelayUnauthorized) as exc:
-        print(f"\nCouldn't report job {txn} failure to the relay: {exc}", file=sys.stderr)
+        relay.submit_response(state.signaling_url, token, txn, content=content, stream=stream)
+    except relay.RelayUnauthorized:
+        if stream or not state.refresh(stale_token=token):
+            raise
+        relay.submit_response(state.signaling_url, state.token(), txn, content=content, stream=stream)
 
 
 def _forward_whole(
@@ -650,9 +679,9 @@ def _forward_whole(
             f"{target_url}/{endpoint}", json=body, headers={"Content-Type": "application/json"}
         )
     if resp.status_code != 200:
-        _try_submit_error(state, txn, f"engine error: {resp.status_code}")
+        _try_submit_error(state, txn, f"engine error {resp.status_code}: {resp.text[:200]}")
         return
-    relay.submit_response(state.signaling_url, state.token(), txn, content=resp.content, stream=False)
+    _submit_response(state, txn, content=resp.content, stream=False)
 
 
 def _forward_stream(
@@ -667,12 +696,10 @@ def _forward_stream(
         ) as engine_resp:
             if engine_resp.status_code != 200:
                 engine_resp.read()
-                _try_submit_error(state, txn, f"engine error: {engine_resp.status_code}")
+                _try_submit_error(state, txn, f"engine error {engine_resp.status_code}: {engine_resp.text[:200]}")
                 return
             # Pass the engine's SSE bytes straight through while its stream is open.
-            relay.submit_response(
-                state.signaling_url, state.token(), txn, content=engine_resp.iter_bytes(), stream=True
-            )
+            _submit_response(state, txn, content=engine_resp.iter_bytes(), stream=True)
 
 
 # ---------------------------------------------------------------------------

--- a/shared/engine/comfyui.py
+++ b/shared/engine/comfyui.py
@@ -146,9 +146,19 @@ def _create_venv() -> None:
         # "No module named ensurepip". `--seed` makes uv install pip directly, independent of the
         # base interpreter, so bring-up works on any host uv can find a 3.11 on.
         _run([uv, "venv", "--seed", "-p", "3.11", str(venv)])
-    else:
-        # Fall back to stdlib venv. The user has to make sure pip is bootstrapped.
-        _run(["python3.11", "-m", "venv", str(venv)])
+        return
+    # No uv: fall back to the stdlib venv, but only if a real python3.11 is on PATH. A bare
+    # `python3.11 -m venv` otherwise dies with an opaque FileNotFoundError — surface actionable
+    # guidance instead (uv is the recommended toolchain and auto-provisions a 3.11).
+    python311 = shutil.which("python3.11")
+    if not python311:
+        raise SystemExit(
+            "Creating the ComfyUI environment needs `uv` (recommended) or Python 3.11, but neither "
+            "is on PATH.\n"
+            "  Install uv:  curl -LsSf https://astral.sh/uv/install.sh | sh    (then re-run)\n"
+            "  or install Python 3.11 so `python3.11` is on PATH."
+        )
+    _run([python311, "-m", "venv", str(venv)])
 
 
 def _pip_install(

--- a/shared/engine/comfyui.py
+++ b/shared/engine/comfyui.py
@@ -140,7 +140,12 @@ def _create_venv() -> None:
     venv.parent.mkdir(parents=True, exist_ok=True)
     uv = shutil.which("uv")
     if uv:
-        _run([uv, "venv", "-p", "3.11", str(venv)])
+        # `--seed` installs pip into the venv. Without it, `uv venv` ships no pip, and when uv
+        # resolves a *system* Python that lacks `ensurepip` (e.g. a distro's python3.11, or a 3.11
+        # rc build), grid's pip bootstrap has nothing to fall back to and the install dies with
+        # "No module named ensurepip". `--seed` makes uv install pip directly, independent of the
+        # base interpreter, so bring-up works on any host uv can find a 3.11 on.
+        _run([uv, "venv", "--seed", "-p", "3.11", str(venv)])
     else:
         # Fall back to stdlib venv. The user has to make sure pip is bootstrapped.
         _run(["python3.11", "-m", "venv", str(venv)])

--- a/shared/engine/comfyui.py
+++ b/shared/engine/comfyui.py
@@ -158,7 +158,18 @@ def _create_venv() -> None:
             "  Install uv:  curl -LsSf https://astral.sh/uv/install.sh | sh    (then re-run)\n"
             "  or install Python 3.11 so `python3.11` is on PATH."
         )
-    _run([python311, "-m", "venv", str(venv)])
+    try:
+        _run([python311, "-m", "venv", str(venv)])
+    except subprocess.CalledProcessError as exc:
+        # stdlib `venv` fails when the interpreter's `ensurepip` is stripped (common on minimal
+        # Debian/Ubuntu images). uv sidesteps this via `uv venv --seed`, so recommend it rather than
+        # let an opaque non-zero exit surface.
+        raise SystemExit(
+            f"`python3.11 -m venv` failed (exit {exc.returncode}); this Python likely lacks pip/"
+            "ensurepip.\n"
+            "  Install uv:  curl -LsSf https://astral.sh/uv/install.sh | sh    (then re-run)\n"
+            "  or install your distro's python3.11-venv (ensurepip) package."
+        ) from exc
 
 
 def _pip_install(

--- a/shared/engine/comfyui.py
+++ b/shared/engine/comfyui.py
@@ -90,8 +90,10 @@ def output_dir() -> Path:
     return paths.home() / "public" / "temp_comfy_output"
 
 
-def comfyui_pid_file() -> Path:
-    return paths.run_dir() / "comfyui.pid"
+def comfyui_pid_file(port: int = COMFYUI_PORT_DEFAULT) -> Path:
+    # Per-port so a box running more than one ComfyUI (distinct --comfyui-port per media engine) can be
+    # torn down without one engine's `grid leave` signaling another engine's ComfyUI.
+    return paths.run_dir() / f"comfyui_{port}.pid"
 
 
 def _is_macos() -> bool:
@@ -170,6 +172,24 @@ def _create_venv() -> None:
             "  Install uv:  curl -LsSf https://astral.sh/uv/install.sh | sh    (then re-run)\n"
             "  or install your distro's python3.11-venv (ensurepip) package."
         ) from exc
+
+
+def _ensure_c_compiler() -> None:
+    """ComfyUI's Triton backend JIT-compiles a CUDA driver module at first start, which needs a C
+    compiler (`cc`/`gcc`/`clang`) on PATH. On `nvidia/cuda:*-runtime` images none is present, so the
+    install would "succeed" and only crash at serve time with "Failed to find C compiler". Fail early
+    with actionable guidance instead. Skipped on macOS: Triton is CUDA-only there, and Xcode CLT
+    provides `cc` anyway."""
+    if _is_macos():
+        return
+    if shutil.which("cc") or shutil.which("gcc") or shutil.which("clang"):
+        return
+    raise SystemExit(
+        "ComfyUI needs a C compiler (its Triton backend JIT-compiles a CUDA module at start), but none "
+        "of `cc`/`gcc`/`clang` is on PATH.\n"
+        "  Install one:  apt-get install -y build-essential    (Debian/Ubuntu; then re-run)\n"
+        "  or install your distro's gcc/clang package so a compiler is on PATH."
+    )
 
 
 def _pip_install(
@@ -288,6 +308,9 @@ def install() -> None:
     if shutil.which("git") is None:
         raise SystemExit("git is required to install ComfyUI. Install it via your distro's package manager.")
 
+    # Fail before ~40 GB of clone/venv/torch work if the C compiler ComfyUI needs at serve time is absent.
+    _ensure_c_compiler()
+
     if not comfyui_dir().exists():
         # Full clone (no --depth 1) so we can check out the pinned commit even
         # if it's not the tip.
@@ -401,12 +424,30 @@ def start(port: int = COMFYUI_PORT_DEFAULT) -> ComfyProcess:
     return cp
 
 
-def wait_for_ready(port: int = COMFYUI_PORT_DEFAULT, timeout: float = 180.0) -> None:
-    """Block until ComfyUI answers /system_stats with 200."""
+def wait_for_ready(
+    port: int = COMFYUI_PORT_DEFAULT,
+    timeout: float = 180.0,
+    proc: subprocess.Popen | None = None,
+) -> None:
+    """Block until ComfyUI answers /system_stats with 200.
+
+    If ``proc`` is given, fail fast the instant it exits rather than polling the full timeout — a
+    ComfyUI that crashed on startup (e.g. Triton can't find a C compiler) will never answer, and waiting
+    180s for a corpse helps no one. On any failure, surface the tail of the ComfyUI log so the real
+    crash reason is visible instead of a bare "Connection refused".
+    """
+    from shared.engine import launcher  # peer helper; reuse its _log_tail rather than a third copy
+
     url = f"http://localhost:{port}/api/system_stats"
+    log_path = paths.logs_dir() / f"comfyui_{port}.log"
     deadline = time.monotonic() + timeout
     last_exc: Exception | None = None
     while time.monotonic() < deadline:
+        if proc is not None and proc.poll() is not None:
+            raise SystemExit(
+                f"ComfyUI exited (code {proc.returncode}) before becoming ready on port {port}. "
+                f"Last log lines from {log_path}:\n{launcher._log_tail(log_path)}"
+            )
         try:
             resp = httpx.get(url, timeout=5.0)
             if resp.status_code == 200:
@@ -415,21 +456,24 @@ def wait_for_ready(port: int = COMFYUI_PORT_DEFAULT, timeout: float = 180.0) -> 
             last_exc = exc
         time.sleep(2.0)
     raise SystemExit(
-        f"ComfyUI did not become ready on port {port} within {timeout}s "
-        f"(last error: {last_exc})"
+        f"ComfyUI did not become ready on port {port} within {timeout}s (last error: {last_exc}). "
+        f"Last log lines from {log_path}:\n{launcher._log_tail(log_path)}"
     )
 
 
 def stop(*, timeout: float = 60.0) -> None:
     global _active
-    if _active is not None and _active.proc.poll() is None:
+    if _active is None:
+        return
+    port = _active.port
+    if _active.proc.poll() is None:
         _active.proc.terminate()
         try:
             _active.proc.wait(timeout=timeout)
         except subprocess.TimeoutExpired:
             _active.proc.kill()
-        _active = None
-    _remove_pid_file()
+    _active = None
+    _remove_pid_file(port)
 
 
 def is_running(port: int = COMFYUI_PORT_DEFAULT) -> bool:
@@ -450,8 +494,8 @@ def ensure_running(comfyui_url: str = "http://localhost:8188/api") -> None:
     port = _port_from_url(comfyui_url)
     if is_running(port):
         return
-    start(port)
-    wait_for_ready(port)
+    cp = start(port)
+    wait_for_ready(port, proc=cp.proc)
 
 
 def _port_from_url(url: str) -> int:
@@ -465,21 +509,21 @@ def _port_from_url(url: str) -> int:
 
 def _write_pid_file(pid: int, port: int) -> None:
     paths.run_dir().mkdir(parents=True, exist_ok=True)
-    comfyui_pid_file().write_text(f"{pid}\n{port}\n")
+    comfyui_pid_file(port).write_text(f"{pid}\n{port}\n")
 
 
-def _remove_pid_file() -> None:
+def _remove_pid_file(port: int) -> None:
     try:
-        comfyui_pid_file().unlink(missing_ok=True)
+        comfyui_pid_file(port).unlink(missing_ok=True)
     except OSError:
         pass
 
 
-def stop_running() -> int:
-    """Stop a previously-started ComfyUI process referenced by the PID file."""
-    pid_path = comfyui_pid_file()
+def stop_running(port: int = COMFYUI_PORT_DEFAULT) -> int:
+    """Stop a previously-started ComfyUI process referenced by its per-port PID file."""
+    pid_path = comfyui_pid_file(port)
     if not pid_path.exists():
-        print("No ComfyUI process tracked.")
+        print(f"No ComfyUI process tracked on port {port}.")
         return 0
     lines = pid_path.read_text().splitlines()
     if not lines:
@@ -488,6 +532,7 @@ def stop_running() -> int:
     try:
         pid = int(lines[0])
     except ValueError:
+        print(f"ComfyUI PID file for port {port} is malformed; discarding.")
         pid_path.unlink(missing_ok=True)
         return 1
     try:
@@ -495,5 +540,5 @@ def stop_running() -> int:
     except ProcessLookupError:
         pass
     pid_path.unlink(missing_ok=True)
-    print(f"Sent SIGTERM to ComfyUI pid={pid}.")
+    print(f"Sent SIGTERM to ComfyUI pid={pid} (port {port}).")
     return 0

--- a/shared/models/media_bundles.py
+++ b/shared/models/media_bundles.py
@@ -126,6 +126,22 @@ def target_path(spec: FileSpec) -> Path:
     return base / name
 
 
+def bundle_is_present(name: str) -> bool:
+    """True when every file of the named bundle is already downloaded to disk."""
+    if name not in BUNDLES:
+        raise SystemExit(f"Unknown media bundle: {name!r}. Known: {sorted(BUNDLES)}")
+    return all(target_path(spec).exists() for spec in BUNDLES[name])
+
+
+def present_bundles() -> list[str]:
+    """The bundles fully pulled to disk, in canonical (BUNDLES) order.
+
+    Used to default `grid join --media` (no `--bundle`) to what's actually pullable, so the happy
+    path (pull one bundle → join) works instead of hard-failing on the un-pulled bundles.
+    """
+    return [name for name in BUNDLES if bundle_is_present(name)]
+
+
 def pull_bundle(name: str, *, on_progress=None) -> list[Path]:
     """Download every file in the named bundle into the ComfyUI/models tree."""
     if name not in BUNDLES:

--- a/shared/run_records.py
+++ b/shared/run_records.py
@@ -52,6 +52,15 @@ def read_record(grid_id: str, engine_id: str) -> dict[str, Any] | None:
     return read_records(grid_id).get(engine_id)
 
 
+def update_record(grid_id: str, engine_id: str, **fields: Any) -> None:
+    """Merge fields into an existing engine record; no-op if the record is already gone."""
+    record = read_records(grid_id).get(engine_id)
+    if record is None:
+        return
+    record.update(fields)
+    write_record(grid_id, engine_id, record)
+
+
 def pid_alive(pid: int) -> bool:
     if not pid:
         return False

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -366,6 +366,75 @@ def test_create_venv_errors_clearly_without_uv_or_python311(monkeypatch, tmp_pat
     assert "uv" in msg and "python 3.11" in msg
 
 
+def test_create_venv_fallback_errors_when_stdlib_venv_cannot_bootstrap_pip(monkeypatch, tmp_path):
+    """No uv, python3.11 present but `-m venv` fails (stripped ensurepip) → actionable SystemExit, not
+    a raw CalledProcessError."""
+    from shared.engine import comfyui
+
+    monkeypatch.setattr(comfyui.shutil, "which",
+                        lambda name: "/usr/bin/python3.11" if name == "python3.11" else None)
+    monkeypatch.setattr(comfyui, "comfyui_venv", lambda: tmp_path / "ComfyUI" / ".venv")
+
+    def boom(cmd, **kw):
+        raise comfyui.subprocess.CalledProcessError(1, cmd)
+
+    monkeypatch.setattr(comfyui, "_run", boom)
+    with pytest.raises(SystemExit) as exc:
+        comfyui._create_venv()
+    assert "ensurepip" in str(exc.value).lower()
+
+
+def _seed_media_bringup(monkeypatch, tmp_path):
+    """Common mocks so `prepare_media_engine` reaches the ComfyUI/media-server bring-up: ComfyUI
+    'installed', one bundle gated in, its files 'present'."""
+    from shared.engine import comfyui
+    from shared.media import media_gating
+    from shared.models import media_bundles as mb
+
+    present = tmp_path / "present"
+    present.write_text("x")
+    monkeypatch.setattr(comfyui, "comfyui_dir", lambda: tmp_path)
+    monkeypatch.setattr(media_gating, "select_bundles", lambda mem, requested=None: [media_gating.GATES[0]])
+    monkeypatch.setattr(mb, "target_path", lambda spec: present)
+
+
+def test_prepare_media_engine_rejects_colliding_ports(monkeypatch, tmp_path):
+    """comfyui_port == media_port is rejected before anything is spawned."""
+    from local import media_engine
+    from shared.engine import comfyui
+
+    _seed_media_bringup(monkeypatch, tmp_path)
+    monkeypatch.setattr(comfyui, "is_running", lambda port: pytest.fail("must reject before starting ComfyUI"))
+    with pytest.raises(SystemExit) as exc:
+        media_engine.prepare_media_engine(
+            media_bundles=["image_generation"], comfyui_port=8188, media_port=8188, advertise_host=None)
+    assert "differ" in str(exc.value).lower()
+
+
+def test_prepare_media_engine_stops_comfyui_when_media_server_fails(monkeypatch, tmp_path):
+    """If the media server fails to launch after ComfyUI started, the ComfyUI we started is stopped,
+    not orphaned (the reviewers' HIGH finding)."""
+    from local import media_engine, media_runtime
+    from shared.engine import comfyui
+
+    _seed_media_bringup(monkeypatch, tmp_path)
+    monkeypatch.setattr(comfyui, "is_running", lambda port: False)
+    monkeypatch.setattr(comfyui, "start",
+                        lambda port: type("CP", (), {"proc": type("P", (), {"pid": 7})(), "log": "l"})())
+    monkeypatch.setattr(comfyui, "wait_for_ready", lambda port: None)
+    stops = {"n": 0}
+    monkeypatch.setattr(comfyui, "stop", lambda **kw: stops.__setitem__("n", stops["n"] + 1))
+
+    def media_boom(**kw):
+        raise SystemExit("media server failed to start")
+
+    monkeypatch.setattr(media_runtime, "start_media_server", media_boom)
+    with pytest.raises(SystemExit):
+        media_engine.prepare_media_engine(
+            media_bundles=["image_generation"], comfyui_port=8188, media_port=8190, advertise_host=None)
+    assert stops["n"] == 1  # the ComfyUI we started was stopped, not left orphaned
+
+
 def test_provider_media_server_streams_sse_events(monkeypatch):
     class FakeHandler:
         def __init__(self, comfyui_url):
@@ -1407,6 +1476,20 @@ def test_remote_join_media_with_serve_carries_both(monkeypatch, tmp_path):
     assert record["models"] == ["m"] and record["engines"][0]["models"] == ["m"]
 
 
+def test_remote_join_detect_requires_confirmation_for_text_plus_media(monkeypatch, tmp_path):
+    """A detected media engine counts toward the multi-engine prompt (like local): a bare join with
+    1 text + 1 media must not silently join both — non-interactive, it asks for --all."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_remote_spawn(monkeypatch)
+    monkeypatch.setattr(cli.provider, "_detect", lambda host: [
+        detect.DetectedEngine(label="ollama", endpoint_url="http://h:11434/v1", models=["llama3"]),
+        detect.DetectedEngine(label="comfyui", endpoint_url="http://h:8188", models=[], media=True),
+    ])
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["join"])
+    assert "multiple engines" in str(exc.value).lower()
+
+
 def test_remote_join_rejects_advertise_host(monkeypatch, tmp_path):
     _seed_running_remote_grid(monkeypatch, tmp_path)
     _mock_remote_spawn(monkeypatch)
@@ -2333,6 +2416,77 @@ def test_serve_handle_job_rejects_unknown_media_endpoint(monkeypatch, tmp_path):
 
     serve.handle_job(state, {"transaction_id": "t1", "endpoint_path": "media/bogus", "body": {}})
     assert "unsupported media endpoint" in captured["error"].lower()
+
+
+def test_serve_submit_response_refreshes_and_retries_on_401(monkeypatch, tmp_path):
+    """A completed non-stream result whose token expired mid-run isn't discarded: submit refreshes
+    once and retries with the new token (mirrors poll/heartbeat)."""
+    from remote import relay, serve
+
+    state = _serve_state(monkeypatch, tmp_path)
+    calls = {"n": 0}
+
+    def submit(url, tok, txn, *, content, stream):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise relay.RelayUnauthorized()
+        calls["tok"] = tok
+
+    monkeypatch.setattr(relay, "submit_response", submit)
+
+    def fake_refresh(stale_token=None):
+        state._access_token = "AT2"
+        return True
+
+    monkeypatch.setattr(state, "refresh", fake_refresh)
+    serve._submit_response(state, "t1", content=b"result", stream=False)
+    assert calls["n"] == 2 and calls["tok"] == "AT2"
+
+
+def test_serve_submit_response_stream_does_not_retry_on_401(monkeypatch, tmp_path):
+    """A streamed body is single-use, so a 401 re-raises rather than replaying (handle_job then reports
+    it via _try_submit_error, which refreshes)."""
+    from remote import relay, serve
+
+    state = _serve_state(monkeypatch, tmp_path)
+    monkeypatch.setattr(relay, "submit_response",
+                        lambda *a, **k: (_ for _ in ()).throw(relay.RelayUnauthorized()))
+    monkeypatch.setattr(state, "refresh", lambda stale_token=None: pytest.fail("stream must not refresh/retry"))
+    with pytest.raises(relay.RelayUnauthorized):
+        serve._submit_response(state, "t1", content=iter([b"x"]), stream=True)
+
+
+def test_serve_try_submit_error_refreshes_on_401(monkeypatch, tmp_path):
+    """Job-failure reporting survives token expiry — else the consumer gets no terminal signal."""
+    from remote import relay, serve
+
+    state = _serve_state(monkeypatch, tmp_path)
+    calls = {"n": 0}
+
+    def submit_err(url, tok, txn, *, message, tokens_delivered=0):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise relay.RelayUnauthorized()
+        calls["tok"] = tok
+
+    monkeypatch.setattr(relay, "submit_error", submit_err)
+
+    def fake_refresh(stale_token=None):
+        state._access_token = "AT2"
+        return True
+
+    monkeypatch.setattr(state, "refresh", fake_refresh)
+    serve._try_submit_error(state, "t1", "boom")
+    assert calls["n"] == 2 and calls["tok"] == "AT2"
+
+
+def test_serve_advertised_models_rejects_comfyui_alias():
+    """A text --advertise-as alias can't hijack the reserved comfyui:* media namespace."""
+    from remote import serve
+
+    with pytest.raises(SystemExit) as exc:
+        serve._advertised_models(["mymodel"], ["comfyui:image_generation"])
+    assert "comfyui" in str(exc.value).lower()
 
 
 def test_run_remote_engine_media_only_registers_comfyui_models(monkeypatch, tmp_path):

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -384,6 +384,81 @@ def test_create_venv_fallback_errors_when_stdlib_venv_cannot_bootstrap_pip(monke
     assert "ensurepip" in str(exc.value).lower()
 
 
+def test_ensure_c_compiler_errors_without_compiler_on_linux(monkeypatch):
+    """No cc/gcc/clang on a non-macOS host → actionable SystemExit at install time, not a Triton
+    'Failed to find C compiler' crash after ~40 GB of downloads at serve time."""
+    from shared.engine import comfyui
+
+    monkeypatch.setattr(comfyui, "_is_macos", lambda: False)
+    monkeypatch.setattr(comfyui.shutil, "which", lambda name: None)  # nothing on PATH
+    with pytest.raises(SystemExit) as exc:
+        comfyui._ensure_c_compiler()
+    msg = str(exc.value).lower()
+    assert "compiler" in msg and ("gcc" in msg or "build-essential" in msg)
+
+
+def test_ensure_c_compiler_ok_when_present(monkeypatch):
+    from shared.engine import comfyui
+
+    monkeypatch.setattr(comfyui, "_is_macos", lambda: False)
+    monkeypatch.setattr(comfyui.shutil, "which", lambda name: "/usr/bin/cc" if name == "cc" else None)
+    comfyui._ensure_c_compiler()  # must not raise
+
+
+def test_ensure_c_compiler_skips_on_macos(monkeypatch):
+    """Triton is CUDA-only; on macOS the compiler check must not fire even with nothing on PATH."""
+    from shared.engine import comfyui
+
+    monkeypatch.setattr(comfyui, "_is_macos", lambda: True)
+    monkeypatch.setattr(comfyui.shutil, "which", lambda name: None)
+    comfyui._ensure_c_compiler()  # must not raise
+
+
+def test_wait_for_ready_fails_fast_when_comfyui_exited(monkeypatch, tmp_path):
+    """A ComfyUI whose process already exited must raise immediately (not poll the full timeout) and
+    surface the log tail, not a bare connection error."""
+    from shared.engine import comfyui
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    logs = tmp_path / "logs"
+    logs.mkdir(parents=True, exist_ok=True)
+    (logs / "comfyui_8188.log").write_text("Traceback ...\nRuntimeError: Failed to find C compiler.\n")
+
+    class _DeadProc:
+        returncode = 1
+
+        def poll(self):
+            return 1
+
+    monkeypatch.setattr(comfyui.httpx, "get",
+                        lambda *a, **k: pytest.fail("must not poll a dead ComfyUI proc"))
+    with pytest.raises(SystemExit) as exc:
+        comfyui.wait_for_ready(port=8188, proc=_DeadProc())
+    assert "Failed to find C compiler" in str(exc.value)
+
+
+def test_wait_for_ready_surfaces_comfyui_log_on_timeout(monkeypatch, tmp_path):
+    """On timeout the error includes the ComfyUI log tail so the real crash reason is visible."""
+    from shared.engine import comfyui
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    logs = tmp_path / "logs"
+    logs.mkdir(parents=True, exist_ok=True)
+    (logs / "comfyui_8188.log").write_text("some import error deep in comfy\n")
+
+    def _refuse(*a, **k):
+        raise comfyui.httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr(comfyui.httpx, "get", _refuse)
+    monkeypatch.setattr(comfyui.time, "sleep", lambda s: None)
+    # deadline call, one in-loop check (enter), one check (exit) → force a fast single-pass timeout.
+    ticks = iter([0.0, 0.0, 1000.0])
+    monkeypatch.setattr(comfyui.time, "monotonic", lambda: next(ticks))
+    with pytest.raises(SystemExit) as exc:
+        comfyui.wait_for_ready(port=8188, timeout=1.0)
+    assert "some import error deep in comfy" in str(exc.value)
+
+
 def _seed_media_bringup(monkeypatch, tmp_path):
     """Common mocks so `prepare_media_engine` reaches the ComfyUI/media-server bring-up: ComfyUI
     'installed', one bundle gated in, its files 'present'."""
@@ -396,6 +471,87 @@ def _seed_media_bringup(monkeypatch, tmp_path):
     monkeypatch.setattr(comfyui, "comfyui_dir", lambda: tmp_path)
     monkeypatch.setattr(media_gating, "select_bundles", lambda mem, requested=None: [media_gating.GATES[0]])
     monkeypatch.setattr(mb, "target_path", lambda spec: present)
+
+
+def test_present_bundles_helper(monkeypatch, tmp_path):
+    """`present_bundles()` returns only bundles whose every file is on disk, in canonical order."""
+    from shared.models import media_bundles as mb
+
+    present = tmp_path / "present"
+    present.write_text("x")
+    missing = tmp_path / "missing"
+    monkeypatch.setattr(mb, "target_path",
+                        lambda spec: present if spec in mb.IMAGE_GENERATION else missing)
+
+    assert mb.bundle_is_present("image_generation") is True
+    assert mb.bundle_is_present("image_editing") is False
+    assert mb.present_bundles() == ["image_generation"]
+
+
+def _seed_media_probe(monkeypatch):
+    """Force the NVIDIA path with one >=22 GB card so the real `select_bundles` gates a bundle in
+    (a no-GPU dev/CI box otherwise returns [] and short-circuits before the assertion)."""
+    from shared.media import media_gating
+    from shared.system import gpu as gpu_probe
+
+    monkeypatch.setattr(media_gating, "is_apple_silicon", lambda: False)
+    monkeypatch.setattr(gpu_probe, "enumerate_gpus", lambda: [SimpleNamespace(memory_total_mb=24564)])
+
+
+def test_prepare_media_engine_defaults_to_present_bundles(monkeypatch, tmp_path):
+    """`grid join --media` with no --bundle advertises only the bundle(s) actually pulled, not all 3."""
+    from local import media_engine, media_runtime, runtime
+    from shared.engine import comfyui
+    from shared.models import media_bundles as mb
+
+    monkeypatch.setattr(comfyui, "comfyui_dir", lambda: tmp_path)
+    present = tmp_path / "present"
+    present.write_text("x")
+    missing = tmp_path / "missing"
+    monkeypatch.setattr(mb, "target_path",
+                        lambda spec: present if spec in mb.IMAGE_GENERATION else missing)
+    _seed_media_probe(monkeypatch)
+    monkeypatch.setattr(comfyui, "is_running", lambda port: True)  # skip real ComfyUI start()
+    monkeypatch.setattr(media_runtime, "start_media_server", lambda **kw: SimpleNamespace(pid=7))
+    monkeypatch.setattr(runtime, "engine_endpoint_url", lambda *a, **k: "http://x/v1")
+
+    out = media_engine.prepare_media_engine(
+        media_bundles=None, comfyui_port=8188, media_port=8190, advertise_host=None)
+    assert out["models"] == ["comfyui:image_generation"]
+
+
+def test_prepare_media_engine_errors_when_no_bundle_present(monkeypatch, tmp_path):
+    """No --bundle and nothing pulled → a clear 'pull a bundle' SystemExit, not a confusing all-3 fail."""
+    from local import media_engine
+    from shared.engine import comfyui
+    from shared.models import media_bundles as mb
+
+    monkeypatch.setattr(comfyui, "comfyui_dir", lambda: tmp_path)
+    monkeypatch.setattr(mb, "target_path", lambda spec: tmp_path / "missing")  # nothing present
+    _seed_media_probe(monkeypatch)
+    monkeypatch.setattr(comfyui, "is_running", lambda port: pytest.fail("must fail before starting ComfyUI"))
+
+    with pytest.raises(SystemExit) as exc:
+        media_engine.prepare_media_engine(
+            media_bundles=None, comfyui_port=8188, media_port=8190, advertise_host=None)
+    assert "pull" in str(exc.value).lower()
+
+
+def test_prepare_media_engine_explicit_bundle_missing_still_errors(monkeypatch, tmp_path):
+    """Explicit --bundle stays strict: naming an un-pulled bundle errors with 'missing files'."""
+    from local import media_engine
+    from shared.engine import comfyui
+    from shared.models import media_bundles as mb
+
+    monkeypatch.setattr(comfyui, "comfyui_dir", lambda: tmp_path)
+    monkeypatch.setattr(mb, "target_path", lambda spec: tmp_path / "missing")
+    _seed_media_probe(monkeypatch)
+    monkeypatch.setattr(comfyui, "is_running", lambda port: pytest.fail("must fail before starting ComfyUI"))
+
+    with pytest.raises(SystemExit) as exc:
+        media_engine.prepare_media_engine(
+            media_bundles=["image_editing"], comfyui_port=8188, media_port=8190, advertise_host=None)
+    assert "missing files" in str(exc.value).lower()
 
 
 def test_prepare_media_engine_rejects_colliding_ports(monkeypatch, tmp_path):
@@ -421,7 +577,7 @@ def test_prepare_media_engine_stops_comfyui_when_media_server_fails(monkeypatch,
     monkeypatch.setattr(comfyui, "is_running", lambda port: False)
     monkeypatch.setattr(comfyui, "start",
                         lambda port: type("CP", (), {"proc": type("P", (), {"pid": 7})(), "log": "l"})())
-    monkeypatch.setattr(comfyui, "wait_for_ready", lambda port: None)
+    monkeypatch.setattr(comfyui, "wait_for_ready", lambda port, proc=None: None)
     stops = {"n": 0}
     monkeypatch.setattr(comfyui, "stop", lambda **kw: stops.__setitem__("n", stops["n"] + 1))
 
@@ -1023,6 +1179,95 @@ def test_leave_all_removes_records(monkeypatch, tmp_path):
     assert cli.provider._read_records(grid_id) == {}
 
 
+def test_leave_media_engine_stops_comfyui(monkeypatch, tmp_path):
+    """Leaving a media engine reaps the ComfyUI it OWNS, targeting that engine's port."""
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    cfg = runtime.init_grid_config(name="home", port=8090)
+    grid_id = cfg["grid_id"]
+    cli.provider._write_record(grid_id, "media1",
+                               {"engine_id": "media1", "node_id": "n", "grid_id": grid_id, "pid": 0,
+                                "media": True, "comfyui_started": True, "comfyui_port": 8288})
+
+    calls = []
+    monkeypatch.setattr(comfyui, "stop_running", lambda port=8188: calls.append(port) or 0)
+    args = cli.build_parser().parse_args(["leave", "home", "--engine", "media1"])
+    assert cli.cmd_leave(args) == 0
+    assert calls == [8288]  # reaped the engine's own port, not the global default
+    assert cli.provider._read_records(grid_id) == {}
+
+
+def test_leave_non_media_engine_skips_comfyui(monkeypatch, tmp_path):
+    """A text engine's leave must not touch ComfyUI."""
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    cfg = runtime.init_grid_config(name="home", port=8090)
+    grid_id = cfg["grid_id"]
+    cli.provider._write_record(grid_id, "text1",
+                               {"engine_id": "text1", "node_id": "n", "grid_id": grid_id, "pid": 0, "media": False})
+
+    monkeypatch.setattr(comfyui, "stop_running",
+                        lambda *a, **k: pytest.fail("must not reap ComfyUI for a text engine"))
+    args = cli.build_parser().parse_args(["leave", "home", "--engine", "text1"])
+    assert cli.cmd_leave(args) == 0
+
+
+def test_leave_media_engine_without_ownership_skips_comfyui(monkeypatch, tmp_path):
+    """A media engine that did NOT start ComfyUI (reused a shared/pre-existing one) must not reap it —
+    else leaving one media join kills another engine's still-serving ComfyUI."""
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    cfg = runtime.init_grid_config(name="home", port=8090)
+    grid_id = cfg["grid_id"]
+    cli.provider._write_record(grid_id, "shared1",
+                               {"engine_id": "shared1", "node_id": "n", "grid_id": grid_id, "pid": 0,
+                                "media": True, "comfyui_started": False, "comfyui_port": 8188})
+
+    monkeypatch.setattr(comfyui, "stop_running",
+                        lambda *a, **k: pytest.fail("must not reap a ComfyUI this engine didn't start"))
+    args = cli.build_parser().parse_args(["leave", "home", "--engine", "shared1"])
+    assert cli.cmd_leave(args) == 0
+    assert cli.provider._read_records(grid_id) == {}
+
+
+def test_run_engine_reaps_record_when_never_registered(monkeypatch, tmp_path):
+    """A media engine that dies before registering (ComfyUI never ready) must reap its own record,
+    not leave a ghost that needs `grid leave --all` to clear."""
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    cfg = runtime.init_grid_config(name="home", port=8090)
+    grid_id = cfg["grid_id"]
+    cli.provider._write_record(grid_id, "media1",
+                               {"engine_id": "media1", "node_id": "n", "grid_id": grid_id, "pid": 123, "media": True})
+
+    def boom(_args):
+        raise SystemExit("ComfyUI did not become ready")
+
+    monkeypatch.setattr(cli.provider, "_prepare_media_engine", boom)
+    args = _engine_args(grid=grid_id, name="media1", enable_media=True)
+    with pytest.raises(SystemExit):
+        cli.provider._run_engine(args)
+    assert cli.provider._read_records(grid_id) == {}
+
+
+def test_run_engine_persists_comfyui_ownership(monkeypatch, tmp_path):
+    """When the engine starts ComfyUI, `comfyui_started` is written to the record so a later
+    `grid leave` reaps only a ComfyUI this engine owns."""
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    cfg = runtime.init_grid_config(name="home", port=8090)
+    grid_id = cfg["grid_id"]
+    cli.provider._write_record(grid_id, "media1",
+                               {"engine_id": "media1", "node_id": "n", "grid_id": grid_id, "pid": 1, "media": True})
+
+    monkeypatch.setattr(cli.provider, "_prepare_media_engine", lambda args: {
+        "models": ["comfyui:image_generation"], "proc": None,
+        "media_url": "http://x:8190", "comfyui_started": True,
+    })
+    monkeypatch.setattr(cli.provider, "_register_engine", lambda url, node_id, payload: None)
+    monkeypatch.setattr(cli.httpx, "delete", lambda *a, **k: None)
+    monkeypatch.setattr(cli.time, "sleep", lambda s: (_ for _ in ()).throw(KeyboardInterrupt()))
+
+    args = _engine_args(grid=grid_id, name="media1", enable_media=True)
+    assert cli.provider._run_engine(args) == 0
+    assert cli.provider._read_records(grid_id)["media1"]["comfyui_started"] is True
+
+
 def test_cli_accepts_engines_and_json_and_aliases():
     parser = cli.build_parser()
 
@@ -1556,6 +1801,23 @@ def test_remote_leave_stops_and_removes_record(monkeypatch, tmp_path, capsys):
     assert cli.main(["leave", "--engine", "rig"]) == 0
     assert cli.provider._read_records("n1") == {}
     assert "Left engine rig" in capsys.readouterr().out
+
+
+def test_remote_leave_media_engine_stops_comfyui(monkeypatch, tmp_path, capsys):
+    """Remote `grid leave` on a media engine reaps ComfyUI too (same shared teardown as local)."""
+    from shared import run_records
+
+    _seed_remote(monkeypatch, tmp_path,
+                 networks=[{"network_id": "n1", "name": "team", "access_token": "AT"}], active="team")
+    run_records.write_record("n1", "rig",
+                             {"engine_id": "rig", "node_id": "node-x", "grid_id": "n1", "pid": 0,
+                              "media": True, "comfyui_started": True, "comfyui_port": 8188})
+
+    calls = []
+    monkeypatch.setattr(comfyui, "stop_running", lambda port=8188: calls.append(port) or 0)
+    assert cli.main(["leave", "--engine", "rig"]) == 0
+    assert calls == [8188]
+    assert cli.provider._read_records("n1") == {}
 
 
 def test_dispatch_runs_agnostic_command_in_remote(monkeypatch, tmp_path, capsys):
@@ -2530,6 +2792,34 @@ def test_run_remote_engine_media_only_registers_comfyui_models(monkeypatch, tmp_
     assert captured["models"] == ["comfyui:image_generation"]
     assert captured["capabilities"]["models"]["comfyui:image_generation"]["endpoints"] == ["media"]
     assert captured["media_url"] == "http://127.0.0.1:8190"  # loopback forward target for the poll loop
+
+
+def test_run_remote_engine_reaps_record_when_never_registered(monkeypatch, tmp_path):
+    """A remote media engine that dies before registering (ComfyUI never ready) must not leave a
+    stale on-disk record behind."""
+    import base64
+    import json as _json
+
+    from shared import run_records
+    from local import media_engine
+    from remote import serve
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    run_records.write_record("n1", "media1", {
+        "engine_id": "media1", "node_id": "ignored", "grid_id": "n1", "pid": 0,
+        "signaling_url": "https://relay.example", "endpoint_url": None, "models": [], "engines": [],
+        "media": True, "media_bundles": ["image_generation"], "comfyui_port": 8188, "media_port": 8190,
+    })
+    claims = base64.urlsafe_b64encode(_json.dumps({"node_id": "node-xyz"}).encode()).decode().rstrip("=")
+    monkeypatch.setattr(serve, "_load_tokens", lambda net: (f"h.{claims}.s", "RT"))
+
+    def boom(**kw):
+        raise SystemExit("ComfyUI did not become ready")
+
+    monkeypatch.setattr(media_engine, "prepare_media_engine", boom)
+
+    assert serve.run_remote_engine_from_record("n1", "media1") == 1  # detached top level reports failure
+    assert run_records.read_records("n1") == {}  # record reaped, not left stale
 
 
 def test_serve_poll_once_returns_none_when_no_work(monkeypatch, tmp_path):

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -333,6 +333,24 @@ def test_media_pinned_engine_versions_and_bundles_are_ported():
     assert media_bundles.CAPABILITY_NAME["image_generation"] == "comfyui:image_generation"
 
 
+def test_create_venv_seeds_pip_into_the_uv_venv(monkeypatch, tmp_path):
+    """`uv venv` ships no pip; when uv resolves a system Python that lacks ensurepip (a 3.11 rc did
+    exactly this) grid's pip bootstrap has nothing to fall back to. `_create_venv` must pass `--seed`
+    so uv installs pip directly, independent of the base interpreter."""
+    from shared.engine import comfyui
+
+    calls: list[list[str]] = []
+    monkeypatch.setattr(comfyui.shutil, "which", lambda name: "/opt/uv" if name == "uv" else None)
+    monkeypatch.setattr(comfyui, "comfyui_venv", lambda: tmp_path / "ComfyUI" / ".venv")
+    monkeypatch.setattr(comfyui, "_run", lambda cmd, **kw: calls.append(list(cmd)))
+
+    comfyui._create_venv()
+
+    assert len(calls) == 1
+    cmd = calls[0]
+    assert cmd[0] == "/opt/uv" and cmd[1] == "venv" and "--seed" in cmd
+
+
 def test_provider_media_server_streams_sse_events(monkeypatch):
     class FakeHandler:
         def __init__(self, comfyui_url):

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -351,6 +351,21 @@ def test_create_venv_seeds_pip_into_the_uv_venv(monkeypatch, tmp_path):
     assert cmd[0] == "/opt/uv" and cmd[1] == "venv" and "--seed" in cmd
 
 
+def test_create_venv_errors_clearly_without_uv_or_python311(monkeypatch, tmp_path):
+    """Neither uv nor python3.11 on PATH → an actionable SystemExit naming both, not a raw
+    FileNotFoundError from a bare `python3.11 -m venv`."""
+    from shared.engine import comfyui
+
+    monkeypatch.setattr(comfyui.shutil, "which", lambda name: None)  # no uv, no python3.11
+    monkeypatch.setattr(comfyui, "comfyui_venv", lambda: tmp_path / "ComfyUI" / ".venv")
+    monkeypatch.setattr(comfyui, "_run", lambda cmd, **kw: pytest.fail(f"must not exec anything: {cmd}"))
+
+    with pytest.raises(SystemExit) as exc:
+        comfyui._create_venv()
+    msg = str(exc.value).lower()
+    assert "uv" in msg and "python 3.11" in msg
+
+
 def test_provider_media_server_streams_sse_events(monkeypatch):
     class FakeHandler:
         def __init__(self, comfyui_url):


### PR DESCRIPTION
## Summary

Hardens the ComfyUI media engine across its full lifecycle — **install → startup → serve → teardown** — turning a class of late, opaque failures into early, actionable ones. All changes are additive bug-fixes on top of `v0.1.7`; no behavior change for the happy path.

Motivated by a live end-to-end serve-media run on an 8×RTX 4090 box, then reviewed by three independent reviewers (general, Python, silent-failure) with their findings folded back in.

## What's fixed

**1. Install — C-compiler preflight**
ComfyUI's Triton backend JIT-compiles a CUDA module at *serve* time, so a missing `cc`/`gcc` let the install "succeed" and then crash on first start with `Failed to find C compiler` — after ~40 GB of downloads on runtime-only CUDA images. `install()` now preflights for `cc`/`gcc`/`clang` (skipped on macOS) and fails early with actionable guidance.

**2. Startup — surface the real crash**
`wait_for_ready()` reported only the HTTP error (`connection refused`) while the real cause sat in the ComfyUI log, and it polled the full 180 s even after the process had exited. It now fails fast when the process dies and includes the tail of the ComfyUI log in the error.

**3. Serve — `join --media` defaults to what's pulled**
`grid join --media` with no `--bundle` enabled all three bundles and hard-failed unless every one was downloaded. It now defaults to the bundles actually present on disk (an explicit `--bundle` stays strict), so the common `pull one bundle → join` path just works.

**4. Teardown — reap only an owned ComfyUI, scoped by port**
`grid leave` never reaped a ComfyUI the engine started, so it could orphan on its port. Leave now reaps it — but **only when this engine actually started it** (ownership persisted to the run record) and **only its own port** (per-port PID file), so a co-resident or operator-started ComfyUI is never touched. Best-effort, so one reap failure can't abort a `leave --all`.

**5. Lifecycle — no stale records**
An engine that exits before registering (e.g. ComfyUI never becomes ready) no longer leaves a ghost run record that required `grid leave --all` to clear.

## Testing

- `pytest`: **322 passing** (14 new tests across the five fixes, incl. ownership/port scoping).
- `ruff check`: clean.
- **E2E on 8×4090**: install completes on a bare `nvidia/cuda:*-runtime` container; `join --media` (no `--bundle`) advertises only the pulled bundle; leave reaps an owned ComfyUI on its own port and correctly leaves a non-owned one serving.

## Notes

- Deferred (documented, out of scope): the pre-existing `stop_running` PID-reuse window and the `_STOP_GRACE_SECONDS` (8 s) vs `comfyui.stop` (60 s) grace mismatch — both lower-risk now that reaps are ownership- and port-scoped.
