### PR TITLE
fix(remote): serve --max-concurrency jobs with N concurrent poll workers

### DIFF
--- a/cli/provider.py
+++ b/cli/provider.py
@@ -315,6 +315,7 @@ def cmd_engines(args: argparse.Namespace) -> int:
                     "engine": _engine_label(engine),
                     "where": engine.get("endpoint_url") or engine.get("media_url") or "",
                     "models": engine.get("models") or [],
+                    "max_concurrency": engine.get("max_concurrency"),
                 }
                 for engine in engines
             ],
@@ -332,8 +333,13 @@ def cmd_engines(args: argparse.Namespace) -> int:
     for engine, label in zip(engines, labels):
         where = engine.get("endpoint_url") or engine.get("media_url") or ""
         models = ",".join(engine.get("models") or []) or "(none)"
+        # max_concurrency is a remote-only advertised field — show it only when the engine reports it.
+        concurrency = engine.get("max_concurrency")
+        detail = f"models: {models}"
+        if concurrency is not None:
+            detail += f"   concurrency: {concurrency}"
         print(f"{label:<{ewidth}}  {where}")
-        print(f"{'':<{ewidth}}  models: {models}")
+        print(f"{'':<{ewidth}}  {detail}")
     return 0
 
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -192,6 +192,8 @@ of `__engine`. That subprocess (`remote/serve.py:run_remote_engine_from_record`)
 2. Registers with the relay (`PUT /nodes/{node_id}` via `remote/relay.py`), then loops
    **poll → forward → submit**: long-poll `GET /relay/v1/poll`, forward each claimed job to the
    local engine, and post the result back (`POST /relay/v1/response/{txn}`, or `/error/{txn}`).
+   `--max-concurrency N` runs N such poll workers under the one identity, serving N jobs at once
+   (see [ADR 0009](adr/0009-remote-provider-concurrency.md)).
 3. A heartbeat thread keeps the node live (`POST /nodes/heartbeat`); a 401 on any call refreshes
    the per-grid token (`control_plane.refresh_network_token`) and retries.
 4. `grid join --all` serves several local engines under **one** identity: it registers the union

--- a/docs/adr/0007-remote-multi-engine-routing.md
+++ b/docs/adr/0007-remote-multi-engine-routing.md
@@ -48,13 +48,16 @@ printed. Vocabulary: `engine` / `grid` / `model` on the surface — `node_id` is
    `None` and the job is failed with "no engine serves model …", never silently mis-routed.
 
 3. **One heartbeat, aggregate load, merged capabilities.** The identity has one `node_id`, one
-   heartbeat thread, and `load = {"active_tasks": <aggregate inflight>}` across the single poll loop.
+   heartbeat thread, and `load = {"active_tasks": <aggregate inflight>}` across its poll worker(s).
    Capabilities are probed **once per engine** (its first model, as the single-engine path did) into a
    one-key envelope, then merged first-wins into one `{schema_version:1, models:{…}}`; sibling models
    on a multi-model engine stay capability-less exactly as before — we do **not** fabricate entries for
    them. A failed probe degrades to `{}` and is tolerated by the merge (registers text-only). Known
    limitation: `max_concurrency` is a single aggregate value advertised for the identity, not tracked
    per engine — acceptable for this slice; revisit if per-engine batch widths diverge materially.
+   **Update (ADR 0009):** that aggregate is now actually enforced — the serve loop runs one poll worker
+   per slot, so the provider serves `max_concurrency` jobs concurrently and `<aggregate inflight>`
+   genuinely ranges 0..N instead of being capped at 1 by a single synchronous loop.
 
 4. **Multi-engine is external-only; the built-in launch stays single-engine.** `--all` only gathers
    already-running engines (each has an `endpoint_url`), so nothing is launched for a multi-engine

--- a/docs/adr/0009-remote-provider-concurrency.md
+++ b/docs/adr/0009-remote-provider-concurrency.md
@@ -1,0 +1,79 @@
+# ADR 0009 — Remote provider concurrency enforcement (`--max-concurrency` = N poll workers)
+
+Status: accepted (2026-07-03)
+
+## Context
+
+Since ADR 0004/0007 a remote engine advertises `max_concurrency` to the master (`PUT /nodes`), and the
+master's capacity-aware router (grid-src `private_server`, already merged) will send it up to that many
+concurrent jobs. But the provider ran a **single synchronous `_poll_loop`** (`remote/serve.py`): claim
+one job → forward to completion → poll again. So `_inflight` never exceeded 1, the advertised capacity
+was inert, and surplus jobs queued on the master. ADR 0007 §3 flagged this. This slice makes the
+provider actually serve `max_concurrency` jobs at once, closing the gap between what it advertises and
+what it does. Parent: branch `fix/max-concurrency`.
+
+Provider-side only. The flag (`cli/parser.py`), the run record (`cli/remote_provider.py`), `_ServeState`
+(clamp `≥1`, `enter/exit_inference`, `load`), the register/heartbeat wire (`remote/relay.py`), and the
+master's routing all already exist and are unchanged — only the orchestration around the loop changes.
+
+**Port-source note.** grid-src `provider_runtime/poll_worker.py:run` spawns one poll loop per slot
+(N−1 daemon threads + the main thread) and joins them on drain. This ports that shape, adapted to the
+in-repo `_ServeState` + testable loop units (`_poll_loop`/`_heartbeat_loop`), with the main thread made
+a **pure waiter** (Decision 3).
+
+Hard invariant: local stays untouched (it already rejects `--max-concurrency` as remote-only via
+`_REMOTE_ONLY_JOIN_FLAGS`); the existing suite stays green; the loop units
+(`register`/`poll_once`/`heartbeat_once`/`handle_job`) are unchanged. Vocabulary: `engine`/`grid`/`model`
+on the surface; `node_id` internal.
+
+## Decisions
+
+1. **One poll worker per concurrency slot.** `_serve_loop` spawns `max(1, max_concurrency)` daemon
+   threads, each running the existing `_poll_loop`; each independently long-polls the relay
+   (`POLL_TIMEOUT=35`, its own `httpx.Client`) and forwards one job, so up to N are in flight while the
+   local engine batches them. `_ServeState` was already thread-safe for this — lock-guarded
+   `enter/exit_inference`/`load`, and a double-locked `refresh()` that serializes 401 refreshes across
+   "the poll + heartbeat threads". N=1 reproduces the pre-fix single-worker behavior exactly.
+
+2. **Default 1, explicit-only — no `--parallel` derivation.** `max_concurrency` stays 1 unless
+   `--max-concurrency` is passed; `--parallel` (llama.cpp batch width) and `--max-concurrency` (jobs
+   pulled) remain independent knobs. Deriving one from the other (grid-src does) was rejected to keep the
+   two flags orthogonal and the default conservative — an operator opts into concurrency explicitly.
+
+3. **Main thread is a pure waiter; drain is bounded by one shared deadline.** SIGTERM raises
+   `KeyboardInterrupt` in the main thread only, so the main thread runs no worker — it parks on
+   `state.stop` — and the signal can never kill an in-flight `handle_job`. All N workers are daemon
+   threads; on stop they are joined against a single `time.monotonic() + _DRAIN_TIMEOUT` deadline, so
+   total teardown is bounded by `_DRAIN_TIMEOUT` (5s) even when every worker is parked in a blocking
+   long-poll that `state.stop` cannot wake. Jobs that finish within the budget submit their response
+   (drain) while the node is still registered; the outer `finally` then unregisters. A per-worker
+   timeout was rejected: it serializes to `N × _DRAIN_TIMEOUT` on an idle `grid leave`. Any worker still
+   in flight when the deadline expires is logged (by name), not dropped silently.
+
+4. **A dead loop fails the engine loudly; concurrency is capped.** Moving `_poll_loop` off the main
+   thread would let an *unexpected* fault (e.g. `relay.poll` decoding a malformed 200 body, or the
+   `SystemExit` a corrupt `credentials.toml` raises on refresh) kill a daemon worker silently, stranding
+   the node advertising capacity it no longer serves. So each loop runs under `_supervise`, which catches
+   any escaped fault, logs it with the thread name, and sets `state.stop` — restoring the pre-fix property
+   that a loop's death stops the engine (a dead *loop* is not a dead *job*; `handle_job` still guards the
+   latter). `relay.poll` additionally maps a malformed body to a retryable `RelayError` so a transient
+   relay hiccup backs off instead of tripping the supervisor. And `max_concurrency` is clamped to
+   `[1, _MAX_CONCURRENCY]` (256) — each slot is a real OS thread, so an absurd `--max-concurrency` can't
+   exhaust threads/sockets.
+
+## Consequences
+
+- `--max-concurrency N` now genuinely serves N concurrent jobs; heartbeat `active_tasks` ranges 0..N,
+  which the master's load score reads relative to capacity. N=1 (the default) is byte-for-byte the old
+  behavior.
+- Net production change is small: `remote/serve.py` gains `import time`, `_DRAIN_TIMEOUT`, and
+  `_serve_loop`; the single `_poll_loop(state)` call site becomes `_serve_loop(state)`. No change to
+  `relay.py`, the record layer, or master routing.
+- Per-engine (vs one aggregate) concurrency tracking stays out of scope — ADR 0007 §3's standing
+  limitation, unchanged.
+- New tests cover one-worker-per-slot, the single-worker default, one-heartbeat, bounded-deadline
+  teardown, the now-concurrently-hit in-flight counter, a dead worker stopping the engine, drain letting
+  an in-flight job finish, and the malformed-poll-body guard.
+- `grid engines <grid>` (and `--json`) surfaces each engine's advertised `max_concurrency`, so an
+  operator can confirm what a join is serving at (remote-only; the field is `null` when unadvertised).
+  The authoritative local value is also readable in the run record `~/.grid/run/engines/<grid_id>/<engine_id>.json`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -231,7 +231,8 @@ The `grid join` flag set is the union of both modes, gated by mode:
   `--media` / `--bundle <bundle>` / `--comfyui-port` / `--media-port`.
 - **local-only:** `--advertise-host` (a remote engine polls the relay outbound — there is no inbound
   endpoint to advertise).
-- **Remote-only:** `--engine-label` (the engine kind shown on the grid page), `--max-concurrency`.
+- **Remote-only:** `--engine-label` (the engine kind shown on the grid page), `--max-concurrency`
+  (how many requests this engine serves at once; default 1 — the provider runs one poll worker per slot).
 - **Deprecated:** `--pricing-input` / `--pricing-output` — kept so old invocations don't hard-error,
   but they no longer advertise a price. Set your authoritative per-model price with `grid price set`
   (see [Price](#price)) instead.

--- a/remote/relay.py
+++ b/remote/relay.py
@@ -134,7 +134,10 @@ def poll(signaling_url: str, access_token: str, *, timeout: float = POLL_TIMEOUT
     if resp.status_code == 204:
         return None
     if resp.status_code == 200:
-        return resp.json()
+        try:
+            return resp.json()
+        except ValueError as exc:  # a malformed 200 body is a transient relay fault — back off, don't die
+            raise RelayError(f"poll returned a malformed body: {exc}") from None
     _guard(resp, "poll")
     raise RelayError(f"poll returned unexpected {resp.status_code}")
 

--- a/remote/serve.py
+++ b/remote/serve.py
@@ -18,7 +18,9 @@ import json
 import signal
 import sys
 import threading
-from typing import Any
+import time
+import traceback
+from typing import Any, Callable
 
 from remote import control_plane, credentials, probe, relay
 from shared import run_records
@@ -26,6 +28,16 @@ from shared import run_records
 
 # Engine read budget when the relay doesn't advertise one (older relay); matches its default.
 _DEFAULT_INFERENCE_TIMEOUT = 600.0
+
+# Bounded drain: total budget (shared across workers) for in-flight jobs to finish + submit on
+# shutdown before we unregister. A worker parked in a long-poll can't be woken by state.stop, so this
+# caps teardown regardless of how many workers are parked.
+_DRAIN_TIMEOUT = 5.0
+
+# Sanity ceiling on max_concurrency: each slot is a real OS thread holding a long-poll, so an absurd
+# value (a typo like 200000) would exhaust threads/sockets and crash the process. 256 is at/above any
+# realistic single-node batch width (e.g. vLLM max_num_seqs) while keeping a mistyped flag survivable.
+_MAX_CONCURRENCY = 256
 
 # The relay-supplied endpoint is interpolated into a local engine URL, so only forward known
 # endpoints — this stops a buggy or compromised relay from probing other local paths via `../`.
@@ -132,9 +144,7 @@ def run_remote_engine_from_record(grid_id: str, engine_id: str) -> int:
         registered = True
         print(f"Engine {state.node_id} serving {union_models} via the relay at {signaling_url}")
         print("Send SIGTERM (grid leave) to unregister.")
-        heartbeat = threading.Thread(target=_heartbeat_loop, args=(state,), daemon=True)
-        heartbeat.start()
-        _poll_loop(state)  # blocks until the loop stops or SIGTERM
+        _serve_loop(state)  # heartbeat + max_concurrency poll workers; blocks until stop/SIGTERM
     except KeyboardInterrupt:
         print("\nEngine unregistered.")
     except (Exception, SystemExit) as exc:  # detached top level: report, tear down, exit non-zero
@@ -448,7 +458,7 @@ class _ServeState:
         self.capabilities = dict(capabilities or {})
         self.meta = dict(meta or {})
         self.pricing = dict(pricing or {})
-        self.max_concurrency = max(1, int(max_concurrency))
+        self.max_concurrency = min(_MAX_CONCURRENCY, max(1, int(max_concurrency)))
         self.stop = threading.Event()
         self._lock = threading.Lock()  # guards the token + inflight count (short critical sections)
         self._refresh_lock = threading.Lock()  # serializes refreshes WITHOUT blocking token() readers
@@ -751,3 +761,65 @@ def _heartbeat_loop(state: _ServeState) -> None:
         except relay.RelayError as exc:
             print(f"\nHeartbeat error: {exc}", file=sys.stderr)
         state.stop.wait(relay.HEARTBEAT_INTERVAL)
+
+
+def _supervise(loop: Callable[[_ServeState], None], state: _ServeState) -> None:
+    """Run one serve-loop thread (``_poll_loop``/``_heartbeat_loop``); if it dies from an unexpected
+    fault, stop the whole engine loudly instead of letting the thread vanish.
+
+    A dead *job* must not kill the loop (``handle_job`` guards that), but a dead *loop* is different: a
+    background worker that silently exits would strand the node advertising capacity it no longer serves
+    (and if all die, a heartbeating zombie at zero capacity). So catch everything — including the
+    ``SystemExit`` a corrupt ``credentials.toml`` raises on refresh — log it with the thread name, and
+    set ``state.stop`` so the main waiter tears the engine down deterministically, as the pre-fix single
+    main-thread loop did when it raised.
+    """
+    try:
+        loop(state)
+    except BaseException as exc:  # a loop-level fault must fail loud, not vanish (a job fault can't reach here)
+        print(f"\n{threading.current_thread().name} stopped unexpectedly: {exc!r}", file=sys.stderr)
+        traceback.print_exc()
+        state.stop.set()
+
+
+def _serve_loop(state: _ServeState) -> None:
+    """Heartbeat + one poll worker per concurrency slot, until stop / SIGTERM.
+
+    ``max_concurrency`` independent daemon workers each long-poll the relay and forward one job, so up
+    to N are in flight while the local engine batches them (a single loop capped real throughput at 1
+    regardless of the advertised capacity). The main thread only parks on ``state.stop``: SIGTERM's
+    KeyboardInterrupt unwinds *here*, never inside a worker's ``handle_job``, so no in-flight job is
+    killed by the signal. Each loop runs under ``_supervise`` so a worker/heartbeat that dies from an
+    unexpected fault stops the engine instead of vanishing. On stop, workers are joined against one
+    shared deadline, so total teardown is bounded by ``_DRAIN_TIMEOUT`` even when every worker is parked
+    in a long-poll (``state.stop`` can't wake a blocking ``relay.poll``); a job that finishes within the
+    budget submits, and any worker still in flight when the budget expires is logged, not dropped silently.
+    """
+    heartbeat = threading.Thread(
+        target=_supervise, args=(_heartbeat_loop, state), daemon=True, name="heartbeat"
+    )
+    heartbeat.start()
+    workers = [
+        threading.Thread(
+            target=_supervise, args=(_poll_loop, state), daemon=True, name=f"poll-worker-{i + 1}"
+        )
+        for i in range(max(1, state.max_concurrency))  # state already clamps to [1, _MAX_CONCURRENCY]
+    ]
+    for worker in workers:
+        worker.start()
+    try:
+        while not state.stop.is_set():
+            state.stop.wait(60)  # park; a worker/heartbeat may set stop, or SIGTERM unwinds here
+    finally:
+        state.stop.set()
+        deadline = time.monotonic() + _DRAIN_TIMEOUT
+        for worker in workers:
+            worker.join(timeout=max(0.0, deadline - time.monotonic()))
+        heartbeat.join(timeout=max(0.0, deadline - time.monotonic()))
+        stragglers = [worker.name for worker in workers if worker.is_alive()]
+        if stragglers:
+            print(
+                f"\n{len(stragglers)} poll worker(s) still in flight after {_DRAIN_TIMEOUT}s drain — "
+                f"abandoning ({', '.join(stragglers)}); their consumers may see no terminal response.",
+                file=sys.stderr,
+            )

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -6,6 +6,8 @@ import json
 import os
 import stat
 import subprocess
+import threading
+import time
 import tomllib
 from pathlib import Path
 from types import SimpleNamespace
@@ -1284,7 +1286,8 @@ def test_cli_accepts_engines_and_json_and_aliases():
 
 _FAKE_ENGINES = [
     {"name": "mac", "endpoint_url": "http://192.168.1.10:8080/v1", "models": ["gemma4-31b"]},
-    {"name": "gpu", "endpoint_url": "http://192.168.1.20:8000/v1", "models": ["devstral", "gemma4-31b"]},
+    {"name": "gpu", "endpoint_url": "http://192.168.1.20:8000/v1", "models": ["devstral", "gemma4-31b"],
+     "max_concurrency": 4},
 ]
 
 
@@ -1321,6 +1324,24 @@ def test_engines_json_lists_joined_engines(monkeypatch, tmp_path, capsys):
     payload = json.loads(capsys.readouterr().out)
     assert [e["engine"] for e in payload] == ["mac", "gpu"]
     assert payload[1]["models"] == ["devstral", "gemma4-31b"]
+
+
+def test_engines_shows_max_concurrency(monkeypatch, tmp_path, capsys):
+    """`grid engines` surfaces the advertised max_concurrency (remote-only): in --json always (null
+    when the engine didn't advertise it), and in the table only for engines that report it."""
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    runtime.init_grid_config(name="home", port=8090)
+    monkeypatch.setattr(cli.provider, "_discover", lambda cfg: _FAKE_ENGINES)
+
+    assert cli.cmd_engines(cli.build_parser().parse_args(["engines", "home", "--json"])) == 0
+    by_name = {e["engine"]: e for e in json.loads(capsys.readouterr().out)}
+    assert by_name["gpu"]["max_concurrency"] == 4
+    assert by_name["mac"]["max_concurrency"] is None  # engine didn't advertise it
+
+    assert cli.cmd_engines(cli.build_parser().parse_args(["engines", "home"])) == 0
+    out = capsys.readouterr().out
+    assert "concurrency: 4" in out            # gpu advertised it
+    assert out.count("concurrency:") == 1     # mac (no field) omits it
 
 
 def test_info_json_uses_contract_keys(monkeypatch, tmp_path, capsys):
@@ -2547,6 +2568,153 @@ def _serve_state(monkeypatch, tmp_path, **overrides):
     )
     kwargs.update(overrides)
     return serve._ServeState(**kwargs)
+
+
+def test_serve_loop_runs_one_poll_worker_per_slot(monkeypatch, tmp_path):
+    """Each concurrency slot gets its own poll worker, so up to max_concurrency jobs run at once."""
+    from remote import serve
+
+    calls: list[str] = []
+
+    def fake_poll(state):
+        calls.append(threading.current_thread().name)
+        state.stop.set()  # release the main-thread waiter so _serve_loop returns
+
+    monkeypatch.setattr(serve, "_poll_loop", fake_poll)
+    monkeypatch.setattr(serve, "_heartbeat_loop", lambda state: None)
+    state = _serve_state(monkeypatch, tmp_path, max_concurrency=4)
+
+    serve._serve_loop(state)
+
+    assert len(calls) == 4
+
+
+def test_serve_loop_single_worker_by_default(monkeypatch, tmp_path):
+    """Default max_concurrency=1 runs exactly one poll worker — the pre-fix behavior, unchanged."""
+    from remote import serve
+
+    calls: list[str] = []
+
+    def fake_poll(state):
+        calls.append(threading.current_thread().name)
+        state.stop.set()
+
+    monkeypatch.setattr(serve, "_poll_loop", fake_poll)
+    monkeypatch.setattr(serve, "_heartbeat_loop", lambda state: None)
+    state = _serve_state(monkeypatch, tmp_path, max_concurrency=1)
+
+    serve._serve_loop(state)
+
+    assert len(calls) == 1
+
+
+def test_serve_loop_starts_heartbeat_once(monkeypatch, tmp_path):
+    """One heartbeat thread regardless of how many poll workers run."""
+    from remote import serve
+
+    heartbeats: list[str] = []
+    monkeypatch.setattr(serve, "_poll_loop", lambda state: state.stop.set())
+    monkeypatch.setattr(serve, "_heartbeat_loop", lambda state: heartbeats.append("hb"))
+    state = _serve_state(monkeypatch, tmp_path, max_concurrency=3)
+
+    serve._serve_loop(state)
+
+    assert heartbeats == ["hb"]
+
+
+def test_serve_loop_teardown_bounded_by_drain_timeout(monkeypatch, tmp_path, capsys):
+    """Shutdown is bounded by one shared drain deadline, not summed per parked worker: workers stuck
+    in a long-poll must not serialize teardown (state.stop can't wake a blocking relay.poll)."""
+    from remote import serve
+
+    monkeypatch.setattr(serve, "_DRAIN_TIMEOUT", 0.2)
+    parked = threading.Event()  # never set during drain → workers stay "in a long-poll"
+
+    def stuck_poll(state):
+        state.stop.set()   # trigger shutdown (release the main-thread waiter)
+        parked.wait(30)    # then block, ignoring state.stop, like a real relay.poll
+
+    monkeypatch.setattr(serve, "_poll_loop", stuck_poll)
+    monkeypatch.setattr(serve, "_heartbeat_loop", lambda state: parked.wait(30))
+    state = _serve_state(monkeypatch, tmp_path, max_concurrency=8)
+
+    start = time.monotonic()
+    try:
+        serve._serve_loop(state)
+        elapsed = time.monotonic() - start
+    finally:
+        parked.set()  # release the daemon workers so they don't linger across the suite
+
+    # One shared 0.2s deadline → ~0.2s total; a per-worker join would be ~8 × 0.2 = 1.6s.
+    assert elapsed < 1.0
+    # Workers still in flight at the deadline are logged, not dropped silently.
+    assert "still in flight after" in capsys.readouterr().err
+
+
+def test_serve_state_inflight_counter_is_thread_safe(monkeypatch, tmp_path):
+    """enter/exit_inference must be atomic — the N poll workers now hit the counter concurrently."""
+    state = _serve_state(monkeypatch, tmp_path, max_concurrency=8)
+
+    def hammer():
+        for _ in range(1000):
+            state.enter_inference()
+            state.exit_inference()
+
+    threads = [threading.Thread(target=hammer) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert state.load() == {"active_tasks": 0}
+
+
+def test_serve_loop_worker_death_stops_engine(monkeypatch, tmp_path):
+    """A poll worker dying from an unexpected fault stops the whole engine (sets stop) instead of
+    silently vanishing and stranding the node at reduced/zero capacity."""
+    from remote import serve
+
+    def boom(state):
+        raise RuntimeError("relay handed us garbage")
+
+    monkeypatch.setattr(serve, "_poll_loop", boom)
+    monkeypatch.setattr(serve, "_heartbeat_loop", lambda state: state.stop.wait(60))
+    state = _serve_state(monkeypatch, tmp_path, max_concurrency=3)
+
+    serve._serve_loop(state)  # returns only because a dead worker set state.stop
+
+    assert state.stop.is_set()
+
+
+def test_serve_loop_drain_lets_inflight_job_finish(monkeypatch, tmp_path):
+    """A job that finishes within the drain budget submits its result before _serve_loop returns —
+    'drain', not 'kill on stop'."""
+    from remote import serve
+
+    submitted: list[str] = []
+
+    def fake_poll(state):
+        state.stop.set()          # shutdown begins while this 'job' is mid-flight
+        time.sleep(0.05)          # in-flight work, well within _DRAIN_TIMEOUT
+        submitted.append("done")  # result submitted before the worker returns
+
+    monkeypatch.setattr(serve, "_poll_loop", fake_poll)
+    monkeypatch.setattr(serve, "_heartbeat_loop", lambda state: None)
+    state = _serve_state(monkeypatch, tmp_path, max_concurrency=1)
+
+    serve._serve_loop(state)
+
+    assert submitted == ["done"]
+
+
+def test_relay_poll_malformed_body_raises_relay_error(monkeypatch):
+    """A 200 with a non-JSON body is a transient relay fault → RelayError (retryable by _poll_loop),
+    not a raw JSONDecodeError that would escape the loop's guards and kill the worker."""
+    from remote import relay
+
+    _mock_serve_engine(monkeypatch, lambda r: httpx.Response(200, content=b"<html>gateway hiccup</html>"))
+    with pytest.raises(relay.RelayError):
+        relay.poll("https://relay.example", "AT")
 
 
 def test_serve_node_id_comes_from_access_token_jwt():


### PR DESCRIPTION
## Summary

Remote providers advertised `max_concurrency` to the relay but ran a single synchronous poll loop, so they only ever served **one job at a time** — the advertised capacity did nothing and surplus jobs queued on the master (ADR 0007 §3 flagged this). This makes the provider genuinely serve `--max-concurrency N` jobs at once.

## What changed
- **Concurrent serving** — `_serve_loop` spawns one daemon poll worker per slot; the main thread is a pure waiter so a `grid leave` SIGTERM never kills an in-flight job.
- **Bounded, uniform drain** — workers join against one shared `_DRAIN_TIMEOUT` deadline; a worker still in flight at the deadline is logged, not dropped silently.
- **Supervised loops** — a poll/heartbeat loop that hits an unexpected fault (incl. the `SystemExit` a corrupt `credentials.toml` raises on refresh) stops the engine loudly instead of a daemon thread vanishing and stranding the node at reduced capacity.
- **Relay guard** — `relay.poll()`'s `resp.json()` maps a malformed 200 body to a retryable `RelayError`.
- **Safety** — `max_concurrency` clamped to `[1, 256]` (each slot is a real OS thread).
- **Visibility** — `grid engines` (+ `--json`) surfaces each engine's advertised `max_concurrency`.
- Default stays **1** (explicit-only; `--parallel` and `--max-concurrency` stay independent).

## Docs
New ADR 0009; ADR 0007 §3 note updated.

## Testing
- **328 tests pass**, ruff clean.
- **E2E-verified against the live relay** with qwen2.5-0.5b: N=4 serves 4 requests concurrently (equal ~5.6s latencies, wall = max), N=1 serializes them (staggered T/2T/3T/4T); provider thread count scales with N.

Default (N=1) is byte-for-byte the old behavior.
