### PR TITLE
feat(cli): UX overhaul — --kind, inline alias, engine ls, fuzzy leave, up guard (ADR 0010)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ grid up
 # grid_url=http://192.168.1.25:8090            ← the one address engines + apps use
 ```
 
-### 4 · Add a node
+### 4 · Add an engine
 
 Point Grid at an inference server you already run (here, a computer running vLLM to serve `qwen3-coder`), and name it.
 
@@ -143,7 +143,7 @@ grid chat -m qwen3-coder "write a haiku about local GPUs"
 > qwen3-coder  gpu-4090    http://192.168.1.20:8000/v1
 > gemma4-31b   mac-studio  http://192.168.1.10:8080/v1
 > ```
-> Two computers, two frameworks — one endpoint serves both. (The same `grid models` and `grid engines` now work for remote grids too — `grid models --verbose` shows each model's engine and node.)
+> Two computers, two frameworks — one endpoint serves both. (The same `grid models` and `grid engine ls` now work for remote grids too — `grid models --verbose` shows each model's engine and where it runs.)
 
 ### 6 · Point your apps at the grid
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Point Grid at an inference server you already run (here, a computer running vLLM
 **🌐 Remote** — serve your local engine to the remote grid. The engine polls the relay outbound, so `--at` is its address **on this computer** (`localhost`) — no inbound port or public IP needed:
 ```bash
 grid join research --at http://localhost:8000/v1 -m qwen3-coder --name gpu-4090
-# Joining engine gpu-4090 to research (pid=12345) — serving via the relay.
+# Joining research (pid=12345) — serving the union via the relay.
 # models=qwen3-coder
 ```
 
@@ -213,13 +213,13 @@ client.chat.completions.create(
 
 ### No engine on a computer yet?
 
-Grid installs and joins a built-in engine for you — `llama.cpp` for text, ComfyUI for media. `grid engine install`
-and `grid pull` work the same in both modes; only the grid you join differs (a remote grid **name**, or a local
-**`grid_url`**).
+Grid ships built-in engines — `llama.cpp` for text, ComfyUI for media. Install one, pull a model, then serve it
+with `grid join --serve`. `grid engine install` and `grid pull` work the same in both modes; only the grid you join
+differs (a remote grid **name**, or a local **`grid_url`**).
 
 ```bash
-grid engine install llama.cpp           # text engine (both modes)
-grid pull qwen36-35b-a3b-mtp            # see `grid catalog`, or any HF GGUF
+grid engine install llama.cpp           # install the text engine (both modes)
+grid pull qwen36-35b-a3b-mtp            # download a text MODEL (see `grid catalog`, or any HF GGUF)
 
 grid join research --serve qwen36-35b-a3b-mtp                    # 🌐 remote: your grid name
 grid join http://192.168.1.25:8090 --serve qwen36-35b-a3b-mtp   # 🏠 local: your grid_url
@@ -228,10 +228,10 @@ grid join http://192.168.1.25:8090 --serve qwen36-35b-a3b-mtp   # 🏠 local: yo
 Media serving (ComfyUI images + video) is **local-only** today:
 
 ```bash
-grid engine install comfyui             # media engine
-grid engine pull image_generation       # also: image_editing, i2v
+grid engine install comfyui             # install the media engine
+grid engine pull image_generation       # download a media BUNDLE (also: image_editing, i2v)
 grid join http://192.168.1.25:8090 --media --bundle image_generation
-grid image "a compact walnut desk beside a sunlit window" --grid http://192.168.1.25:8090
+grid image "a compact walnut desk beside a sunlit window" --grid http://192.168.1.25:8090   # --grid: use-commands take the grid as a flag (positional = prompt)
 ```
 
 ## How it works

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -29,6 +29,7 @@ from .remote_request import (
 )
 from .engine import (
     cmd_engine_install,
+    cmd_engine_list,
     cmd_engine_pull,
     cmd_engine_start,
     cmd_engine_status,
@@ -86,6 +87,7 @@ __all__ = [
     "cmd_edit",
     "cmd_video",
     "cmd_engine_install",
+    "cmd_engine_list",
     "cmd_engine_pull",
     "cmd_engine_status",
     "cmd_engine_start",

--- a/cli/engine.py
+++ b/cli/engine.py
@@ -65,6 +65,24 @@ def cmd_engine_stop(args: argparse.Namespace) -> int:
     return comfyui.stop_running()
 
 
+def cmd_engine_list(args: argparse.Namespace) -> int:
+    """`grid engine ls` — live engines joined to the grid (mode-aware, the same view as `grid engines`).
+
+    `engine` is dispatch-AGNOSTIC, so this leaf runs its handler in both modes; branch on the mode
+    dispatch stamped on ``args`` (falling back to the persisted mode for a direct call), mirroring
+    ``cli.grid.cmd_overview``."""
+    from shared import state
+
+    mode = getattr(args, "mode", None) or state.get_mode()
+    if mode == "remote":
+        from . import remote_overview
+
+        return remote_overview.cmd_remote_engines(args)
+    from . import provider
+
+    return provider.cmd_engines(args)
+
+
 def _install_llama_cpp(args: argparse.Namespace) -> int:
     from shared.engine import installer
 

--- a/cli/grid.py
+++ b/cli/grid.py
@@ -23,14 +23,7 @@ def cmd_up(args: argparse.Namespace) -> int:
     name = args.name or "home"
     cfg = _grid_by_name(name)
     if cfg is None:
-        if _looks_like_grid_id(name):
-            # An unsynced grid id, not a new grid's name — the old behaviour created a junk grid named
-            # after the id string. Point at the real grid instead (ADR 0010 D-f). Guard runs before any
-            # create/start, so nothing is written or spawned.
-            raise SystemExit(
-                f"No local grid with id {name!r}. That looks like a grid id, not a new grid's name — "
-                f"run `grid ls` to see your grids. (If it's a remote grid: `grid mode remote`, then `grid sync`.)"
-            )
+        _reject_foreign_grid(name)  # a known remote grid or an id-shaped arg → don't auto-create junk
         cfg = runtime.init_grid_config(
             name=name,
             port=args.port,
@@ -189,6 +182,25 @@ _GRID_ID_RE = re.compile(r"ag-.+-[0-9a-f]{8}")
 
 def _looks_like_grid_id(name: str) -> bool:
     return bool(_GRID_ID_RE.fullmatch(name))
+
+
+def _reject_foreign_grid(name: str) -> None:
+    """Refuse to auto-create when `name` is really an existing grid the user hasn't synced here — one of
+    their known remote grids (exact name/id match, zero false-positive), or a string shaped like a minted
+    local grid id — instead of silently making a junk local grid named after it (ADR 0010 D-f). Runs
+    before any create/start, so nothing is written or spawned."""
+    from . import remote_grid
+
+    if remote_grid._by_name(name) is not None:  # a grid from `grid login`, pasted in local mode
+        raise SystemExit(
+            f"{name!r} is one of your remote grids, not a new local grid. Switch to it with "
+            f"`grid mode remote` (or `grid --remote up {name}`)."
+        )
+    if _looks_like_grid_id(name):
+        raise SystemExit(
+            f"No local grid with id {name!r}. That looks like a grid id, not a new grid's name — run "
+            f"`grid ls` to see your grids (or `grid mode remote` + `grid sync` for a remote one)."
+        )
 
 
 def _grid_by_name(name: str) -> dict[str, Any] | None:

--- a/cli/grid.py
+++ b/cli/grid.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 from typing import Any
 
 import httpx
@@ -20,12 +21,22 @@ def cmd_version(args: argparse.Namespace) -> int:
 
 def cmd_up(args: argparse.Namespace) -> int:
     name = args.name or "home"
-    cfg = _grid_by_name(name) or runtime.init_grid_config(
-        name=name,
-        port=args.port,
-        host=args.host,
-        advertise_host=args.advertise_host,
-    )
+    cfg = _grid_by_name(name)
+    if cfg is None:
+        if _looks_like_grid_id(name):
+            # An unsynced grid id, not a new grid's name — the old behaviour created a junk grid named
+            # after the id string. Point at the real grid instead (ADR 0010 D-f). Guard runs before any
+            # create/start, so nothing is written or spawned.
+            raise SystemExit(
+                f"No local grid with id {name!r}. That looks like a grid id, not a new grid's name — "
+                f"run `grid ls` to see your grids. (If it's a remote grid: `grid mode remote`, then `grid sync`.)"
+            )
+        cfg = runtime.init_grid_config(
+            name=name,
+            port=args.port,
+            host=args.host,
+            advertise_host=args.advertise_host,
+        )
     runtime.start_grid(cfg)
     print(f"grid={cfg['name']}")
     print(f"grid_url={runtime.grid_url(cfg)}")
@@ -169,6 +180,16 @@ def _overview_local(as_json: bool) -> int:
 # ---------------------------------------------------------------------------
 # helpers
 # ---------------------------------------------------------------------------
+
+# Local grid ids are minted as ``ag-<slug>-<hex8>`` (local/runtime.init_grid_config). `grid up` uses this
+# to refuse auto-creating a junk grid when the arg is an unsynced id, not a new name (ADR 0010 D-f).
+# fullmatch (anchored) so a real name like ``ag-team`` still creates.
+_GRID_ID_RE = re.compile(r"ag-.+-[0-9a-f]{8}")
+
+
+def _looks_like_grid_id(name: str) -> bool:
+    return bool(_GRID_ID_RE.fullmatch(name))
+
 
 def _grid_by_name(name: str) -> dict[str, Any] | None:
     for cfg in config.iter_grid_configs():

--- a/cli/grid.py
+++ b/cli/grid.py
@@ -48,6 +48,7 @@ def cmd_ls(args: argparse.Namespace) -> int:
         print(json.dumps([
             {
                 "grid": cfg["name"],
+                "id": cfg["grid_id"],
                 "grid_url": runtime.grid_url(cfg),
                 "local": bool(cfg.get("managed_server", True)),
             }
@@ -59,7 +60,7 @@ def cmd_ls(args: argparse.Namespace) -> int:
         return 0
     for cfg in grids:
         where = "local" if cfg.get("managed_server", True) else "remote"
-        print(f"{cfg['name']}\t{where}\t{runtime.grid_url(cfg)}")
+        print(f"{cfg['name']}\t{cfg['grid_id']}\t{where}\t{runtime.grid_url(cfg)}")
     return 0
 
 

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -73,7 +73,8 @@ def build_parser() -> argparse.ArgumentParser:
 
 def _add_grid_lifecycle(sub) -> None:
     up = sub.add_parser("up", help="Bring a grid online (creates it on first run; default: home)")
-    up.add_argument("name", nargs="?", default=None)
+    up.add_argument("name", nargs="?", default=None,
+                    help="Grid name or id (ag-…). Omit for 'home'.")
     up.add_argument("--port", type=int, default=runtime.DEFAULT_PORT)
     up.add_argument("--host", default=runtime.DEFAULT_HOST)
     up.add_argument("--advertise-host", default=None)
@@ -88,7 +89,8 @@ def _add_grid_lifecycle(sub) -> None:
     up.set_defaults(handler=cmd_up)
 
     down = sub.add_parser("down", help="Take a grid offline (config persists)")
-    down.add_argument("name", nargs="?", default=None)
+    down.add_argument("name", nargs="?", default=None,
+                      help="Grid name or id (ag-…). Omit for the active grid.")
     down.set_defaults(handler=cmd_down)
 
     ls = sub.add_parser("ls", help="List your grids")
@@ -100,7 +102,8 @@ def _add_grid_lifecycle(sub) -> None:
     list_alias.set_defaults(handler=cmd_ls)
 
     info = sub.add_parser("info", help="Endpoint, key, and live models for a grid")
-    info.add_argument("grid", nargs="?", default=None)
+    info.add_argument("grid", nargs="?", default=None,
+                      help="Grid name or id (ag-…). Omit for the active grid.")
     info.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
     info.add_argument("--env", action="store_true", help="Print OPENAI_* shell exports.")
     info.set_defaults(handler=cmd_info)
@@ -108,12 +111,16 @@ def _add_grid_lifecycle(sub) -> None:
 
 def _add_engines(sub) -> None:
     join = sub.add_parser("join", help="Join an engine to a grid")
-    join.add_argument("grid", nargs="?", default=None)
-    join.add_argument("--at", default=None, help="URL of an existing OpenAI-compatible engine.")
-    join.add_argument("-m", "--model", action="append", dest="models", default=[])
-    join.add_argument("--serve", default=None, help="Start the built-in engine for this model, then join.")
-    join.add_argument("--media", action="store_true", help="Join this box as a media (ComfyUI) engine.")
-    join.add_argument(
+    join.add_argument("grid", nargs="?", default=None,
+                      help="Grid name or id (ag-…). Omit for the active grid.")
+
+    choose = join.add_argument_group("Choose an engine")
+    choose.add_argument("-m", "--model", action="append", dest="models", default=[],
+                        help="A model an engine serves; pair with --at, or use --serve for the built-in.")
+    choose.add_argument("--at", default=None, help="URL of an existing OpenAI-compatible engine.")
+    choose.add_argument("--serve", default=None, help="Start the built-in engine for this model, then join.")
+    choose.add_argument("--media", action="store_true", help="Join this box as a media (ComfyUI) engine.")
+    choose.add_argument(
         "--bundle",
         action="append",
         dest="bundles",
@@ -121,59 +128,75 @@ def _add_engines(sub) -> None:
         default=[],
         help="Media bundle to advertise; repeat for multiple bundles.",
     )
-    join.add_argument("--name", default=None,
-                      help="Local: engine id. Remote: display name shown on the grid page.")
-    join.add_argument("--all", action="store_true", help="Join every detected engine.")
-    join.add_argument("--engine", default=None, help="Join only the detected engine of this kind.")
-    join.add_argument(
+    choose.add_argument("--all", action="store_true", help="Join every detected engine.")
+    choose.add_argument("--engine", default=None, help="Join only the detected engine of this kind.")
+
+    naming = join.add_argument_group("Name & display")
+    naming.add_argument("--name", default=None,
+                        help="Local: engine id. Remote: display name shown on the grid page.")
+    naming.add_argument(
         "--advertise-as",
         action="append",
         dest="advertise_as",
         default=[],
         help="Model name advertised to the grid. Repeat once per -m/--model.",
     )
-    join.add_argument("--endpoint-port", "--llama-port", type=int, default=8081)
-    join.add_argument("--heartbeat-interval", type=float, default=15.0)
-    join.add_argument("--ctx-size", type=int, default=None)
-    join.add_argument("--n-predict", type=int, default=None)
-    join.add_argument("--parallel", type=int, default=None)
-    join.add_argument("--flash-attn", default=None)
-    join.add_argument("--temp", type=float, default=None)
-    join.add_argument("--reasoning-budget", type=int, default=None)
-    join.add_argument("--comfyui-port", type=int, default=8188)
-    # local-only: remote has no inbound endpoint, so there is nothing to advertise (rejected in remote mode).
-    join.add_argument("--advertise-host", default=None)
-    join.add_argument("--media-port", type=int, default=8190)
+
+    tuning = join.add_argument_group("Built-in tuning (--serve)")
+    tuning.add_argument("--endpoint-port", "--llama-port", type=int, default=8081)
+    tuning.add_argument("--heartbeat-interval", type=float, default=15.0)
+    tuning.add_argument("--ctx-size", type=int, default=None)
+    tuning.add_argument("--n-predict", type=int, default=None)
+    tuning.add_argument("--parallel", type=int, default=None)
+    tuning.add_argument("--flash-attn", default=None)
+    tuning.add_argument("--temp", type=float, default=None)
+    tuning.add_argument("--reasoning-budget", type=int, default=None)
+
+    media = join.add_argument_group("Media")
+    media.add_argument("--comfyui-port", type=int, default=8188)
+    media.add_argument("--media-port", type=int, default=8190)
+
+    local_only = join.add_argument_group("Local only")
+    # A remote engine polls the relay outbound, so it has no inbound endpoint to advertise.
+    local_only.add_argument("--advertise-host", default=None,
+                            help="Host/IP to advertise this engine at (local only).")
+
+    remote_only = join.add_argument_group("Remote only")
     # Remote-only: billing + pull-based capacity + grid-page display (rejected in local). default=None
     # so a wrong-mode use is detectable.
-    join.add_argument("--engine-label", default=None,
-                      help="Remote-only: label for this engine's kind on the grid page.")
+    remote_only.add_argument("--engine-label", default=None,
+                             help="Remote-only: label for this engine's kind on the grid page.")
     # Deprecated: pricing now lives in the authoritative per-provider table — set it with
     # `grid price set` instead. Kept so old invocations don't hard-error; they no longer advertise a price.
-    join.add_argument("--pricing-input", type=float, default=None,
-                      help="Deprecated — use `grid price set`. (No longer advertises a price.)")
-    join.add_argument("--pricing-output", type=float, default=None,
-                      help="Deprecated — use `grid price set`. (No longer advertises a price.)")
-    join.add_argument("--max-concurrency", type=int, default=None,
-                      help="Remote-only: how many requests this engine serves at once.")
+    remote_only.add_argument("--pricing-input", type=float, default=None,
+                             help="Deprecated — use `grid price set`. (No longer advertises a price.)")
+    remote_only.add_argument("--pricing-output", type=float, default=None,
+                             help="Deprecated — use `grid price set`. (No longer advertises a price.)")
+    remote_only.add_argument("--max-concurrency", type=int, default=None,
+                             help="How many requests this engine serves at once (remote only).")
     join.set_defaults(handler=cmd_join)
 
     leave = sub.add_parser("leave", help="Stop and unregister engines from a grid")
-    leave.add_argument("grid", nargs="?", default=None)
+    leave.add_argument("grid", nargs="?", default=None,
+                       help="Grid name or id (ag-…). Omit for the active grid.")
     leave.add_argument("--engine", default=None,
-                       help="Local: engine id to leave. Remote: endpoint URL (or unique label) of one "
-                            "engine to drop from the grid's identity.")
-    leave.add_argument("--all", action="store_true", help="Leave every engine on this grid.")
+                       help="Engine to leave. Matches, in order: exact engine id, endpoint URL, a "
+                            "served model, or a URL fragment (e.g. :8000).")
+    leave.add_argument("--all", action="store_true",
+                       help="Leave every engine on this grid. Without --engine: a one-engine grid "
+                            "leaves that one; a multi-engine grid requires --all.")
     leave.set_defaults(handler=cmd_leave)
 
     models = sub.add_parser("models", help="Live models the grid can run now")
-    models.add_argument("grid", nargs="?", default=None)
+    models.add_argument("grid", nargs="?", default=None,
+                        help="Grid name or id (ag-…). Omit for the active grid.")
     models.add_argument("--verbose", action="store_true", help="Show the engine serving each model.")
     models.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
     models.set_defaults(handler=cmd_models)
 
     engines = sub.add_parser("engines", help="Live engines joined to a grid")
-    engines.add_argument("grid", nargs="?", default=None)
+    engines.add_argument("grid", nargs="?", default=None,
+                         help="Grid name or id (ag-…). Omit for the active grid.")
     engines.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
     engines.set_defaults(handler=cmd_engines)
 

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -129,7 +129,8 @@ def _add_engines(sub) -> None:
         help="Media bundle to advertise; repeat for multiple bundles.",
     )
     choose.add_argument("--all", action="store_true", help="Join every detected engine.")
-    choose.add_argument("--engine", default=None, help="Join only the detected engine of this kind.")
+    choose.add_argument("--kind", "--engine", dest="kind", default=None,
+                        help="Join only the detected engine of this kind (e.g. ollama, vllm).")
 
     naming = join.add_argument_group("Name & display")
     naming.add_argument("--name", default=None,

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -19,6 +19,7 @@ from .remote_grid import cmd_remote_members
 from .remote_price import cmd_remote_price
 from .engine import (
     cmd_engine_install,
+    cmd_engine_list,
     cmd_engine_pull,
     cmd_engine_start,
     cmd_engine_status,
@@ -382,7 +383,7 @@ def _add_price(sub) -> None:
 
 
 def _add_engine_setup(sub) -> None:
-    engine = sub.add_parser("engine", help="Set up the built-in engines")
+    engine = sub.add_parser("engine", help="Set up built-in engines and list live ones")
     engine_sub = engine.add_subparsers(dest="subcommand", required=True)
 
     install = engine_sub.add_parser("install", help="Install an engine: llama.cpp (text) or comfyui (media)")
@@ -421,6 +422,15 @@ def _add_engine_setup(sub) -> None:
 
     stop = engine_sub.add_parser("stop", help="Stop the built-in media engine (ComfyUI)")
     stop.set_defaults(handler=cmd_engine_stop)
+
+    # `grid engine ls`/`list`: live engines joined to the grid (mode-aware, like `grid engines`).
+    for verb, help_text in (("ls", "List live engines (like `grid engines`)"),
+                            ("list", "Alias for `grid engine ls`")):
+        engine_list = engine_sub.add_parser(verb, help=help_text)
+        engine_list.add_argument("grid", nargs="?", default=None,
+                                 help="Grid name or id (ag-…). Omit for the active grid.")
+        engine_list.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+        engine_list.set_defaults(handler=cmd_engine_list)
 
 
 def _add_media_common(parser: argparse.ArgumentParser) -> None:

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -166,7 +166,8 @@ def _add_engines(sub) -> None:
     # Remote-only: billing + pull-based capacity + grid-page display (rejected in local). default=None
     # so a wrong-mode use is detectable.
     remote_only.add_argument("--engine-label", default=None,
-                             help="Remote-only: label for this engine's kind on the grid page.")
+                             help="Deprecated — the grid page derives the engine kind automatically; "
+                                  "no longer changes display (remote only).")
     # Deprecated: pricing now lives in the authoritative per-provider table — set it with
     # `grid price set` instead. Kept so old invocations don't hard-error; they no longer advertise a price.
     remote_only.add_argument("--pricing-input", type=float, default=None,

--- a/cli/provider.py
+++ b/cli/provider.py
@@ -69,6 +69,8 @@ def _apply_inline_aliases(args: argparse.Namespace) -> None:
     reals: list[str] = []
     aliases: list[str] = []
     for item in models:
+        if item.count("=") != 1:
+            raise SystemExit(f"Inline alias {item!r} must be exactly one `real=alias` pair.")
         real, _, alias = item.partition("=")
         real, alias = real.strip(), alias.strip()
         if not real or not alias:
@@ -81,6 +83,8 @@ def _apply_inline_aliases(args: argparse.Namespace) -> None:
 
 def cmd_join(args: argparse.Namespace) -> int:
     _reject_remote_only_flags(args)
+    if args.serve and args.models:
+        raise SystemExit("--serve serves one built-in model; drop -m/--model (alias a built-in with --advertise-as).")
     _apply_inline_aliases(args)
     advertise_host = getattr(args, "advertise_host", None)
     cfg = config.select_grid(getattr(args, "grid", None))

--- a/cli/provider.py
+++ b/cli/provider.py
@@ -49,8 +49,39 @@ def _reject_remote_only_flags(args: argparse.Namespace) -> None:
         )
 
 
+def _apply_inline_aliases(args: argparse.Namespace) -> None:
+    """Desugar inline ``-m real=alias`` into the flat ``models`` / ``advertise_as`` lists both join
+    handlers already consume. Same contract as ``--advertise-as``: all-or-nothing across the -m/--model
+    values, and mutually exclusive with ``--advertise-as``. A no-op when no ``-m`` contains ``=``. Runs
+    before the record is built / ``args.models`` is read. Splits on the first ``=`` only — model names
+    can't contain ``=`` (ollama's ``:`` and media's ``comfyui:*`` are untouched)."""
+    serve = getattr(args, "serve", None)
+    if serve and "=" in serve:
+        raise SystemExit("`--serve` takes a bare model; alias it with `--advertise-as`, not `=`.")
+    models = list(getattr(args, "models", []) or [])
+    inline = [item for item in models if "=" in item]
+    if not inline:
+        return
+    if getattr(args, "advertise_as", None):
+        raise SystemExit("Use inline `-m real=alias` or `--advertise-as`, not both.")
+    if len(inline) != len(models):
+        raise SystemExit("Alias every -m/--model as `real=alias`, or none of them.")
+    reals: list[str] = []
+    aliases: list[str] = []
+    for item in models:
+        real, _, alias = item.partition("=")
+        real, alias = real.strip(), alias.strip()
+        if not real or not alias:
+            raise SystemExit(f"Inline alias {item!r} needs a non-empty model and alias (real=alias).")
+        reals.append(real)
+        aliases.append(alias)
+    args.models = reals
+    args.advertise_as = aliases
+
+
 def cmd_join(args: argparse.Namespace) -> int:
     _reject_remote_only_flags(args)
+    _apply_inline_aliases(args)
     advertise_host = getattr(args, "advertise_host", None)
     cfg = config.select_grid(getattr(args, "grid", None))
     grid_id = cfg["grid_id"]

--- a/cli/provider.py
+++ b/cli/provider.py
@@ -260,9 +260,7 @@ def cmd_leave(args: argparse.Namespace) -> int:
     if args.all:
         targets = list(records)
     elif args.engine:
-        if args.engine not in records:
-            raise SystemExit(f"No engine {args.engine!r} joined to {cfg['name']}.")
-        targets = [args.engine]
+        targets = [_resolve_leave_target(records, args.engine, cfg["name"])]
     elif len(records) == 1:
         targets = list(records)
     elif not records:
@@ -276,6 +274,37 @@ def cmd_leave(args: argparse.Namespace) -> int:
         _stop_engine(grid_id, engine_id, records[engine_id])
         print(f"Left engine {engine_id} on {cfg['name']}.")
     return 0
+
+
+def _resolve_leave_target(records: dict[str, dict[str, Any]], selector: str, grid_name: str) -> str:
+    """The engine id to leave for ``--engine <selector>``: an exact engine id wins; otherwise match by
+    endpoint URL, a served model, or a URL fragment — the same order as remote (ADR 0010 D-d)."""
+    if selector in records:
+        return selector
+    specs = [
+        {"id": engine_id, "endpoint_url": record.get("endpoint_url"),
+         "models": record.get("models") or [], "engine_label": None}  # local records carry no label
+        for engine_id, record in records.items()
+    ]
+    matched = run_records.match_engine(
+        specs, selector, label=grid_name, summary=_leave_summary(records),
+        hint="pass the exact engine id instead",
+    )
+    if not matched:
+        raise SystemExit(
+            f"No engine {selector!r} joined to {grid_name} (match by id, endpoint URL, a served "
+            f"model, or a URL fragment). Engines: {_leave_summary(records)}."
+        )
+    return str(matched[0]["id"])
+
+
+def _leave_summary(records: dict[str, dict[str, Any]]) -> str:
+    """A short human list of joined engines for a leave error / ambiguity message."""
+    parts = []
+    for engine_id, record in records.items():
+        models = ",".join(record.get("models") or [])
+        parts.append(f"{engine_id} [{models}]" if models else engine_id)
+    return "; ".join(parts)
 
 
 def _stop_engine(grid_id: str, engine_id: str, record: dict[str, Any]) -> None:

--- a/cli/provider.py
+++ b/cli/provider.py
@@ -79,10 +79,10 @@ def cmd_join(args: argparse.Namespace) -> int:
             "No running engine detected on this box. Point at one with "
             "`grid join --at <url> -m <model>`, or start the built-in engine with `grid join --serve <model>`."
         )
-    if args.engine:
-        detected = [engine for engine in detected if engine.label == args.engine]
+    if args.kind:
+        detected = [engine for engine in detected if engine.label == args.kind]
         if not detected:
-            raise SystemExit(f"No detected engine named {args.engine!r}. Run `grid join` to list them.")
+            raise SystemExit(f"No detected engine of kind {args.kind!r}. Run `grid join` to list them.")
     elif len(detected) > 1 and not args.all:
         _print_plan(detected)
         if _interactive():
@@ -90,7 +90,7 @@ def cmd_join(args: argparse.Namespace) -> int:
                 print("Nothing joined.")
                 return 0
         else:
-            raise SystemExit("Multiple engines detected; pass --all, --engine <kind>, or --at <url>.")
+            raise SystemExit("Multiple engines detected; pass --all, --kind <kind>, or --at <url>.")
 
     used: set[str] = set()
     rc = 0
@@ -501,7 +501,7 @@ def _print_plan(detected: list[Any]) -> None:
     for engine in detected:
         models = ",".join(engine.models) or ("comfyui" if engine.media else "(no models listed)")
         print(f"  {engine.label:<12} {engine.endpoint_url:<34} {models}")
-    print("\nJoin them:\n  grid join --all\n  grid join --engine <kind>")
+    print("\nJoin them:\n  grid join --all\n  grid join --kind <kind>")
 
 
 def _interactive() -> bool:

--- a/cli/remote_grid.py
+++ b/cli/remote_grid.py
@@ -213,7 +213,10 @@ def cmd_remote_ls(args: argparse.Namespace) -> int:
     nets = _networks()  # local only — `grid login` already fetched these; no network call
     active = state.get_active("remote")
     if args.json:
-        print(json.dumps([{"grid": n.get("name"), "type": n.get("network_type")} for n in nets], indent=2))
+        print(json.dumps(
+            [{"grid": n.get("name"), "type": n.get("network_type"), "id": n.get("network_id")} for n in nets],
+            indent=2,
+        ))
         return 0
     if not nets:
         print("(no grids — run `grid up <name>` to bring one online)")
@@ -221,7 +224,7 @@ def cmd_remote_ls(args: argparse.Namespace) -> int:
     for net in nets:
         is_active = active and (net.get("network_id") == active or net.get("name") == active)
         marker = "* " if is_active else "  "
-        print(f"{marker}{net.get('name') or ''}\t{net.get('network_type') or ''}")
+        print(f"{marker}{net.get('name') or ''}\t{net.get('network_id') or ''}\t{net.get('network_type') or ''}")
     return 0
 
 

--- a/cli/remote_provider.py
+++ b/cli/remote_provider.py
@@ -364,10 +364,10 @@ def _resolve_serve_targets(args: argparse.Namespace) -> tuple[list[dict[str, obj
             "No running engine detected on this box. Point at one with "
             "`grid join --at <url> -m <model>`, or start the built-in engine with `grid join --serve <model>`."
         )
-    if args.engine:
-        detected = [engine for engine in detected if engine.label == args.engine]
+    if args.kind:
+        detected = [engine for engine in detected if engine.label == args.kind]
         if not detected:
-            raise SystemExit(f"No detected engine named {args.engine!r}. Run `grid join` to list them.")
+            raise SystemExit(f"No detected engine of kind {args.kind!r}. Run `grid join` to list them.")
 
     media_detected = any(engine.media for engine in detected)
     text = [engine for engine in detected if not engine.media]
@@ -377,7 +377,7 @@ def _resolve_serve_targets(args: argparse.Namespace) -> tuple[list[dict[str, obj
             if not provider._confirm("Join all detected engines?"):
                 return [], False
         else:
-            raise SystemExit("Multiple engines detected; pass --all, --engine <kind>, or --at <url>.")
+            raise SystemExit("Multiple engines detected; pass --all, --kind <kind>, or --at <url>.")
     return [
         {"endpoint_url": engine.endpoint_url, "models": list(engine.models), "engine_label": engine.label}
         for engine in text

--- a/cli/remote_provider.py
+++ b/cli/remote_provider.py
@@ -57,6 +57,12 @@ def cmd_remote_join(args: argparse.Namespace) -> int:
             "Set your model price with `grid price set` after joining.",
             file=sys.stderr,
         )
+    if getattr(args, "engine_label", None) is not None:
+        print(
+            "Note: --engine-label is deprecated and no longer changes the grid page — the engine's kind "
+            "is derived automatically. (It still matches `grid leave --engine <label>`.)",
+            file=sys.stderr,
+        )
     if args.at and args.serve:
         raise SystemExit("Use either --at (point at an existing engine) or --serve, not both.")
 

--- a/cli/remote_provider.py
+++ b/cli/remote_provider.py
@@ -44,25 +44,31 @@ def _reject_local_only_flags(args: argparse.Namespace) -> None:
         )
 
 
+def _warn_deprecated(triggered: bool, message: str) -> None:
+    """Print a one-line deprecation note to stderr when a deprecated flag was used."""
+    if triggered:
+        print(message, file=sys.stderr)
+
+
 def cmd_remote_join(args: argparse.Namespace) -> int:
     from remote import credentials
 
     from . import provider, remote_grid
 
     _reject_local_only_flags(args)
+    if args.serve and args.models:
+        raise SystemExit("--serve serves one built-in model; drop -m/--model (alias a built-in with --advertise-as).")
     provider._apply_inline_aliases(args)
-    if getattr(args, "pricing_input", None) is not None or getattr(args, "pricing_output", None) is not None:
-        print(
-            "Note: --pricing-input/--pricing-output are deprecated and no longer advertise a price. "
-            "Set your model price with `grid price set` after joining.",
-            file=sys.stderr,
-        )
-    if getattr(args, "engine_label", None) is not None:
-        print(
-            "Note: --engine-label is deprecated and no longer changes the grid page — the engine's kind "
-            "is derived automatically. (It still matches `grid leave --engine <label>`.)",
-            file=sys.stderr,
-        )
+    _warn_deprecated(
+        getattr(args, "pricing_input", None) is not None or getattr(args, "pricing_output", None) is not None,
+        "Note: --pricing-input/--pricing-output are deprecated and no longer advertise a price. "
+        "Set your model price with `grid price set` after joining.",
+    )
+    _warn_deprecated(
+        getattr(args, "engine_label", None) is not None,
+        "Note: --engine-label is deprecated and no longer changes the grid page — the engine's kind "
+        "is derived automatically. (It still matches `grid leave --engine <label>`.)",
+    )
     if args.at and args.serve:
         raise SystemExit("Use either --at (point at an existing engine) or --serve, not both.")
 

--- a/cli/remote_provider.py
+++ b/cli/remote_provider.py
@@ -576,28 +576,7 @@ def _engines_summary(union: list[dict[str, object]]) -> str:
 def _drop_spec(
     union: list[dict[str, object]], selector: str, label: str
 ) -> list[dict[str, object]]:
-    """The spec(s) to remove for ``selector``, tried in order: exact ``endpoint_url``, exact
-    ``engine_label``, a served model, then a URL substring (host/port). Each non-URL match must resolve to
-    ONE engine or it errors and lists the engines — so `grid leave --engine mistral` (by model) or
-    `grid leave --engine :8000` (by port) work, not just the full URL."""
-
-    def unique(matches: list[dict[str, object]], how: str) -> list[dict[str, object]]:
-        if len(matches) > 1:
-            raise SystemExit(
-                f"{how} {selector!r} matches several engines on {label}; pass the exact endpoint URL "
-                f"instead. Engines: {_engines_summary(union)}."
-            )
-        return matches
-
-    by_url = [spec for spec in union if spec.get("endpoint_url") == selector]
-    if by_url:
-        return by_url
-    by_label = unique([spec for spec in union if spec.get("engine_label") == selector], "Label")
-    if by_label:
-        return by_label
-    by_model = unique([spec for spec in union if selector in (spec.get("models") or [])], "Model")
-    if by_model:
-        return by_model
-    return unique(
-        [spec for spec in union if selector in (spec.get("endpoint_url") or "")], "URL fragment"
-    )
+    """The spec(s) to remove for ``selector`` — exact endpoint_url → engine_label → served model → URL
+    substring — via the shared matcher (`shared.run_records.match_engine`). Remote engines are keyed by
+    URL/label, so no exact-id short-circuit here (that's the local caller's job)."""
+    return run_records.match_engine(union, selector, label=label, summary=_engines_summary(union))

--- a/cli/remote_provider.py
+++ b/cli/remote_provider.py
@@ -47,9 +47,10 @@ def _reject_local_only_flags(args: argparse.Namespace) -> None:
 def cmd_remote_join(args: argparse.Namespace) -> int:
     from remote import credentials
 
-    from . import remote_grid
+    from . import provider, remote_grid
 
     _reject_local_only_flags(args)
+    provider._apply_inline_aliases(args)
     if getattr(args, "pricing_input", None) is not None or getattr(args, "pricing_output", None) is not None:
         print(
             "Note: --pricing-input/--pricing-output are deprecated and no longer advertise a price. "

--- a/docs/adr/0010-cli-ux-vocabulary.md
+++ b/docs/adr/0010-cli-ux-vocabulary.md
@@ -68,14 +68,16 @@ reworded from "Set up the built-in engines" to "Set up built-in engines and list
 namespace coherently covers setup **and** listing. Chosen over a new top-level `grid ps` (which would
 cost a `dispatch.py` bucket + a `REMOTE_HANDLERS` entry + a third spelling for "list engines").
 
-**D-f (`grid up` id guard).** `grid up <arg>` no longer auto-creates when `<arg>` matches the local
-grid-id shape `ag-<slug>-<hex8>` (anchored `fullmatch`) but isn't found locally; it exits with guidance
-to `grid ls` (and, if the grid is remote, `grid mode remote` then `grid sync`). An ordinary name still
-creates as before. This is the one non-additive change. Accepted trade-off: a chosen grid *name* shaped
-exactly like an id (`ag-…-<8 hex>`) is refused — acceptable, since that collides with the reserved id
-form. No remote mirror: remote `network_id`s are opaque and indistinguishable from a chosen name, so any
-heuristic would false-positive; remote keeps create-on-unknown-name (the correct lever there would be an
-explicit `--create`, out of scope).
+**D-f (`grid up` id guard).** `grid up <arg>` no longer auto-creates a junk local grid when `<arg>` is
+really an existing grid the user hasn't synced here — instead of making a grid named after the string, it
+exits with guidance. Two signals, both run before any create/start: **(a)** an exact match against the
+user's known remote grids (`grid login`'s `credentials.toml` networks, by name or network_id) — a
+zero-false-positive signal that works for the opaque remote ids a shape check can't recognise; and **(b)**
+the local grid-id shape `ag-<slug>-<hex8>` (anchored `fullmatch`). An ordinary, unknown name still creates
+as before. This is the one non-additive change. Accepted trade-off: signal (b) also refuses a chosen grid
+*name* shaped like an id (`ag-…-<8 hex-valid chars>`, including an all-digit suffix such as
+`ag-nightly-20260706`), since that collides with the reserved local-id form. Remote `grid up` keeps
+create-on-unknown-name (an explicit `--create` would be the lever there, out of scope).
 
 **D-g (`leave --all` stays required for multi-engine).** Local bare `grid leave` on a grid with several
 engines keeps its safety guard — it errors asking for `--engine`/`--all` (`cli/provider.py:240`) rather
@@ -87,5 +89,6 @@ correcting the handoff's assumption that bare-leave already meant "all".
 
 - Back-compat: `grid join --engine ollama`, `grid engines`, and `-m x --advertise-as y` all keep working.
 - No new top-level command → the dispatch classification test is untouched by every decision here.
-- The only behavior a v0.1.6 user could notice as *removed* is `grid up <an-id-you-didn't-sync>`
-  auto-creating a junk grid — now a clean error (D-f).
+- The only behavior a v0.1.6 user could notice as *removed* is `grid up <arg>` auto-creating a junk local
+  grid when `<arg>` is a grid id, or a known remote grid's name, that isn't a local grid — now a clean
+  error (D-f).

--- a/docs/adr/0010-cli-ux-vocabulary.md
+++ b/docs/adr/0010-cli-ux-vocabulary.md
@@ -1,0 +1,91 @@
+# ADR 0010 — CLI vocabulary & UX for `join` / `leave` / `engine`
+
+Status: accepted (2026-07-06). Scope: the public `grid` CLI surface (v0.1.6 shipped). All changes are
+additive / alias-preserving except Decision D-f (`grid up` no longer auto-creates an id-shaped arg).
+
+## Context
+
+The released CLI accumulated avoidable friction, each verified against the tree on `feat/cli-ux`:
+
+- **`--engine` is overloaded.** On `grid join` it *filters auto-detected engines by kind*
+  (`cli/provider.py:82-85`, `cli/remote_provider.py:367-370`); on `grid leave` it *names the joined
+  instance to drop* (`cli/provider.py:231`). Two meanings, one flag — the reader can't tell "type" from
+  "instance".
+- **Model aliasing needs two positionally-paired flags.** `-m real --advertise-as pub` must be given in
+  matching order and equal count (`_advertised_text_models`, `cli/provider.py:525-539`). Easy to
+  mis-pair; nothing signals the pairing at the call site.
+- **`grid engines` sits one keystroke from `grid engine`.** `engines` (plural) lists live joined engines
+  (`cli/parser.py:175`); `engine` (singular) is the built-in-engine setup namespace
+  (`install`/`pull`/`status`/`start`/`stop`, `cli/parser.py:359-398`). Typo-adjacent, and inconsistent
+  with the rest of the surface.
+- **`leave --engine` help lies.** It says "endpoint URL (or unique label)" (`cli/parser.py:163-165`) but
+  the remote matcher already accepts URL / label / served-model / URL-fragment (`_drop_spec`,
+  `cli/remote_provider.py:569-596`); the *local* handler accepts only the exact engine-id.
+- **`grid up <unknown>` silently creates.** Any unknown positional becomes a brand-new grid named after
+  the string (`cli/grid.py:23`). Paste a grid *id* you haven't synced locally and you get a junk grid
+  named after the id, not an error.
+
+Design constraints: the CLI is mode-aware (local/remote) and dispatch is classified **per top-level
+command only** (`cli/dispatch.py`; a test enforces every command is classified). Grid ids are
+`ag-<slug>-<hex8>` locally (`local/runtime.py:65`) and opaque `[A-Za-z0-9_-]+` remotely
+(`cli/remote_grid.py:32`). There is no `DECISIONS.md`; design is recorded in these ADRs.
+
+## Decisions
+
+**D-a (join `--kind`).** The pre-join engine-*type* filter is `--kind` (e.g. `--kind ollama`).
+`--engine` is retained as a compatibility alias on the same dest (two option strings, one `dest="kind"`
+— the repo precedent is `--endpoint-port`/`--llama-port`, `cli/parser.py:135`). Vocabulary is now
+consistent: **kind** = the type you filter on *before* joining; **engine** = the instance you name
+*after* joining (and `leave --engine`). Consequence: `grid join --engine ollama` keeps working; help and
+error text move to `--kind`.
+
+**D-b (inline alias `-m real=pub`).** Model aliasing gains an inline spelling that desugars into today's
+flat `models` / `advertise_as` lists before any handler reads them (`_apply_inline_aliases`). It is
+**minimal**: same all-or-nothing rule as `--advertise-as` (alias every text model, or none), mutually
+exclusive with `--advertise-as`, and rejected on `--serve` (which bypasses the models list — alias a
+built-in via `--advertise-as`). Split on the first `=`. Consequence: **zero** change to
+`_advertised_text_models`, `_reject_unserveable_union`, the run record, or the SIGHUP reload path;
+`--advertise-as` remains as the escape hatch for exotic model names.
+
+**D-c (deprecate `--engine-label`).** The grid page derives an engine's kind automatically
+(`remote/serve.py` `_meta`), so `--engine-label` no longer changes any display. It is deprecated:
+accepted (no hard error), marked deprecated in help, warns on stderr when used (mirroring the
+`--pricing-*` deprecation, `cli/remote_provider.py:53-58`), and is still stored in the record so
+`grid leave --engine <label>` keeps matching an engine a prior join labelled.
+
+**D-d (local fuzzy `leave --engine`).** Local `leave --engine` gains the same match order as remote —
+exact engine-id → endpoint URL → served model → URL fragment — via one shared, pure matcher
+`shared.run_records.match_engine`, which the remote `_drop_spec` also delegates to (byte-identical
+remote messages). The exact engine-id (== local `--name`) short-circuits first, before fuzzy matching.
+The ambiguity guidance is parameterized per mode: remote says "pass the exact endpoint URL instead",
+local says "pass the exact engine id instead" (a local built-in `--serve` engine has no URL, so the
+always-unique engine-id is the actionable disambiguator).
+
+**D-e (`grid engine ls`).** Live-engine listing gains a canonical `grid engine ls` (+ `list` alias);
+`grid engines` is kept as a legacy alias. The handler branches on mode internally (the `cmd_overview`
+pattern) so `engine` stays AGNOSTIC and needs no dispatch change. The `grid engine` group help is
+reworded from "Set up the built-in engines" to "Set up built-in engines and list live ones", so the
+namespace coherently covers setup **and** listing. Chosen over a new top-level `grid ps` (which would
+cost a `dispatch.py` bucket + a `REMOTE_HANDLERS` entry + a third spelling for "list engines").
+
+**D-f (`grid up` id guard).** `grid up <arg>` no longer auto-creates when `<arg>` matches the local
+grid-id shape `ag-<slug>-<hex8>` (anchored `fullmatch`) but isn't found locally; it exits with guidance
+to `grid ls` (and, if the grid is remote, `grid mode remote` then `grid sync`). An ordinary name still
+creates as before. This is the one non-additive change. Accepted trade-off: a chosen grid *name* shaped
+exactly like an id (`ag-…-<8 hex>`) is refused — acceptable, since that collides with the reserved id
+form. No remote mirror: remote `network_id`s are opaque and indistinguishable from a chosen name, so any
+heuristic would false-positive; remote keeps create-on-unknown-name (the correct lever there would be an
+explicit `--create`, out of scope).
+
+**D-g (`leave --all` stays required for multi-engine).** Local bare `grid leave` on a grid with several
+engines keeps its safety guard — it errors asking for `--engine`/`--all` (`cli/provider.py:240`) rather
+than silently tearing down everything. (A one-engine grid still leaves that engine on a bare `leave`;
+remote tears the single identity down.) Only the help wording changes, to state this accurately —
+correcting the handoff's assumption that bare-leave already meant "all".
+
+## Consequences
+
+- Back-compat: `grid join --engine ollama`, `grid engines`, and `-m x --advertise-as y` all keep working.
+- No new top-level command → the dispatch classification test is untouched by every decision here.
+- The only behavior a v0.1.6 user could notice as *removed* is `grid up <an-id-you-didn't-sync>`
+  auto-creating a junk grid — now a clean error (D-f).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -9,7 +9,8 @@ Internal protocol words stay out of the user-facing CLI.
 ```
 grid      a named local AI endpoint, usually `home` or `work`
 grid_url  the URL engines join; apps call it through `/v1`
-engine    something that runs models: Ollama, LM Studio, vLLM, MLX, llama.cpp, ComfyUI
+engine    a running instance joined to a grid: Ollama, LM Studio, vLLM, MLX, llama.cpp, ComfyUI
+kind      an engine's type (ollama, vllm, mlx, llama.cpp, comfyui) — filter auto-detect with --kind
 join      connect this machine or engine to a grid
 model     a live capability exposed by joined engines
 mode      which world the CLI targets: `local` (default) or `remote`
@@ -140,9 +141,9 @@ commands exit with guidance to switch — sign-in is a remote concept. See
 ## Grid Lifecycle
 
 ```
-grid up [name] [--type <t>]           # create/start a grid (--type sets a remote grid's type on create)
+grid up [name] [--type <t>]           # create/start a grid by name or id (--type: remote grid type on create)
 grid down [name]                      # stop a grid; the grid/config persists
-grid ls [--json]                      # list saved grids
+grid ls [--json]                      # list saved grids (name, id, where, url)
 grid info [grid] [--json]             # endpoint, key, engines, live models
 grid info [grid] --env                # print OPENAI_* exports (local key, or remote relay URL + token)
 ```
@@ -174,8 +175,8 @@ grid join [grid] --all                                # join every detected engi
 grid join [grid] --at <url> -m <model>... [--name <id>]
 grid join [grid] --serve <model> [--name <id>]
 grid join [grid] --media [--bundle <bundle>]... [--name <id>]
-grid leave [grid] [--engine <id>] [--all]
-grid engines [grid] [--json]                          # live engines joined to a grid
+grid leave [grid] [--engine <sel>] [--all]            # <sel>: engine id, endpoint URL, served model, or :port fragment
+grid engine ls [grid] [--json]                        # live engines joined to a grid (legacy alias: grid engines)
 ```
 
 `grid join` with no flags should detect local engines in this order:
@@ -188,7 +189,7 @@ grid engines [grid] [--json]                          # live engines joined to a
 6. ComfyUI
 
 When detection finds more than one engine, print the plan and ask for confirmation in
-interactive terminals. In non-interactive mode, require `--all`, `--engine <kind>`, or
+interactive terminals. In non-interactive mode, require `--all`, `--kind <kind>`, or
 explicit `--at`.
 
 Example detection output:
@@ -196,16 +197,17 @@ Example detection output:
 ```text
 Detected engines on this machine:
 
-  mac-studio     MLX        http://192.168.1.10:8080/v1      gemma4-31b
-  gpu-4090       vLLM       http://192.168.1.20:8000/v1      devstral-small-2
+  mlx          http://192.168.1.10:8080/v1        gemma4-31b
+  vllm         http://192.168.1.20:8000/v1        devstral-small-2
 
 Join them:
   grid join --all
-  grid join --engine gpu-4090
+  grid join --kind <kind>
 ```
 
-Engine IDs are local names shown by `grid engines`, `grid info`, and
-`grid models --verbose`; they are accepted by `grid leave --engine <id>`.
+Engine IDs are local names shown by `grid engine ls`, `grid info`, and `grid models --verbose`.
+`grid leave --engine <sel>` takes an exact engine id, or — tried in that order — an endpoint URL,
+a served model, or a URL fragment such as `:8000`.
 
 ### `grid join` in remote mode
 
@@ -225,16 +227,17 @@ files) streams back exactly as in local mode.
 
 The `grid join` flag set is the union of both modes, gated by mode:
 
-- **Both modes:** `--at` / `--serve` / `-m,--model` / `--engine <kind>` / `--name` / `--all`,
-  `--advertise-as`, `--endpoint-port` (alias `--llama-port`), the llama tuning flags
-  (`--ctx-size --n-predict --parallel --flash-attn --temp --reasoning-budget`), and the media flags
-  `--media` / `--bundle <bundle>` / `--comfyui-port` / `--media-port`.
+- **Both modes:** `--at` / `--serve` / `-m,--model` / `--kind <kind>` (alias `--engine`) / `--name`
+  / `--all`, `--advertise-as` (or inline `-m real=pub`), `--endpoint-port` (alias `--llama-port`),
+  the llama tuning flags (`--ctx-size --n-predict --parallel --flash-attn --temp --reasoning-budget`),
+  and the media flags `--media` / `--bundle <bundle>` / `--comfyui-port` / `--media-port`.
 - **local-only:** `--advertise-host` (a remote engine polls the relay outbound — there is no inbound
   endpoint to advertise).
-- **Remote-only:** `--engine-label` (the engine kind shown on the grid page), `--max-concurrency`.
-- **Deprecated:** `--pricing-input` / `--pricing-output` — kept so old invocations don't hard-error,
-  but they no longer advertise a price. Set your authoritative per-model price with `grid price set`
-  (see [Price](#price)) instead.
+- **Remote-only:** `--max-concurrency`.
+- **Deprecated:** `--engine-label` — the grid page now derives the engine kind automatically, so it is
+  accepted but inert (still matched by `grid leave --engine <label>`); `--pricing-input` /
+  `--pricing-output` — kept so old invocations don't hard-error, but they no longer advertise a price.
+  Set your authoritative per-model price with `grid price set` (see [Price](#price)) instead.
 
 A flag used in the wrong mode fails with a clear message. (`--advertise-as` is single-engine only and
 is rejected with `--all`.) See [ADR 0004](./adr/0004-remote-provider-serve.md),
@@ -352,6 +355,7 @@ guidance to switch.
 grid engine install llama.cpp          # default text engine
 grid engine install comfyui            # default media engine
 grid engine pull <bundle>              # ComfyUI media bundle: image_generation, image_editing, i2v
+grid engine ls [grid] [--json]         # live engines joined to a grid (same view as grid engines)
 ```
 
 Grid has no inference engine of its own. These commands install open-source default
@@ -361,6 +365,8 @@ engines so a bare machine can join a grid without Ollama, LM Studio, or vLLM.
 
 ```
 grid list                              # alias for grid ls
+grid engine list                       # alias for grid engine ls
+grid engines                           # legacy alias for grid engine ls
 grid remove <model> [--yes]            # alias for grid rm
 ```
 

--- a/shared/run_records.py
+++ b/shared/run_records.py
@@ -52,6 +52,41 @@ def read_record(grid_id: str, engine_id: str) -> dict[str, Any] | None:
     return read_records(grid_id).get(engine_id)
 
 
+def match_engine(
+    specs: list[dict[str, Any]],
+    selector: str,
+    *,
+    label: str,
+    summary: str,
+    hint: str = "pass the exact endpoint URL instead",
+) -> list[dict[str, Any]]:
+    """Engine spec(s) a `grid leave --engine <selector>` picks out of ``specs``, tried in order: exact
+    ``endpoint_url`` → exact ``engine_label`` → a served model → an ``endpoint_url`` substring. Each match
+    must resolve to exactly ONE engine or it raises ``SystemExit`` (naming ``summary`` and ``hint``);
+    returns ``[]`` on no match so the caller raises its own not-found. Returned dicts are the SAME objects
+    passed in — identity is preserved for an ``id()``-based drop filter. An exact engine-*id* match is the
+    caller's job BEFORE this (remote keys engines by URL/label; local by record id). ``hint`` is the
+    disambiguation instruction, per mode: remote points at the endpoint URL, local at the engine id."""
+
+    def unique(matches: list[dict[str, Any]], how: str) -> list[dict[str, Any]]:
+        if len(matches) > 1:
+            raise SystemExit(
+                f"{how} {selector!r} matches several engines on {label}; {hint}. Engines: {summary}."
+            )
+        return matches
+
+    by_url = unique([s for s in specs if s.get("endpoint_url") == selector], "URL")
+    if by_url:
+        return by_url
+    by_label = unique([s for s in specs if s.get("engine_label") == selector], "Label")
+    if by_label:
+        return by_label
+    by_model = unique([s for s in specs if selector in (s.get("models") or [])], "Model")
+    if by_model:
+        return by_model
+    return unique([s for s in specs if selector in (s.get("endpoint_url") or "")], "URL fragment")
+
+
 def media_signature(record: dict[str, Any]) -> tuple[bool, tuple[str, ...], int, int]:
     """A comparable fingerprint of an identity's media config (on/off, bundles, ports). A SIGHUP
     hot-reload can't bring media up/down or swap bundles, so ``grid join``/``leave`` (CLI) and the serve

--- a/shared/run_records.py
+++ b/shared/run_records.py
@@ -67,6 +67,8 @@ def match_engine(
     passed in — identity is preserved for an ``id()``-based drop filter. An exact engine-*id* match is the
     caller's job BEFORE this (remote keys engines by URL/label; local by record id). ``hint`` is the
     disambiguation instruction, per mode: remote points at the endpoint URL, local at the engine id."""
+    if not selector:  # defensive: an empty selector is a substring of every URL — never "match all"
+        return []
 
     def unique(matches: list[dict[str, Any]], how: str) -> list[dict[str, Any]]:
         if len(matches) > 1:

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -1129,6 +1129,43 @@ def test_engine_label_is_deprecated_but_still_recorded(monkeypatch, tmp_path, ca
     assert cli.provider._read_records("n1")["remote"]["engine_label"] == "rig"
 
 
+def test_engine_ls_and_list_route_to_cmd_engine_list():
+    parser = cli.build_parser()
+    assert parser.parse_args(["engine", "ls"]).handler is cli.cmd_engine_list
+    assert parser.parse_args(["engine", "list"]).handler is cli.cmd_engine_list
+
+
+def test_engine_ls_accepts_grid_and_json():
+    args = cli.build_parser().parse_args(["engine", "ls", "home", "--json"])
+    assert args.grid == "home" and args.json is True
+
+
+def test_engine_ls_local_delegates_to_cmd_engines(monkeypatch, tmp_path):
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    seen = {}
+
+    def fake_engines(args):
+        seen["grid"] = args.grid
+        return 0
+
+    monkeypatch.setattr(cli.provider, "cmd_engines", fake_engines)
+    assert cli.main(["engine", "ls", "home"]) == 0  # default mode is local
+    assert seen["grid"] == "home"
+
+
+def test_engine_ls_remote_delegates_to_remote_engines(monkeypatch, tmp_path):
+    _seed_remote(monkeypatch, tmp_path)
+    seen = {}
+
+    def fake_remote_engines(args):
+        seen["hit"] = True
+        return 0
+
+    monkeypatch.setattr(cli.remote_overview, "cmd_remote_engines", fake_remote_engines)
+    assert cli.main(["engine", "ls"]) == 0
+    assert seen.get("hit") is True
+
+
 _FAKE_ENGINES = [
     {"name": "mac", "endpoint_url": "http://192.168.1.10:8080/v1", "models": ["gemma4-31b"]},
     {"name": "gpu", "endpoint_url": "http://192.168.1.20:8000/v1", "models": ["devstral", "gemma4-31b"]},

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -983,6 +983,12 @@ def test_ls_shows_grid_id_local(monkeypatch, tmp_path, capsys):
     assert json.loads(capsys.readouterr().out)[0]["id"] == cfg["grid_id"]
 
 
+def test_join_kind_flag_with_engine_alias():
+    parser = cli.build_parser()
+    assert parser.parse_args(["join", "--kind", "ollama"]).kind == "ollama"
+    assert parser.parse_args(["join", "--engine", "vllm"]).kind == "vllm"  # --engine is a back-compat alias
+
+
 _FAKE_ENGINES = [
     {"name": "mac", "endpoint_url": "http://192.168.1.10:8080/v1", "models": ["gemma4-31b"]},
     {"name": "gpu", "endpoint_url": "http://192.168.1.20:8000/v1", "models": ["devstral", "gemma4-31b"]},

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -922,6 +922,74 @@ def test_leave_all_removes_records(monkeypatch, tmp_path):
     assert cli.provider._read_records(grid_id) == {}
 
 
+def _seed_local_engine(grid_id, engine_id, *, endpoint_url=None, models=None):
+    cli.provider._write_record(grid_id, engine_id, {
+        "engine_id": engine_id, "node_id": engine_id, "grid_id": grid_id, "pid": 0,
+        "endpoint_url": endpoint_url, "models": models or [],
+    })
+
+
+def _leave(*argv):
+    return cli.cmd_leave(cli.build_parser().parse_args(["leave", *argv]))
+
+
+def test_leave_local_matches_by_endpoint_url(monkeypatch, tmp_path):
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    grid_id = runtime.init_grid_config(name="home", port=8090)["grid_id"]
+    _seed_local_engine(grid_id, "mac", endpoint_url="http://h:8000/v1", models=["mistral"])
+    _seed_local_engine(grid_id, "gpu", endpoint_url="http://h:9000/v1", models=["devstral"])
+    assert _leave("home", "--engine", "http://h:8000/v1") == 0
+    assert set(cli.provider._read_records(grid_id)) == {"gpu"}
+
+
+def test_leave_local_matches_by_served_model(monkeypatch, tmp_path):
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    grid_id = runtime.init_grid_config(name="home", port=8090)["grid_id"]
+    _seed_local_engine(grid_id, "mac", endpoint_url="http://h:8000/v1", models=["mistral"])
+    _seed_local_engine(grid_id, "gpu", endpoint_url="http://h:9000/v1", models=["devstral"])
+    assert _leave("home", "--engine", "devstral") == 0
+    assert set(cli.provider._read_records(grid_id)) == {"mac"}
+
+
+def test_leave_local_matches_by_url_fragment(monkeypatch, tmp_path):
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    grid_id = runtime.init_grid_config(name="home", port=8090)["grid_id"]
+    _seed_local_engine(grid_id, "mac", endpoint_url="http://h:8000/v1", models=["mistral"])
+    _seed_local_engine(grid_id, "gpu", endpoint_url="http://h:9000/v1", models=["devstral"])
+    assert _leave("home", "--engine", ":9000") == 0
+    assert set(cli.provider._read_records(grid_id)) == {"mac"}
+
+
+def test_leave_local_exact_id_wins_over_url_substring(monkeypatch, tmp_path):
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    grid_id = runtime.init_grid_config(name="home", port=8090)["grid_id"]
+    _seed_local_engine(grid_id, "mac", endpoint_url="http://h:8000/v1", models=["m1"])
+    _seed_local_engine(grid_id, "gpu", endpoint_url="http://mac-host:9000/v1", models=["m2"])
+    assert _leave("home", "--engine", "mac") == 0  # exact id, not the substring of gpu's URL
+    assert set(cli.provider._read_records(grid_id)) == {"gpu"}
+
+
+def test_leave_local_ambiguous_model_lists_ids(monkeypatch, tmp_path):
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    grid_id = runtime.init_grid_config(name="home", port=8090)["grid_id"]
+    _seed_local_engine(grid_id, "mac", endpoint_url="http://h:8000/v1", models=["shared"])
+    _seed_local_engine(grid_id, "gpu", endpoint_url="http://h:9000/v1", models=["shared"])
+    with pytest.raises(SystemExit) as exc:
+        _leave("home", "--engine", "shared")
+    msg = str(exc.value)
+    assert "several" in msg.lower() and "mac" in msg and "gpu" in msg
+
+
+def test_leave_local_unknown_selector_errors(monkeypatch, tmp_path):
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    grid_id = runtime.init_grid_config(name="home", port=8090)["grid_id"]
+    _seed_local_engine(grid_id, "mac", endpoint_url="http://h:8000/v1", models=["mistral"])
+    with pytest.raises(SystemExit) as exc:
+        _leave("home", "--engine", "ghost")
+    assert "ghost" in str(exc.value)
+    assert set(cli.provider._read_records(grid_id)) == {"mac"}  # nothing dropped on a miss
+
+
 def test_cli_accepts_engines_and_json_and_aliases():
     parser = cli.build_parser()
 

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -807,6 +807,29 @@ def test_join_all_joins_every_detected_engine(monkeypatch, tmp_path):
     assert set(records) == {"ollama", "vllm"}
 
 
+def test_join_kind_filters_to_one_engine(monkeypatch, tmp_path):
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    grid_id = runtime.init_grid_config(name="home", port=8090)["grid_id"]
+    monkeypatch.setattr(
+        cli.provider,
+        "_detect",
+        lambda host: [
+            detect.DetectedEngine(label="ollama", endpoint_url="http://h:11434/v1", models=["llama3"]),
+            detect.DetectedEngine(label="vllm", endpoint_url="http://h:8000/v1", models=["mistral"]),
+        ],
+    )
+    monkeypatch.setattr(cli.provider.subprocess, "Popen", lambda cmd, **kw: type("P", (), {"pid": 1})())
+    monkeypatch.setattr(cli.provider, "_await_engine_start", lambda *a, **k: "registered")
+
+    assert cli.cmd_join(cli.build_parser().parse_args(["join", "home", "--kind", "vllm"])) == 0
+    assert set(cli.provider._read_records(grid_id)) == {"vllm"}  # only the vllm engine joined
+    # the --engine alias drives the same filter (and errors on no match)
+    assert cli.cmd_join(cli.build_parser().parse_args(["join", "home", "--engine", "ollama"])) == 0
+    assert set(cli.provider._read_records(grid_id)) == {"vllm", "ollama"}
+    with pytest.raises(SystemExit):
+        cli.cmd_join(cli.build_parser().parse_args(["join", "home", "--kind", "nope"]))
+
+
 def test_join_cleans_up_record_when_engine_dies(monkeypatch, tmp_path, capsys):
     monkeypatch.setenv("GRID_HOME", str(tmp_path))
     cfg = runtime.init_grid_config(name="home", port=8090)
@@ -1110,6 +1133,19 @@ def test_serve_rejects_inline_equals():
     assert "--advertise-as" in str(exc.value)
 
 
+def test_serve_rejects_extra_model_flag():
+    # --serve serves one built-in model; a separate -m (aliased or not) would be silently dropped.
+    for argv in (["--serve", "modelY", "-m", "real=pub"], ["--serve", "modelY", "-m", "foo"]):
+        with pytest.raises(SystemExit) as exc:
+            cli.cmd_join(_parse_join(*argv))
+        assert "--serve" in str(exc.value)
+
+
+def test_inline_alias_rejects_multiple_equals():
+    with pytest.raises(SystemExit):
+        cli.provider._apply_inline_aliases(_parse_join("--at", "u", "-m", "a=b=c"))
+
+
 def test_remote_join_inline_alias_desugars_into_record(monkeypatch, tmp_path):
     _seed_running_remote_grid(monkeypatch, tmp_path)
     _mock_remote_spawn(monkeypatch)
@@ -1194,6 +1230,17 @@ def test_up_starts_existing_grid_by_id(monkeypatch, tmp_path):
     cfg = runtime.init_grid_config(name="home", port=8090)
     monkeypatch.setattr(cli.grid.runtime, "start_grid", lambda cfg: None)
     assert cli.main(["up", cfg["grid_id"]]) == 0  # found by id → guard skipped
+
+
+def test_up_rejects_known_remote_grid_in_local_mode(monkeypatch, tmp_path):
+    _seed_remote(monkeypatch, tmp_path, networks=[{"network_id": "n1", "name": "team"}])
+    state.set_mode("local")  # the remote grid is known via credentials, but we're in local mode
+    from local import config as local_config
+    for arg in ("team", "n1"):  # matched by name and by network_id
+        with pytest.raises(SystemExit) as exc:
+            cli.main(["up", arg])
+        assert "remote" in str(exc.value).lower()
+    assert local_config.iter_grid_configs() == []  # nothing created
 
 
 _FAKE_ENGINES = [
@@ -4843,6 +4890,7 @@ def test_remote_ls_lists_local_without_network_call(monkeypatch, tmp_path, capsy
     out = capsys.readouterr().out
     assert "team" in out and "permissioned-public" in out
     assert "lab" in out and "permissioned-providers" in out
+    assert "n1" in out and "n2" in out  # network_id column (ADR 0010 item 9b)
 
 
 def test_remote_ls_json_emits_grid_and_type(monkeypatch, tmp_path, capsys):

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -1166,6 +1166,36 @@ def test_engine_ls_remote_delegates_to_remote_engines(monkeypatch, tmp_path):
     assert seen.get("hit") is True
 
 
+def test_looks_like_grid_id_detector():
+    assert cli.grid._looks_like_grid_id("ag-home-deadbeef") is True
+    assert cli.grid._looks_like_grid_id("workshop") is False
+    assert cli.grid._looks_like_grid_id("ag-team") is False  # no hex8 suffix → still a creatable name
+
+
+def test_up_rejects_unknown_grid_id_without_creating(monkeypatch, tmp_path):
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["up", "ag-home-deadbeef"])
+    assert "grid ls" in str(exc.value)
+    from local import config as local_config
+    assert local_config.iter_grid_configs() == []  # nothing created, nothing spawned
+
+
+def test_up_creates_for_human_name(monkeypatch, tmp_path):
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    monkeypatch.setattr(cli.grid.runtime, "start_grid", lambda cfg: None)
+    assert cli.main(["up", "workshop"]) == 0
+    from local import config as local_config
+    assert any(c["name"] == "workshop" for c in local_config.iter_grid_configs())
+
+
+def test_up_starts_existing_grid_by_id(monkeypatch, tmp_path):
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    cfg = runtime.init_grid_config(name="home", port=8090)
+    monkeypatch.setattr(cli.grid.runtime, "start_grid", lambda cfg: None)
+    assert cli.main(["up", cfg["grid_id"]]) == 0  # found by id → guard skipped
+
+
 _FAKE_ENGINES = [
     {"name": "mac", "endpoint_url": "http://192.168.1.10:8080/v1", "models": ["gemma4-31b"]},
     {"name": "gpu", "endpoint_url": "http://192.168.1.20:8000/v1", "models": ["devstral", "gemma4-31b"]},

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -1051,6 +1051,16 @@ def test_remote_join_inline_alias_desugars_into_record(monkeypatch, tmp_path):
     assert rec["advertise_as"] == ["pub-a"]
 
 
+def test_engine_label_is_deprecated_but_still_recorded(monkeypatch, tmp_path, capsys):
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_remote_spawn(monkeypatch)
+    assert cli.main(["join", "--serve", "m", "--engine-label", "rig"]) == 0
+    err = capsys.readouterr().err
+    assert "engine-label" in err and "deprecated" in err.lower()
+    # still stored so `grid leave --engine <label>` keeps matching (ADR 0010 D-c)
+    assert cli.provider._read_records("n1")["remote"]["engine_label"] == "rig"
+
+
 _FAKE_ENGINES = [
     {"name": "mac", "endpoint_url": "http://192.168.1.10:8080/v1", "models": ["gemma4-31b"]},
     {"name": "gpu", "endpoint_url": "http://192.168.1.20:8000/v1", "models": ["devstral", "gemma4-31b"]},

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -989,6 +989,68 @@ def test_join_kind_flag_with_engine_alias():
     assert parser.parse_args(["join", "--engine", "vllm"]).kind == "vllm"  # --engine is a back-compat alias
 
 
+def _parse_join(*argv):
+    return cli.build_parser().parse_args(["join", *argv])
+
+
+def test_join_inline_alias_desugars_into_record(monkeypatch, tmp_path):
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    cfg = runtime.init_grid_config(name="home", port=8090)
+
+    class FakePopen:
+        def __init__(self, cmd, **kwargs):
+            self.pid = 4321
+
+    monkeypatch.setattr(cli.provider.subprocess, "Popen", FakePopen)
+    monkeypatch.setattr(cli.provider, "_await_engine_start", lambda *a, **k: "registered")
+    args = _parse_join("home", "--at", "http://h:11434/v1", "-m", "real-a=pub-a", "--name", "mac")
+    assert cli.cmd_join(args) == 0
+    rec = cli.provider._read_records(cfg["grid_id"])["mac"]
+    assert rec["models"] == ["real-a"]
+    assert rec["advertise_as"] == ["pub-a"]
+
+
+def test_inline_alias_rejects_mixing_with_advertise_as():
+    args = _parse_join("--at", "u", "-m", "real=pub", "--advertise-as", "x")
+    with pytest.raises(SystemExit) as exc:
+        cli.provider._apply_inline_aliases(args)
+    assert "not both" in str(exc.value)
+
+
+def test_inline_alias_all_or_nothing():
+    args = _parse_join("--at", "u", "-m", "real=pub", "-m", "plain")
+    with pytest.raises(SystemExit):
+        cli.provider._apply_inline_aliases(args)
+
+
+def test_inline_alias_rejects_empty_side():
+    for bad in ("=pub", "real="):
+        with pytest.raises(SystemExit):
+            cli.provider._apply_inline_aliases(_parse_join("--at", "u", "-m", bad))
+
+
+def test_inline_alias_no_equals_is_untouched():
+    args = _parse_join("--at", "u", "-m", "qwen3:0.6b")
+    cli.provider._apply_inline_aliases(args)
+    assert args.models == ["qwen3:0.6b"] and args.advertise_as == []
+
+
+def test_serve_rejects_inline_equals():
+    args = _parse_join("--serve", "real=pub")
+    with pytest.raises(SystemExit) as exc:
+        cli.provider._apply_inline_aliases(args)
+    assert "--advertise-as" in str(exc.value)
+
+
+def test_remote_join_inline_alias_desugars_into_record(monkeypatch, tmp_path):
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_remote_spawn(monkeypatch)
+    assert cli.main(["join", "--at", "http://h:11434/v1", "-m", "real-a=pub-a"]) == 0
+    rec = cli.provider._read_records("n1")["remote"]
+    assert rec["models"] == ["real-a"]
+    assert rec["advertise_as"] == ["pub-a"]
+
+
 _FAKE_ENGINES = [
     {"name": "mac", "endpoint_url": "http://192.168.1.10:8080/v1", "models": ["gemma4-31b"]},
     {"name": "gpu", "endpoint_url": "http://192.168.1.20:8000/v1", "models": ["devstral", "gemma4-31b"]},

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -936,6 +936,53 @@ def test_cli_accepts_engines_and_json_and_aliases():
     assert parser.parse_args(["remove", "m.gguf"]).handler is cli.cmd_rm
 
 
+# ---------------------------------------------------------------------------
+# CLI UX overhaul (ADR 0010): help text, join flag groups, `grid ls` id column
+# ---------------------------------------------------------------------------
+
+def _subcmd_help(cmd: str) -> str:
+    """Whitespace-collapsed --help text for a subcommand. argparse re-wraps help to the terminal
+    width, so collapsing runs of whitespace lets substring asserts survive line breaks."""
+    parser = cli.build_parser()
+    sub = next(a for a in parser._actions if isinstance(a, argparse._SubParsersAction))
+    return " ".join(sub.choices[cmd].format_help().split())
+
+
+def test_leave_help_lists_all_match_kinds():
+    help_text = _subcmd_help("leave")
+    for kind in ("engine id", "endpoint URL", "served model", "URL fragment"):
+        assert kind in help_text, f"leave --engine help should mention {kind!r}"
+
+
+def test_leave_all_help_states_multi_engine_needs_all():
+    assert "multi-engine" in _subcmd_help("leave")
+
+
+def test_join_help_groups_flags():
+    help_text = _subcmd_help("join")
+    for title in ("Choose an engine", "Name & display", "Media", "Built-in", "Local only", "Remote only"):
+        assert title in help_text, f"join -h should have a {title!r} group"
+
+
+def test_join_help_marks_mode_scoped_flags():
+    help_text = _subcmd_help("join")
+    assert "(local only)" in help_text and "(remote only)" in help_text
+
+
+def test_positional_grid_help_present():
+    assert "Grid name or id" in _subcmd_help("up")
+    assert "Grid name or id" in _subcmd_help("join")
+
+
+def test_ls_shows_grid_id_local(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    cfg = runtime.init_grid_config(name="home", port=8090)
+    assert cli.cmd_ls(cli.build_parser().parse_args(["ls"])) == 0
+    assert cfg["grid_id"] in capsys.readouterr().out  # id column present in human output
+    assert cli.cmd_ls(cli.build_parser().parse_args(["ls", "--json"])) == 0
+    assert json.loads(capsys.readouterr().out)[0]["id"] == cfg["grid_id"]
+
+
 _FAKE_ENGINES = [
     {"name": "mac", "endpoint_url": "http://192.168.1.10:8080/v1", "models": ["gemma4-31b"]},
     {"name": "gpu", "endpoint_url": "http://192.168.1.20:8000/v1", "models": ["devstral", "gemma4-31b"]},
@@ -4589,7 +4636,8 @@ def test_remote_ls_json_emits_grid_and_type(monkeypatch, tmp_path, capsys):
     _seed_remote(monkeypatch, tmp_path, networks=[
         {"network_id": "n1", "name": "team", "network_type": "permissioned-public"}])
     assert cli.main(["ls", "--json"]) == 0
-    assert json.loads(capsys.readouterr().out) == [{"grid": "team", "type": "permissioned-public"}]
+    assert json.loads(capsys.readouterr().out) == [
+        {"grid": "team", "type": "permissioned-public", "id": "n1"}]
 
 
 def test_remote_list_alias_lists_like_ls(monkeypatch, tmp_path, capsys):


### PR DESCRIPTION
## Summary

CLI UX overhaul for `join` / `leave` / `engine`, per **ADR 0010** (`docs/adr/0010-cli-ux-vocabulary.md`).
Alias-preserving — every released (v0.1.6) spelling still works — except one deliberate `grid up` guard.

## Changes (ADR 0010 D-a…D-g)

- **`--kind`** — the join-time engine-*type* filter is now `--kind` (e.g. `--kind ollama`); `--engine`
  kept as a back-compat alias on the same dest. Vocabulary: *kind* = type before join, *engine* =
  instance after.
- **Inline alias `-m real=pub`** — desugars into the existing `models`/`advertise_as` pair
  (all-or-nothing, mutually exclusive with `--advertise-as`, rejected together with `--serve`). Zero
  downstream change to routing/records/reload.
- **`--engine-label` deprecated** — accepted but inert + warns; still stored so
  `leave --engine <label>` keeps matching.
- **Local `leave --engine` fuzzy match** — exact id → endpoint URL → served model → URL fragment, via a
  shared pure `run_records.match_engine` that the remote `_drop_spec` now delegates to.
- **`grid engine ls` / `list`** — canonical live-engines command (mode-branching handler);
  `grid engines` kept as a legacy alias.
- **`grid up` id guard** — refuses to auto-create a junk local grid when the arg is a known remote grid
  (exact name/network_id) or matches the local id shape `ag-<slug>-<hex8>`; ordinary names still create.
- **Help + `grid ls` id column** — `join -h` flag groups + `(local only)/(remote only)` suffixes,
  positional *name-or-id* help, and an id column on `grid ls`.

## Review

Ran 3 parallel reviewers (python / silent-failure / code). Fixed 2 HIGH (silent `--serve` + `-m`
mis-advertise; `grid up` missing the known-remote-grid guard) plus MEDIUMs; all findings addressed.

## Tests

`pytest tests/test_local_cli.py` → **377 passed** (33 new), `ruff` clean. Smoke-tested the real `grid`
entry point end-to-end.

## Note on target

Base is `fix/remote-join` (this work sits on the remote-join lineage). Integrating the remote-provider
lines into `main` (additive-join/SIGHUP + concurrency) is a separate, tested effort.
