### PR TITLE
fix(remote): metadata-first capability probing + probe every model of a spec

### DIFF
--- a/remote/probe.py
+++ b/remote/probe.py
@@ -24,6 +24,20 @@ _PROPS_TIMEOUT = 5.0
 _SHOW_TIMEOUT = 5.0
 _BENCHMARK_TIMEOUT = 60.0
 
+# A minimal valid image for the live vision probe — we only test whether the engine ACCEPTS image
+# input, not the answer, so any decodable pixel works. Bump the size if a specific engine rejects
+# sub-minimum images (some vision encoders do).
+_PROBE_IMAGE_DATA_URI = (
+    "data:image/png;base64,"
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+)
+
+# Token budget for the structured inference probes (json/tools). A reasoning model that ignores
+# `enable_thinking:False` spends its budget thinking, so a small cap yields an empty completion and the
+# probe false-negatives; 512 lets the model still emit the tool_call / JSON afterward. Non-reasoning
+# models emit and stop early, so the higher cap costs them nothing.
+_STRUCTURED_PROBE_MAX_TOKENS = 512
+
 
 def capabilities(
     llm_url: str,
@@ -132,12 +146,15 @@ def _probe_has_tool_calls(payload: dict[str, Any]) -> bool:
     return isinstance(tool_calls, list) and bool(tool_calls)
 
 
+def _server_root(llm_url: str) -> str:
+    """The engine's server root — native metadata APIs (llama.cpp ``/props``, Ollama ``/api/show``, LM
+    Studio ``/api/v0/models``) live at the root, not under the OpenAI ``/v1`` prefix."""
+    return llm_url.rstrip("/").removesuffix("/v1").rstrip("/")
+
+
 def _props_url(llm_url: str) -> str:
     """llama-server's ``/props`` lives at the server root, not under ``/v1``."""
-    base = llm_url.rstrip("/")
-    if base.endswith("/v1"):
-        base = base[:-3]
-    return f"{base}/props"
+    return f"{_server_root(llm_url)}/props"
 
 
 def _probe_props(llm_url: str, timeout: float = _PROPS_TIMEOUT) -> dict[str, bool]:
@@ -149,26 +166,25 @@ def _probe_props(llm_url: str, timeout: float = _PROPS_TIMEOUT) -> dict[str, boo
         payload = resp.json()
     except ValueError:
         return {}
+    if not isinstance(payload, dict):  # a 200 with a non-object body (list/null/str) — never .get() it
+        return {}
     template_caps = payload.get("chat_template_caps") or {}
     modalities = payload.get("modalities") or {}
     if not isinstance(template_caps, dict):
         template_caps = {}
     if not isinstance(modalities, dict):
         modalities = {}
+    if not template_caps and not modalities:
+        # Not a real llama.cpp /props response. A genuine one always carries one of these; LM Studio
+        # (and other servers) 200 an unknown path with a bare ``{"error": ...}`` body — returning a
+        # non-empty all-False dict here would masquerade as authoritative metadata downstream.
+        return {}
     return {
         "vision": bool(modalities.get("vision")),
         "tools": bool(template_caps.get("supports_tools")),
         "tool_calls": bool(template_caps.get("supports_tool_calls")),
         "parallel_tool_calls": bool(template_caps.get("supports_parallel_tool_calls")),
     }
-
-
-def _ollama_base(llm_url: str) -> str:
-    """Ollama's native API (``/api/...``) lives at the server root, not under ``/v1``."""
-    base = llm_url.rstrip("/")
-    if base.endswith("/v1"):
-        base = base[:-3]
-    return base.rstrip("/")
 
 
 def _probe_ollama_caps(llm_url: str, model: str, timeout: float = _SHOW_TIMEOUT) -> dict[str, bool]:
@@ -179,12 +195,47 @@ def _probe_ollama_caps(llm_url: str, model: str, timeout: float = _SHOW_TIMEOUT)
     Ollama still *knows* the template supports tools. Best-effort: a non-Ollama engine (llama.cpp,
     vLLM, …) 404s here and we return ``{}``, leaving the live probe + ``/props`` to decide.
     """
-    payload = _post_json(f"{_ollama_base(llm_url)}/api/show", {"model": model}, timeout=timeout)
+    payload = _post_json(f"{_server_root(llm_url)}/api/show", {"model": model}, timeout=timeout)
     caps = (payload or {}).get("capabilities")
     if not isinstance(caps, list):
         return {}
     names = {str(c).lower() for c in caps}
     return {"vision": "vision" in names, "tools": "tools" in names}
+
+
+def _probe_lmstudio_caps(llm_url: str, llm_model: str, timeout: float = _SHOW_TIMEOUT) -> dict[str, bool]:
+    """Read LM Studio's native ``GET /api/v0/models`` — one GET, no inference, deterministic (unlike the
+    live probes). ``type == "vlm"`` → vision, ``"tool_use" in capabilities`` → tools. Returns ``{}`` for a
+    non-LM-Studio engine (404 / connection refused / a ``{"error": ...}`` 200 body with no ``data`` list)
+    or a model not in the list, so the caller falls through to /props, /api/show, and the live probes.
+    Authoritative where the inference probes false-negative — LM Studio serves GGUF *and* MLX models and
+    reports both here, and a reasoning model's forced-tool probe stays silent (it spends its token budget
+    thinking) yet LM Studio still declares ``tool_use``. (``max_context_length`` is also reported but not
+    consumed yet — the caps envelope's context still comes from ``--ctx-size``.)"""
+    resp = _get(f"{_server_root(llm_url)}/api/v0/models", timeout=timeout)
+    if resp is None or resp.status_code != 200:
+        return {}
+    try:
+        data = resp.json()
+    except ValueError:
+        return {}
+    entries = data.get("data") if isinstance(data, dict) else None
+    if not isinstance(entries, list):
+        return {}
+    for entry in entries:
+        # Matched by exact id: the probe is called with the engine's real upstream model name (any
+        # ``--advertise-as`` alias already resolved), and LM Studio's ``/api/v0/models`` id is that name.
+        if isinstance(entry, dict) and entry.get("id") == llm_model:
+            entry_type = entry.get("type")
+            if not entry_type:
+                # Not LM Studio's shape — its /api/v0/models entries always carry a `type`
+                # (vlm/llm/embeddings). A bare `{"id": ...}` is a plain /v1/models entry; treat as no
+                # metadata so the caller falls through to the live probe rather than reading all-False.
+                return {}
+            caps = entry.get("capabilities")
+            names = {str(c).lower() for c in caps} if isinstance(caps, list) else set()
+            return {"vision": entry_type == "vlm", "tools": "tool_use" in names}
+    return {}
 
 
 def _probe_models(llm_url: str, llm_model: str, timeout: float = _PROPS_TIMEOUT) -> set[str]:
@@ -194,6 +245,8 @@ def _probe_models(llm_url: str, llm_model: str, timeout: float = _PROPS_TIMEOUT)
     try:
         payload = resp.json()
     except ValueError:
+        return set()
+    if not isinstance(payload, dict):  # non-object 200 body — the comprehension below would .get() it
         return set()
     entries = [
         entry
@@ -216,37 +269,46 @@ def _probe_models(llm_url: str, llm_model: str, timeout: float = _PROPS_TIMEOUT)
     return caps
 
 
-def probe_llama_capabilities(llm_url: str, llm_model: str) -> dict[str, bool]:
-    """Live-test which OpenAI capabilities the engine actually honours."""
-    base = {"model": llm_model, "stream": False, "max_tokens": 32, "temperature": 0}
-    # Structured probes bypass thinking-mode so the response is the raw tool-call / JSON payload.
-    structured_base = {**base, "chat_template_kwargs": {"enable_thinking": False}}
-    probed = {
-        "vision": False,
-        "json_object": False,
-        "json_schema": False,
-        "tools": False,
-        "parallel_tool_calls": False,
-    }
+def _probe_vision_live(llm_url: str, llm_model: str, timeout: float = _PROBE_TIMEOUT) -> bool:
+    """Live-test image input for engines that expose no modality metadata (vLLM, LM Studio, MLX — no
+    ``/props``, no ``/api/show``, and a plain ``/v1/models``): send a tiny image and see if the engine
+    accepts it. A vision model returns a normal 200 completion; a text-only model rejects the image
+    content (4xx) so ``_post_chat`` returns ``None``. Conservative — any non-200, non-object 200 body, or
+    transport error → False (better to under-claim vision than route an image job to a text model). A text
+    model rejects at input validation, before any forward pass, so this stays cheap for it.
 
-    props_caps = _probe_props(llm_url)
-    ollama_caps = _probe_ollama_caps(llm_url, llm_model)
-    probed["vision"] = bool(
-        (_probe_models(llm_url, llm_model) & {"image", "multimodal", "vision"})
-        or props_caps.get("vision")
-        or ollama_caps.get("vision")
-    )
+    Limitation: this tests *acceptance* (the engine answered 200 to an image request), not *comprehension*.
+    A non-validating engine that accepts the multimodal request but silently ignores the image part — or a
+    model that replies "I can't see images" — would false-positive. vLLM and LM Studio (the engines that
+    reach this fallback) validate image support and 4xx a text model, so in practice this only bites exotic
+    shims; a stricter content check was rejected because it false-negatives real VLMs on a synthetic 1×1
+    image. This runs at all only when no modality metadata was found (see the caller's gate)."""
+    resp = _post_chat(llm_url, {
+        "model": llm_model, "stream": False, "max_tokens": 1, "temperature": 0,
+        "messages": [{"role": "user", "content": [
+            {"type": "text", "text": "."},
+            {"type": "image_url", "image_url": {"url": _PROBE_IMAGE_DATA_URI}},
+        ]}],
+    }, timeout=timeout)
+    # ``_post_chat`` returns the raw parsed 200 body, which may not be a dict (list/str/number) — guard
+    # like every other ``_post_chat`` caller here, so a malformed body degrades to False, never raises
+    # (``_bring_up_engines`` relies on ``probe.capabilities`` never raising).
+    return bool(isinstance(resp, dict) and _probe_message(resp))
 
-    json_object_resp = _post_chat(llm_url, {
+
+def _probe_json_object_mode(llm_url: str, structured_base: dict[str, Any]) -> bool:
+    """Live-test whether the engine honours ``response_format: {"type": "json_object"}``."""
+    resp = _post_chat(llm_url, {
         **structured_base,
         "messages": [{"role": "user", "content": 'Return exactly {"ok": true}.'}],
         "response_format": {"type": "json_object"},
     })
-    probed["json_object"] = isinstance(
-        _probe_json_object(json_object_resp) if isinstance(json_object_resp, dict) else None, dict
-    )
+    return isinstance(_probe_json_object(resp) if isinstance(resp, dict) else None, dict)
 
-    json_schema_resp = _post_chat(llm_url, {
+
+def _probe_json_schema_mode(llm_url: str, structured_base: dict[str, Any]) -> bool:
+    """Live-test whether the engine honours ``response_format: {"type": "json_schema"}``."""
+    resp = _post_chat(llm_url, {
         **structured_base,
         "messages": [{"role": "user", "content": "Return a JSON object with ok=true."}],
         "response_format": {
@@ -262,12 +324,16 @@ def probe_llama_capabilities(llm_url: str, llm_model: str) -> dict[str, bool]:
             },
         },
     })
-    js = _probe_json_object(json_schema_resp) if isinstance(json_schema_resp, dict) else None
-    probed["json_schema"] = isinstance(js, dict) and isinstance(js.get("ok"), bool)
+    js = _probe_json_object(resp) if isinstance(resp, dict) else None
+    return isinstance(js, dict) and isinstance(js.get("ok"), bool)
 
-    tools_resp = _post_chat(llm_url, {
+
+def _probe_tools_live(llm_url: str, structured_base: dict[str, Any]) -> bool:
+    """Live-test tool support by forcing a ``tool_choice`` and checking the reply for a tool_call. The
+    flaky fallback used only when no metadata source declares tools — a reasoning model can spend its
+    token budget thinking and emit no tool_call even when it supports tools (hence the large budget)."""
+    resp = _post_chat(llm_url, {
         **structured_base,
-        "max_tokens": 96,
         "messages": [{"role": "user", "content": "Call the echo tool with value ping."}],
         "tools": [{
             "type": "function",
@@ -283,11 +349,53 @@ def probe_llama_capabilities(llm_url: str, llm_model: str) -> dict[str, bool]:
         }],
         "tool_choice": {"type": "function", "function": {"name": "echo"}},
     })
-    probed["tools"] = bool(
-        (isinstance(tools_resp, dict) and _probe_has_tool_calls(tools_resp))
-        or (props_caps.get("tools") and props_caps.get("tool_calls"))
-        or ollama_caps.get("tools")
+    return bool(isinstance(resp, dict) and _probe_has_tool_calls(resp))
+
+
+def probe_llama_capabilities(llm_url: str, llm_model: str) -> dict[str, bool]:
+    """Live-test which OpenAI capabilities the engine actually honours."""
+    base = {"model": llm_model, "stream": False, "max_tokens": _STRUCTURED_PROBE_MAX_TOKENS, "temperature": 0}
+    # Structured probes bypass thinking-mode so the response is the raw tool-call / JSON payload. Some
+    # engines ignore this kwarg, so the budget above still has to cover a thinking pass (see the constant).
+    structured_base = {**base, "chat_template_kwargs": {"enable_thinking": False}}
+    probed = {
+        "vision": False,
+        "json_object": False,
+        "json_schema": False,
+        "tools": False,
+        "parallel_tool_calls": False,
+    }
+
+    props_caps = _probe_props(llm_url)              # llama.cpp
+    ollama_caps = _probe_ollama_caps(llm_url, llm_model)   # Ollama
+    lmstudio_caps = _probe_lmstudio_caps(llm_url, llm_model)  # LM Studio (covers GGUF + MLX served by it)
+    model_caps = _probe_models(llm_url, llm_model)  # OpenAI /v1/models `capabilities`, when present
+    # Fall back to the live image probe ONLY when NO metadata source answered (bare vLLM / direct
+    # mlx_lm.server). props / api/show / api/v0/models are per-model authoritative sources — an answer,
+    # even a negative one, is trusted over the live probe (which can false-positive). model_caps (a
+    # `/v1/models` `capabilities` list) is deliberately NOT in this gate: it's speculative — most engines
+    # omit it and _probe_models falls back to a lone entry — so it only feeds vision via the intersection
+    # below, never suppresses the fallback.
+    has_modality_metadata = bool(props_caps) or bool(ollama_caps) or bool(lmstudio_caps)
+    probed["vision"] = bool(
+        (model_caps & {"image", "multimodal", "vision"})
+        or props_caps.get("vision")
+        or ollama_caps.get("vision")
+        or lmstudio_caps.get("vision")
+        or (not has_modality_metadata and _probe_vision_live(llm_url, llm_model))
     )
+
+    probed["json_object"] = _probe_json_object_mode(llm_url, structured_base)
+    probed["json_schema"] = _probe_json_schema_mode(llm_url, structured_base)
+
+    # Tools: trust a metadata source first; the forced-tool inference probe (flaky on reasoning models)
+    # runs only when none answered — ``or`` short-circuits, so it's skipped when metadata already affirms it.
+    meta_tools = bool(
+        (props_caps.get("tools") and props_caps.get("tool_calls"))
+        or ollama_caps.get("tools")
+        or lmstudio_caps.get("tools")
+    )
+    probed["tools"] = bool(meta_tools or _probe_tools_live(llm_url, structured_base))
     probed["parallel_tool_calls"] = bool(probed["tools"] and props_caps.get("parallel_tool_calls"))
     return probed
 

--- a/remote/serve.py
+++ b/remote/serve.py
@@ -203,9 +203,10 @@ def _bring_up_engines(
     ``[(llm_url, advertised_models, upstream_models, caps_envelope), ...]`` in record order — fed to
     ``_build_routing``. ``upstream_models`` is what the *local engine answers to* (the real model name
     for an external ``--at`` engine; the ``--advertise-as`` alias for a built-in llama-server launched
-    with ``--alias``), so a job's advertised model can be rewritten to it before forwarding. Each engine
-    is probed by its upstream name (Ollama/vLLM only know that) but the caps envelope is keyed by the
-    advertised name (what consumers ask for). ``launched`` collects the built-in llama-servers to stop
+    with ``--alias``), so a job's advertised model can be rewritten to it before forwarding. Every model
+    a spec serves is probed by its upstream name (Ollama/vLLM only know that) but the caps envelope is
+    keyed by the advertised name (what consumers ask for), so a spec serving several models advertises
+    caps for all of them, not just the first. ``launched`` collects the built-in llama-servers to stop
     on teardown (empty when every engine is external). Only a built-in ``--serve`` launches, and only as
     the **sole** engine: ``grid join --all`` gathers already-running engines, so a multi-engine record
     is all external URLs.
@@ -224,9 +225,20 @@ def _bring_up_engines(
             if proc is not None:
                 launched.append(proc)
                 launcher_mod = mod
-            caps = probe.capabilities(
-                llm_url, upstream[0], advertise_as=advertised[0], context_window=record.get("ctx_size"),
-            ) if upstream else {}
+            # Probe EVERY model this spec serves, not just the first — an external `--at` with N `-m`
+            # (or an auto-detected engine serving several models) collapses to one spec whose
+            # advertised/upstream are N-length, and each model needs its own caps or the relay can't
+            # route capability-gated (e.g. tool_choice) requests to models 2..N. N sequential probes at
+            # join (one-time; N is small) keep this simple; a failed probe returns all-False caps for
+            # that one model (probe.capabilities never raises), so one bad model can't sink the node.
+            caps_models: dict[str, Any] = {}
+            for advertised_model, upstream_model in zip(advertised, upstream, strict=True):
+                env = probe.capabilities(
+                    llm_url, upstream_model, advertise_as=advertised_model,
+                    context_window=record.get("ctx_size"),
+                )
+                caps_models.update((env or {}).get("models") or {})
+            caps = {"schema_version": 1, "models": caps_models} if caps_models else {}
             results.append((llm_url, advertised, upstream, caps))
     except BaseException:  # a later spec failed — don't orphan a server an earlier spec already launched
         if launcher_mod is not None:
@@ -331,8 +343,9 @@ def _build_routing(
     - ``warnings`` — one human line per shadowed duplicate, so the operator sees why a second engine's
       copy of a model is ignored.
 
-    A failed probe degrades to ``{}`` upstream (``probe.capabilities``), so the caps merge reads
-    ``env.get("models") or {}`` and never KeyErrors the whole table on one bad engine.
+    A failed probe degrades to a full all-``False`` capability entry, not to ``{}`` — ``probe.capabilities``
+    never raises and always returns a one-model envelope; ``caps == {}`` only when a spec serves zero models.
+    The caps merge reads ``(caps or {}).get("models") or {}`` so it never KeyErrors the table on one bad engine.
     """
     routes: dict[str, str] = {}
     upstream_routes: dict[str, str] = {}

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -2519,6 +2519,284 @@ def test_probe_tools_from_live_probe_without_props_or_show(monkeypatch, tmp_path
     assert env["models"]["m"]["features"]["tools"] is True  # live probe carries LM Studio/MLX/vLLM
 
 
+def _has_image_part(body):
+    """True if a chat-completions body carries an OpenAI image_url content part (the live vision probe)."""
+    for msg in body.get("messages", []):
+        content = msg.get("content")
+        if isinstance(content, list) and any(
+            isinstance(part, dict) and part.get("type") == "image_url" for part in content
+        ):
+            return True
+    return False
+
+
+def test_probe_vision_from_live_image_probe_when_engine_accepts(monkeypatch, tmp_path):
+    """An OpenAI engine with no /props, no /api/show, and no /v1/models capabilities (vLLM / LM Studio /
+    MLX shape) still detects vision via a live image probe: send a tiny image, and a model that ACCEPTS
+    image input answers 200 → vision True. This is the only signal for engines exposing no modality
+    metadata."""
+    from remote import probe
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    seen = {}
+
+    def handler(request):
+        path = request.url.path
+        if path in ("/props", "/api/show"):
+            return httpx.Response(404)  # neither llama.cpp nor Ollama metadata
+        if path.endswith("/models"):
+            return httpx.Response(200, json={"data": [{"id": "m"}]})  # no per-model capabilities
+        if path.endswith("/chat/completions"):
+            if _has_image_part(json.loads(request.content)):
+                seen["image_probe"] = True
+                return httpx.Response(200, json={"choices": [{"message": {"content": "a pixel"}}]})
+            return httpx.Response(200, json={"choices": [{"message": {"content": "x"}}]})
+        return httpx.Response(404)
+
+    _mock_engine(monkeypatch, handler)
+    entry = probe.capabilities("http://h:8000/v1", "m")["models"]["m"]
+    assert entry["features"]["vision"] is True and entry["input_modalities"] == ["text", "image"]
+    assert seen.get("image_probe") is True  # the probe actually sent an image_url part
+
+
+def test_probe_vision_live_probe_rejected_stays_text_only(monkeypatch, tmp_path):
+    """A text-only OpenAI engine rejects image content (4xx); the live vision probe must NOT falsely
+    advertise vision — over-claiming would route image jobs to a text model and hard-fail."""
+    from remote import probe
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+
+    def handler(request):
+        path = request.url.path
+        if path in ("/props", "/api/show"):
+            return httpx.Response(404)
+        if path.endswith("/models"):
+            return httpx.Response(200, json={"data": [{"id": "m"}]})
+        if path.endswith("/chat/completions"):
+            if _has_image_part(json.loads(request.content)):
+                return httpx.Response(400, json={"error": {"message": "this model does not support image input"}})
+            return httpx.Response(200, json={"choices": [{"message": {"content": "x"}}]})
+        return httpx.Response(404)
+
+    _mock_engine(monkeypatch, handler)
+    entry = probe.capabilities("http://h:8000/v1", "m")["models"]["m"]
+    assert entry["features"]["vision"] is False and entry["input_modalities"] == ["text"]
+
+
+def test_probe_vision_live_survives_non_dict_200_body(monkeypatch, tmp_path):
+    """A 200 whose JSON body isn't an object (list/str/number) must degrade vision to False, not crash:
+    `_bring_up_engines` probes every model and relies on `probe.capabilities` never raising."""
+    from remote import probe
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+
+    def handler(request):
+        path = request.url.path
+        if path in ("/props", "/api/show"):
+            return httpx.Response(404)
+        if path.endswith("/models"):
+            return httpx.Response(200, json={"data": [{"id": "m"}]})
+        if path.endswith("/chat/completions"):
+            return httpx.Response(200, json=[])  # 200, but not a JSON object
+        return httpx.Response(404)
+
+    _mock_engine(monkeypatch, handler)
+    entry = probe.capabilities("http://h:8000/v1", "m")["models"]["m"]  # must not raise
+    assert entry["features"]["vision"] is False
+
+
+def test_probe_vision_metadata_present_negative_skips_live_probe(monkeypatch, tmp_path):
+    """When /props authoritatively reports vision:false, the live image probe must NOT run (nor override
+    the metadata) — even if the engine would 200 an image. Guards the metadata-absence gate: a text-only
+    llama.cpp/Ollama model must not pay a needless probe or risk a false positive."""
+    from remote import probe
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    seen = {"image_probe": False}
+
+    def handler(request):
+        path = request.url.path
+        if path == "/props":
+            return httpx.Response(200, json={"chat_template_caps": {}, "modalities": {"vision": False}})
+        if path == "/api/show":
+            return httpx.Response(404)
+        if path.endswith("/models"):
+            return httpx.Response(200, json={"data": [{"id": "m"}]})  # no per-model capabilities
+        if path.endswith("/chat/completions"):
+            if _has_image_part(json.loads(request.content)):
+                seen["image_probe"] = True  # a permissive engine would answer — but we must never ask
+                return httpx.Response(200, json={"choices": [{"message": {"content": "a pixel"}}]})
+            return httpx.Response(200, json={"choices": [{"message": {"content": "x"}}]})
+        return httpx.Response(404)
+
+    _mock_engine(monkeypatch, handler)
+    entry = probe.capabilities("http://h:8081/v1", "m")["models"]["m"]
+    assert entry["features"]["vision"] is False and entry["input_modalities"] == ["text"]
+    assert seen["image_probe"] is False  # /props answered (vision:false) → live probe gated out
+
+
+def _lmstudio_v0_handler(entries):
+    """LM Studio's native GET /api/v0/models shape (rich per-model metadata); other paths 404."""
+    def handler(request):
+        if request.url.path == "/api/v0/models":
+            return httpx.Response(200, json={"data": entries, "object": "list"})
+        return httpx.Response(404)
+    return handler
+
+
+def test_probe_lmstudio_caps_reads_vlm_and_tool_use(monkeypatch, tmp_path):
+    from remote import probe
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    _mock_engine(monkeypatch, _lmstudio_v0_handler([
+        {"id": "google/gemma-4-e4b", "type": "vlm", "capabilities": ["tool_use"], "max_context_length": 131072},
+    ]))
+    assert probe._probe_lmstudio_caps("http://h:1234/v1", "google/gemma-4-e4b") == {"vision": True, "tools": True}
+
+
+def test_probe_lmstudio_caps_llm_without_tool_use(monkeypatch, tmp_path):
+    from remote import probe
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    _mock_engine(monkeypatch, _lmstudio_v0_handler([
+        {"id": "some-llm", "type": "llm", "capabilities": [], "max_context_length": 4096},
+    ]))
+    assert probe._probe_lmstudio_caps("http://h:1234/v1", "some-llm") == {"vision": False, "tools": False}
+
+
+def test_probe_lmstudio_caps_model_not_listed_is_empty(monkeypatch, tmp_path):
+    from remote import probe
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    _mock_engine(monkeypatch, _lmstudio_v0_handler([{"id": "other", "type": "llm"}]))
+    assert probe._probe_lmstudio_caps("http://h:1234/v1", "missing") == {}
+
+
+def test_probe_lmstudio_caps_non_lmstudio_is_empty(monkeypatch, tmp_path):
+    from remote import probe
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    _mock_engine(monkeypatch, lambda r: httpx.Response(404))  # vLLM/llama.cpp: no /api/v0/models
+    assert probe._probe_lmstudio_caps("http://h:8000/v1", "m") == {}
+
+
+def test_probe_lmstudio_caps_ignores_error_body(monkeypatch, tmp_path):
+    from remote import probe
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    # LM Studio 200s unknown/edge paths with a JSON error object (no `data` list) — must not be read as caps.
+    _mock_engine(monkeypatch, lambda r: httpx.Response(200, json={"error": "Unexpected endpoint"}))
+    assert probe._probe_lmstudio_caps("http://h:1234/v1", "m") == {}
+
+
+def test_probe_props_and_models_survive_non_dict_200_body(monkeypatch, tmp_path):
+    """A 200 whose JSON body is a list/null (not an object) must degrade, not raise: probe.capabilities
+    must never raise (`_bring_up_engines` has no per-model try/except around it)."""
+    from remote import probe
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    _mock_engine(monkeypatch, lambda r: httpx.Response(200, json=[]))  # every path returns a JSON array
+    assert probe._probe_props("http://h:8081/v1") == {}
+    assert probe._probe_models("http://h:8081/v1", "m") == set()
+    # And end-to-end: no raise, degrades to all-False text-only.
+    entry = probe.capabilities("http://h:8081/v1", "m")["models"]["m"]
+    assert entry["features"]["vision"] is False and entry["features"]["tools"] is False
+
+
+def test_probe_props_rejects_error_body_masquerade(monkeypatch, tmp_path):
+    """LM Studio 200s /props with an error object; _probe_props must return {} (not a non-empty all-False
+    dict), else it masquerades as authoritative metadata and gates out other probes."""
+    from remote import probe
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    _mock_engine(monkeypatch, lambda r: httpx.Response(200, json={"error": "Unexpected endpoint or method."}))
+    assert probe._probe_props("http://h:1234/v1") == {}
+
+
+def test_probe_capabilities_lmstudio_metadata_beats_silent_inference(monkeypatch, tmp_path):
+    """The real LM Studio failure→fix: /props 200s an error body, /api/show 404s, /v1/models is bare,
+    /api/v0/models declares type:vlm + tool_use, and the model is a reasoning model whose forced-tool
+    inference probe emits NO tool_call. Deterministic metadata must win → vision + tools both True."""
+    from remote import probe
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+
+    def handler(request):
+        path = request.url.path
+        if path == "/props":
+            return httpx.Response(200, json={"error": "Unexpected endpoint or method. (GET /props)"})
+        if path == "/api/show":
+            return httpx.Response(404)
+        if path == "/api/v0/models":
+            return httpx.Response(200, json={"data": [
+                {"id": "google/gemma-4-e4b", "type": "vlm", "capabilities": ["tool_use"], "max_context_length": 131072},
+            ]})
+        if path.endswith("/models"):  # /v1/models — bare, no per-model capabilities
+            return httpx.Response(200, json={"data": [{"id": "google/gemma-4-e4b"}]})
+        if path.endswith("/chat/completions"):  # reasoning model: empty completion, no tool_call
+            return httpx.Response(200, json={"choices": [{"message": {"role": "assistant", "content": ""}}]})
+        return httpx.Response(404)
+
+    _mock_engine(monkeypatch, handler)
+    f = probe.capabilities("http://h:1234/v1", "google/gemma-4-e4b")["models"]["google/gemma-4-e4b"]["features"]
+    assert f["vision"] is True and f["tools"] is True
+
+
+def test_probe_tools_metadata_skips_inference_probe(monkeypatch, tmp_path):
+    """When a metadata source declares tools, the forced-tool /chat/completions inference probe must not
+    be sent (it's the flaky, reasoning-fragile fallback)."""
+    from remote import probe
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    seen = {"tool_probe": False}
+
+    def handler(request):
+        path = request.url.path
+        if path == "/api/v0/models":
+            return httpx.Response(200, json={"data": [{"id": "m", "type": "llm", "capabilities": ["tool_use"]}]})
+        if path in ("/props", "/api/show"):
+            return httpx.Response(404)
+        if path.endswith("/chat/completions"):
+            if json.loads(request.content).get("tools"):
+                seen["tool_probe"] = True
+            return httpx.Response(200, json={"choices": [{"message": {"content": "{}"}}]})
+        if path.endswith("/models"):
+            return httpx.Response(200, json={"data": [{"id": "m"}]})
+        return httpx.Response(404)
+
+    _mock_engine(monkeypatch, handler)
+    f = probe.capabilities("http://h:1234/v1", "m")["models"]["m"]["features"]
+    assert f["tools"] is True
+    assert seen["tool_probe"] is False  # metadata answered → no inference tool-probe
+
+
+def test_probe_tools_inference_uses_high_max_tokens(monkeypatch, tmp_path):
+    """No metadata → the forced-tool inference probe runs, and must request enough tokens for a reasoning
+    model to still emit the tool_call after thinking (LM Studio gemma needed >=500)."""
+    from remote import probe
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    seen = {}
+
+    def handler(request):
+        path = request.url.path
+        if path in ("/props", "/api/show", "/api/v0/models"):
+            return httpx.Response(404)
+        if path.endswith("/models"):
+            return httpx.Response(200, json={"data": [{"id": "m"}]})
+        if path.endswith("/chat/completions"):
+            body = json.loads(request.content)
+            if body.get("tools"):
+                seen["tool_max_tokens"] = body.get("max_tokens")
+                return httpx.Response(200, json={"choices": [{"message": {"tool_calls": [{"id": "1"}]}}]})
+            return httpx.Response(200, json={"choices": [{"message": {"content": "x"}}]})
+        return httpx.Response(404)
+
+    _mock_engine(monkeypatch, handler)
+    probe.capabilities("http://h:8000/v1", "m")
+    assert seen.get("tool_max_tokens", 0) >= 500
+
+
 def test_probe_benchmark_tok_s_prefers_predicted_per_second(monkeypatch, tmp_path):
     from remote import probe
 
@@ -3315,6 +3593,33 @@ def test_bring_up_engines_external_multi_probes_each(monkeypatch, tmp_path):
         ("http://h:8000/v1", ["mistral"], ["mistral"], {"schema_version": 1, "models": {"mistral": {"f": "mistral"}}}),
     ]
     assert seen == [("http://h:11434/v1", "llama3"), ("http://h:8000/v1", "mistral")]  # each probed by real name
+
+
+def test_bring_up_engines_single_spec_multi_model_probes_every_model(monkeypatch, tmp_path):
+    """One engine spec serving several models must probe & advertise caps for EVERY model, not just the
+    first — else models B, C… register with routes but no `features`, so the relay can't route
+    capability-gated (e.g. tool_choice) requests to them. This one-spec/N-models shape is what BOTH
+    `grid join --at <url> -m A -m B -m C` AND a bare `grid join` against an auto-detected engine serving
+    several models (e.g. one Ollama with A/B/C pulled — detect returns one spec carrying all of them)
+    collapse to, so this test covers the common consumer setup, not just a hand-rolled --at."""
+    from remote import probe, serve
+
+    record = {
+        "engines": [{"endpoint_url": "http://h:9000/v1", "models": ["A", "B", "C"], "engine_label": "vllm"}],
+        "advertise_as": [],
+    }
+    seen = []
+    monkeypatch.setattr(probe, "capabilities",
+                        lambda url, model, *, advertise_as=None, context_window=None: seen.append(model)
+                        or {"schema_version": 1, "models": {advertise_as or model: {"f": model}}})
+
+    results, launched, _ = serve._bring_up_engines(record)
+    assert launched == []
+    assert seen == ["A", "B", "C"]                          # every model probed, not just the first
+    (llm_url, advertised, upstream, caps), = results
+    assert advertised == ["A", "B", "C"] and upstream == ["A", "B", "C"]
+    assert set(caps["models"]) == {"A", "B", "C"}           # one merged envelope carries all models
+    assert caps["models"]["B"] == {"f": "B"}                # later models keep their own probed entry
 
 
 def test_bring_up_engines_external_alias_probes_real_name_keys_alias(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Remote providers advertised wrong or missing model capabilities, so the relay refused `tool_choice` / json / vision requests to models it should have routed. Two related probe bugs, both fixed here, plus hardening:

- **Multi-model specs probed only the first model.** `_bring_up_engines` probed only `upstream[0]`/`advertised[0]`, so one engine serving N models (external `--at -m A -m B`, or an auto-detected Ollama/LM Studio serving several) registered caps for model A only — B, C… got routes but no `features`. Now probes every `(advertised, upstream)` pair and merges into one envelope.

- **Metadata-first capability probing.** The inference-only probe got LM Studio's `gemma-4-e4b` (an MLX VLM) **wrong and non-deterministic** — vision and tools both `False`, flaky across runs. Root causes, verified live:
  - LM Studio returns HTTP 200 (not 404) for unknown endpoints, so `_probe_props` on `/props` parsed a `{"error":...}` body into a non-empty all-`False` dict and masqueraded as authoritative metadata.
  - Reasoning models burn the forced-tool probe's token budget thinking → no `tool_call` → `tools:False`.

  Fix: read LM Studio's `/api/v0/models` (`type:vlm`→vision, `tool_use`→tools) — one GET, no inference, deterministic; guard `_probe_props` to return `{}` on a non-`/props` 200 body; run the flaky forced-tool inference probe **only** when no metadata source answered; raise the structured-probe token budget to 512 so reasoning models can still emit.

- **Live vision probe for no-metadata engines** (bare vLLM / direct `mlx_lm.server`): sends a 1×1 image and treats a 200 as accept, gated so it never overrides metadata.

- **Never-raise hardening.** `_bring_up_engines` relies on `probe.capabilities` never raising; guarded `_probe_props` / `_probe_models` / `_probe_vision_live` against non-dict 200 bodies so one malformed response can't sink the whole node.

## Verification

- `.venv/bin/pytest tests/ -q` → **349 passed**; `ruff check` clean.
- **Live E2E against a real LM Studio**: `gemma-4-e4b` now probes `vision=True, tools=True`, **3/3 deterministic** (was `False/False`, flaky).

## Notes / follow-ups (tracked, out of scope)

- Bare vLLM / direct `mlx_lm.server` (no metadata endpoint) rely on the inference fallback — mock-tested only (no such engine available to E2E here).
- Static-file probing (MLX `config.json` / `tokenizer_config.json`) not built: grid has no model→disk-path resolution.
- LM Studio's `max_context_length` is read but not yet plumbed into the caps envelope (still sourced from `--ctx-size`).
