### PR TITLE
chore(release): v0.1.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "grid"
-version = "0.1.7"
+version = "0.1.8"
 description = "Grid: one private OpenAI-compatible endpoint for the AI engines you already run."
 requires-python = ">=3.11"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -81,7 +81,7 @@ wheels = [
 
 [[package]]
 name = "grid"
-version = "0.1.7"
+version = "0.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Version bump to **v0.1.8** (pyproject + uv.lock). Contents merged in #10 — ComfyUI media engine hardening (install C-compiler preflight, wait_for_ready log surfacing, join --media present-bundle default, ownership/port-scoped ComfyUI reap on leave, stale-record reap). Build-verified: freshly built wheel prints `grid 0.1.8`. Merging this, then pushing the `v0.1.8` tag, triggers the release workflow.