### PR TITLE
Merge fix/remote-join: additive remote join + SIGHUP hot-reload × N-worker concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ grid up
 # grid_url=http://192.168.1.25:8090            ← the one address engines + apps use
 ```
 
-### 4 · Add a node
+### 4 · Add an engine
 
 Point Grid at an inference server you already run (here, a computer running vLLM to serve `qwen3-coder`), and name it.
 
@@ -143,7 +143,7 @@ grid chat -m qwen3-coder "write a haiku about local GPUs"
 > qwen3-coder  gpu-4090    http://192.168.1.20:8000/v1
 > gemma4-31b   mac-studio  http://192.168.1.10:8080/v1
 > ```
-> Two computers, two frameworks — one endpoint serves both. (The same `grid models` and `grid engines` now work for remote grids too — `grid models --verbose` shows each model's engine and node.)
+> Two computers, two frameworks — one endpoint serves both. (The same `grid models` and `grid engine ls` now work for remote grids too — `grid models --verbose` shows each model's engine and where it runs.)
 
 ### 6 · Point your apps at the grid
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Point Grid at an inference server you already run (here, a computer running vLLM
 **🌐 Remote** — serve your local engine to the remote grid. The engine polls the relay outbound, so `--at` is its address **on this computer** (`localhost`) — no inbound port or public IP needed:
 ```bash
 grid join research --at http://localhost:8000/v1 -m qwen3-coder --name gpu-4090
-# Joining engine gpu-4090 to research (pid=12345) — serving via the relay.
+# Joining research (pid=12345) — serving the union via the relay.
 # models=qwen3-coder
 ```
 
@@ -213,13 +213,13 @@ client.chat.completions.create(
 
 ### No engine on a computer yet?
 
-Grid installs and joins a built-in engine for you — `llama.cpp` for text, ComfyUI for media. `grid engine install`
-and `grid pull` work the same in both modes; only the grid you join differs (a remote grid **name**, or a local
-**`grid_url`**).
+Grid ships built-in engines — `llama.cpp` for text, ComfyUI for media. Install one, pull a model, then serve it
+with `grid join --serve`. `grid engine install` and `grid pull` work the same in both modes; only the grid you join
+differs (a remote grid **name**, or a local **`grid_url`**).
 
 ```bash
-grid engine install llama.cpp           # text engine (both modes)
-grid pull qwen36-35b-a3b-mtp            # see `grid catalog`, or any HF GGUF
+grid engine install llama.cpp           # install the text engine (both modes)
+grid pull qwen36-35b-a3b-mtp            # download a text MODEL (see `grid catalog`, or any HF GGUF)
 
 grid join research --serve qwen36-35b-a3b-mtp                    # 🌐 remote: your grid name
 grid join http://192.168.1.25:8090 --serve qwen36-35b-a3b-mtp   # 🏠 local: your grid_url
@@ -228,10 +228,10 @@ grid join http://192.168.1.25:8090 --serve qwen36-35b-a3b-mtp   # 🏠 local: yo
 Media serving (ComfyUI images + video) is **local-only** today:
 
 ```bash
-grid engine install comfyui             # media engine
-grid engine pull image_generation       # also: image_editing, i2v
+grid engine install comfyui             # install the media engine
+grid engine pull image_generation       # download a media BUNDLE (also: image_editing, i2v)
 grid join http://192.168.1.25:8090 --media --bundle image_generation
-grid image "a compact walnut desk beside a sunlit window" --grid http://192.168.1.25:8090
+grid image "a compact walnut desk beside a sunlit window" --grid http://192.168.1.25:8090   # --grid: use-commands take the grid as a flag (positional = prompt)
 ```
 
 ## How it works

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -29,6 +29,7 @@ from .remote_request import (
 )
 from .engine import (
     cmd_engine_install,
+    cmd_engine_list,
     cmd_engine_pull,
     cmd_engine_start,
     cmd_engine_status,
@@ -86,6 +87,7 @@ __all__ = [
     "cmd_edit",
     "cmd_video",
     "cmd_engine_install",
+    "cmd_engine_list",
     "cmd_engine_pull",
     "cmd_engine_status",
     "cmd_engine_start",

--- a/cli/engine.py
+++ b/cli/engine.py
@@ -65,6 +65,24 @@ def cmd_engine_stop(args: argparse.Namespace) -> int:
     return comfyui.stop_running()
 
 
+def cmd_engine_list(args: argparse.Namespace) -> int:
+    """`grid engine ls` — live engines joined to the grid (mode-aware, the same view as `grid engines`).
+
+    `engine` is dispatch-AGNOSTIC, so this leaf runs its handler in both modes; branch on the mode
+    dispatch stamped on ``args`` (falling back to the persisted mode for a direct call), mirroring
+    ``cli.grid.cmd_overview``."""
+    from shared import state
+
+    mode = getattr(args, "mode", None) or state.get_mode()
+    if mode == "remote":
+        from . import remote_overview
+
+        return remote_overview.cmd_remote_engines(args)
+    from . import provider
+
+    return provider.cmd_engines(args)
+
+
 def _install_llama_cpp(args: argparse.Namespace) -> int:
     from shared.engine import installer
 

--- a/cli/grid.py
+++ b/cli/grid.py
@@ -23,14 +23,7 @@ def cmd_up(args: argparse.Namespace) -> int:
     name = args.name or "home"
     cfg = _grid_by_name(name)
     if cfg is None:
-        if _looks_like_grid_id(name):
-            # An unsynced grid id, not a new grid's name — the old behaviour created a junk grid named
-            # after the id string. Point at the real grid instead (ADR 0010 D-f). Guard runs before any
-            # create/start, so nothing is written or spawned.
-            raise SystemExit(
-                f"No local grid with id {name!r}. That looks like a grid id, not a new grid's name — "
-                f"run `grid ls` to see your grids. (If it's a remote grid: `grid mode remote`, then `grid sync`.)"
-            )
+        _reject_foreign_grid(name)  # a known remote grid or an id-shaped arg → don't auto-create junk
         cfg = runtime.init_grid_config(
             name=name,
             port=args.port,
@@ -189,6 +182,25 @@ _GRID_ID_RE = re.compile(r"ag-.+-[0-9a-f]{8}")
 
 def _looks_like_grid_id(name: str) -> bool:
     return bool(_GRID_ID_RE.fullmatch(name))
+
+
+def _reject_foreign_grid(name: str) -> None:
+    """Refuse to auto-create when `name` is really an existing grid the user hasn't synced here — one of
+    their known remote grids (exact name/id match, zero false-positive), or a string shaped like a minted
+    local grid id — instead of silently making a junk local grid named after it (ADR 0010 D-f). Runs
+    before any create/start, so nothing is written or spawned."""
+    from . import remote_grid
+
+    if remote_grid._by_name(name) is not None:  # a grid from `grid login`, pasted in local mode
+        raise SystemExit(
+            f"{name!r} is one of your remote grids, not a new local grid. Switch to it with "
+            f"`grid mode remote` (or `grid --remote up {name}`)."
+        )
+    if _looks_like_grid_id(name):
+        raise SystemExit(
+            f"No local grid with id {name!r}. That looks like a grid id, not a new grid's name — run "
+            f"`grid ls` to see your grids (or `grid mode remote` + `grid sync` for a remote one)."
+        )
 
 
 def _grid_by_name(name: str) -> dict[str, Any] | None:

--- a/cli/grid.py
+++ b/cli/grid.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 from typing import Any
 
 import httpx
@@ -20,12 +21,22 @@ def cmd_version(args: argparse.Namespace) -> int:
 
 def cmd_up(args: argparse.Namespace) -> int:
     name = args.name or "home"
-    cfg = _grid_by_name(name) or runtime.init_grid_config(
-        name=name,
-        port=args.port,
-        host=args.host,
-        advertise_host=args.advertise_host,
-    )
+    cfg = _grid_by_name(name)
+    if cfg is None:
+        if _looks_like_grid_id(name):
+            # An unsynced grid id, not a new grid's name — the old behaviour created a junk grid named
+            # after the id string. Point at the real grid instead (ADR 0010 D-f). Guard runs before any
+            # create/start, so nothing is written or spawned.
+            raise SystemExit(
+                f"No local grid with id {name!r}. That looks like a grid id, not a new grid's name — "
+                f"run `grid ls` to see your grids. (If it's a remote grid: `grid mode remote`, then `grid sync`.)"
+            )
+        cfg = runtime.init_grid_config(
+            name=name,
+            port=args.port,
+            host=args.host,
+            advertise_host=args.advertise_host,
+        )
     runtime.start_grid(cfg)
     print(f"grid={cfg['name']}")
     print(f"grid_url={runtime.grid_url(cfg)}")
@@ -169,6 +180,16 @@ def _overview_local(as_json: bool) -> int:
 # ---------------------------------------------------------------------------
 # helpers
 # ---------------------------------------------------------------------------
+
+# Local grid ids are minted as ``ag-<slug>-<hex8>`` (local/runtime.init_grid_config). `grid up` uses this
+# to refuse auto-creating a junk grid when the arg is an unsynced id, not a new name (ADR 0010 D-f).
+# fullmatch (anchored) so a real name like ``ag-team`` still creates.
+_GRID_ID_RE = re.compile(r"ag-.+-[0-9a-f]{8}")
+
+
+def _looks_like_grid_id(name: str) -> bool:
+    return bool(_GRID_ID_RE.fullmatch(name))
+
 
 def _grid_by_name(name: str) -> dict[str, Any] | None:
     for cfg in config.iter_grid_configs():

--- a/cli/grid.py
+++ b/cli/grid.py
@@ -48,6 +48,7 @@ def cmd_ls(args: argparse.Namespace) -> int:
         print(json.dumps([
             {
                 "grid": cfg["name"],
+                "id": cfg["grid_id"],
                 "grid_url": runtime.grid_url(cfg),
                 "local": bool(cfg.get("managed_server", True)),
             }
@@ -59,7 +60,7 @@ def cmd_ls(args: argparse.Namespace) -> int:
         return 0
     for cfg in grids:
         where = "local" if cfg.get("managed_server", True) else "remote"
-        print(f"{cfg['name']}\t{where}\t{runtime.grid_url(cfg)}")
+        print(f"{cfg['name']}\t{cfg['grid_id']}\t{where}\t{runtime.grid_url(cfg)}")
     return 0
 
 

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -121,7 +121,8 @@ def _add_engines(sub) -> None:
         default=[],
         help="Media bundle to advertise; repeat for multiple bundles.",
     )
-    join.add_argument("--name", default=None, help="Engine id (for `grid leave --engine <id>`).")
+    join.add_argument("--name", default=None,
+                      help="Local: engine id. Remote: display name shown on the grid page.")
     join.add_argument("--all", action="store_true", help="Join every detected engine.")
     join.add_argument("--engine", default=None, help="Join only the detected engine of this kind.")
     join.add_argument(
@@ -159,7 +160,9 @@ def _add_engines(sub) -> None:
 
     leave = sub.add_parser("leave", help="Stop and unregister engines from a grid")
     leave.add_argument("grid", nargs="?", default=None)
-    leave.add_argument("--engine", default=None, help="Engine id to leave.")
+    leave.add_argument("--engine", default=None,
+                       help="Local: engine id to leave. Remote: endpoint URL (or unique label) of one "
+                            "engine to drop from the grid's identity.")
     leave.add_argument("--all", action="store_true", help="Leave every engine on this grid.")
     leave.set_defaults(handler=cmd_leave)
 

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -73,7 +73,8 @@ def build_parser() -> argparse.ArgumentParser:
 
 def _add_grid_lifecycle(sub) -> None:
     up = sub.add_parser("up", help="Bring a grid online (creates it on first run; default: home)")
-    up.add_argument("name", nargs="?", default=None)
+    up.add_argument("name", nargs="?", default=None,
+                    help="Grid name or id (ag-…). Omit for 'home'.")
     up.add_argument("--port", type=int, default=runtime.DEFAULT_PORT)
     up.add_argument("--host", default=runtime.DEFAULT_HOST)
     up.add_argument("--advertise-host", default=None)
@@ -88,7 +89,8 @@ def _add_grid_lifecycle(sub) -> None:
     up.set_defaults(handler=cmd_up)
 
     down = sub.add_parser("down", help="Take a grid offline (config persists)")
-    down.add_argument("name", nargs="?", default=None)
+    down.add_argument("name", nargs="?", default=None,
+                      help="Grid name or id (ag-…). Omit for the active grid.")
     down.set_defaults(handler=cmd_down)
 
     ls = sub.add_parser("ls", help="List your grids")
@@ -100,7 +102,8 @@ def _add_grid_lifecycle(sub) -> None:
     list_alias.set_defaults(handler=cmd_ls)
 
     info = sub.add_parser("info", help="Endpoint, key, and live models for a grid")
-    info.add_argument("grid", nargs="?", default=None)
+    info.add_argument("grid", nargs="?", default=None,
+                      help="Grid name or id (ag-…). Omit for the active grid.")
     info.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
     info.add_argument("--env", action="store_true", help="Print OPENAI_* shell exports.")
     info.set_defaults(handler=cmd_info)
@@ -108,12 +111,16 @@ def _add_grid_lifecycle(sub) -> None:
 
 def _add_engines(sub) -> None:
     join = sub.add_parser("join", help="Join an engine to a grid")
-    join.add_argument("grid", nargs="?", default=None)
-    join.add_argument("--at", default=None, help="URL of an existing OpenAI-compatible engine.")
-    join.add_argument("-m", "--model", action="append", dest="models", default=[])
-    join.add_argument("--serve", default=None, help="Start the built-in engine for this model, then join.")
-    join.add_argument("--media", action="store_true", help="Join this box as a media (ComfyUI) engine.")
-    join.add_argument(
+    join.add_argument("grid", nargs="?", default=None,
+                      help="Grid name or id (ag-…). Omit for the active grid.")
+
+    choose = join.add_argument_group("Choose an engine")
+    choose.add_argument("-m", "--model", action="append", dest="models", default=[],
+                        help="A model an engine serves; pair with --at, or use --serve for the built-in.")
+    choose.add_argument("--at", default=None, help="URL of an existing OpenAI-compatible engine.")
+    choose.add_argument("--serve", default=None, help="Start the built-in engine for this model, then join.")
+    choose.add_argument("--media", action="store_true", help="Join this box as a media (ComfyUI) engine.")
+    choose.add_argument(
         "--bundle",
         action="append",
         dest="bundles",
@@ -121,59 +128,75 @@ def _add_engines(sub) -> None:
         default=[],
         help="Media bundle to advertise; repeat for multiple bundles.",
     )
-    join.add_argument("--name", default=None,
-                      help="Local: engine id. Remote: display name shown on the grid page.")
-    join.add_argument("--all", action="store_true", help="Join every detected engine.")
-    join.add_argument("--engine", default=None, help="Join only the detected engine of this kind.")
-    join.add_argument(
+    choose.add_argument("--all", action="store_true", help="Join every detected engine.")
+    choose.add_argument("--engine", default=None, help="Join only the detected engine of this kind.")
+
+    naming = join.add_argument_group("Name & display")
+    naming.add_argument("--name", default=None,
+                        help="Local: engine id. Remote: display name shown on the grid page.")
+    naming.add_argument(
         "--advertise-as",
         action="append",
         dest="advertise_as",
         default=[],
         help="Model name advertised to the grid. Repeat once per -m/--model.",
     )
-    join.add_argument("--endpoint-port", "--llama-port", type=int, default=8081)
-    join.add_argument("--heartbeat-interval", type=float, default=15.0)
-    join.add_argument("--ctx-size", type=int, default=None)
-    join.add_argument("--n-predict", type=int, default=None)
-    join.add_argument("--parallel", type=int, default=None)
-    join.add_argument("--flash-attn", default=None)
-    join.add_argument("--temp", type=float, default=None)
-    join.add_argument("--reasoning-budget", type=int, default=None)
-    join.add_argument("--comfyui-port", type=int, default=8188)
-    # local-only: remote has no inbound endpoint, so there is nothing to advertise (rejected in remote mode).
-    join.add_argument("--advertise-host", default=None)
-    join.add_argument("--media-port", type=int, default=8190)
+
+    tuning = join.add_argument_group("Built-in tuning (--serve)")
+    tuning.add_argument("--endpoint-port", "--llama-port", type=int, default=8081)
+    tuning.add_argument("--heartbeat-interval", type=float, default=15.0)
+    tuning.add_argument("--ctx-size", type=int, default=None)
+    tuning.add_argument("--n-predict", type=int, default=None)
+    tuning.add_argument("--parallel", type=int, default=None)
+    tuning.add_argument("--flash-attn", default=None)
+    tuning.add_argument("--temp", type=float, default=None)
+    tuning.add_argument("--reasoning-budget", type=int, default=None)
+
+    media = join.add_argument_group("Media")
+    media.add_argument("--comfyui-port", type=int, default=8188)
+    media.add_argument("--media-port", type=int, default=8190)
+
+    local_only = join.add_argument_group("Local only")
+    # A remote engine polls the relay outbound, so it has no inbound endpoint to advertise.
+    local_only.add_argument("--advertise-host", default=None,
+                            help="Host/IP to advertise this engine at (local only).")
+
+    remote_only = join.add_argument_group("Remote only")
     # Remote-only: billing + pull-based capacity + grid-page display (rejected in local). default=None
     # so a wrong-mode use is detectable.
-    join.add_argument("--engine-label", default=None,
-                      help="Remote-only: label for this engine's kind on the grid page.")
+    remote_only.add_argument("--engine-label", default=None,
+                             help="Remote-only: label for this engine's kind on the grid page.")
     # Deprecated: pricing now lives in the authoritative per-provider table — set it with
     # `grid price set` instead. Kept so old invocations don't hard-error; they no longer advertise a price.
-    join.add_argument("--pricing-input", type=float, default=None,
-                      help="Deprecated — use `grid price set`. (No longer advertises a price.)")
-    join.add_argument("--pricing-output", type=float, default=None,
-                      help="Deprecated — use `grid price set`. (No longer advertises a price.)")
-    join.add_argument("--max-concurrency", type=int, default=None,
-                      help="Remote-only: how many requests this engine serves at once.")
+    remote_only.add_argument("--pricing-input", type=float, default=None,
+                             help="Deprecated — use `grid price set`. (No longer advertises a price.)")
+    remote_only.add_argument("--pricing-output", type=float, default=None,
+                             help="Deprecated — use `grid price set`. (No longer advertises a price.)")
+    remote_only.add_argument("--max-concurrency", type=int, default=None,
+                             help="How many requests this engine serves at once (remote only).")
     join.set_defaults(handler=cmd_join)
 
     leave = sub.add_parser("leave", help="Stop and unregister engines from a grid")
-    leave.add_argument("grid", nargs="?", default=None)
+    leave.add_argument("grid", nargs="?", default=None,
+                       help="Grid name or id (ag-…). Omit for the active grid.")
     leave.add_argument("--engine", default=None,
-                       help="Local: engine id to leave. Remote: endpoint URL (or unique label) of one "
-                            "engine to drop from the grid's identity.")
-    leave.add_argument("--all", action="store_true", help="Leave every engine on this grid.")
+                       help="Engine to leave. Matches, in order: exact engine id, endpoint URL, a "
+                            "served model, or a URL fragment (e.g. :8000).")
+    leave.add_argument("--all", action="store_true",
+                       help="Leave every engine on this grid. Without --engine: a one-engine grid "
+                            "leaves that one; a multi-engine grid requires --all.")
     leave.set_defaults(handler=cmd_leave)
 
     models = sub.add_parser("models", help="Live models the grid can run now")
-    models.add_argument("grid", nargs="?", default=None)
+    models.add_argument("grid", nargs="?", default=None,
+                        help="Grid name or id (ag-…). Omit for the active grid.")
     models.add_argument("--verbose", action="store_true", help="Show the engine serving each model.")
     models.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
     models.set_defaults(handler=cmd_models)
 
     engines = sub.add_parser("engines", help="Live engines joined to a grid")
-    engines.add_argument("grid", nargs="?", default=None)
+    engines.add_argument("grid", nargs="?", default=None,
+                         help="Grid name or id (ag-…). Omit for the active grid.")
     engines.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
     engines.set_defaults(handler=cmd_engines)
 

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -129,7 +129,8 @@ def _add_engines(sub) -> None:
         help="Media bundle to advertise; repeat for multiple bundles.",
     )
     choose.add_argument("--all", action="store_true", help="Join every detected engine.")
-    choose.add_argument("--engine", default=None, help="Join only the detected engine of this kind.")
+    choose.add_argument("--kind", "--engine", dest="kind", default=None,
+                        help="Join only the detected engine of this kind (e.g. ollama, vllm).")
 
     naming = join.add_argument_group("Name & display")
     naming.add_argument("--name", default=None,

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -19,6 +19,7 @@ from .remote_grid import cmd_remote_members
 from .remote_price import cmd_remote_price
 from .engine import (
     cmd_engine_install,
+    cmd_engine_list,
     cmd_engine_pull,
     cmd_engine_start,
     cmd_engine_status,
@@ -382,7 +383,7 @@ def _add_price(sub) -> None:
 
 
 def _add_engine_setup(sub) -> None:
-    engine = sub.add_parser("engine", help="Set up the built-in engines")
+    engine = sub.add_parser("engine", help="Set up built-in engines and list live ones")
     engine_sub = engine.add_subparsers(dest="subcommand", required=True)
 
     install = engine_sub.add_parser("install", help="Install an engine: llama.cpp (text) or comfyui (media)")
@@ -421,6 +422,15 @@ def _add_engine_setup(sub) -> None:
 
     stop = engine_sub.add_parser("stop", help="Stop the built-in media engine (ComfyUI)")
     stop.set_defaults(handler=cmd_engine_stop)
+
+    # `grid engine ls`/`list`: live engines joined to the grid (mode-aware, like `grid engines`).
+    for verb, help_text in (("ls", "List live engines (like `grid engines`)"),
+                            ("list", "Alias for `grid engine ls`")):
+        engine_list = engine_sub.add_parser(verb, help=help_text)
+        engine_list.add_argument("grid", nargs="?", default=None,
+                                 help="Grid name or id (ag-…). Omit for the active grid.")
+        engine_list.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+        engine_list.set_defaults(handler=cmd_engine_list)
 
 
 def _add_media_common(parser: argparse.ArgumentParser) -> None:

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -166,7 +166,8 @@ def _add_engines(sub) -> None:
     # Remote-only: billing + pull-based capacity + grid-page display (rejected in local). default=None
     # so a wrong-mode use is detectable.
     remote_only.add_argument("--engine-label", default=None,
-                             help="Remote-only: label for this engine's kind on the grid page.")
+                             help="Deprecated — the grid page derives the engine kind automatically; "
+                                  "no longer changes display (remote only).")
     # Deprecated: pricing now lives in the authoritative per-provider table — set it with
     # `grid price set` instead. Kept so old invocations don't hard-error; they no longer advertise a price.
     remote_only.add_argument("--pricing-input", type=float, default=None,

--- a/cli/provider.py
+++ b/cli/provider.py
@@ -69,6 +69,8 @@ def _apply_inline_aliases(args: argparse.Namespace) -> None:
     reals: list[str] = []
     aliases: list[str] = []
     for item in models:
+        if item.count("=") != 1:
+            raise SystemExit(f"Inline alias {item!r} must be exactly one `real=alias` pair.")
         real, _, alias = item.partition("=")
         real, alias = real.strip(), alias.strip()
         if not real or not alias:
@@ -81,6 +83,8 @@ def _apply_inline_aliases(args: argparse.Namespace) -> None:
 
 def cmd_join(args: argparse.Namespace) -> int:
     _reject_remote_only_flags(args)
+    if args.serve and args.models:
+        raise SystemExit("--serve serves one built-in model; drop -m/--model (alias a built-in with --advertise-as).")
     _apply_inline_aliases(args)
     advertise_host = getattr(args, "advertise_host", None)
     cfg = config.select_grid(getattr(args, "grid", None))

--- a/cli/provider.py
+++ b/cli/provider.py
@@ -49,8 +49,39 @@ def _reject_remote_only_flags(args: argparse.Namespace) -> None:
         )
 
 
+def _apply_inline_aliases(args: argparse.Namespace) -> None:
+    """Desugar inline ``-m real=alias`` into the flat ``models`` / ``advertise_as`` lists both join
+    handlers already consume. Same contract as ``--advertise-as``: all-or-nothing across the -m/--model
+    values, and mutually exclusive with ``--advertise-as``. A no-op when no ``-m`` contains ``=``. Runs
+    before the record is built / ``args.models`` is read. Splits on the first ``=`` only — model names
+    can't contain ``=`` (ollama's ``:`` and media's ``comfyui:*`` are untouched)."""
+    serve = getattr(args, "serve", None)
+    if serve and "=" in serve:
+        raise SystemExit("`--serve` takes a bare model; alias it with `--advertise-as`, not `=`.")
+    models = list(getattr(args, "models", []) or [])
+    inline = [item for item in models if "=" in item]
+    if not inline:
+        return
+    if getattr(args, "advertise_as", None):
+        raise SystemExit("Use inline `-m real=alias` or `--advertise-as`, not both.")
+    if len(inline) != len(models):
+        raise SystemExit("Alias every -m/--model as `real=alias`, or none of them.")
+    reals: list[str] = []
+    aliases: list[str] = []
+    for item in models:
+        real, _, alias = item.partition("=")
+        real, alias = real.strip(), alias.strip()
+        if not real or not alias:
+            raise SystemExit(f"Inline alias {item!r} needs a non-empty model and alias (real=alias).")
+        reals.append(real)
+        aliases.append(alias)
+    args.models = reals
+    args.advertise_as = aliases
+
+
 def cmd_join(args: argparse.Namespace) -> int:
     _reject_remote_only_flags(args)
+    _apply_inline_aliases(args)
     advertise_host = getattr(args, "advertise_host", None)
     cfg = config.select_grid(getattr(args, "grid", None))
     grid_id = cfg["grid_id"]

--- a/cli/provider.py
+++ b/cli/provider.py
@@ -260,9 +260,7 @@ def cmd_leave(args: argparse.Namespace) -> int:
     if args.all:
         targets = list(records)
     elif args.engine:
-        if args.engine not in records:
-            raise SystemExit(f"No engine {args.engine!r} joined to {cfg['name']}.")
-        targets = [args.engine]
+        targets = [_resolve_leave_target(records, args.engine, cfg["name"])]
     elif len(records) == 1:
         targets = list(records)
     elif not records:
@@ -276,6 +274,37 @@ def cmd_leave(args: argparse.Namespace) -> int:
         _stop_engine(grid_id, engine_id, records[engine_id])
         print(f"Left engine {engine_id} on {cfg['name']}.")
     return 0
+
+
+def _resolve_leave_target(records: dict[str, dict[str, Any]], selector: str, grid_name: str) -> str:
+    """The engine id to leave for ``--engine <selector>``: an exact engine id wins; otherwise match by
+    endpoint URL, a served model, or a URL fragment — the same order as remote (ADR 0010 D-d)."""
+    if selector in records:
+        return selector
+    specs = [
+        {"id": engine_id, "endpoint_url": record.get("endpoint_url"),
+         "models": record.get("models") or [], "engine_label": None}  # local records carry no label
+        for engine_id, record in records.items()
+    ]
+    matched = run_records.match_engine(
+        specs, selector, label=grid_name, summary=_leave_summary(records),
+        hint="pass the exact engine id instead",
+    )
+    if not matched:
+        raise SystemExit(
+            f"No engine {selector!r} joined to {grid_name} (match by id, endpoint URL, a served "
+            f"model, or a URL fragment). Engines: {_leave_summary(records)}."
+        )
+    return str(matched[0]["id"])
+
+
+def _leave_summary(records: dict[str, dict[str, Any]]) -> str:
+    """A short human list of joined engines for a leave error / ambiguity message."""
+    parts = []
+    for engine_id, record in records.items():
+        models = ",".join(record.get("models") or [])
+        parts.append(f"{engine_id} [{models}]" if models else engine_id)
+    return "; ".join(parts)
 
 
 def _stop_engine(grid_id: str, engine_id: str, record: dict[str, Any]) -> None:

--- a/cli/provider.py
+++ b/cli/provider.py
@@ -79,10 +79,10 @@ def cmd_join(args: argparse.Namespace) -> int:
             "No running engine detected on this box. Point at one with "
             "`grid join --at <url> -m <model>`, or start the built-in engine with `grid join --serve <model>`."
         )
-    if args.engine:
-        detected = [engine for engine in detected if engine.label == args.engine]
+    if args.kind:
+        detected = [engine for engine in detected if engine.label == args.kind]
         if not detected:
-            raise SystemExit(f"No detected engine named {args.engine!r}. Run `grid join` to list them.")
+            raise SystemExit(f"No detected engine of kind {args.kind!r}. Run `grid join` to list them.")
     elif len(detected) > 1 and not args.all:
         _print_plan(detected)
         if _interactive():
@@ -90,7 +90,7 @@ def cmd_join(args: argparse.Namespace) -> int:
                 print("Nothing joined.")
                 return 0
         else:
-            raise SystemExit("Multiple engines detected; pass --all, --engine <kind>, or --at <url>.")
+            raise SystemExit("Multiple engines detected; pass --all, --kind <kind>, or --at <url>.")
 
     used: set[str] = set()
     rc = 0
@@ -501,7 +501,7 @@ def _print_plan(detected: list[Any]) -> None:
     for engine in detected:
         models = ",".join(engine.models) or ("comfyui" if engine.media else "(no models listed)")
         print(f"  {engine.label:<12} {engine.endpoint_url:<34} {models}")
-    print("\nJoin them:\n  grid join --all\n  grid join --engine <kind>")
+    print("\nJoin them:\n  grid join --all\n  grid join --kind <kind>")
 
 
 def _interactive() -> bool:

--- a/cli/remote_grid.py
+++ b/cli/remote_grid.py
@@ -213,7 +213,10 @@ def cmd_remote_ls(args: argparse.Namespace) -> int:
     nets = _networks()  # local only — `grid login` already fetched these; no network call
     active = state.get_active("remote")
     if args.json:
-        print(json.dumps([{"grid": n.get("name"), "type": n.get("network_type")} for n in nets], indent=2))
+        print(json.dumps(
+            [{"grid": n.get("name"), "type": n.get("network_type"), "id": n.get("network_id")} for n in nets],
+            indent=2,
+        ))
         return 0
     if not nets:
         print("(no grids — run `grid up <name>` to bring one online)")
@@ -221,7 +224,7 @@ def cmd_remote_ls(args: argparse.Namespace) -> int:
     for net in nets:
         is_active = active and (net.get("network_id") == active or net.get("name") == active)
         marker = "* " if is_active else "  "
-        print(f"{marker}{net.get('name') or ''}\t{net.get('network_type') or ''}")
+        print(f"{marker}{net.get('name') or ''}\t{net.get('network_id') or ''}\t{net.get('network_type') or ''}")
     return 0
 
 

--- a/cli/remote_provider.py
+++ b/cli/remote_provider.py
@@ -364,10 +364,10 @@ def _resolve_serve_targets(args: argparse.Namespace) -> tuple[list[dict[str, obj
             "No running engine detected on this box. Point at one with "
             "`grid join --at <url> -m <model>`, or start the built-in engine with `grid join --serve <model>`."
         )
-    if args.engine:
-        detected = [engine for engine in detected if engine.label == args.engine]
+    if args.kind:
+        detected = [engine for engine in detected if engine.label == args.kind]
         if not detected:
-            raise SystemExit(f"No detected engine named {args.engine!r}. Run `grid join` to list them.")
+            raise SystemExit(f"No detected engine of kind {args.kind!r}. Run `grid join` to list them.")
 
     media_detected = any(engine.media for engine in detected)
     text = [engine for engine in detected if not engine.media]
@@ -377,7 +377,7 @@ def _resolve_serve_targets(args: argparse.Namespace) -> tuple[list[dict[str, obj
             if not provider._confirm("Join all detected engines?"):
                 return [], False
         else:
-            raise SystemExit("Multiple engines detected; pass --all, --engine <kind>, or --at <url>.")
+            raise SystemExit("Multiple engines detected; pass --all, --kind <kind>, or --at <url>.")
     return [
         {"endpoint_url": engine.endpoint_url, "models": list(engine.models), "engine_label": engine.label}
         for engine in text

--- a/cli/remote_provider.py
+++ b/cli/remote_provider.py
@@ -57,6 +57,12 @@ def cmd_remote_join(args: argparse.Namespace) -> int:
             "Set your model price with `grid price set` after joining.",
             file=sys.stderr,
         )
+    if getattr(args, "engine_label", None) is not None:
+        print(
+            "Note: --engine-label is deprecated and no longer changes the grid page — the engine's kind "
+            "is derived automatically. (It still matches `grid leave --engine <label>`.)",
+            file=sys.stderr,
+        )
     if args.at and args.serve:
         raise SystemExit("Use either --at (point at an existing engine) or --serve, not both.")
 

--- a/cli/remote_provider.py
+++ b/cli/remote_provider.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import signal
 import socket
 import subprocess
 import sys
@@ -105,7 +106,13 @@ def cmd_remote_join(args: argparse.Namespace) -> int:
             args, network_id, engine_id, signaling_url, merged_specs,
             media=media, meta_name=meta_name, bundles=bundles,
         )
-        _respawn_identity(network_id, record, live)  # stops prior process(es) then respawns; aborts on failure
+        # Zero-drop when we can: SIGHUP the live singleton to hot-reload the union in place. Fall back to
+        # stop-respawn for a first join, a legacy/pre-handler process, a launch, or a media change.
+        reloaded = _hot_reloadable(live, merged_specs, record)
+        if reloaded:
+            reloaded = _hot_reload_identity(network_id, record, live)  # False if it fell back to a respawn
+        else:
+            _respawn_identity(network_id, record, live)  # stops prior process(es) then respawns; aborts on failure
 
     appended = bool(live)
     verb = "Appended to" if appended else "Joining"
@@ -119,8 +126,11 @@ def cmd_remote_join(args: argparse.Namespace) -> int:
     if media:  # the comfyui:* models are resolved from bundle gating at serve time, not here
         print("media=on (serving comfyui:* workflows via the relay)")
     print(f"log={paths.engines_dir(network_id) / f'{engine_id}.log'}")
-    # The relay isn't locally pollable, so we can't confirm "registered" here — report starting.
-    print(f"(starting — stop with `grid leave {label}`)")
+    if reloaded:  # the live process re-advertised in place — nothing restarted, nothing dropped
+        print(f"(hot-reloaded — no in-flight requests dropped; stop with `grid leave {label}`)")
+    else:
+        # The relay isn't locally pollable, so we can't confirm "registered" here — report starting.
+        print(f"(starting — stop with `grid leave {label}`)")
     return 0
 
 
@@ -208,12 +218,75 @@ def _reject_unserveable_union(
             "The built-in engine (`--serve`) serves a single model and can't join a multi-engine "
             "identity. Run `grid leave`, then re-join every engine as external `--at <url> -m <model>`."
         )
+    # --advertise-as aliases don't merge across joins (the record's `advertise_as` is a flat, positionally
+    # keyed list), so appending onto — or with — an alias would drop an alias or mismatch the alias/model
+    # counts (which crashes the reload's _advertised_models). Reject any changing append touching aliases;
+    # the no-op case already returned earlier, so `live` here means a real change (ADR 0009).
     aliased = bool(getattr(args, "advertise_as", []) or []) or any(rec.get("advertise_as") for rec in live)
-    if len(merged_specs) > 1 and aliased:
+    if aliased and (len(merged_specs) > 1 or live):
         raise SystemExit(
-            "--advertise-as aliases a single engine; this identity would serve several. Run `grid leave`, "
-            "then re-join every engine without --advertise-as."
+            "--advertise-as aliases are single-engine and don't merge across joins. Run `grid leave`, "
+            "then re-join every engine in one command with its -m/--advertise-as pairs."
         )
+
+
+def _media_key(record: dict[str, object]) -> tuple[bool, tuple[str, ...], int, int]:
+    """See ``shared.run_records.media_signature`` — one shared definition so this hot-reload-vs-respawn
+    decision and the serve loop's reload guard can't desync (ADR 0009 C3)."""
+    return run_records.media_signature(record)
+
+
+def _hot_reloadable(
+    live: list[dict[str, object]], merged_specs: list[dict[str, object]], record: dict[str, object]
+) -> bool:
+    """Whether this update can be SIGHUP-hot-reloaded into the live singleton (zero-drop) instead of a
+    stop-respawn. True only when the SOLE live process is the singleton, it was started by a build that
+    installs the SIGHUP reload handler (``reload_signal``), the merged union is external-only, and the
+    media config is unchanged. Everything else — a first join, a legacy/pre-handler sibling, a built-in
+    ``--serve`` launch, or any media/bundle change — still respawns (ADR 0009 D3 / C1 / C3).
+    """
+    if len(live) != 1:
+        return False
+    singleton = live[0]
+    if singleton.get("engine_id") != _REMOTE_IDENTITY:
+        return False
+    if singleton.get("reload_signal") != "sighup":  # a pre-Slice-2 process has no SIGHUP handler (C1)
+        return False
+    if any(not spec.get("endpoint_url") for spec in merged_specs):  # a built-in --serve needs a launch
+        return False
+    return _media_key(record) == _media_key(singleton)  # a media/bundle change needs a bring-up (C3)
+
+
+def _signal_reload(pid: int) -> None:
+    """SIGHUP the live singleton so it hot-reloads the merged record in place — no restart, no dropped
+    in-flight requests (ADR 0009 D3)."""
+    os.kill(pid, signal.SIGHUP)
+
+
+def _hot_reload_identity(
+    network_id: str, record: dict[str, object], live: list[dict[str, object]]
+) -> bool:
+    """Write the merged record then SIGHUP the live singleton so it re-advertises the union in place. The
+    process keeps its pid; write BEFORE signalling so the reload reads the new record (ADR 0009 D3).
+
+    Returns ``True`` if it hot-reloaded in place, ``False`` if it had to fall back to a respawn — so the
+    caller reports honestly instead of claiming zero-drop. The fallback fires when the singleton vanished
+    between the liveness check and the signal (``os.kill`` raises ``ProcessLookupError``); the residual
+    PID-reuse TOCTOU (same window, pid recycled to an unrelated process) is shared with
+    ``run_records.terminate_pid`` and not fully fixable without pidfd.
+    """
+    pid = int(live[0].get("pid") or 0)
+    if pid <= 0:  # defensive: a live singleton always has a real pid, and os.kill(0) hits our own group
+        _respawn_identity(network_id, record, live)
+        return False
+    record["pid"] = pid
+    run_records.write_record(network_id, _REMOTE_IDENTITY, record)
+    try:
+        _signal_reload(pid)
+        return True
+    except ProcessLookupError:  # the process died between the liveness check and the signal — respawn
+        _respawn_identity(network_id, record, [])
+        return False
 
 
 def _respawn_identity(
@@ -352,6 +425,9 @@ def _build_record(
 
     return {
         "engine_id": engine_id,
+        # Written by a build whose serve loop installs the SIGHUP reload handler, so a later `grid
+        # join`/`leave` can hot-reload this identity in place instead of stop-respawning it (ADR 0009 C1).
+        "reload_signal": "sighup",
         "node_id": f"node-{uuid.uuid4().hex[:12]}",
         "grid_id": network_id,  # the remote network_id doubles as the run record's grid_id
         "meta_name": meta_name,  # grid-page display name (--name, or hostname); NOT the record key
@@ -447,7 +523,10 @@ def _leave_one_engine(
     union = _engine_union(survivors)
     to_drop = _drop_spec(union, args.engine, label)
     if not to_drop:
-        raise SystemExit(f"No engine {args.engine!r} serving on {label}. Run `grid engines {label}` to list them.")
+        raise SystemExit(
+            f"No engine {args.engine!r} on {label} (match by endpoint URL, a served model, or a URL "
+            f"fragment). Engines: {_engines_summary(union)}."
+        )
     drop_ids = {id(spec) for spec in to_drop}  # filter by identity — value-equal specs must not both drop
     remaining = [spec for spec in union if id(spec) not in drop_ids]
     media = any(bool(rec.get("media")) for rec in survivors)
@@ -463,25 +542,55 @@ def _leave_one_engine(
     # a job for the just-dropped model now forwards to the survivor instead of erroring; existing semantics.)
     record = dict(next(iter(survivors)))
     record["engine_id"] = _REMOTE_IDENTITY
+    record["reload_signal"] = "sighup"  # stamp it so a pre-handler identity self-heals on leave (like join)
     record["engines"] = remaining
     record["models"] = list(dict.fromkeys(m for spec in remaining for m in spec.get("models") or []))
     record["endpoint_url"] = remaining[0]["endpoint_url"] if len(remaining) == 1 else None
     record["media"] = media  # recompute from the survivors, don't inherit the arbitrary template's flag
     record["media_bundles"] = list(dict.fromkeys(b for rec in survivors for b in (rec.get("media_bundles") or [])))
-    _respawn_identity(network_id, record, survivors)  # aborts on a stuck prior / raises on a dead respawn
+    if _hot_reloadable(survivors, remaining, record):
+        _hot_reload_identity(network_id, record, survivors)  # SIGHUP the survivor — zero-drop shrink
+    else:
+        _respawn_identity(network_id, record, survivors)  # aborts on a stuck prior / raises on a dead respawn
     print(f"Dropped {args.engine!r} from {label}; re-serving {len(remaining)} engine(s).")
     return 0
+
+
+def _engines_summary(union: list[dict[str, object]]) -> str:
+    """A short human list of an identity's engines for a leave error / ambiguity message."""
+    parts = []
+    for spec in union:
+        url = spec.get("endpoint_url") or "(built-in)"
+        models = ",".join(spec.get("models") or [])
+        parts.append(f"{url} [{models}]" if models else str(url))
+    return "; ".join(parts)
 
 
 def _drop_spec(
     union: list[dict[str, object]], selector: str, label: str
 ) -> list[dict[str, object]]:
-    """The spec(s) to remove for ``selector``: an exact ``endpoint_url`` match (unique in the union), else
-    a ``engine_label`` match — ambiguous when a label is shared, so require the URL then."""
+    """The spec(s) to remove for ``selector``, tried in order: exact ``endpoint_url``, exact
+    ``engine_label``, a served model, then a URL substring (host/port). Each non-URL match must resolve to
+    ONE engine or it errors and lists the engines — so `grid leave --engine mistral` (by model) or
+    `grid leave --engine :8000` (by port) work, not just the full URL."""
+
+    def unique(matches: list[dict[str, object]], how: str) -> list[dict[str, object]]:
+        if len(matches) > 1:
+            raise SystemExit(
+                f"{how} {selector!r} matches several engines on {label}; pass the exact endpoint URL "
+                f"instead. Engines: {_engines_summary(union)}."
+            )
+        return matches
+
     by_url = [spec for spec in union if spec.get("endpoint_url") == selector]
     if by_url:
         return by_url
-    by_label = [spec for spec in union if spec.get("engine_label") == selector]
-    if len(by_label) > 1:
-        raise SystemExit(f"Several engines are labelled {selector!r} on {label}; pass the endpoint URL instead.")
-    return by_label
+    by_label = unique([spec for spec in union if spec.get("engine_label") == selector], "Label")
+    if by_label:
+        return by_label
+    by_model = unique([spec for spec in union if selector in (spec.get("models") or [])], "Model")
+    if by_model:
+        return by_model
+    return unique(
+        [spec for spec in union if selector in (spec.get("endpoint_url") or "")], "URL fragment"
+    )

--- a/cli/remote_provider.py
+++ b/cli/remote_provider.py
@@ -44,25 +44,31 @@ def _reject_local_only_flags(args: argparse.Namespace) -> None:
         )
 
 
+def _warn_deprecated(triggered: bool, message: str) -> None:
+    """Print a one-line deprecation note to stderr when a deprecated flag was used."""
+    if triggered:
+        print(message, file=sys.stderr)
+
+
 def cmd_remote_join(args: argparse.Namespace) -> int:
     from remote import credentials
 
     from . import provider, remote_grid
 
     _reject_local_only_flags(args)
+    if args.serve and args.models:
+        raise SystemExit("--serve serves one built-in model; drop -m/--model (alias a built-in with --advertise-as).")
     provider._apply_inline_aliases(args)
-    if getattr(args, "pricing_input", None) is not None or getattr(args, "pricing_output", None) is not None:
-        print(
-            "Note: --pricing-input/--pricing-output are deprecated and no longer advertise a price. "
-            "Set your model price with `grid price set` after joining.",
-            file=sys.stderr,
-        )
-    if getattr(args, "engine_label", None) is not None:
-        print(
-            "Note: --engine-label is deprecated and no longer changes the grid page — the engine's kind "
-            "is derived automatically. (It still matches `grid leave --engine <label>`.)",
-            file=sys.stderr,
-        )
+    _warn_deprecated(
+        getattr(args, "pricing_input", None) is not None or getattr(args, "pricing_output", None) is not None,
+        "Note: --pricing-input/--pricing-output are deprecated and no longer advertise a price. "
+        "Set your model price with `grid price set` after joining.",
+    )
+    _warn_deprecated(
+        getattr(args, "engine_label", None) is not None,
+        "Note: --engine-label is deprecated and no longer changes the grid page — the engine's kind "
+        "is derived automatically. (It still matches `grid leave --engine <label>`.)",
+    )
     if args.at and args.serve:
         raise SystemExit("Use either --at (point at an existing engine) or --serve, not both.")
 

--- a/cli/remote_provider.py
+++ b/cli/remote_provider.py
@@ -576,28 +576,7 @@ def _engines_summary(union: list[dict[str, object]]) -> str:
 def _drop_spec(
     union: list[dict[str, object]], selector: str, label: str
 ) -> list[dict[str, object]]:
-    """The spec(s) to remove for ``selector``, tried in order: exact ``endpoint_url``, exact
-    ``engine_label``, a served model, then a URL substring (host/port). Each non-URL match must resolve to
-    ONE engine or it errors and lists the engines — so `grid leave --engine mistral` (by model) or
-    `grid leave --engine :8000` (by port) work, not just the full URL."""
-
-    def unique(matches: list[dict[str, object]], how: str) -> list[dict[str, object]]:
-        if len(matches) > 1:
-            raise SystemExit(
-                f"{how} {selector!r} matches several engines on {label}; pass the exact endpoint URL "
-                f"instead. Engines: {_engines_summary(union)}."
-            )
-        return matches
-
-    by_url = [spec for spec in union if spec.get("endpoint_url") == selector]
-    if by_url:
-        return by_url
-    by_label = unique([spec for spec in union if spec.get("engine_label") == selector], "Label")
-    if by_label:
-        return by_label
-    by_model = unique([spec for spec in union if selector in (spec.get("models") or [])], "Model")
-    if by_model:
-        return by_model
-    return unique(
-        [spec for spec in union if selector in (spec.get("endpoint_url") or "")], "URL fragment"
-    )
+    """The spec(s) to remove for ``selector`` — exact endpoint_url → engine_label → served model → URL
+    substring — via the shared matcher (`shared.run_records.match_engine`). Remote engines are keyed by
+    URL/label, so no exact-id short-circuit here (that's the local caller's job)."""
+    return run_records.match_engine(union, selector, label=label, summary=_engines_summary(union))

--- a/cli/remote_provider.py
+++ b/cli/remote_provider.py
@@ -15,12 +15,21 @@ from __future__ import annotations
 
 import argparse
 import os
+import socket
 import subprocess
 import sys
 import time
 import uuid
 
 from shared import paths, run_records
+from shared.filelock import file_lock
+
+# Remote has exactly ONE identity per grid: the relay node_id is pinned to the per-grid access token
+# (remote/serve._node_id_from_token), so two `grid join`s on a grid would register the same node and
+# clobber each other. The run record is therefore a singleton keyed by this constant — one file
+# engines_dir(<network_id>)/remote.json — and repeated joins are additive (ADR 0009). `--name` no longer
+# keys the record (it can't mint a second identity); it is the grid-page display name (record["meta_name"]).
+_REMOTE_IDENTITY = "remote"
 
 
 def _reject_local_only_flags(args: argparse.Namespace) -> None:
@@ -67,18 +76,173 @@ def cmd_remote_join(args: argparse.Namespace) -> int:
     if not specs and not media:  # engines detected and the operator declined, or nothing to serve
         print("Nothing joined.")
         return 0
-    if len(specs) > 1 and (getattr(args, "advertise_as", []) or []):
-        raise SystemExit("--advertise-as serves a single engine; it can't alias the union of --all.")
-    _warn_shadowed_models(specs)  # the detached loop logs this too, but show it on the operator's terminal
+    engine_id = _REMOTE_IDENTITY
+    meta_name = getattr(args, "name", None) or socket.gethostname()
 
-    engine_id = getattr(args, "name", None) or f"engine-{uuid.uuid4().hex[:8]}"
-    existing = run_records.read_record(network_id, engine_id)
-    if existing and run_records.pid_alive(int(existing.get("pid") or 0)):
-        raise SystemExit(f"Engine {engine_id!r} is already joined to {label}. Use a different --name.")
+    # Remote has ONE identity per grid (the token pins the relay node_id), so `grid join` is additive:
+    # merge this join's engines into whatever is already serving, then respawn the single detached engine.
+    # The read-merge-write is serialized so two concurrent joins can't lost-update the union (ADR 0009).
+    with file_lock(run_records.record_path(network_id, engine_id)):
+        live = _live_records(network_id)  # normally just the singleton; also legacy `engine-<uuid>` on upgrade
+        merged_specs, changed = _merge_engines(_engine_union(live), specs)
+        base_media = any(bool(rec.get("media")) for rec in live)
+        media = base_media or media
+        base_bundles = list(dict.fromkeys(b for rec in live for b in (rec.get("media_bundles") or [])))
+        bundles = list(dict.fromkeys(base_bundles + list(getattr(args, "bundles", []) or [])))
+        # An idempotent re-join (no new engine/model, and no display-name/media/bundle change) is a no-op,
+        # so it doesn't needlessly restart a live identity. A change in ANY of those does respawn to apply
+        # it — there is no other way to rename or add a bundle in Slice 1.
+        if (
+            live and not changed and media == base_media and bundles == base_bundles
+            and meta_name == _identity_field(live, "meta_name")
+        ):
+            print(f"Already serving on {label}; nothing to append.")
+            return 0
+        _reject_unserveable_union(merged_specs, args, live)
+        _warn_shadowed_models(merged_specs)  # the serve loop logs this too; show it on the operator's terminal
 
-    record = _build_record(args, network_id, engine_id, signaling_url, specs, media=media)
+        record = _build_record(
+            args, network_id, engine_id, signaling_url, merged_specs,
+            media=media, meta_name=meta_name, bundles=bundles,
+        )
+        _respawn_identity(network_id, record, live)  # stops prior process(es) then respawns; aborts on failure
+
+    appended = bool(live)
+    verb = "Appended to" if appended else "Joining"
+    print(f"{verb} {label} (pid={record['pid']}) — {'re-serving' if appended else 'serving'} the union via the relay.")
+    if len(record["engines"]) > 1:
+        print(f"engines={len(record['engines'])} (serving the union under one identity)")
+    elif record["endpoint_url"]:
+        print(f"endpoint_url={record['endpoint_url']}")
+    if record["models"]:
+        print(f"models={','.join(record['models'])}")
+    if media:  # the comfyui:* models are resolved from bundle gating at serve time, not here
+        print("media=on (serving comfyui:* workflows via the relay)")
+    print(f"log={paths.engines_dir(network_id) / f'{engine_id}.log'}")
+    # The relay isn't locally pollable, so we can't confirm "registered" here — report starting.
+    print(f"(starting — stop with `grid leave {label}`)")
+    return 0
+
+
+def _live_records(network_id: str) -> list[dict[str, object]]:
+    """Every remote run record for this grid whose detached process is still alive. Normally that's just
+    the singleton ``remote.json``; on upgrade it also catches legacy ``engine-<uuid>`` records so the join
+    can adopt their engines and stop their processes (they share the token node_id)."""
+    return [
+        rec for rec in run_records.read_records(network_id).values()
+        if run_records.pid_alive(int(rec.get("pid") or 0))
+    ]
+
+
+def _flat_spec(record: dict[str, object]) -> dict[str, object]:
+    """One engine spec synthesised from a record written before the multi-engine ``engines`` field
+    (mirrors ``remote/serve._flat_spec``) so an old-format live record is still adopted, not dropped."""
+    return {
+        "endpoint_url": record.get("endpoint_url"),
+        "models": list(record.get("models") or []),
+        "engine_label": record.get("engine_label"),
+    }
+
+
+def _spec_key(spec: dict[str, object]) -> object:
+    """Identity of an engine for dedup/merge: its endpoint URL, or — for the built-in ``--serve`` engine,
+    which has no URL — a marker plus its model set, so re-joining the same built-in is recognised."""
+    url = spec.get("endpoint_url")
+    return url if url else ("__builtin__", tuple(spec.get("models") or []))
+
+
+def _merge_engines(
+    base: list[dict[str, object]], incoming: list[dict[str, object]]
+) -> tuple[list[dict[str, object]], bool]:
+    """Merge ``incoming`` specs into a fresh copy of ``base``. The same engine (by ``_spec_key``) unions its
+    models; a new engine is appended. Returns ``(merged, changed)`` where ``changed`` is True only when a
+    model or engine was actually added — so an idempotent re-join (including adding a model to an engine
+    already in the union) stays a no-op instead of silently dropping the request."""
+    merged = [dict(spec) for spec in base]
+    index = {_spec_key(spec): spec for spec in merged}
+    changed = False
+    for spec in incoming:
+        existing = index.get(_spec_key(spec))
+        if existing is None:
+            copy = dict(spec)
+            copy["models"] = list(copy.get("models") or [])
+            merged.append(copy)
+            index[_spec_key(copy)] = copy
+            changed = True
+            continue
+        added = [m for m in (spec.get("models") or []) if m not in (existing.get("models") or [])]
+        if added:
+            existing["models"] = list(existing.get("models") or []) + added
+            changed = True
+    return merged, changed
+
+
+def _engine_union(records: list[dict[str, object]]) -> list[dict[str, object]]:
+    """The merged union of every engine across ``records`` (same engine → models unioned). A record with no
+    ``engines`` array falls back to a flat spec so a pre-multi-engine live record isn't silently lost."""
+    union: list[dict[str, object]] = []
+    for record in records:
+        specs = record.get("engines")
+        if not specs and (record.get("endpoint_url") or record.get("models")):
+            specs = [_flat_spec(record)]
+        union, _ = _merge_engines(union, specs or [])
+    return union
+
+
+def _identity_field(live: list[dict[str, object]], key: str) -> object:
+    """One field of the live identity — the singleton's if present, else the first live record's."""
+    for record in live:
+        if record.get("engine_id") == _REMOTE_IDENTITY:
+            return record.get(key)
+    return live[0].get(key) if live else None
+
+
+def _reject_unserveable_union(
+    merged_specs: list[dict[str, object]], args: argparse.Namespace, live: list[dict[str, object]]
+) -> None:
+    """Guard the merged union: the built-in engine can't join a multi-engine identity (external-only,
+    ADR 0007 D4), and ``--advertise-as`` aliases only a single engine (so appending onto an already-aliased
+    identity is rejected rather than silently dropping the alias)."""
+    if len(merged_specs) > 1 and any(not spec.get("endpoint_url") for spec in merged_specs):
+        raise SystemExit(
+            "The built-in engine (`--serve`) serves a single model and can't join a multi-engine "
+            "identity. Run `grid leave`, then re-join every engine as external `--at <url> -m <model>`."
+        )
+    aliased = bool(getattr(args, "advertise_as", []) or []) or any(rec.get("advertise_as") for rec in live)
+    if len(merged_specs) > 1 and aliased:
+        raise SystemExit(
+            "--advertise-as aliases a single engine; this identity would serve several. Run `grid leave`, "
+            "then re-join every engine without --advertise-as."
+        )
+
+
+def _respawn_identity(
+    network_id: str, record: dict[str, object], priors: list[dict[str, object]]
+) -> None:
+    """Stop the prior process(es), then write ``record`` and (re)spawn the one detached engine, setting
+    ``record["pid"]``. Shared by join-append and leave-shrink (respawn is Slice 1's update mechanism).
+
+    Aborts (SystemExit) BEFORE spawning if any prior can't be confirmed stopped — a second live child on
+    the same token-pinned node_id would clobber it (the original bug). Raises if the fresh process dies
+    during start-up: the grid is left not serving either way, so the operator must know.
+    """
+    engine_id = _REMOTE_IDENTITY
+    undead: list[str] = []
+    for prior in priors:
+        if not run_records.terminate_pid(int(prior.get("pid") or 0)):
+            undead.append(str(prior.get("pid")))
+            continue
+        prior_id = str(prior.get("engine_id") or "")
+        if prior_id and prior_id != engine_id:  # drop a legacy record's file so only the singleton remains
+            run_records.record_path(network_id, prior_id).unlink(missing_ok=True)
+    if undead:
+        raise SystemExit(
+            f"Could not stop the engine(s) already serving this grid (pid(s) {', '.join(undead)}); they may "
+            "still be registered on the relay. Investigate before re-joining — starting another would clobber them."
+        )
+
+    record["pid"] = 0
     run_records.write_record(network_id, engine_id, record)
-
     proc = _spawn_remote_engine(network_id, engine_id)
     record["pid"] = proc.pid
     run_records.write_record(network_id, engine_id, record)
@@ -89,22 +253,9 @@ def cmd_remote_join(args: argparse.Namespace) -> int:
         from . import provider
 
         raise SystemExit(
-            f"Engine {engine_id} exited before it started. See {log_path}:\n{provider._log_tail(log_path)}"
+            f"Engine exited before it started — the grid is not serving now. See {log_path}:\n"
+            f"{provider._log_tail(log_path)}"
         )
-
-    print(f"Joining engine {engine_id} to {label} (pid={proc.pid}) — serving via the relay.")
-    if len(specs) > 1:
-        print(f"engines={len(specs)} (serving the union under one identity)")
-    elif record["endpoint_url"]:
-        print(f"endpoint_url={record['endpoint_url']}")
-    if record["models"]:
-        print(f"models={','.join(record['models'])}")
-    if media:  # the comfyui:* models are resolved from bundle gating at serve time, not here
-        print("media=on (serving comfyui:* workflows via the relay)")
-    print(f"log={log_path}")
-    # The relay isn't locally pollable, so we can't confirm "registered" here — report starting.
-    print(f"(starting — stop with `grid leave {label} --engine {engine_id}`)")
-    return 0
 
 
 def _resolve_serve_targets(args: argparse.Namespace) -> tuple[list[dict[str, object]], bool]:
@@ -183,6 +334,8 @@ def _build_record(
     signaling_url: str,
     specs: list[dict[str, object]],
     media: bool = False,
+    meta_name: str | None = None,
+    bundles: list[str] | None = None,
 ) -> dict[str, object]:
     """The remote engine's run record — non-secret routing only; the token stays in credentials.toml.
 
@@ -201,13 +354,14 @@ def _build_record(
         "engine_id": engine_id,
         "node_id": f"node-{uuid.uuid4().hex[:12]}",
         "grid_id": network_id,  # the remote network_id doubles as the run record's grid_id
+        "meta_name": meta_name,  # grid-page display name (--name, or hostname); NOT the record key
         "pid": 0,
         "signaling_url": signaling_url,
         "endpoint_url": single_endpoint,
         "models": union,
         "engines": specs,
         "media": bool(media),
-        "media_bundles": list(getattr(args, "bundles", []) or []),
+        "media_bundles": list(bundles if bundles is not None else (getattr(args, "bundles", []) or [])),
         "comfyui_port": getattr(args, "comfyui_port", 8188),
         "media_port": getattr(args, "media_port", 8190),
         "advertise_as": list(getattr(args, "advertise_as", []) or []),
@@ -264,24 +418,70 @@ def cmd_remote_leave(args: argparse.Namespace) -> int:
     rec = remote_grid._select(getattr(args, "grid", None))
     network_id = remote_grid._network_id(rec)
     label = rec.get("name") or network_id
-    records = run_records.read_records(network_id)
 
-    if args.all:
-        targets = list(records)
-    elif args.engine:
-        if args.engine not in records:
-            raise SystemExit(f"No engine {args.engine!r} joined to {label}.")
-        targets = [args.engine]
-    elif len(records) == 1:
-        targets = list(records)
-    elif not records:
-        print(f"No engines joined to {label}.")
+    with file_lock(run_records.record_path(network_id, _REMOTE_IDENTITY)):
+        records = run_records.read_records(network_id)
+        if not records:
+            print(f"No engines joined to {label}.")
+            return 0
+        # `--engine <endpoint_url|label>` drops one engine from the union; anything else (bare / `--all`)
+        # tears down the whole identity — remote has one identity per grid, so both mean the same here.
+        if args.engine and not args.all:
+            return _leave_one_engine(args, network_id, label, records)
+        for engine_id, record in records.items():
+            run_records.stop_engine(network_id, engine_id, record)
+        print(f"Left {label}.")
         return 0
-    else:
-        names = ", ".join(sorted(records))
-        raise SystemExit(f"Several engines joined ({names}); pass --engine <id> or --all.")
 
-    for engine_id in targets:
-        run_records.stop_engine(network_id, engine_id, records[engine_id])
-        print(f"Left engine {engine_id} on {label}.")
+
+def _leave_one_engine(
+    args: argparse.Namespace, network_id: str, label: str, records: dict[str, dict[str, object]]
+) -> int:
+    """Drop the engine matching ``--engine`` (endpoint URL, or a unique label) from the identity's union.
+
+    Removing the last text engine (with no media) tears the whole identity down; otherwise the singleton
+    is respawned serving the reduced union. Operates on the live record(s), adopting any legacy sibling.
+    """
+    survivors = [rec for rec in records.values() if run_records.pid_alive(int(rec.get("pid") or 0))]
+    survivors = survivors or list(records.values())
+    union = _engine_union(survivors)
+    to_drop = _drop_spec(union, args.engine, label)
+    if not to_drop:
+        raise SystemExit(f"No engine {args.engine!r} serving on {label}. Run `grid engines {label}` to list them.")
+    drop_ids = {id(spec) for spec in to_drop}  # filter by identity — value-equal specs must not both drop
+    remaining = [spec for spec in union if id(spec) not in drop_ids]
+    media = any(bool(rec.get("media")) for rec in survivors)
+
+    if not remaining and not media:  # nothing left to serve → tear the whole identity down
+        for engine_id, record in records.items():
+            run_records.stop_engine(network_id, engine_id, record)
+        print(f"Left {label} (removed the last engine).")
+        return 0
+
+    # Rebuild the singleton from the identity's own record, minus the dropped engine, and respawn it.
+    # (When one engine remains, `remote/serve._ServeState.route()` falls back to it for an unknown model —
+    # a job for the just-dropped model now forwards to the survivor instead of erroring; existing semantics.)
+    record = dict(next(iter(survivors)))
+    record["engine_id"] = _REMOTE_IDENTITY
+    record["engines"] = remaining
+    record["models"] = list(dict.fromkeys(m for spec in remaining for m in spec.get("models") or []))
+    record["endpoint_url"] = remaining[0]["endpoint_url"] if len(remaining) == 1 else None
+    record["media"] = media  # recompute from the survivors, don't inherit the arbitrary template's flag
+    record["media_bundles"] = list(dict.fromkeys(b for rec in survivors for b in (rec.get("media_bundles") or [])))
+    _respawn_identity(network_id, record, survivors)  # aborts on a stuck prior / raises on a dead respawn
+    print(f"Dropped {args.engine!r} from {label}; re-serving {len(remaining)} engine(s).")
     return 0
+
+
+def _drop_spec(
+    union: list[dict[str, object]], selector: str, label: str
+) -> list[dict[str, object]]:
+    """The spec(s) to remove for ``selector``: an exact ``endpoint_url`` match (unique in the union), else
+    a ``engine_label`` match — ambiguous when a label is shared, so require the URL then."""
+    by_url = [spec for spec in union if spec.get("endpoint_url") == selector]
+    if by_url:
+        return by_url
+    by_label = [spec for spec in union if spec.get("engine_label") == selector]
+    if len(by_label) > 1:
+        raise SystemExit(f"Several engines are labelled {selector!r} on {label}; pass the endpoint URL instead.")
+    return by_label

--- a/cli/remote_provider.py
+++ b/cli/remote_provider.py
@@ -47,9 +47,10 @@ def _reject_local_only_flags(args: argparse.Namespace) -> None:
 def cmd_remote_join(args: argparse.Namespace) -> int:
     from remote import credentials
 
-    from . import remote_grid
+    from . import provider, remote_grid
 
     _reject_local_only_flags(args)
+    provider._apply_inline_aliases(args)
     if getattr(args, "pricing_input", None) is not None or getattr(args, "pricing_output", None) is not None:
         print(
             "Note: --pricing-input/--pricing-output are deprecated and no longer advertise a price. "

--- a/docs/adr/0009-remote-join-append.md
+++ b/docs/adr/0009-remote-join-append.md
@@ -1,9 +1,10 @@
 # ADR 0009 — Remote `grid join` is additive (one identity per grid)
 
 Status: accepted (2026-07-02) — supersedes **ADR 0007 Decision 1 for remote mode**. Shipped as **Slice 1**
-(singleton + additive append via **stop-respawn** + leave + migration). **Slice 2** (SIGHUP hot-reload for
-zero-drop append, Decision 3) is a deferred fast-follow, gated on a live append-during-stream test — see
-"On the zero-drop claim" below for why it is not settled in-repo.
+(singleton + additive append via **stop-respawn** + leave + migration), then **Slice 2** (SIGHUP hot-reload
+for zero-drop append/shrink/rename, Decisions 3 & 4). Slice 2's gate — a live append-during-stream test —
+was **CLEARED 2026-07-03** on the hosted relay (see "On the zero-drop claim" below); it is now implemented,
+with the concurrency/correctness fixes recorded in **"Slice 2 as built"**.
 
 ## Context
 
@@ -52,9 +53,11 @@ default ports. No `--scan-port` flag.
 3. **The live serve process hot-reloads in place; re-register is non-destructive.** `grid join`/`grid leave`
    rewrite the record and signal the running process (**SIGHUP**, not mtime — avoids the spurious
    pid-double-write reload, coarse-mtime misses, and ~2s latency). A reload thread (like `_heartbeat_loop`)
-   rebuilds routing from the record (`_bring_up_engines` → `_build_routing`, probing **only newly-added**
-   engines), atomically swaps an immutable snapshot into `_ServeState`, then re-`register()`s the union
-   (swap **then** register). The poll loop and heartbeat never stop.
+   rebuilds routing from the record — a bespoke **external-only, probe-only** reassembly (`_reload_once`,
+   **not** `_bring_up_engines`, which would re-launch built-ins and re-probe everything): it reuses retained
+   caps for unchanged engines and probes **only newly-added** `--at` endpoints via `probe.capabilities`,
+   then `_build_routing` + `_merge_media` → atomically swaps one immutable snapshot into `_ServeState` →
+   re-`register`s the union (swap **then** register). The poll loop and heartbeat never stop.
 
    **On the zero-drop claim — NOT settled in this repo.** The relay *server* that would guarantee re-register
    preserves in-flight work lives in a **separate** repo (`grid-src/grid_cli/private_server/`, the upstream
@@ -63,7 +66,16 @@ default ports. No `--scan-port` flag.
    here. In-repo the evidence is *asymmetric*: `unregister_node` flips role→consumer specifically to make the
    relay drain (`remote/relay.py:88-91`), corroborating that a `role=provider` re-register does **not** drain
    *queued* work — but nothing in-repo corroborates in-flight **stream** survival across a re-register. So
-   hot-reload's zero-drop is gated on a live 2-host append-during-stream test before Slice 2 ships.
+   hot-reload's zero-drop is gated on a live append-during-stream test before Slice 2 ships.
+
+   **UPDATE 2026-07-03 — gate CLEARED (live test passed on the hosted relay).** Single-host test against
+   `grid.autonomous.ai`: a real streaming SSE consumer (`stream: true`) with a `PUT /nodes/{node_id}`
+   re-register (role=provider, same token/node_id) fired **mid-stream** from a separate process. The stream
+   completed uninterrupted — provider `submit_response` returned "relay accepted the full stream" at t=855.079
+   with the re-register PUT concurrent (854.343→855.079); the job was `handled in 5.20s` with no error; the
+   consumer received all 982 SSE chunks + `[DONE]`, tokens flowing during and after the PUT. (A whole-forward
+   txn survived a re-register too.) So the hosted relay preserves in-flight work across a provider re-register
+   — Slice 2 (SIGHUP hot-reload) zero-drop is viable and unblocked.
 
 4. **Concurrency correctness (from the design audit) — required, not optional.**
    - **Snapshot reads (F4):** `_ServeState.route()`/`upstream_model()` currently read `self._routes` several
@@ -108,13 +120,62 @@ hot-reload: `cli/remote_provider._respawn_identity` stops the prior process(es) 
   true no-op / respawn-to-apply — never a silent drop. Appending onto a `--advertise-as` identity is rejected
   (aliases are single-engine, ADR 0007 D4).
 
+## Slice 2 as built (SIGHUP hot-reload)
+
+Decisions 3/4 shipped: `grid join --at` (append), `grid leave --engine` (shrink), and rename now re-advertise
+the union **in place** — no restart, no dropped in-flight requests. Genuine bring-ups still respawn (below).
+
+- **Serve side (`remote/serve.py`).** One immutable `_Snapshot` (frozen dataclass: routes/upstream/models/
+  capabilities/meta/pricing/max_concurrency) holds all reload-swappable routing; `_ServeState._snapshot` is
+  rebound atomically by `apply()` under `_lock` (readers bind it once, lock-free — F4). `register_once` PUTs
+  one snapshot under `_register_lock` (serializes the reload's register vs the heartbeat-404 re-register — F5)
+  and refreshes+retries once on 401. `_reload_once` (driven by `_reload_loop`, which a SIGHUP handler wakes via
+  a `reload_requested` Event) re-reads the record, refuses anything needing a launch/media-change, reuses
+  retained caps for unchanged engines and probes only new `--at` endpoints, builds the whole snapshot, then
+  swap-then-`register_once`. `_start_reload_watcher` + the startup `pthread_sigmask` ordering keep SIGHUP off
+  the worker threads. `_meta` now labels an all-external union `external` (only a built-in `--serve` is `llama.cpp`).
+- **CLI side (`cli/remote_provider.py`).** `_hot_reloadable` picks SIGHUP (`_hot_reload_identity` → write record
+  then `os.kill(pid, SIGHUP)`) only when the sole live process is the singleton, external-only, media unchanged,
+  and the record carries the `reload_signal` marker; otherwise `_respawn_identity`. Record is written **before**
+  the signal (the reload clears its event before re-reading, so a write+signal is never lost).
+
+**Review-hardened (findings folded in before implementation):**
+- **C1 — pre-handler process.** SIGHUP's default disposition is *terminate*. `_build_record` stamps
+  `reload_signal: "sighup"`; `_hot_reloadable` requires it, so a live singleton from a pre-Slice-2 build (no
+  handler) is **respawned** once on the upgrade boundary, never SIGHUP-killed.
+- **C2 — appended-model reuse.** `_reload_once` reuses only the retained *caps* for an unchanged engine;
+  advertised/upstream come from the record, so a model appended to an existing engine is not dropped.
+- **C3 — media change.** `_media_key`/`_media_signature` compare `(media, bundles, ports)`; any media/bundle
+  change routes to respawn (a new bundle needs a ComfyUI bring-up the reload can't do).
+- **C4 — signal delivery.** Heartbeat + reload daemons start while SIGHUP is blocked (inherit the block); main
+  unblocks it **last**, so the signal always lands on the main thread → its long-poll EINTRs and the handler
+  fires promptly, not after a 35s poll.
+- **C5 — post-swap register failure.** A transient re-register failure after the swap re-arms `reload_requested`
+  (after a short back-off) so the new union self-heals rather than staying unadvertised.
+
+**Review round 3 (three parallel reviewers) — hardened before commit:**
+- The reload watcher catches `(Exception, SystemExit)` — a `SystemExit` from `jsonio.load_json` (a corrupt
+  record) or `_advertised_models` (an alias/model mismatch) no longer silently kills the daemon thread (F6).
+- `--advertise-as` doesn't merge across joins, so the CLI rejects any *changing* append onto/with an aliased
+  identity (was: a re-join could mismatch alias/model counts → crash the reload, or silently drop an alias).
+- `register_once` binds the snapshot+token INSIDE `_register_lock`, so a descheduled racer can't PUT a stale
+  union last (F5 freshness, not just non-interleaving).
+- Reload refusals/failures log unconditionally (not `GRID_ENGINE_DEBUG`-gated); the post-swap re-register
+  retry is bounded and distinguishes exhausted-auth (stop) from transient (bounded re-arm).
+- `_hot_reload_identity` returns whether it hot-reloaded or fell back to respawn, so the CLI never prints a
+  false "no in-flight requests dropped"; `grid leave` shrink also stamps `reload_signal` (self-heal parity).
+- `media_signature` factored into `shared/run_records.py` so the CLI and serve decisions can't desync.
+- **Known, pre-existing (not fixed here):** a multi-model engine registers caps only for its first model
+  (same at startup and reload; the relay may drop the whole envelope) — tracked separately, not a Slice-2
+  regression. Residual `os.kill` PID-reuse TOCTOU is shared with `run_records.terminate_pid`.
+
 ## Considered options (reload mechanism)
 
 - **Stop + respawn (Slice 1, shipped).** No new threads/locks; drops in-flight requests + a re-register gap
   (seconds, incl. re-probe) on each append. Ships the clobber fix immediately; hot-reload replaces it later
   with **no change to the singleton core** (Decisions 1/2/5/6 are shared).
-- **SIGHUP hot-reload (Slice 2, deferred).** Zero-drop, but rests on the unverified-in-repo relay behavior
-  (Decision 3) and adds the concurrency surface in Decision 4. Gated on the live test.
+- **SIGHUP hot-reload (Slice 2, shipped).** Zero-drop; rested on relay behavior confirmed by the now-cleared
+  live gate (Decision 3) and adds the concurrency surface in Decision 4 (see "Slice 2 as built").
 - **mtime-watch trigger.** Rejected in favor of SIGHUP (spurious pid-double-write reload, coarse-mtime
   misses, ~2s latency).
 

--- a/docs/adr/0009-remote-join-append.md
+++ b/docs/adr/0009-remote-join-append.md
@@ -1,0 +1,131 @@
+# ADR 0009 — Remote `grid join` is additive (one identity per grid)
+
+Status: accepted (2026-07-02) — supersedes **ADR 0007 Decision 1 for remote mode**. Shipped as **Slice 1**
+(singleton + additive append via **stop-respawn** + leave + migration). **Slice 2** (SIGHUP hot-reload for
+zero-drop append, Decision 3) is a deferred fast-follow, gated on a live append-during-stream test — see
+"On the zero-drop claim" below for why it is not settled in-repo.
+
+## Context
+
+ADR 0007 Decision 1 chose "one `grid join` = one identity; repeated joins stay *separate* (status quo)".
+That holds in **local** mode — the node_id is the record's random `node-<uuid>` (`cli/provider.py:131`
+written, `:355` read back into `_register_engine`), and the local server holds N nodes. It is **false in
+remote** mode: a remote engine's relay node_id is derived from the per-grid access-token JWT
+(`remote/serve.py` `_node_id_from_token`, used where `run_remote_engine_from_record` sets `node_id`), so
+**every** `grid join` on one grid registers under the **same** node_id. `relay.register_node` is
+`PUT /nodes/{node_id}` — a full replace (`remote/relay.py:82`), authorized only for the token's own node.
+
+Maintainer-observed symptoms of running `grid join` twice on one remote grid:
+- Two detached `__remote-engine` processes register the same node_id → **last-win clobber** of advertised
+  models/caps.
+- Both long-poll the same per-provider queue → a job for model A can be claimed by the process serving only
+  B → *"no engine serves model A" / "No providers available"*.
+
+The record's random `node_id` (`cli/remote_provider.py:202`) is **dead** in remote — the serve loop ignores
+it. So remote has, and can only have, **one identity per grid**. Repeated `grid join` must be **additive**
+(append engines to that one identity), never "separate".
+
+**Cross-machine is out of scope but fine:** the per-grid tokens are fetched with a stable per-machine
+`device_id` (`remote/credentials.py:61` → `control_plane.fetch_tokens(session_token, device_id)`), so the
+node_id is per-*(device, grid)* — two boxes get distinct node_ids and serve as separate identities. The
+singleton is per-box, which matches; it does not (and need not) coordinate across machines.
+
+Secondary ask: `--all` misses a llama.cpp on a non-default port. Resolved by the now-appendable `--at`
+(`grid join --all` then `grid join --at http://127.0.0.1:9000 -m foo`); `--all` keeps scanning only the
+default ports. No `--scan-port` flag.
+
+## Decisions
+
+1. **Remote is one identity per grid; the run record is a singleton.** The remote record is keyed by a
+   constant (`"remote"`) — one file `engines_dir(network_id)/remote.json` — replacing the random
+   `engine-{uuid}` at `cli/remote_provider.py:74`. At most one `__remote-engine` process per grid. `--name`
+   in remote becomes the grid-page **display name** only (a new `meta_name` record field read by
+   `remote/serve.py:_meta`), not the record key and not a way to mint a second identity (impossible under
+   one-token-one-node). **Local `--name` is unchanged.**
+
+2. **`grid join` is additive (auto-merge).** When a live singleton record exists, merge the newly-resolved
+   spec(s) into its `engines` union: dedup by `endpoint_url`, recompute top-level `models` (union) and
+   `endpoint_url` (sole url or `None`), write the merged record. **External-only guard** (ADR 0007 D4): a
+   union with >1 engine may not contain a built-in `--serve` spec (no `endpoint_url`); appending anything
+   that needs a launch or a media/ComfyUI bring-up mid-serve is rejected with "leave + re-join" guidance.
+
+3. **The live serve process hot-reloads in place; re-register is non-destructive.** `grid join`/`grid leave`
+   rewrite the record and signal the running process (**SIGHUP**, not mtime — avoids the spurious
+   pid-double-write reload, coarse-mtime misses, and ~2s latency). A reload thread (like `_heartbeat_loop`)
+   rebuilds routing from the record (`_bring_up_engines` → `_build_routing`, probing **only newly-added**
+   engines), atomically swaps an immutable snapshot into `_ServeState`, then re-`register()`s the union
+   (swap **then** register). The poll loop and heartbeat never stop.
+
+   **On the zero-drop claim — NOT settled in this repo.** The relay *server* that would guarantee re-register
+   preserves in-flight work lives in a **separate** repo (`grid-src/grid_cli/private_server/`, the upstream
+   this was ported from) — its `node_update` upserts on `role=provider` and only cleans up in-flight on
+   `role=consumer`/`DELETE`/prune, which is encouraging, but it is **not** the hosted relay and not verifiable
+   here. In-repo the evidence is *asymmetric*: `unregister_node` flips role→consumer specifically to make the
+   relay drain (`remote/relay.py:88-91`), corroborating that a `role=provider` re-register does **not** drain
+   *queued* work — but nothing in-repo corroborates in-flight **stream** survival across a re-register. So
+   hot-reload's zero-drop is gated on a live 2-host append-during-stream test before Slice 2 ships.
+
+4. **Concurrency correctness (from the design audit) — required, not optional.**
+   - **Snapshot reads (F4):** `_ServeState.route()`/`upstream_model()` currently read `self._routes` several
+     times unlocked (`serve.py:465-467`). Bind the map once per call, or have the reload swap a single
+     immutable snapshot attribute readers load exactly once — else a mid-swap read KeyErrors and the job is
+     dropped **without** a `submit_error` (consumer hangs to timeout).
+   - **Lock discipline (F5):** `_lock` is a plain (non-reentrant) `Lock`; `register()`→`token()` takes it.
+     `apply()` must swap under `_lock`, **release**, then register. A dedicated register lock serializes the
+     reload's register with heartbeat's 404-reregister so neither PUTs a torn snapshot.
+   - **Reload isolation (F6):** wrap the reload body so a failure (unreachable appended `--at`) logs and
+     keeps the watcher thread alive; build fully then swap (never half-apply); probe only new engines.
+
+5. **Migration + merge safety.**
+   - **Migration (F2):** `read_records` keys by the record's `engine_id` field, so a pre-change
+     `engine-<uuid>.json` is a different key from `remote.json`. Adopt/stop **any** live legacy remote
+     record for the grid before creating/using the singleton — else the old process stays live and the two
+     clobber on the same token node_id (the bug, resurrected on upgrade).
+   - **Merge race (F3):** `atomic_write_json` makes each write atomic but does not serialize
+     read-modify-write across two concurrent `grid join` processes. flock the record (or a sibling lockfile)
+     around read-merge-write.
+
+6. **`grid leave`.** Bare `grid leave` → SIGTERM teardown (unchanged). `grid leave --engine <endpoint_url|
+   label>` removes the matching spec (key on `endpoint_url`; label only when set+unique) → same reload path
+   shrinks the union; removing the last spec → full teardown (never reload-to-empty).
+
+## Slice 1 as built (respawn)
+
+Decisions 1/2/5/6 shipped; Decision 3 is deferred (Slice 2). The update mechanism is **stop-respawn**, not
+hot-reload: `cli/remote_provider._respawn_identity` stops the prior process(es) then spawns one fresh
+`__remote-engine` from the merged record. Consequences and the review-hardened behavior:
+
+- **Respawn is not atomic.** The prior process is stopped before the replacement is confirmed alive, so each
+  append interrupts in-flight requests and, if the fresh process dies at start-up, the grid is left not
+  serving — surfaced as a clear `SystemExit` with the log tail (both join-append and leave-shrink go through
+  the shared helper, so neither can silently claim success). Slice 2's hot-reload removes the interrupt.
+- **Never spawn over a live prior.** `run_records.terminate_pid` now returns whether the process is confirmed
+  gone (and `pid_alive` treats `EPERM` as alive); `_respawn_identity` aborts before spawning if a prior can't
+  be stopped, rather than starting a second child that would clobber the shared node_id.
+- **Additive merge is by engine, model-aware.** `_merge_engines` unions models into an engine already in the
+  union (re-joining a known URL with a new `-m` model adds it, not drops it) and treats the built-in `--serve`
+  engine as keyed by its model set, so a re-join with nothing new (or only a `--name`/`--bundle` change) is a
+  true no-op / respawn-to-apply — never a silent drop. Appending onto a `--advertise-as` identity is rejected
+  (aliases are single-engine, ADR 0007 D4).
+
+## Considered options (reload mechanism)
+
+- **Stop + respawn (Slice 1, shipped).** No new threads/locks; drops in-flight requests + a re-register gap
+  (seconds, incl. re-probe) on each append. Ships the clobber fix immediately; hot-reload replaces it later
+  with **no change to the singleton core** (Decisions 1/2/5/6 are shared).
+- **SIGHUP hot-reload (Slice 2, deferred).** Zero-drop, but rests on the unverified-in-repo relay behavior
+  (Decision 3) and adds the concurrency surface in Decision 4. Gated on the live test.
+- **mtime-watch trigger.** Rejected in favor of SIGHUP (spurious pid-double-write reload, coarse-mtime
+  misses, ~2s latency).
+
+## Consequences
+
+- local stays local-only / byte-identical; single-engine remote serve unchanged; remote reaches the relay
+  only via `remote/*`; tokens never enter the record or logs.
+- Tests: update `test_remote_join_at_serves_external_engine` (`test_local_cli.py:1249`) and
+  `test_remote_join_died_cleans_up_record` (`:1425`); add the missing coverage — double-join/append, union
+  dedup, external-only reject, `--name`→display-name, migration sweep, concurrent-merge, hot-reload swap +
+  register, reload-failure isolation, leave-shrink, leave-last-teardown. (The suite currently has **no**
+  double-join test — that gap let the bug through.)
+- One live 2-host test (append `--at` during an in-flight stream; assert the stream completes) is the final
+  confirmation for Decision 3 on the hosted relay.

--- a/docs/adr/0010-cli-ux-vocabulary.md
+++ b/docs/adr/0010-cli-ux-vocabulary.md
@@ -68,14 +68,16 @@ reworded from "Set up the built-in engines" to "Set up built-in engines and list
 namespace coherently covers setup **and** listing. Chosen over a new top-level `grid ps` (which would
 cost a `dispatch.py` bucket + a `REMOTE_HANDLERS` entry + a third spelling for "list engines").
 
-**D-f (`grid up` id guard).** `grid up <arg>` no longer auto-creates when `<arg>` matches the local
-grid-id shape `ag-<slug>-<hex8>` (anchored `fullmatch`) but isn't found locally; it exits with guidance
-to `grid ls` (and, if the grid is remote, `grid mode remote` then `grid sync`). An ordinary name still
-creates as before. This is the one non-additive change. Accepted trade-off: a chosen grid *name* shaped
-exactly like an id (`ag-…-<8 hex>`) is refused — acceptable, since that collides with the reserved id
-form. No remote mirror: remote `network_id`s are opaque and indistinguishable from a chosen name, so any
-heuristic would false-positive; remote keeps create-on-unknown-name (the correct lever there would be an
-explicit `--create`, out of scope).
+**D-f (`grid up` id guard).** `grid up <arg>` no longer auto-creates a junk local grid when `<arg>` is
+really an existing grid the user hasn't synced here — instead of making a grid named after the string, it
+exits with guidance. Two signals, both run before any create/start: **(a)** an exact match against the
+user's known remote grids (`grid login`'s `credentials.toml` networks, by name or network_id) — a
+zero-false-positive signal that works for the opaque remote ids a shape check can't recognise; and **(b)**
+the local grid-id shape `ag-<slug>-<hex8>` (anchored `fullmatch`). An ordinary, unknown name still creates
+as before. This is the one non-additive change. Accepted trade-off: signal (b) also refuses a chosen grid
+*name* shaped like an id (`ag-…-<8 hex-valid chars>`, including an all-digit suffix such as
+`ag-nightly-20260706`), since that collides with the reserved local-id form. Remote `grid up` keeps
+create-on-unknown-name (an explicit `--create` would be the lever there, out of scope).
 
 **D-g (`leave --all` stays required for multi-engine).** Local bare `grid leave` on a grid with several
 engines keeps its safety guard — it errors asking for `--engine`/`--all` (`cli/provider.py:240`) rather
@@ -87,5 +89,6 @@ correcting the handoff's assumption that bare-leave already meant "all".
 
 - Back-compat: `grid join --engine ollama`, `grid engines`, and `-m x --advertise-as y` all keep working.
 - No new top-level command → the dispatch classification test is untouched by every decision here.
-- The only behavior a v0.1.6 user could notice as *removed* is `grid up <an-id-you-didn't-sync>`
-  auto-creating a junk grid — now a clean error (D-f).
+- The only behavior a v0.1.6 user could notice as *removed* is `grid up <arg>` auto-creating a junk local
+  grid when `<arg>` is a grid id, or a known remote grid's name, that isn't a local grid — now a clean
+  error (D-f).

--- a/docs/adr/0010-cli-ux-vocabulary.md
+++ b/docs/adr/0010-cli-ux-vocabulary.md
@@ -1,0 +1,91 @@
+# ADR 0010 — CLI vocabulary & UX for `join` / `leave` / `engine`
+
+Status: accepted (2026-07-06). Scope: the public `grid` CLI surface (v0.1.6 shipped). All changes are
+additive / alias-preserving except Decision D-f (`grid up` no longer auto-creates an id-shaped arg).
+
+## Context
+
+The released CLI accumulated avoidable friction, each verified against the tree on `feat/cli-ux`:
+
+- **`--engine` is overloaded.** On `grid join` it *filters auto-detected engines by kind*
+  (`cli/provider.py:82-85`, `cli/remote_provider.py:367-370`); on `grid leave` it *names the joined
+  instance to drop* (`cli/provider.py:231`). Two meanings, one flag — the reader can't tell "type" from
+  "instance".
+- **Model aliasing needs two positionally-paired flags.** `-m real --advertise-as pub` must be given in
+  matching order and equal count (`_advertised_text_models`, `cli/provider.py:525-539`). Easy to
+  mis-pair; nothing signals the pairing at the call site.
+- **`grid engines` sits one keystroke from `grid engine`.** `engines` (plural) lists live joined engines
+  (`cli/parser.py:175`); `engine` (singular) is the built-in-engine setup namespace
+  (`install`/`pull`/`status`/`start`/`stop`, `cli/parser.py:359-398`). Typo-adjacent, and inconsistent
+  with the rest of the surface.
+- **`leave --engine` help lies.** It says "endpoint URL (or unique label)" (`cli/parser.py:163-165`) but
+  the remote matcher already accepts URL / label / served-model / URL-fragment (`_drop_spec`,
+  `cli/remote_provider.py:569-596`); the *local* handler accepts only the exact engine-id.
+- **`grid up <unknown>` silently creates.** Any unknown positional becomes a brand-new grid named after
+  the string (`cli/grid.py:23`). Paste a grid *id* you haven't synced locally and you get a junk grid
+  named after the id, not an error.
+
+Design constraints: the CLI is mode-aware (local/remote) and dispatch is classified **per top-level
+command only** (`cli/dispatch.py`; a test enforces every command is classified). Grid ids are
+`ag-<slug>-<hex8>` locally (`local/runtime.py:65`) and opaque `[A-Za-z0-9_-]+` remotely
+(`cli/remote_grid.py:32`). There is no `DECISIONS.md`; design is recorded in these ADRs.
+
+## Decisions
+
+**D-a (join `--kind`).** The pre-join engine-*type* filter is `--kind` (e.g. `--kind ollama`).
+`--engine` is retained as a compatibility alias on the same dest (two option strings, one `dest="kind"`
+— the repo precedent is `--endpoint-port`/`--llama-port`, `cli/parser.py:135`). Vocabulary is now
+consistent: **kind** = the type you filter on *before* joining; **engine** = the instance you name
+*after* joining (and `leave --engine`). Consequence: `grid join --engine ollama` keeps working; help and
+error text move to `--kind`.
+
+**D-b (inline alias `-m real=pub`).** Model aliasing gains an inline spelling that desugars into today's
+flat `models` / `advertise_as` lists before any handler reads them (`_apply_inline_aliases`). It is
+**minimal**: same all-or-nothing rule as `--advertise-as` (alias every text model, or none), mutually
+exclusive with `--advertise-as`, and rejected on `--serve` (which bypasses the models list — alias a
+built-in via `--advertise-as`). Split on the first `=`. Consequence: **zero** change to
+`_advertised_text_models`, `_reject_unserveable_union`, the run record, or the SIGHUP reload path;
+`--advertise-as` remains as the escape hatch for exotic model names.
+
+**D-c (deprecate `--engine-label`).** The grid page derives an engine's kind automatically
+(`remote/serve.py` `_meta`), so `--engine-label` no longer changes any display. It is deprecated:
+accepted (no hard error), marked deprecated in help, warns on stderr when used (mirroring the
+`--pricing-*` deprecation, `cli/remote_provider.py:53-58`), and is still stored in the record so
+`grid leave --engine <label>` keeps matching an engine a prior join labelled.
+
+**D-d (local fuzzy `leave --engine`).** Local `leave --engine` gains the same match order as remote —
+exact engine-id → endpoint URL → served model → URL fragment — via one shared, pure matcher
+`shared.run_records.match_engine`, which the remote `_drop_spec` also delegates to (byte-identical
+remote messages). The exact engine-id (== local `--name`) short-circuits first, before fuzzy matching.
+The ambiguity guidance is parameterized per mode: remote says "pass the exact endpoint URL instead",
+local says "pass the exact engine id instead" (a local built-in `--serve` engine has no URL, so the
+always-unique engine-id is the actionable disambiguator).
+
+**D-e (`grid engine ls`).** Live-engine listing gains a canonical `grid engine ls` (+ `list` alias);
+`grid engines` is kept as a legacy alias. The handler branches on mode internally (the `cmd_overview`
+pattern) so `engine` stays AGNOSTIC and needs no dispatch change. The `grid engine` group help is
+reworded from "Set up the built-in engines" to "Set up built-in engines and list live ones", so the
+namespace coherently covers setup **and** listing. Chosen over a new top-level `grid ps` (which would
+cost a `dispatch.py` bucket + a `REMOTE_HANDLERS` entry + a third spelling for "list engines").
+
+**D-f (`grid up` id guard).** `grid up <arg>` no longer auto-creates when `<arg>` matches the local
+grid-id shape `ag-<slug>-<hex8>` (anchored `fullmatch`) but isn't found locally; it exits with guidance
+to `grid ls` (and, if the grid is remote, `grid mode remote` then `grid sync`). An ordinary name still
+creates as before. This is the one non-additive change. Accepted trade-off: a chosen grid *name* shaped
+exactly like an id (`ag-…-<8 hex>`) is refused — acceptable, since that collides with the reserved id
+form. No remote mirror: remote `network_id`s are opaque and indistinguishable from a chosen name, so any
+heuristic would false-positive; remote keeps create-on-unknown-name (the correct lever there would be an
+explicit `--create`, out of scope).
+
+**D-g (`leave --all` stays required for multi-engine).** Local bare `grid leave` on a grid with several
+engines keeps its safety guard — it errors asking for `--engine`/`--all` (`cli/provider.py:240`) rather
+than silently tearing down everything. (A one-engine grid still leaves that engine on a bare `leave`;
+remote tears the single identity down.) Only the help wording changes, to state this accurately —
+correcting the handoff's assumption that bare-leave already meant "all".
+
+## Consequences
+
+- Back-compat: `grid join --engine ollama`, `grid engines`, and `-m x --advertise-as y` all keep working.
+- No new top-level command → the dispatch classification test is untouched by every decision here.
+- The only behavior a v0.1.6 user could notice as *removed* is `grid up <an-id-you-didn't-sync>`
+  auto-creating a junk grid — now a clean error (D-f).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -9,7 +9,8 @@ Internal protocol words stay out of the user-facing CLI.
 ```
 grid      a named local AI endpoint, usually `home` or `work`
 grid_url  the URL engines join; apps call it through `/v1`
-engine    something that runs models: Ollama, LM Studio, vLLM, MLX, llama.cpp, ComfyUI
+engine    a running instance joined to a grid: Ollama, LM Studio, vLLM, MLX, llama.cpp, ComfyUI
+kind      an engine's type (ollama, vllm, mlx, llama.cpp, comfyui) — filter auto-detect with --kind
 join      connect this machine or engine to a grid
 model     a live capability exposed by joined engines
 mode      which world the CLI targets: `local` (default) or `remote`
@@ -140,9 +141,9 @@ commands exit with guidance to switch — sign-in is a remote concept. See
 ## Grid Lifecycle
 
 ```
-grid up [name] [--type <t>]           # create/start a grid (--type sets a remote grid's type on create)
+grid up [name] [--type <t>]           # create/start a grid by name or id (--type: remote grid type on create)
 grid down [name]                      # stop a grid; the grid/config persists
-grid ls [--json]                      # list saved grids
+grid ls [--json]                      # list saved grids (name, id, where, url)
 grid info [grid] [--json]             # endpoint, key, engines, live models
 grid info [grid] --env                # print OPENAI_* exports (local key, or remote relay URL + token)
 ```
@@ -174,8 +175,8 @@ grid join [grid] --all                                # join every detected engi
 grid join [grid] --at <url> -m <model>... [--name <id>]
 grid join [grid] --serve <model> [--name <id>]
 grid join [grid] --media [--bundle <bundle>]... [--name <id>]
-grid leave [grid] [--engine <id>] [--all]
-grid engines [grid] [--json]                          # live engines joined to a grid
+grid leave [grid] [--engine <sel>] [--all]            # <sel>: engine id, endpoint URL, served model, or :port fragment
+grid engine ls [grid] [--json]                        # live engines joined to a grid (legacy alias: grid engines)
 ```
 
 `grid join` with no flags should detect local engines in this order:
@@ -188,7 +189,7 @@ grid engines [grid] [--json]                          # live engines joined to a
 6. ComfyUI
 
 When detection finds more than one engine, print the plan and ask for confirmation in
-interactive terminals. In non-interactive mode, require `--all`, `--engine <kind>`, or
+interactive terminals. In non-interactive mode, require `--all`, `--kind <kind>`, or
 explicit `--at`.
 
 Example detection output:
@@ -196,16 +197,17 @@ Example detection output:
 ```text
 Detected engines on this machine:
 
-  mac-studio     MLX        http://192.168.1.10:8080/v1      gemma4-31b
-  gpu-4090       vLLM       http://192.168.1.20:8000/v1      devstral-small-2
+  mlx          http://192.168.1.10:8080/v1        gemma4-31b
+  vllm         http://192.168.1.20:8000/v1        devstral-small-2
 
 Join them:
   grid join --all
-  grid join --engine gpu-4090
+  grid join --kind <kind>
 ```
 
-Engine IDs are local names shown by `grid engines`, `grid info`, and
-`grid models --verbose`; they are accepted by `grid leave --engine <id>`.
+Engine IDs are local names shown by `grid engine ls`, `grid info`, and `grid models --verbose`.
+`grid leave --engine <sel>` takes an exact engine id, or — tried in that order — an endpoint URL,
+a served model, or a URL fragment such as `:8000`.
 
 ### `grid join` in remote mode
 
@@ -225,16 +227,17 @@ files) streams back exactly as in local mode.
 
 The `grid join` flag set is the union of both modes, gated by mode:
 
-- **Both modes:** `--at` / `--serve` / `-m,--model` / `--engine <kind>` / `--name` / `--all`,
-  `--advertise-as`, `--endpoint-port` (alias `--llama-port`), the llama tuning flags
-  (`--ctx-size --n-predict --parallel --flash-attn --temp --reasoning-budget`), and the media flags
-  `--media` / `--bundle <bundle>` / `--comfyui-port` / `--media-port`.
+- **Both modes:** `--at` / `--serve` / `-m,--model` / `--kind <kind>` (alias `--engine`) / `--name`
+  / `--all`, `--advertise-as` (or inline `-m real=pub`), `--endpoint-port` (alias `--llama-port`),
+  the llama tuning flags (`--ctx-size --n-predict --parallel --flash-attn --temp --reasoning-budget`),
+  and the media flags `--media` / `--bundle <bundle>` / `--comfyui-port` / `--media-port`.
 - **local-only:** `--advertise-host` (a remote engine polls the relay outbound — there is no inbound
   endpoint to advertise).
-- **Remote-only:** `--engine-label` (the engine kind shown on the grid page), `--max-concurrency`.
-- **Deprecated:** `--pricing-input` / `--pricing-output` — kept so old invocations don't hard-error,
-  but they no longer advertise a price. Set your authoritative per-model price with `grid price set`
-  (see [Price](#price)) instead.
+- **Remote-only:** `--max-concurrency`.
+- **Deprecated:** `--engine-label` — the grid page now derives the engine kind automatically, so it is
+  accepted but inert (still matched by `grid leave --engine <label>`); `--pricing-input` /
+  `--pricing-output` — kept so old invocations don't hard-error, but they no longer advertise a price.
+  Set your authoritative per-model price with `grid price set` (see [Price](#price)) instead.
 
 A flag used in the wrong mode fails with a clear message. (`--advertise-as` is single-engine only and
 is rejected with `--all`.) See [ADR 0004](./adr/0004-remote-provider-serve.md),
@@ -352,6 +355,7 @@ guidance to switch.
 grid engine install llama.cpp          # default text engine
 grid engine install comfyui            # default media engine
 grid engine pull <bundle>              # ComfyUI media bundle: image_generation, image_editing, i2v
+grid engine ls [grid] [--json]         # live engines joined to a grid (same view as grid engines)
 ```
 
 Grid has no inference engine of its own. These commands install open-source default
@@ -361,6 +365,8 @@ engines so a bare machine can join a grid without Ollama, LM Studio, or vLLM.
 
 ```
 grid list                              # alias for grid ls
+grid engine list                       # alias for grid engine ls
+grid engines                           # legacy alias for grid engine ls
 grid remove <model> [--yes]            # alias for grid rm
 ```
 

--- a/remote/serve.py
+++ b/remote/serve.py
@@ -15,9 +15,11 @@ from __future__ import annotations
 
 import base64
 import json
+import os
 import signal
 import sys
 import threading
+import time
 from typing import Any
 
 from remote import control_plane, credentials, probe, relay
@@ -33,6 +35,17 @@ _DEFAULT_INFERENCE_TIMEOUT = 600.0
 # allowlist (the media paths are NOT under `_ALLOWED_ENDPOINTS` — they route to a different URL).
 _ALLOWED_ENDPOINTS = frozenset({"chat/completions", "completions"})
 _MEDIA_ENDPOINTS = frozenset({"media/image/generate", "media/image/edit", "media/video/i2v"})
+
+# Opt-in poll/heartbeat tracing. Off by default so a healthy engine's log stays quiet — only errors
+# and job failures are recorded (a successful long-poll and a served job are otherwise silent).
+# Set GRID_ENGINE_DEBUG=1 before `grid join` to trace every poll cycle when debugging the relay loop.
+_DEBUG = bool(os.getenv("GRID_ENGINE_DEBUG"))
+
+
+def _debug(msg: str) -> None:
+    """Emit a poll/heartbeat trace line, but only when GRID_ENGINE_DEBUG is set."""
+    if _DEBUG:
+        print(f"[engine] {msg}", file=sys.stderr, flush=True)
 
 
 # ---------------------------------------------------------------------------
@@ -332,10 +345,12 @@ def _build_routing(
 
 
 def _meta(record: dict[str, Any], engine_id: str) -> dict[str, Any]:
-    """How the node appears on the grid page: name (from --name/engine_id) + engine kind label.
+    """How the node appears on the grid page: name + engine kind label.
 
-    A multi-engine identity shows the kinds it gathered (e.g. ``ollama+vllm``) when no explicit
-    ``--engine-label`` was given, so the page reflects what is actually serving.
+    The display name comes from the record's ``meta_name`` (the ``--name`` a remote operator gave, or
+    the box's hostname when omitted), falling back to ``engine_id`` for a record written before the
+    singleton change. A multi-engine identity shows the kinds it gathered (e.g. ``ollama+vllm``) when no
+    explicit ``--engine-label`` was given, so the page reflects what is actually serving.
     """
     label = record.get("engine_label")
     if not label:
@@ -351,7 +366,7 @@ def _meta(record: dict[str, Any], engine_id: str) -> dict[str, Any]:
             label = "comfyui"
         else:
             label = "llama.cpp"
-    return {"name": engine_id, "engine": label}
+    return {"name": record.get("meta_name") or engine_id, "engine": label}
 
 
 def _pricing(record: dict[str, Any]) -> dict[str, float]:
@@ -692,17 +707,24 @@ def _poll_loop(state: _ServeState) -> None:
             state.stop.wait(2)
             continue
         if job is None:  # 204 — no work waiting; poll again
+            _debug("poll: no job (204), re-polling")
             continue
+        started = time.monotonic()
         try:
             handle_job(state, job)
         except Exception as exc:  # defence in depth: handle_job already guards, but never die here
             print(f"\nUnexpected error handling a job: {exc!r}", file=sys.stderr)
+        else:
+            if _DEBUG:
+                txn = job.get("transaction_id")
+                model = (job.get("body") or {}).get("model")
+                _debug(f"poll: job txn={txn} model={model!r} handled in {time.monotonic() - started:.2f}s")
 
 
 def _heartbeat_loop(state: _ServeState) -> None:
     while not state.stop.is_set():
         try:
-            heartbeat_once(state)
+            result = heartbeat_once(state)
         except relay.RelayUnauthorized:
             # Auth is exhausted (refresh failed too) — stop now rather than spin re-failing until
             # the poll loop happens to notice, which can be up to a full long-poll away.
@@ -711,4 +733,6 @@ def _heartbeat_loop(state: _ServeState) -> None:
             break
         except relay.RelayError as exc:
             print(f"\nHeartbeat error: {exc}", file=sys.stderr)
+        else:
+            _debug(f"heartbeat: ok ({result})")
         state.stop.wait(relay.HEARTBEAT_INTERVAL)

--- a/remote/serve.py
+++ b/remote/serve.py
@@ -20,14 +20,23 @@ import signal
 import sys
 import threading
 import time
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
 from typing import Any
 
 from remote import control_plane, credentials, probe, relay
 from shared import run_records
 
+# One engine's probe result: (normalized llm_url, advertised models, upstream models, caps envelope).
+_EngineResults = list[tuple[str, list[str], list[str], dict[str, Any]]]
+
 
 # Engine read budget when the relay doesn't advertise one (older relay); matches its default.
 _DEFAULT_INFERENCE_TIMEOUT = 600.0
+
+# How many consecutive post-swap re-register failures a reload retries before giving up loudly (so a
+# permanent relay/validation error doesn't PUT every 2s forever; the next join/leave re-triggers it).
+_MAX_RELOAD_REGISTER_RETRIES = 5
 
 # The relay-supplied endpoint is interpolated into a local engine URL, so only forward known
 # endpoints — this stops a buggy or compromised relay from probing other local paths via `../`.
@@ -46,6 +55,13 @@ def _debug(msg: str) -> None:
     """Emit a poll/heartbeat trace line, but only when GRID_ENGINE_DEBUG is set."""
     if _DEBUG:
         print(f"[engine] {msg}", file=sys.stderr, flush=True)
+
+
+def _warn(msg: str) -> None:
+    """Always log a reload problem to stderr (unlike ``_debug``, which is opt-in tracing). A refused or
+    failed hot-reload must leave a trace — the CLI has already told the operator the join/leave
+    succeeded, so a silent stale union would be invisible (ADR 0009 D4 F6)."""
+    print(f"[engine] {msg}", file=sys.stderr, flush=True)
 
 
 # ---------------------------------------------------------------------------
@@ -77,6 +93,13 @@ def run_remote_engine_from_record(grid_id: str, engine_id: str) -> int:
         raise KeyboardInterrupt
 
     signal.signal(signal.SIGTERM, _on_term)
+    # Block SIGHUP for the whole startup window: its default disposition is *terminate*, and a concurrent
+    # re-join may `os.kill(pid, SIGHUP)` while we're still in engine bring-up/probe — before the handler
+    # exists. Blocked, that signal is queued (not fatal) and delivered once we unblock, after the reload
+    # watcher is up, so the first reload folds it in. The worker threads spawned below inherit this mask,
+    # so SIGHUP only ever lands on the main thread (ADR 0009 C4).
+    if hasattr(signal, "SIGHUP"):
+        signal.pthread_sigmask(signal.SIG_BLOCK, {signal.SIGHUP})
 
     launched: list[Any] = []
     launcher = None
@@ -100,9 +123,9 @@ def run_remote_engine_from_record(grid_id: str, engine_id: str) -> int:
         # reached by the poll loop on loopback (the relay forwards `media/*` jobs to us like text).
         # Its `comfyui:*` models + caps merge into the one identity we register (DECISIONS D9).
         media_url = None
+        media_models: list[str] = []
         if record.get("media"):
             from local import media_engine
-            from shared.media import media_gating
 
             media_port = int(record.get("media_port") or 8190)
             prepared = media_engine.prepare_media_engine(
@@ -114,12 +137,8 @@ def run_remote_engine_from_record(grid_id: str, engine_id: str) -> int:
             media_proc = prepared["proc"]
             comfyui_started = bool(prepared["comfyui_started"])
             media_url = f"http://127.0.0.1:{media_port}"
-            caps_models = dict((capabilities or {}).get("models") or {})
-            for model in prepared["models"]:
-                if model not in union_models:
-                    union_models.append(model)
-                caps_models[model] = media_gating.capability_entry()
-            capabilities = {"schema_version": 1, "models": caps_models} if caps_models else {}
+            media_models = list(prepared["models"])
+            union_models, capabilities = _merge_media(union_models, capabilities, media_models)
 
         state = _ServeState(
             signaling_url=signaling_url,
@@ -137,11 +156,18 @@ def run_remote_engine_from_record(grid_id: str, engine_id: str) -> int:
             upstream=upstream,
             media_url=media_url,
         )
-        register(state)
+        register_once(state)
         print(f"Engine {state.node_id} serving {union_models} via the relay at {signaling_url}")
         print("Send SIGTERM (grid leave) to unregister.")
         heartbeat = threading.Thread(target=_heartbeat_loop, args=(state,), daemon=True)
         heartbeat.start()
+        # Start the SIGHUP-driven reload watcher, then unblock SIGHUP on the main thread LAST — the worker
+        # threads above inherited the block, so a `grid join`/`leave` SIGHUP now always lands on main: its
+        # long-poll takes EINTR (PEP 475 retries it) and the handler sets the reload event, which the
+        # watcher (waiting on the event, not the signal) services within ≤1s (ADR 0009 C4).
+        _start_reload_watcher(state, engine_id, engine_results, media_models, record)
+        if hasattr(signal, "SIGHUP"):
+            signal.pthread_sigmask(signal.SIG_UNBLOCK, {signal.SIGHUP})
         _poll_loop(state)  # blocks until the loop stops or SIGTERM
     except KeyboardInterrupt:
         print("\nEngine unregistered.")
@@ -344,6 +370,45 @@ def _build_routing(
     return routes, upstream_routes, union_models, merged_caps, warnings
 
 
+def _merge_media(
+    union_models: list[str], capabilities: dict[str, Any], media_models: list[str]
+) -> tuple[list[str], dict[str, Any]]:
+    """Merge this box's media (``comfyui:*``) models + caps into the text routing union (DECISIONS D9).
+
+    Media models come after the text ones (first-seen order), each with the static media capability
+    stub — so both startup and a hot-reload produce the same union/caps for the same media bundles.
+    A no-media identity passes ``media_models=[]`` and the union is returned unchanged.
+    """
+    if not media_models:
+        return union_models, capabilities
+    from shared.media import media_gating
+
+    models = list(union_models)
+    caps_models = dict((capabilities or {}).get("models") or {})
+    for model in media_models:
+        if model not in models:
+            models.append(model)
+        caps_models[model] = media_gating.capability_entry()
+    return models, {"schema_version": 1, "models": caps_models}
+
+
+def _assemble_snapshot(
+    engine_results: _EngineResults, media_models: list[str], record: dict[str, Any], engine_id: str
+) -> _Snapshot:
+    """Build one routing snapshot from probe results + this box's media models. Used by BOTH startup and
+    a hot-reload so their routing/caps/meta never drift (ADR 0009 D4). Surfaces shadowed-model warnings
+    to stderr exactly as startup does."""
+    routes, upstream, union_models, capabilities, warnings = _build_routing(engine_results)
+    for line in warnings:
+        print(line, file=sys.stderr)
+    union_models, capabilities = _merge_media(union_models, capabilities, media_models)
+    return _Snapshot.build(
+        routes=routes, upstream=upstream, models=union_models, capabilities=capabilities,
+        meta=_meta(record, engine_id), pricing=_pricing(record),
+        max_concurrency=int(record.get("max_concurrency") or 1),
+    )
+
+
 def _meta(record: dict[str, Any], engine_id: str) -> dict[str, Any]:
     """How the node appears on the grid page: name + engine kind label.
 
@@ -358,10 +423,13 @@ def _meta(record: dict[str, Any], engine_id: str) -> dict[str, Any]:
         if kinds:
             label = "+".join(dict.fromkeys(kinds))
     if not label:
-        if record.get("endpoint_url"):
-            label = "external"
-        elif record.get("models") or record.get("engines"):
-            label = "llama.cpp"
+        # An all-external union is "external"; only a built-in `--serve` spec (no endpoint_url) launches
+        # llama.cpp. Derive from the specs so a multi-engine external union isn't mislabelled llama.cpp.
+        specs = record.get("engines") or (
+            [_flat_spec(record)] if (record.get("endpoint_url") or record.get("models")) else []
+        )
+        if specs:
+            label = "llama.cpp" if any(not s.get("endpoint_url") for s in specs) else "external"
         elif record.get("media"):  # a media-only identity has no text engine to name
             label = "comfyui"
         else:
@@ -374,6 +442,12 @@ def _pricing(record: dict[str, Any]) -> dict[str, float]:
     # per-provider, and set explicitly with `grid price set` (relay `grid_chat_pricing`). Always {} so a
     # stale `--pricing-input/output` in an old run record can't reintroduce an advertised price.
     return {}
+
+
+def _media_signature(record: dict[str, Any]) -> tuple[bool, tuple[str, ...], int, int]:
+    """See ``shared.run_records.media_signature`` — one shared definition so the CLI's hot-reload-vs-
+    respawn choice and this reload guard can't desync (ADR 0009 D4 F6 / C3)."""
+    return run_records.media_signature(record)
 
 
 def _load_tokens(network_id: str) -> tuple[str | None, str | None]:
@@ -407,6 +481,43 @@ def _node_id_from_token(access_token: str) -> str:
 # Serve state (thread-safe token + load shared by the poll loop and heartbeat)
 # ---------------------------------------------------------------------------
 
+@dataclass(frozen=True)
+class _Snapshot:
+    """The identity's reload-swappable routing, as one immutable object. ``_reload_once`` builds a new
+    snapshot and ``_ServeState.apply`` rebinds it in a single atomic reference store, so readers that
+    bind it once never see a torn half-update (ADR 0009 D4 F4). ``build`` is the sole normalization
+    site: it copies every dict/list, so a published snapshot is never mutated in place.
+    """
+    routes: dict[str, str]        # advertised model -> local engine URL (normalized, no trailing /)
+    upstream: dict[str, str]      # advertised model -> the name the engine itself answers to
+    models: list[str]             # advertised union, first-seen order (text engines, then media)
+    capabilities: dict[str, Any]  # {"schema_version": 1, "models": {...}} envelope, or {}
+    meta: dict[str, Any]          # grid-page {name, engine}
+    pricing: dict[str, float]     # always {} today (advertised pricing is deprecated)
+    max_concurrency: int
+
+    @staticmethod
+    def build(
+        *,
+        routes: dict[str, str],
+        upstream: dict[str, str],
+        models: list[str],
+        capabilities: dict[str, Any],
+        meta: dict[str, Any],
+        pricing: dict[str, float],
+        max_concurrency: int,
+    ) -> "_Snapshot":
+        return _Snapshot(
+            routes={model: url.rstrip("/") for model, url in routes.items()},
+            upstream=dict(upstream or {}),
+            models=list(models),
+            capabilities=dict(capabilities or {}),
+            meta=dict(meta or {}),
+            pricing=dict(pricing or {}),
+            max_concurrency=max(1, int(max_concurrency)),
+        )
+
+
 class _ServeState:
     def __init__(
         self,
@@ -430,30 +541,75 @@ class _ServeState:
         self.node_id = node_id
         self.network_id = network_id
         self.llm_url = llm_url.rstrip("/")
-        self.models = list(models)
         # This box's media server base (`http://127.0.0.1:<media_port>`) when the identity serves
         # media, else None. `media/*` jobs forward here instead of an LLM engine; all media models
         # share the one server, so a single URL (not a per-model route) is enough.
         self.media_url = media_url.rstrip("/") if media_url else None
-        # model → local engine URL. Several engines may serve under one identity (DECISIONS D9); for
-        # the single-engine case the map is derived so every advertised model points at the one engine.
-        if routes is not None:
-            self._routes = {model: url.rstrip("/") for model, url in routes.items()}
-        else:
-            self._routes = {model: self.llm_url for model in self.models}
-        # advertised model → the name the local engine answers to (``--advertise-as`` maps the
-        # consumer-facing alias back to the engine's real model name). Empty means identity.
-        self._upstream = dict(upstream or {})
-        self.capabilities = dict(capabilities or {})
-        self.meta = dict(meta or {})
-        self.pricing = dict(pricing or {})
-        self.max_concurrency = max(1, int(max_concurrency))
+        # The reload-swappable routing (routes/upstream/models/caps/meta/pricing/concurrency) lives in
+        # one immutable snapshot so a hot-reload can swap it atomically (ADR 0009 D4). Several engines
+        # may serve under one identity (DECISIONS D9); for the single-engine case the route map is
+        # derived so every advertised model points at the one engine.
+        route_map = routes if routes is not None else {model: self.llm_url for model in models}
+        self._snapshot = _Snapshot.build(
+            routes=route_map, upstream=upstream or {}, models=models, capabilities=capabilities,
+            meta=meta, pricing=pricing, max_concurrency=max_concurrency,
+        )
+        # The probe results the live snapshot was built from, kept so a reload probes only newly-added
+        # engines (ADR 0009 D4 F6). Reload-owned: set at startup, thereafter only the reload loop writes.
+        self._engine_results: _EngineResults = []
+        # This box's media (comfyui:*) model names + a fingerprint of the media config the process
+        # brought up. A hot-reload can't launch/teardown media or swap bundles, so a reload whose re-read
+        # record differs here is refused — the CLI respawns instead (ADR 0009 D4 F6 / C3). Set at startup.
+        self.media_models: list[str] = []
+        self.media_signature: tuple[bool, tuple[str, ...], int, int] = _media_signature({})
+        self._reload_register_fails = 0  # consecutive post-swap re-register failures (bounded retry, C5)
         self.stop = threading.Event()
-        self._lock = threading.Lock()  # guards the token + inflight count (short critical sections)
+        self._lock = threading.Lock()  # guards the snapshot swap + token + inflight (short sections)
+        self._register_lock = threading.Lock()  # serializes reload-register vs heartbeat-404 re-register
+        self.reload_requested = threading.Event()  # SIGHUP sets this; the reload loop waits on it
         self._refresh_lock = threading.Lock()  # serializes refreshes WITHOUT blocking token() readers
         self._access_token = access_token
         self._refresh_token = refresh_token
         self._inflight = 0
+
+    @property
+    def models(self) -> list[str]:
+        return self._snapshot.models
+
+    @property
+    def capabilities(self) -> dict[str, Any]:
+        return self._snapshot.capabilities
+
+    @property
+    def meta(self) -> dict[str, Any]:
+        return self._snapshot.meta
+
+    @property
+    def pricing(self) -> dict[str, float]:
+        return self._snapshot.pricing
+
+    @property
+    def max_concurrency(self) -> int:
+        return self._snapshot.max_concurrency
+
+    def snapshot(self) -> _Snapshot:
+        """The current routing snapshot — one atomic reference load (no lock). Bind it ONCE per
+        operation, then read fields off the result, so a concurrent reload swap is never seen
+        half-applied (ADR 0009 D4 F4)."""
+        return self._snapshot
+
+    def apply(self, snapshot: _Snapshot, engine_results: _EngineResults) -> None:
+        """Swap in a freshly-built routing snapshot and the probe results it was built from. Rebinds
+        under ``_lock`` then RELEASES before the caller re-registers, so the ``_register_lock → _lock``
+        order stays acyclic — never register while holding ``_lock`` (ADR 0009 D4 F5)."""
+        with self._lock:
+            self._snapshot = snapshot
+            self._engine_results = engine_results
+
+    def engine_results(self) -> _EngineResults:
+        """The probe results the live snapshot was built from — a reload reuses them so it re-probes
+        only newly-added engines (ADR 0009 D4 F6)."""
+        return self._engine_results
 
     def route(self, model: str | None) -> str | None:
         """The local engine URL serving ``model``.
@@ -464,9 +620,10 @@ class _ServeState:
         body unchanged, letting the engine answer). With several distinct engines and no match, return
         ``None`` so the caller reports "no engine serves" instead of guessing.
         """
-        if model and model in self._routes:
-            return self._routes[model]
-        distinct = set(self._routes.values())
+        snap = self._snapshot  # bind once — a concurrent reload swap is never seen half-applied
+        if model and model in snap.routes:
+            return snap.routes[model]
+        distinct = set(snap.routes.values())
         if len(distinct) == 1:
             return next(iter(distinct))
         return None
@@ -476,8 +633,9 @@ class _ServeState:
         consumer-facing alias back to the engine's real model name). ``None`` when unmapped — the caller
         then forwards the body's model unchanged (single-engine fallback / built-in, where they match).
         """
-        if model and model in self._upstream:
-            return self._upstream[model]
+        snap = self._snapshot
+        if model and model in snap.upstream:
+            return snap.upstream[model]
         return None
 
     def token(self) -> str:
@@ -548,17 +706,34 @@ class _ServeState:
 # Loop units (each independently testable against a mocked relay/engine)
 # ---------------------------------------------------------------------------
 
-def register(state: _ServeState) -> None:
-    relay.register_node(
-        state.signaling_url,
-        state.token(),
-        state.node_id,
-        models=state.models,
-        capabilities=state.capabilities or None,
-        meta=state.meta or None,
-        pricing=state.pricing or None,
-        max_concurrency=state.max_concurrency,
-    )
+def register_once(state: _ServeState, *, _allow_refresh: bool = True) -> None:
+    """Advertise the identity's current snapshot to the relay (``PUT /nodes/{node_id}``).
+
+    Binds the snapshot + token INSIDE ``_register_lock`` so whichever racing register actually PUTs
+    sends the freshest union — the reload's register and the heartbeat's 404 re-register can't interleave
+    two PUTs, and a slow racer can't land a stale snapshot last (ADR 0009 D4 F4/F5). On a 401 it refreshes
+    and retries once — like ``poll_once``/``heartbeat_once`` — so a reload landing at token expiry still
+    re-advertises instead of silently leaving the old union live.
+    """
+    token = None
+    try:
+        with state._register_lock:
+            token = state.token()      # bound inside the lock: whoever PUTs sends the current token and
+            snap = state.snapshot()    # the current snapshot, so a descheduled racer can't PUT a stale one
+            relay.register_node(
+                state.signaling_url,
+                token,
+                state.node_id,
+                models=snap.models,
+                capabilities=snap.capabilities or None,
+                meta=snap.meta or None,
+                pricing=snap.pricing or None,
+                max_concurrency=snap.max_concurrency,
+            )
+    except relay.RelayUnauthorized:
+        if _allow_refresh and token is not None and state.refresh(stale_token=token):
+            return register_once(state, _allow_refresh=False)
+        raise
 
 
 def poll_once(state: _ServeState, *, _allow_refresh: bool = True) -> dict[str, Any] | None:
@@ -582,8 +757,79 @@ def heartbeat_once(state: _ServeState, *, _allow_refresh: bool = True) -> str:
             return heartbeat_once(state, _allow_refresh=False)
         raise
     if result == "missing":
-        register(state)
+        register_once(state)
     return result
+
+
+def _reload_once(state: _ServeState, engine_id: str) -> None:
+    """Rebuild routing from the (re-read) record and re-advertise the union in place — the body of the
+    SIGHUP hot-reload (ADR 0009 D3). External-only and probe-only: reuse retained caps for engines
+    already serving, probe only newly-added ``--at`` endpoints, and build the whole new snapshot before
+    one atomic swap — so in-flight requests keep flowing on the old snapshot until the swap (D4 F6).
+    Anything needing a launch (a built-in ``--serve``) or a media bring-up/bundle change is refused
+    here; the CLI respawns those instead, so the reload thread never blocks on a heavy start.
+    """
+    record = run_records.read_record(state.network_id, engine_id)
+    if not record:  # a concurrent full `grid leave` removed the record — SIGTERM will tear us down
+        _debug("reload: record gone; keeping current routing")
+        return
+    specs = record.get("engines") or (
+        [_flat_spec(record)] if (record.get("endpoint_url") or record.get("models")) else []
+    )
+    aliases = list(record.get("advertise_as") or [])
+    # These refusals mean the CLI signalled something it should have respawned (or a manual SIGHUP) —
+    # surface them, don't hide behind GRID_ENGINE_DEBUG (the CLI already reported the join/leave).
+    if any(not spec.get("endpoint_url") for spec in specs):
+        _warn("reload: record needs a built-in launch; refusing (respawn required)")
+        return
+    if len(specs) > 1 and aliases:
+        _warn("reload: multi-engine identity with --advertise-as; refusing (respawn required)")
+        return
+    if _media_signature(record) != state.media_signature:
+        _warn("reload: media config changed; refusing (respawn required)")
+        return
+
+    retained = {r[0]: r for r in state.engine_results()}  # keyed by the normalized llm_url
+    reassembled: _EngineResults = []
+    for spec in specs:
+        url = (spec.get("endpoint_url") or "").rstrip("/")
+        models = list(spec.get("models") or [])
+        advertised = _advertised_models(models, aliases)
+        prev = retained.get(url)
+        if prev is not None and prev[1][:1] == advertised[:1]:
+            # Already serving this engine: reuse ONLY its probed caps. advertised/upstream come from the
+            # record, so a model appended to this engine is still picked up, not dropped (ADR 0009 C2).
+            reassembled.append((url, advertised, list(models), prev[3]))
+        else:  # a genuinely new engine (or a changed first model) → probe it once
+            caps = probe.capabilities(
+                url, models[0], advertise_as=advertised[0], context_window=record.get("ctx_size"),
+            ) if models else {}
+            reassembled.append((url, advertised, list(models), caps))
+
+    snapshot = _assemble_snapshot(reassembled, state.media_models, record, engine_id)
+    state.apply(snapshot, reassembled)  # atomic swap; in-flight requests were unaffected until here
+    try:
+        register_once(state)  # swap THEN register — a new model is routable before the relay sends it
+        state._reload_register_fails = 0  # a clean re-advertise resets the retry budget
+    except relay.RelayUnauthorized:
+        # Auth is exhausted (refresh failed too). The heartbeat loop stops the process on the same
+        # condition, so don't spin re-registering — surface it (the new union stays unadvertised until re-auth).
+        _warn("reload: re-register rejected the token and refresh is unavailable — new union not advertised")
+    except Exception as exc:
+        # Post-swap transient failure: the new snapshot serves locally but the relay still has the old
+        # union (a healthy node is never heartbeat-404'd). Re-arm so a later tick retries — but BOUNDED, so
+        # a permanent failure doesn't PUT every 2s forever; give up loudly and let the next join re-trigger
+        # (ADR 0009 C5). Reuse means the retry never re-probes.
+        state._reload_register_fails += 1
+        if state._reload_register_fails <= _MAX_RELOAD_REGISTER_RETRIES:
+            _warn(f"reload: re-register failed post-swap ({exc!r}); retry "
+                  f"{state._reload_register_fails}/{_MAX_RELOAD_REGISTER_RETRIES}")
+            state.stop.wait(2)
+            state.reload_requested.set()
+        else:
+            _warn(f"reload: re-register still failing after {_MAX_RELOAD_REGISTER_RETRIES} tries "
+                  f"({exc!r}); giving up until the next join/leave")
+            state._reload_register_fails = 0
 
 
 def handle_job(state: _ServeState, job: dict[str, Any]) -> None:
@@ -686,8 +932,23 @@ def _forward_stream(
                 return
             # Pass the engine's SSE bytes straight through while its stream is open.
             relay.submit_response(
-                state.signaling_url, state.token(), txn, content=engine_resp.iter_bytes(), stream=True
+                state.signaling_url, state.token(), txn,
+                content=_traced_stream(txn, engine_resp.iter_bytes()), stream=True,
             )
+            _debug(f"stream txn={txn} submit_response returned (relay accepted the full stream) t={time.time():.3f}")
+
+
+def _traced_stream(txn: str, chunks: Iterable[bytes]) -> Iterator[bytes]:
+    """Pass engine SSE chunks straight through; when GRID_ENGINE_DEBUG is set, trace chunk progress with a
+    wall-clock timestamp so a mid-stream event (e.g. a node re-register) can be correlated with whether
+    bytes keep flowing to the relay. No-op overhead beyond a counter when debug is off."""
+    n = 0
+    for chunk in chunks:
+        n += 1
+        if _DEBUG and (n == 1 or n % 40 == 0):
+            _debug(f"stream txn={txn} chunk#{n} t={time.time():.3f}")
+        yield chunk
+    _debug(f"stream txn={txn} engine finished after {n} chunks t={time.time():.3f}")
 
 
 # ---------------------------------------------------------------------------
@@ -736,3 +997,46 @@ def _heartbeat_loop(state: _ServeState) -> None:
         else:
             _debug(f"heartbeat: ok ({result})")
         state.stop.wait(relay.HEARTBEAT_INTERVAL)
+
+
+def _reload_loop(state: _ServeState, engine_id: str) -> None:
+    """Wait for a SIGHUP-set reload request and hot-reload the routing in place (ADR 0009 D3).
+
+    Clearing the event BEFORE the reload reads the record means a write+signal that lands during a
+    reload re-sets the event (one extra, harmless reload) instead of being lost — the CLI's contract is
+    write-record-then-signal. A failed reload logs and keeps the thread alive with the old routing
+    intact (D4 F6); the 1s wait bounds how often ``stop`` is checked.
+    """
+    while not state.stop.is_set():
+        if state.reload_requested.wait(timeout=1.0):
+            state.reload_requested.clear()
+            try:
+                _reload_once(state, engine_id)
+            except (Exception, SystemExit) as exc:  # SystemExit too — jsonio.load_json (a corrupt record)
+                # and _advertised_models raise it; catching only Exception would let it kill the watcher
+                # thread, silently disabling hot-reload for the process's life (ADR 0009 D4 F6). Mirrors
+                # run_remote_engine_from_record's own (Exception, SystemExit) handler.
+                _warn(f"reload failed (keeping current routing): {exc!r}")
+
+
+def _start_reload_watcher(
+    state: _ServeState, engine_id: str, engine_results: _EngineResults, media_models: list[str],
+    record: dict[str, Any],
+) -> threading.Thread:
+    """Make the running engine reload-ready and start the SIGHUP-driven reload daemon (ADR 0009 D3/C4).
+
+    Retains the probe results + media fingerprint the reload reuses, installs the SIGHUP handler (which
+    only sets ``reload_requested`` — it must never raise, so PEP 475 retries the interrupted long-poll),
+    and starts ``_reload_loop``. The caller keeps SIGHUP blocked while calling this — so the daemon
+    inherits the block and the signal lands on the main thread — then unblocks it on main afterwards.
+    """
+    state._engine_results = engine_results
+    state.media_models = list(media_models)
+    state.media_signature = _media_signature(record)
+    if hasattr(signal, "SIGHUP"):
+        def _on_sighup(_signum, _frame):  # noqa: ANN001 — only sets the event; never raises, so PEP 475
+            state.reload_requested.set()   # retries the interrupted long-poll
+        signal.signal(signal.SIGHUP, _on_sighup)
+    thread = threading.Thread(target=_reload_loop, args=(state, engine_id), daemon=True)
+    thread.start()
+    return thread

--- a/shared/filelock.py
+++ b/shared/filelock.py
@@ -1,0 +1,39 @@
+"""A tiny cross-process advisory file lock (POSIX ``fcntl.flock``).
+
+Run records are written atomically (``shared.jsonio`` — tmp file + ``os.replace``), but a
+*read-merge-write* of the singleton remote record (read the current union, add an engine, write it
+back) spans two syscalls, so two concurrent ``grid join`` processes could lost-update the union
+(``cli.remote_provider``, ADR 0009). ``file_lock`` serializes that critical section with an exclusive
+lock on a sibling ``<name>.lock`` file.
+
+POSIX-only, which matches the macOS/Linux CLI target (there is no Windows path). ``flock`` locks are
+tied to the open file description and released on ``close``/process exit, so a crashed holder never
+strands the lock. The lock file itself is created ``0o600`` and intentionally left on disk (an empty
+sentinel — creating/removing it per acquire would itself race).
+"""
+from __future__ import annotations
+
+import contextlib
+import fcntl
+import os
+from collections.abc import Iterator
+from pathlib import Path
+
+
+@contextlib.contextmanager
+def file_lock(path: Path) -> Iterator[None]:
+    """Hold an exclusive advisory lock for the body of the ``with`` block.
+
+    ``path`` is the file whose read-modify-write is being guarded; the lock is taken on a sibling
+    ``<path>.lock`` so it never collides with the atomic-rename target. Parent directories are created
+    as needed. Blocks until the lock is acquired, and always releases (and closes the fd) on exit.
+    """
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)  # blocks until no other holder
+        yield
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)

--- a/shared/run_records.py
+++ b/shared/run_records.py
@@ -52,6 +52,41 @@ def read_record(grid_id: str, engine_id: str) -> dict[str, Any] | None:
     return read_records(grid_id).get(engine_id)
 
 
+def match_engine(
+    specs: list[dict[str, Any]],
+    selector: str,
+    *,
+    label: str,
+    summary: str,
+    hint: str = "pass the exact endpoint URL instead",
+) -> list[dict[str, Any]]:
+    """Engine spec(s) a `grid leave --engine <selector>` picks out of ``specs``, tried in order: exact
+    ``endpoint_url`` → exact ``engine_label`` → a served model → an ``endpoint_url`` substring. Each match
+    must resolve to exactly ONE engine or it raises ``SystemExit`` (naming ``summary`` and ``hint``);
+    returns ``[]`` on no match so the caller raises its own not-found. Returned dicts are the SAME objects
+    passed in — identity is preserved for an ``id()``-based drop filter. An exact engine-*id* match is the
+    caller's job BEFORE this (remote keys engines by URL/label; local by record id). ``hint`` is the
+    disambiguation instruction, per mode: remote points at the endpoint URL, local at the engine id."""
+
+    def unique(matches: list[dict[str, Any]], how: str) -> list[dict[str, Any]]:
+        if len(matches) > 1:
+            raise SystemExit(
+                f"{how} {selector!r} matches several engines on {label}; {hint}. Engines: {summary}."
+            )
+        return matches
+
+    by_url = unique([s for s in specs if s.get("endpoint_url") == selector], "URL")
+    if by_url:
+        return by_url
+    by_label = unique([s for s in specs if s.get("engine_label") == selector], "Label")
+    if by_label:
+        return by_label
+    by_model = unique([s for s in specs if selector in (s.get("models") or [])], "Model")
+    if by_model:
+        return by_model
+    return unique([s for s in specs if selector in (s.get("endpoint_url") or "")], "URL fragment")
+
+
 def media_signature(record: dict[str, Any]) -> tuple[bool, tuple[str, ...], int, int]:
     """A comparable fingerprint of an identity's media config (on/off, bundles, ports). A SIGHUP
     hot-reload can't bring media up/down or swap bundles, so ``grid join``/``leave`` (CLI) and the serve

--- a/shared/run_records.py
+++ b/shared/run_records.py
@@ -52,6 +52,19 @@ def read_record(grid_id: str, engine_id: str) -> dict[str, Any] | None:
     return read_records(grid_id).get(engine_id)
 
 
+def media_signature(record: dict[str, Any]) -> tuple[bool, tuple[str, ...], int, int]:
+    """A comparable fingerprint of an identity's media config (on/off, bundles, ports). A SIGHUP
+    hot-reload can't bring media up/down or swap bundles, so ``grid join``/``leave`` (CLI) and the serve
+    loop's reload both compare this to choose hot-reload vs respawn — ONE definition so the two decisions
+    can never desync (ADR 0009 C3)."""
+    return (
+        bool(record.get("media")),
+        tuple(sorted(record.get("media_bundles") or [])),
+        int(record.get("comfyui_port") or 8188),
+        int(record.get("media_port") or 8190),
+    )
+
+
 def pid_alive(pid: int) -> bool:
     if not pid:
         return False

--- a/shared/run_records.py
+++ b/shared/run_records.py
@@ -67,6 +67,8 @@ def match_engine(
     passed in — identity is preserved for an ``id()``-based drop filter. An exact engine-*id* match is the
     caller's job BEFORE this (remote keys engines by URL/label; local by record id). ``hint`` is the
     disambiguation instruction, per mode: remote points at the endpoint URL, local at the engine id."""
+    if not selector:  # defensive: an empty selector is a substring of every URL — never "match all"
+        return []
 
     def unique(matches: list[dict[str, Any]], how: str) -> list[dict[str, Any]]:
         if len(matches) > 1:

--- a/shared/run_records.py
+++ b/shared/run_records.py
@@ -58,6 +58,11 @@ def pid_alive(pid: int) -> bool:
     try:
         os.kill(pid, 0)
         return True
+    except ProcessLookupError:
+        return False  # ESRCH: no such process
+    except PermissionError:
+        return True  # EPERM: the process exists, it's just owned by another uid — reporting it dead would
+        # let a join spawn a second engine under the same token node_id and clobber it.
     except OSError:
         return False
 
@@ -72,22 +77,37 @@ def kill_group(pid: int) -> None:
         pass
 
 
+def terminate_pid(pid: int) -> bool:
+    """SIGTERM a detached engine child and wait for it to exit, escalating to SIGKILL of its process
+    group after the grace window. Does **not** touch any run record — the caller decides whether to
+    remove it (a `grid leave` teardown) or keep it (a respawn that rewrites the record in place, so the
+    engine child unregisters + stops what it launched, but the merged record survives). A ``0``/dead pid
+    is a no-op.
+
+    Returns whether the process is confirmed gone. ``False`` means it survived even SIGKILL — the caller
+    must NOT spawn a replacement, because two live children on one token-pinned relay node_id clobber
+    each other (the exact bug this whole flow exists to prevent).
+    """
+    if not (pid and pid_alive(pid)):
+        return True
+    # SIGTERM the detached engine so it unregisters and stops anything it started.
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return True
+    deadline = time.time() + _STOP_GRACE_SECONDS
+    while time.time() < deadline and pid_alive(pid):
+        time.sleep(0.2)
+    if pid_alive(pid):
+        kill_group(pid)
+    return not pid_alive(pid)
+
+
 def stop_engine(grid_id: str, engine_id: str, record: dict[str, Any]) -> None:
     """SIGTERM the detached engine child so it unregisters + tears down, then drop its record.
 
     Escalates to SIGKILL of the process group if it does not exit within the grace window. The
     record is removed either way, so a leave never leaves a stale handle behind.
     """
-    pid = int(record.get("pid") or 0)
-    if pid and pid_alive(pid):
-        # SIGTERM the detached engine so it unregisters and stops anything it started.
-        try:
-            os.kill(pid, signal.SIGTERM)
-        except ProcessLookupError:
-            pass
-        deadline = time.time() + _STOP_GRACE_SECONDS
-        while time.time() < deadline and pid_alive(pid):
-            time.sleep(0.2)
-        if pid_alive(pid):
-            kill_group(pid)
+    terminate_pid(int(record.get("pid") or 0))
     record_path(grid_id, engine_id).unlink(missing_ok=True)

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -1304,8 +1304,10 @@ def _seed_running_remote_grid(monkeypatch, tmp_path, *, access_token="AT"):
 
 
 def _mock_remote_spawn(monkeypatch, *, pid=4242):
-    """Capture the detached __remote-engine spawn and skip the real liveness wait."""
-    spawned = {}
+    """Capture the detached __remote-engine spawn AND any SIGHUP hot-reload signal, and skip the real
+    liveness wait. Returns a dict with 'cmd' (the spawn argv) and 'signals' (list of (pid, sig)) — the
+    os.kill mock also keeps a stray SIGHUP from ever hitting a real process with the test pid."""
+    spawned = {"signals": []}
 
     def fake_popen(cmd, **kw):
         spawned["cmd"] = cmd
@@ -1313,6 +1315,7 @@ def _mock_remote_spawn(monkeypatch, *, pid=4242):
 
     monkeypatch.setattr(cli.remote_provider.subprocess, "Popen", fake_popen)
     monkeypatch.setattr(cli.remote_provider, "_await_remote_engine_start", lambda *a, **k: "starting")
+    monkeypatch.setattr(cli.remote_provider.os, "kill", lambda p, s: spawned["signals"].append((p, s)))
     return spawned
 
 
@@ -1517,25 +1520,28 @@ def test_remote_join_died_cleans_up_record(monkeypatch, tmp_path):
     assert cli.provider._read_records("n1") == {}  # stale record removed on a failed start
 
 
-def test_remote_join_appends_via_respawn(monkeypatch, tmp_path):
-    """A second `grid join` on a remote grid is ADDITIVE: it merges into the one singleton identity and
-    respawns it (stopping the prior process first, since both share the token-pinned node_id)."""
+def test_remote_join_appends_via_hot_reload(monkeypatch, tmp_path):
+    """A second `grid join` on a remote grid is ADDITIVE and ZERO-DROP: it merges into the one singleton
+    identity and SIGHUP-hot-reloads the live process in place — no restart, no terminate (ADR 0009 D3)."""
+    import signal as _sig
+
     _seed_running_remote_grid(monkeypatch, tmp_path)
-    _mock_remote_spawn(monkeypatch)
+    spawned = _mock_remote_spawn(monkeypatch)
     terminated = []
     monkeypatch.setattr(cli.remote_provider.run_records, "terminate_pid", lambda pid: terminated.append(pid) or True)
 
-    assert cli.main(["join", "--at", "http://h:11434/v1", "-m", "llama3"]) == 0
+    assert cli.main(["join", "--at", "http://h:11434/v1", "-m", "llama3"]) == 0  # first join spawns
     # The first identity is now live — make its recorded pid look alive so the 2nd join appends to it.
     monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
-    assert cli.main(["join", "--at", "http://h:8000/v1", "-m", "mistral"]) == 0
+    assert cli.main(["join", "--at", "http://h:8000/v1", "-m", "mistral"]) == 0  # second appends via SIGHUP
 
     records = cli.provider._read_records("n1")
     assert list(records) == ["remote"]  # exactly one singleton identity per grid
     rec = records["remote"]
     assert [e["endpoint_url"] for e in rec["engines"]] == ["http://h:11434/v1", "http://h:8000/v1"]  # union
     assert rec["models"] == ["llama3", "mistral"] and rec["endpoint_url"] is None
-    assert terminated == [4242]  # the 2nd join stopped the 1st process before respawning the union
+    assert spawned["signals"] == [(4242, _sig.SIGHUP)]  # hot-reloaded the live singleton in place
+    assert terminated == []                             # never stopped the live process (zero-drop)
 
 
 def test_remote_join_appending_same_url_is_noop(monkeypatch, tmp_path, capsys):
@@ -1627,20 +1633,23 @@ def test_remote_join_serve_rejoin_same_model_is_noop(monkeypatch, tmp_path, caps
     assert "already serving" in capsys.readouterr().out.lower()
 
 
-def test_remote_join_rename_respawns_to_apply_meta_name(monkeypatch, tmp_path):
-    """A re-join that only changes --name is not silently dropped: it respawns so the new display name
-    actually takes effect (there is no other way to rename in Slice 1)."""
+def test_remote_join_rename_hot_reloads_meta_name(monkeypatch, tmp_path):
+    """A re-join that only changes --name hot-reloads (zero-drop) so the new display name takes effect —
+    the reload recomputes meta from the rewritten record (ADR 0009 D3)."""
+    import signal as _sig
+
     _seed_running_remote_grid(monkeypatch, tmp_path)
-    _mock_remote_spawn(monkeypatch)
-    respawned = []
-    monkeypatch.setattr(cli.remote_provider.run_records, "terminate_pid", lambda pid: respawned.append(pid) or True)
+    spawned = _mock_remote_spawn(monkeypatch)
+    terminated = []
+    monkeypatch.setattr(cli.remote_provider.run_records, "terminate_pid", lambda pid: terminated.append(pid) or True)
 
     assert cli.main(["join", "--at", "http://h:11434/v1", "-m", "llama3", "--name", "first"]) == 0
     monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
     assert cli.main(["join", "--at", "http://h:11434/v1", "-m", "llama3", "--name", "second"]) == 0
 
     assert cli.provider._read_records("n1")["remote"]["meta_name"] == "second"  # rename applied
-    assert respawned == [4242]  # respawned to apply it
+    assert spawned["signals"] == [(4242, _sig.SIGHUP)]  # via a zero-drop hot-reload, not a respawn
+    assert terminated == []
 
 
 def test_remote_join_append_onto_aliased_identity_is_rejected(monkeypatch, tmp_path):
@@ -1657,15 +1666,37 @@ def test_remote_join_append_onto_aliased_identity_is_rejected(monkeypatch, tmp_p
     assert "advertise-as" in str(exc.value).lower()
 
 
-def test_remote_join_aborts_when_prior_process_wont_die(monkeypatch, tmp_path):
-    """If a prior engine can't be confirmed stopped, the join aborts BEFORE spawning — spawning anyway
-    would put two processes on the same token node_id (the original clobber bug)."""
+def test_remote_join_rejoin_aliased_engine_with_new_alias_is_rejected(monkeypatch, tmp_path):
+    """Re-joining ONE engine with a second -m/--advertise-as would mismatch the alias/model counts and
+    crash the reload's _advertised_models (SystemExit); the CLI rejects it up front instead — aliases
+    don't merge across joins (reviewer CRITICAL root cause)."""
     _seed_running_remote_grid(monkeypatch, tmp_path)
     _mock_remote_spawn(monkeypatch)
-    monkeypatch.setattr(cli.remote_provider.run_records, "terminate_pid", lambda pid: False)  # won't die
+    monkeypatch.setattr(cli.remote_provider.run_records, "terminate_pid", lambda pid: True)
 
-    assert cli.main(["join", "--at", "http://h:11434/v1", "-m", "llama3"]) == 0  # first join: no prior to stop
+    assert cli.main(["join", "--at", "http://h:11434/v1", "-m", "m1", "--advertise-as", "a1"]) == 0
     monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["join", "--at", "http://h:11434/v1", "-m", "m2", "--advertise-as", "a2"])  # same engine, 2nd pair
+    assert "advertise-as" in str(exc.value).lower()
+
+
+def test_remote_join_aborts_when_prior_process_wont_die(monkeypatch, tmp_path):
+    """On the respawn path (here a pre-handler prior that can't be SIGHUP-hot-reloaded), if the prior
+    can't be confirmed stopped the join aborts BEFORE spawning — spawning anyway would put two processes
+    on the same token node_id (the original clobber bug)."""
+    from shared import run_records as _rr
+
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_remote_spawn(monkeypatch)
+    _rr.write_record("n1", "remote", {  # a pre-handler (no reload_signal) live singleton → append respawns
+        "engine_id": "remote", "grid_id": "n1", "pid": 4242, "media": False, "reload_signal": None,
+        "signaling_url": "https://relay.example", "meta_name": "mybox",
+        "engines": [{"endpoint_url": "http://h:11434/v1", "models": ["llama3"], "engine_label": None}],
+        "models": ["llama3"], "endpoint_url": "http://h:11434/v1",
+    })
+    monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
+    monkeypatch.setattr(cli.remote_provider.run_records, "terminate_pid", lambda pid: False)  # won't die
     spawns = []
     monkeypatch.setattr(cli.remote_provider, "_spawn_remote_engine",
                         lambda *a, **k: spawns.append(a) or type("P", (), {"pid": 1})())
@@ -1675,13 +1706,92 @@ def test_remote_join_aborts_when_prior_process_wont_die(monkeypatch, tmp_path):
     assert spawns == []  # never spawned the clobbering second process
 
 
-def _seed_remote_identity(monkeypatch, tmp_path, engines, *, pid=4242, media=False):
+def test_remote_join_pre_handler_singleton_respawns_not_sighup(monkeypatch, tmp_path):
+    """C1: appending onto a live singleton with NO reload_signal (a pre-Slice-2 process with no SIGHUP
+    handler) RESPAWNS — a raw SIGHUP would terminate that process and drop every in-flight request."""
+    from shared import run_records as _rr
+
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    spawned = _mock_remote_spawn(monkeypatch)
+    terminated = []
+    monkeypatch.setattr(cli.remote_provider.run_records, "terminate_pid", lambda pid: terminated.append(pid) or True)
+    _rr.write_record("n1", "remote", {  # pre-handler live singleton (no reload_signal)
+        "engine_id": "remote", "grid_id": "n1", "pid": 4242, "media": False,
+        "signaling_url": "https://relay.example", "meta_name": "mybox",
+        "engines": [{"endpoint_url": "http://h:11434/v1", "models": ["llama3"], "engine_label": None}],
+        "models": ["llama3"], "endpoint_url": "http://h:11434/v1",
+    })
+    monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
+
+    assert cli.main(["join", "--at", "http://h:8000/v1", "-m", "mistral"]) == 0
+    assert terminated == [4242]              # respawned: the pre-handler process was stopped, not SIGHUP'd
+    assert spawned["signals"] == []          # no SIGHUP to a process that can't handle it
+    rec = cli.provider._read_records("n1")["remote"]
+    assert [e["endpoint_url"] for e in rec["engines"]] == ["http://h:11434/v1", "http://h:8000/v1"]
+    assert rec["reload_signal"] == "sighup"  # the respawned record is now Slice-2 (future joins hot-reload)
+
+
+def test_remote_join_hot_reload_falls_back_to_respawn_if_pid_vanished(monkeypatch, tmp_path, capsys):
+    """If the live singleton dies between the liveness check and the SIGHUP (os.kill → ProcessLookupError),
+    the append falls back to a respawn so the merged record is actually served, not lost to a dead pid —
+    and the CLI reports the respawn honestly, not a false 'hot-reloaded, no drops' (reviewer HIGH)."""
+    from shared import run_records as _rr
+
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    spawned = _mock_remote_spawn(monkeypatch)  # provides the respawn Popen + await
+
+    def _vanished(pid, sig):
+        raise ProcessLookupError()
+
+    monkeypatch.setattr(cli.remote_provider.os, "kill", _vanished)  # process gone at signal time
+    _rr.write_record("n1", "remote", {
+        "engine_id": "remote", "grid_id": "n1", "pid": 4242, "media": False, "reload_signal": "sighup",
+        "signaling_url": "https://relay.example", "meta_name": "mybox",
+        "engines": [{"endpoint_url": "http://h:11434/v1", "models": ["llama3"], "engine_label": None}],
+        "models": ["llama3"], "endpoint_url": "http://h:11434/v1",
+    })
+    monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
+
+    assert cli.main(["join", "--at", "http://h:8000/v1", "-m", "mistral"]) == 0
+    rec = cli.provider._read_records("n1")["remote"]
+    assert [e["endpoint_url"] for e in rec["engines"]] == ["http://h:11434/v1", "http://h:8000/v1"]  # served
+    assert spawned["cmd"][-3:] == ["__remote-engine", "n1", "remote"]  # respawned fresh after the vanish
+    out = capsys.readouterr().out
+    assert "hot-reloaded" not in out and "starting" in out  # honest: reported the respawn, not zero-drop
+
+
+def test_remote_join_media_bundle_add_respawns_not_sighup(monkeypatch, tmp_path):
+    """C3: adding a media --bundle to a live media identity RESPAWNS (a new bundle needs a ComfyUI
+    bring-up the hot-reload can't do), rather than SIGHUP'ing and silently dropping the new models."""
+    from shared import run_records as _rr
+
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    spawned = _mock_remote_spawn(monkeypatch)
+    terminated = []
+    monkeypatch.setattr(cli.remote_provider.run_records, "terminate_pid", lambda pid: terminated.append(pid) or True)
+    _rr.write_record("n1", "remote", {  # a live Slice-2 media identity serving one bundle
+        "engine_id": "remote", "grid_id": "n1", "pid": 4242, "media": True, "reload_signal": "sighup",
+        "signaling_url": "https://relay.example", "meta_name": "mybox",
+        "media_bundles": ["image_generation"], "comfyui_port": 8188, "media_port": 8190,
+        "engines": [], "models": [], "endpoint_url": None,
+    })
+    monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
+
+    assert cli.main(["join", "--media", "--bundle", "i2v"]) == 0  # add a new bundle
+    assert terminated == [4242]        # respawned to bring up the new bundle
+    assert spawned["signals"] == []    # not a SIGHUP hot-reload (which would drop the new bundle's models)
+    rec = cli.provider._read_records("n1")["remote"]
+    assert set(rec["media_bundles"]) == {"image_generation", "i2v"}
+
+
+def _seed_remote_identity(monkeypatch, tmp_path, engines, *, pid=4242, media=False, reload_signal="sighup"):
     from shared import run_records
 
     _seed_remote(monkeypatch, tmp_path,
                 networks=[{"network_id": "n1", "name": "team", "access_token": "AT"}], active="team")
     run_records.write_record("n1", "remote", {
         "engine_id": "remote", "grid_id": "n1", "pid": pid, "media": media,
+        "reload_signal": reload_signal,  # a Slice-2 identity supports SIGHUP hot-reload; None = pre-handler
         "signaling_url": "https://relay.example", "meta_name": "mybox",
         "engines": engines,
         "models": list(dict.fromkeys(m for e in engines for m in e.get("models") or [])),
@@ -1699,11 +1809,15 @@ def test_remote_leave_tears_down_the_identity(monkeypatch, tmp_path, capsys):
 
 
 def test_remote_leave_engine_shrinks_union(monkeypatch, tmp_path):
+    """`grid leave --engine` drops one engine and SIGHUP-hot-reloads the reduced union in place — zero
+    drop, no restart (ADR 0009 D3)."""
+    import signal as _sig
+
     _seed_remote_identity(monkeypatch, tmp_path, [
         {"endpoint_url": "http://h:11434/v1", "models": ["llama3"], "engine_label": "ollama"},
         {"endpoint_url": "http://h:8000/v1", "models": ["mistral"], "engine_label": "vllm"},
     ])
-    _mock_remote_spawn(monkeypatch)  # the reduced union is respawned
+    spawned = _mock_remote_spawn(monkeypatch)
     terminated = []
     monkeypatch.setattr(cli.remote_provider.run_records, "terminate_pid", lambda pid: terminated.append(pid) or True)
     monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
@@ -1712,7 +1826,8 @@ def test_remote_leave_engine_shrinks_union(monkeypatch, tmp_path):
     rec = cli.provider._read_records("n1")["remote"]
     assert [e["endpoint_url"] for e in rec["engines"]] == ["http://h:8000/v1"]  # only the survivor remains
     assert rec["models"] == ["mistral"] and rec["endpoint_url"] == "http://h:8000/v1"
-    assert terminated == [4242]  # respawned with the reduced union
+    assert spawned["signals"] == [(4242, _sig.SIGHUP)]  # hot-reloaded the reduced union
+    assert terminated == []                             # never stopped the live process
 
 
 def test_remote_leave_engine_last_tears_down(monkeypatch, tmp_path, capsys):
@@ -1729,32 +1844,80 @@ def test_remote_leave_engine_unknown_errors(monkeypatch, tmp_path):
                           [{"endpoint_url": "http://h:11434/v1", "models": ["llama3"], "engine_label": "ollama"}], pid=0)
     with pytest.raises(SystemExit) as exc:
         cli.main(["leave", "--engine", "http://nope:9999/v1"])
-    assert "no engine" in str(exc.value).lower()
+    msg = str(exc.value).lower()
+    assert "no engine" in msg and "http://h:11434/v1" in msg  # lists what IS serving so the operator can pick
+
+
+def test_remote_leave_engine_matches_by_served_model(monkeypatch, tmp_path):
+    """`grid leave --engine <model>` drops the engine serving that model — friendlier than the full URL."""
+    import signal as _sig
+
+    _seed_remote_identity(monkeypatch, tmp_path, [
+        {"endpoint_url": "http://h:11434/v1", "models": ["llama3"], "engine_label": "ollama"},
+        {"endpoint_url": "http://h:8000/v1", "models": ["mistral"], "engine_label": "vllm"},
+    ])
+    spawned = _mock_remote_spawn(monkeypatch)
+    monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
+
+    assert cli.main(["leave", "--engine", "mistral"]) == 0  # match by served model
+    rec = cli.provider._read_records("n1")["remote"]
+    assert [e["endpoint_url"] for e in rec["engines"]] == ["http://h:11434/v1"]  # mistral's engine dropped
+    assert spawned["signals"] == [(4242, _sig.SIGHUP)]
+
+
+def test_remote_leave_engine_matches_by_url_fragment(monkeypatch, tmp_path):
+    """`grid leave --engine :8000` drops the engine whose URL contains that fragment (host/port)."""
+    _seed_remote_identity(monkeypatch, tmp_path, [
+        {"endpoint_url": "http://h:11434/v1", "models": ["llama3"], "engine_label": "ollama"},
+        {"endpoint_url": "http://h:8000/v1", "models": ["mistral"], "engine_label": "vllm"},
+    ])
+    _mock_remote_spawn(monkeypatch)
+    monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
+
+    assert cli.main(["leave", "--engine", ":8000"]) == 0  # match by port fragment
+    rec = cli.provider._read_records("n1")["remote"]
+    assert [e["endpoint_url"] for e in rec["engines"]] == ["http://h:11434/v1"]
+
+
+def test_remote_leave_engine_ambiguous_lists_engines(monkeypatch, tmp_path):
+    """An ambiguous selector (a model two engines serve) errors and lists the engines, asking for the URL."""
+    _seed_remote_identity(monkeypatch, tmp_path, [
+        {"endpoint_url": "http://h:1/v1", "models": ["shared"], "engine_label": "a"},
+        {"endpoint_url": "http://h:2/v1", "models": ["shared"], "engine_label": "b"},
+    ])
+    monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["leave", "--engine", "shared"])
+    msg = str(exc.value).lower()
+    assert "several" in msg and "http://h:1/v1" in msg and "http://h:2/v1" in msg
 
 
 def test_remote_leave_shrink_preserves_media(monkeypatch, tmp_path):
-    """Dropping a text engine from an identity that also serves media keeps media on in the respawn."""
+    """Dropping a text engine from an identity that also serves media keeps media on and hot-reloads —
+    media is unchanged, so no respawn/bring-up is needed."""
+    import signal as _sig
+
     _seed_remote_identity(monkeypatch, tmp_path, [
         {"endpoint_url": "http://h:11434/v1", "models": ["llama3"], "engine_label": "ollama"},
         {"endpoint_url": "http://h:8000/v1", "models": ["mistral"], "engine_label": "vllm"},
     ], media=True)
-    _mock_remote_spawn(monkeypatch)
-    monkeypatch.setattr(cli.remote_provider.run_records, "terminate_pid", lambda pid: True)
+    spawned = _mock_remote_spawn(monkeypatch)
     monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
 
     assert cli.main(["leave", "--engine", "http://h:11434/v1"]) == 0
     rec = cli.provider._read_records("n1")["remote"]
     assert rec["media"] is True  # media survives an engine drop
     assert [e["endpoint_url"] for e in rec["engines"]] == ["http://h:8000/v1"]
+    assert spawned["signals"] == [(4242, _sig.SIGHUP)]  # hot-reloaded (media unchanged)
 
 
 def test_remote_leave_shrink_reports_a_dead_respawn(monkeypatch, tmp_path):
-    """A shrink whose respawn dies must surface an error, not print 're-serving N engine(s)' success while
-    the grid serves nothing."""
+    """On the respawn path (a pre-handler identity), a shrink whose respawn dies must surface an error,
+    not print 're-serving N engine(s)' success while the grid serves nothing."""
     _seed_remote_identity(monkeypatch, tmp_path, [
         {"endpoint_url": "http://h:11434/v1", "models": ["llama3"], "engine_label": "ollama"},
         {"endpoint_url": "http://h:8000/v1", "models": ["mistral"], "engine_label": "vllm"},
-    ])
+    ], reload_signal=None)
     monkeypatch.setattr(cli.remote_provider.subprocess, "Popen", lambda cmd, **kw: type("P", (), {"pid": 7})())
     monkeypatch.setattr(cli.remote_provider, "_await_remote_engine_start", lambda *a, **k: "died")
     monkeypatch.setattr(cli.remote_provider.run_records, "terminate_pid", lambda pid: True)
@@ -1763,6 +1926,24 @@ def test_remote_leave_shrink_reports_a_dead_respawn(monkeypatch, tmp_path):
     with pytest.raises(SystemExit) as exc:
         cli.main(["leave", "--engine", "http://h:11434/v1"])
     assert "not serving" in str(exc.value).lower() or "exited" in str(exc.value).lower()
+
+
+def test_remote_leave_shrink_respawn_refreshes_reload_signal(monkeypatch, tmp_path):
+    """A leave-shrink respawn from a pre-handler identity stamps reload_signal so future ops hot-reload
+    (self-heal, matching the join side — reviewer MEDIUM)."""
+    _seed_remote_identity(monkeypatch, tmp_path, [
+        {"endpoint_url": "http://h:11434/v1", "models": ["llama3"], "engine_label": "ollama"},
+        {"endpoint_url": "http://h:8000/v1", "models": ["mistral"], "engine_label": "vllm"},
+    ], reload_signal=None)  # pre-handler → shrink respawns rather than hot-reloads
+    _mock_remote_spawn(monkeypatch)
+    terminated = []
+    monkeypatch.setattr(cli.remote_provider.run_records, "terminate_pid", lambda pid: terminated.append(pid) or True)
+    monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
+
+    assert cli.main(["leave", "--engine", "http://h:11434/v1"]) == 0
+    rec = cli.provider._read_records("n1")["remote"]
+    assert rec["reload_signal"] == "sighup"   # respawn stamped it → future leave/join hot-reload
+    assert terminated == [4242]               # pre-handler → respawn (not SIGHUP)
 
 
 def test_dispatch_runs_agnostic_command_in_remote(monkeypatch, tmp_path, capsys):
@@ -2511,7 +2692,7 @@ def test_serve_node_id_comes_from_access_token_jwt():
     assert serve._node_id_from_token("opaque-not-a-jwt") == ""         # not a JWT at all
 
 
-def test_serve_register_sends_cached_payload(monkeypatch, tmp_path):
+def test_serve_register_once_sends_cached_payload(monkeypatch, tmp_path):
     from remote import relay, serve
 
     state = _serve_state(monkeypatch, tmp_path,
@@ -2519,10 +2700,503 @@ def test_serve_register_sends_cached_payload(monkeypatch, tmp_path):
     seen = {}
     monkeypatch.setattr(relay, "register_node", lambda url, tok, node, **kw: seen.update(url=url, tok=tok, node=node, **kw))
 
-    serve.register(state)
+    serve.register_once(state)
     assert (seen["url"], seen["tok"], seen["node"]) == ("https://relay.example", "AT", "node-1")
     assert seen["models"] == ["m"] and seen["max_concurrency"] == 3
     assert seen["capabilities"] == {"schema_version": 1, "models": {"m": {}}}
+
+
+def test_serve_register_once_refreshes_then_retries_on_401(monkeypatch, tmp_path):
+    """A reload/re-register that lands at token expiry refreshes + retries once (like poll/heartbeat),
+    so it re-advertises instead of silently leaving the old union registered."""
+    from remote import control_plane, credentials, relay, serve
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    credentials.save_credentials({"networks": [{"network_id": "n1", "access_token": "AT", "refresh_token": "RT"}]})
+    state = _serve_state(monkeypatch, tmp_path, access_token="AT", refresh_token="RT")
+    monkeypatch.setattr(control_plane, "refresh_network_token",
+                        lambda *, network_id, refresh_token, api_url=None: {"access_token": "AT2", "refresh_token": "RT2"})
+    tokens = []
+
+    def fake_register(url, tok, node, **kw):
+        tokens.append(tok)
+        if len(tokens) == 1:
+            raise relay.RelayUnauthorized()
+
+    monkeypatch.setattr(relay, "register_node", fake_register)
+    serve.register_once(state)
+    assert tokens == ["AT", "AT2"]  # retried with the refreshed token
+
+
+def test_serve_register_once_holds_register_lock_during_put(monkeypatch, tmp_path):
+    """The PUT runs under _register_lock so the reload's register and the heartbeat-404 re-register
+    can never interleave two PUTs on the one token-pinned node_id (ADR 0009 D4 F5)."""
+    from remote import relay, serve
+
+    state = _serve_state(monkeypatch, tmp_path)
+    held = []
+    monkeypatch.setattr(relay, "register_node", lambda *a, **k: held.append(state._register_lock.locked()))
+    serve.register_once(state)
+    assert held == [True]
+
+
+def test_serve_apply_swaps_snapshot_atomically(monkeypatch, tmp_path):
+    """apply() rebinds one immutable snapshot: readers see the new routing union, and a snapshot
+    captured before the swap stays frozen-intact (F4 — the swap never mutates a published snapshot)."""
+    from remote import serve
+
+    state = _serve_state(monkeypatch, tmp_path, models=["a"], routes={"a": "http://e1/v1"})
+    before = state.snapshot()
+    assert state.route("a") == "http://e1/v1" and state.models == ["a"]
+
+    new = serve._Snapshot.build(
+        routes={"a": "http://e1/v1", "b": "http://e2/v1"}, upstream={},
+        models=["a", "b"], capabilities={"schema_version": 1, "models": {}},
+        meta={"name": "e1", "engine": "external"}, pricing={}, max_concurrency=1,
+    )
+    state.apply(new, [("http://e1/v1", ["a"], ["a"], {}), ("http://e2/v1", ["b"], ["b"], {})])
+
+    assert state.route("b") == "http://e2/v1"          # the appended engine is now routable
+    assert state.models == ["a", "b"]                  # the property reflects the swapped snapshot
+    assert before.routes == {"a": "http://e1/v1"}      # the captured old snapshot is unchanged
+
+
+def _seed_reload_state(monkeypatch, tmp_path, engines, *, retained, media_models=None,
+                       record_media=False, record_bundles=None, startup_bundles=None):
+    """A ``_ServeState`` wired for a ``_reload_once`` test: ``GRID_HOME`` set, the singleton record
+    written with ``engines``, and the retained probe results + media state the reload reads. ``retained``
+    is the ``[(url, advertised, upstream, caps), ...]`` the live snapshot was built from; the state's
+    ``media_signature`` reflects the STARTUP media config (``startup_bundles``), which the reload
+    compares the re-read record against."""
+    from remote import serve
+    from shared import run_records
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    routes, upstream, models, caps, _warn = (
+        serve._build_routing([tuple(r) for r in retained]) if retained else ({}, {}, [], {}, [])
+    )
+    state = _serve_state(monkeypatch, tmp_path, models=models, routes=routes,
+                         upstream=upstream, capabilities=caps)
+    state._engine_results = [tuple(r) for r in retained]
+    state.media_models = list(media_models or [])
+    state.media_signature = serve._media_signature(
+        {"media": record_media, "media_bundles": list(startup_bundles or [])})
+    run_records.write_record("n1", "remote", {
+        "engine_id": "remote", "grid_id": "n1", "media": record_media,
+        "media_bundles": list(record_bundles if record_bundles is not None else (startup_bundles or [])),
+        "engines": engines,
+    })
+    return state
+
+
+def test_serve_reload_probes_only_new_engine_and_registers_union(monkeypatch, tmp_path):
+    """A hot-reload reuses retained caps for engines already serving and probes ONLY newly-added --at
+    endpoints, then re-registers the full union after the swap (ADR 0009 D3 / D4 F6)."""
+    from remote import probe, relay, serve
+
+    state = _seed_reload_state(monkeypatch, tmp_path, retained=[
+        ("http://e1/v1", ["a"], ["a"], {"schema_version": 1, "models": {"a": {}}}),
+    ], engines=[
+        {"endpoint_url": "http://e1/v1", "models": ["a"], "engine_label": None},
+        {"endpoint_url": "http://e2/v1", "models": ["b"], "engine_label": None},
+    ])
+    probed = []
+    monkeypatch.setattr(probe, "capabilities",
+                        lambda url, model, **kw: probed.append((url, model)) or {"schema_version": 1, "models": {model: {}}})
+    seen = {}
+    monkeypatch.setattr(relay, "register_node", lambda url, tok, node, **kw: seen.update(kw))
+
+    serve._reload_once(state, "remote")
+
+    assert probed == [("http://e2/v1", "b")]            # only the new engine probed; A reused from retained
+    assert state.route("a") == "http://e1/v1" and state.route("b") == "http://e2/v1"
+    assert seen["models"] == ["a", "b"]                 # re-registered the full union after the swap
+
+
+def test_serve_reload_appended_model_kept_no_reprobe(monkeypatch, tmp_path):
+    """Re-joining an engine already serving [a] with an extra model b keeps the union [a,b] and does NOT
+    re-probe it — advertised/upstream come from the record, only the caps are reused (ADR 0009 C2)."""
+    from remote import probe, relay, serve
+
+    state = _seed_reload_state(monkeypatch, tmp_path, retained=[
+        ("http://e1/v1", ["a"], ["a"], {"schema_version": 1, "models": {"a": {}}}),
+    ], engines=[
+        {"endpoint_url": "http://e1/v1", "models": ["a", "b"], "engine_label": None},
+    ])
+    probed = []
+    monkeypatch.setattr(probe, "capabilities", lambda url, model, **kw: probed.append(url) or {})
+    seen = {}
+    monkeypatch.setattr(relay, "register_node", lambda url, tok, node, **kw: seen.update(kw))
+
+    serve._reload_once(state, "remote")
+
+    assert probed == []                                 # same engine, first model unchanged → no re-probe
+    assert seen["models"] == ["a", "b"]                 # the appended model is served, not dropped
+    assert state.route("b") == "http://e1/v1"
+
+
+def test_serve_reload_drops_removed_engine(monkeypatch, tmp_path):
+    """Leave-shrink: dropping an engine from the record removes it from the union on the next reload."""
+    from remote import probe, relay, serve
+
+    state = _seed_reload_state(monkeypatch, tmp_path, retained=[
+        ("http://e1/v1", ["a"], ["a"], {"schema_version": 1, "models": {"a": {}}}),
+        ("http://e2/v1", ["b"], ["b"], {"schema_version": 1, "models": {"b": {}}}),
+    ], engines=[
+        {"endpoint_url": "http://e1/v1", "models": ["a"], "engine_label": None},
+    ])
+    monkeypatch.setattr(probe, "capabilities", lambda *a, **k: pytest.fail("a pure drop must not probe"))
+    seen = {}
+    monkeypatch.setattr(relay, "register_node", lambda url, tok, node, **kw: seen.update(kw))
+
+    serve._reload_once(state, "remote")
+
+    assert seen["models"] == ["a"]                      # b's engine dropped from the advertised union
+    assert state.snapshot().routes == {"a": "http://e1/v1"}  # e2 no longer routed
+
+
+def test_serve_reload_refuses_builtin_spec(monkeypatch, tmp_path):
+    """A record needing a built-in launch (a spec with no endpoint_url) is refused; the reload never
+    launches — old routing intact, nothing registered (ADR 0009 D4 F6)."""
+    from remote import probe, relay, serve
+
+    state = _seed_reload_state(monkeypatch, tmp_path, retained=[
+        ("http://e1/v1", ["a"], ["a"], {"schema_version": 1, "models": {"a": {}}}),
+    ], engines=[
+        {"endpoint_url": "http://e1/v1", "models": ["a"], "engine_label": None},
+        {"endpoint_url": None, "models": ["builtin"], "engine_label": None},
+    ])
+    monkeypatch.setattr(probe, "capabilities", lambda *a, **k: pytest.fail("must not probe when refusing"))
+    monkeypatch.setattr(relay, "register_node", lambda *a, **k: pytest.fail("must not register when refusing"))
+    before = state.snapshot()
+
+    serve._reload_once(state, "remote")
+    assert state.snapshot() is before                  # refused: the live snapshot is untouched
+
+
+def test_serve_reload_refuses_media_bundle_change(monkeypatch, tmp_path):
+    """A reload whose record grew media_bundles needs a ComfyUI bring-up the reload can't do → refused,
+    old snapshot intact (ADR 0009 C3)."""
+    from remote import relay, serve
+
+    state = _seed_reload_state(monkeypatch, tmp_path, retained=[
+        ("http://e1/v1", ["a"], ["a"], {"schema_version": 1, "models": {"a": {}}}),
+    ], media_models=["comfyui:image_generation"], record_media=True,
+        startup_bundles=["image_generation"], record_bundles=["image_generation", "video_generation"],
+        engines=[{"endpoint_url": "http://e1/v1", "models": ["a"], "engine_label": None}])
+    monkeypatch.setattr(relay, "register_node", lambda *a, **k: pytest.fail("must not register on a media change"))
+    before = state.snapshot()
+
+    serve._reload_once(state, "remote")
+    assert state.snapshot() is before                  # refused: respawn required for a media change
+
+
+def test_serve_reload_preserves_media_models_and_caps(monkeypatch, tmp_path):
+    """A reload that adds a text engine keeps the identity's media (comfyui:*) models + caps, appended
+    after the text models."""
+    from remote import probe, relay, serve
+    from shared.media import media_gating
+
+    state = _seed_reload_state(monkeypatch, tmp_path, retained=[
+        ("http://e1/v1", ["a"], ["a"], {"schema_version": 1, "models": {"a": {}}}),
+    ], media_models=["comfyui:image_generation"], record_media=True, startup_bundles=["image_generation"],
+        engines=[
+            {"endpoint_url": "http://e1/v1", "models": ["a"], "engine_label": None},
+            {"endpoint_url": "http://e2/v1", "models": ["b"], "engine_label": None},
+        ])
+    monkeypatch.setattr(probe, "capabilities", lambda url, model, **kw: {"schema_version": 1, "models": {model: {}}})
+    seen = {}
+    monkeypatch.setattr(relay, "register_node", lambda url, tok, node, **kw: seen.update(kw))
+
+    serve._reload_once(state, "remote")
+
+    assert seen["models"] == ["a", "b", "comfyui:image_generation"]  # media last, preserved across reload
+    assert seen["capabilities"]["models"]["comfyui:image_generation"] == media_gating.capability_entry()
+
+
+def test_serve_reload_skips_when_record_missing(monkeypatch, tmp_path):
+    """A concurrent full `grid leave` removes the record mid-reload → keep the current snapshot, don't
+    register (SIGTERM tears the process down)."""
+    from remote import relay, serve
+
+    state = _seed_reload_state(monkeypatch, tmp_path, retained=[
+        ("http://e1/v1", ["a"], ["a"], {"schema_version": 1, "models": {"a": {}}}),
+    ], engines=[{"endpoint_url": "http://e1/v1", "models": ["a"], "engine_label": None}])
+    monkeypatch.setattr(serve.run_records, "read_record", lambda net, eid: None)
+    monkeypatch.setattr(relay, "register_node", lambda *a, **k: pytest.fail("must not register when record gone"))
+    before = state.snapshot()
+
+    serve._reload_once(state, "remote")
+    assert state.snapshot() is before
+
+
+def test_serve_reload_loop_runs_reload_then_clears(monkeypatch, tmp_path):
+    """The reload loop wakes on a set reload_requested, clears it, and runs one reload."""
+    from remote import serve
+
+    state = _serve_state(monkeypatch, tmp_path)
+    calls = []
+
+    def fake_reload(s, eid):
+        calls.append(eid)
+        s.stop.set()  # stop after the first reload so the loop exits
+
+    monkeypatch.setattr(serve, "_reload_once", fake_reload)
+    state.reload_requested.set()
+    serve._reload_loop(state, "remote")
+
+    assert calls == ["remote"]                    # ran the reload once
+    assert not state.reload_requested.is_set()    # cleared after handling
+
+
+def test_serve_reload_loop_stops_when_stop_set(monkeypatch, tmp_path):
+    """A stopped state exits the reload loop immediately without reloading."""
+    from remote import serve
+
+    state = _serve_state(monkeypatch, tmp_path)
+    monkeypatch.setattr(serve, "_reload_once", lambda *a: pytest.fail("must not reload once stopped"))
+    state.stop.set()
+    serve._reload_loop(state, "remote")  # returns immediately
+
+
+def test_serve_reload_loop_coalesces_resignal(monkeypatch, tmp_path):
+    """A write+SIGHUP that lands while a reload is running re-sets the event and is picked up by one more
+    reload — never lost (clear-before-read coalescing)."""
+    from remote import serve
+
+    state = _serve_state(monkeypatch, tmp_path)
+    calls = []
+
+    def fake_reload(s, eid):
+        calls.append(eid)
+        if len(calls) == 1:
+            s.reload_requested.set()   # a signal arrives during the first reload
+        else:
+            s.stop.set()               # the second reload handles it, then stop
+
+    monkeypatch.setattr(serve, "_reload_once", fake_reload)
+    state.reload_requested.set()
+    serve._reload_loop(state, "remote")
+
+    assert calls == ["remote", "remote"]           # the re-signal triggered exactly one more reload
+
+
+def test_serve_reload_loop_survives_a_systemexit_reload(monkeypatch, tmp_path):
+    """A reload that raises SystemExit (jsonio.load_json on a corrupt record, or _advertised_models on an
+    alias/model mismatch) must NOT kill the watcher thread — SystemExit is a BaseException, so the loop
+    catches (Exception, SystemExit) (ADR 0009 D4 F6, reviewer CRITICAL)."""
+    from remote import serve
+
+    state = _serve_state(monkeypatch, tmp_path)
+    calls = []
+
+    def flaky_reload(s, eid):
+        calls.append(eid)
+        if len(calls) == 1:
+            s.reload_requested.set()    # keep the loop awake, then raise SystemExit
+            raise SystemExit("--advertise-as must be provided once for each model.")
+        s.stop.set()                    # the loop survived to a second reload; now stop
+
+    monkeypatch.setattr(serve, "_reload_once", flaky_reload)
+    state.reload_requested.set()
+    serve._reload_loop(state, "remote")   # must not propagate the SystemExit / kill the thread
+    assert calls == ["remote", "remote"]  # kept looping after the first reload raised SystemExit
+
+
+def test_serve_reload_rearms_on_post_swap_register_failure(monkeypatch, tmp_path):
+    """Swap succeeds but the re-register fails (transient) → the reload re-arms reload_requested so a
+    later tick retries; the new union is not left unadvertised (ADR 0009 C5)."""
+    from remote import probe, relay, serve
+
+    state = _seed_reload_state(monkeypatch, tmp_path, retained=[
+        ("http://e1/v1", ["a"], ["a"], {"schema_version": 1, "models": {"a": {}}}),
+    ], engines=[
+        {"endpoint_url": "http://e1/v1", "models": ["a"], "engine_label": None},
+        {"endpoint_url": "http://e2/v1", "models": ["b"], "engine_label": None},
+    ])
+    monkeypatch.setattr(probe, "capabilities", lambda url, model, **kw: {"schema_version": 1, "models": {model: {}}})
+
+    def boom(*a, **k):
+        raise relay.RelayError("relay 503")
+
+    monkeypatch.setattr(relay, "register_node", boom)
+    monkeypatch.setattr(state.stop, "wait", lambda t: None)  # skip the back-off in the test
+
+    serve._reload_once(state, "remote")
+
+    assert state.route("b") == "http://e2/v1"   # the swap happened — the new union serves locally
+    assert state.reload_requested.is_set()      # re-armed to retry the re-register
+
+
+def test_serve_reload_does_not_rearm_on_exhausted_auth(monkeypatch, tmp_path):
+    """A post-swap re-register that fails auth with refresh exhausted does NOT re-arm — the heartbeat loop
+    stops the process on the same condition, so re-arming would just spin (reviewer HIGH)."""
+    from remote import probe, relay, serve
+
+    state = _seed_reload_state(monkeypatch, tmp_path, retained=[
+        ("http://e1/v1", ["a"], ["a"], {"schema_version": 1, "models": {"a": {}}}),
+    ], engines=[
+        {"endpoint_url": "http://e1/v1", "models": ["a"], "engine_label": None},
+        {"endpoint_url": "http://e2/v1", "models": ["b"], "engine_label": None},
+    ])
+    monkeypatch.setattr(probe, "capabilities", lambda url, model, **kw: {"schema_version": 1, "models": {model: {}}})
+
+    def unauth(*a, **k):
+        raise relay.RelayUnauthorized()
+
+    monkeypatch.setattr(relay, "register_node", unauth)
+    monkeypatch.setattr(state, "refresh", lambda stale_token=None: False)  # refresh exhausted
+
+    serve._reload_once(state, "remote")
+
+    assert state.route("b") == "http://e2/v1"   # the swap still happened (serves locally)
+    assert not state.reload_requested.is_set()  # but did NOT re-arm on exhausted auth
+
+
+def test_serve_reload_failing_probe_keeps_old_routing(monkeypatch, tmp_path):
+    """If probing a newly-added --at engine raises, the reload aborts BEFORE the swap — the old snapshot
+    keeps serving and nothing is registered; the loop's guard then logs and survives (ADR 0009 D4 F6)."""
+    from remote import probe, relay, serve
+
+    state = _seed_reload_state(monkeypatch, tmp_path, retained=[
+        ("http://e1/v1", ["a"], ["a"], {"schema_version": 1, "models": {"a": {}}}),
+    ], engines=[
+        {"endpoint_url": "http://e1/v1", "models": ["a"], "engine_label": None},
+        {"endpoint_url": "http://e2/v1", "models": ["b"], "engine_label": None},
+    ])
+
+    def boom(*a, **k):
+        raise RuntimeError("probe timeout")
+
+    monkeypatch.setattr(probe, "capabilities", boom)
+    monkeypatch.setattr(relay, "register_node", lambda *a, **k: pytest.fail("must not register on a failed probe"))
+    before = state.snapshot()
+
+    with pytest.raises(RuntimeError):
+        serve._reload_once(state, "remote")     # propagates; _reload_loop's guard catches it in production
+    assert state.snapshot() is before           # no partial apply — the old routing is untouched
+
+
+def test_serve_route_survives_concurrent_swap(monkeypatch, tmp_path):
+    """route() binds the snapshot once, so a reload swapping mid-call never raises or returns a torn
+    result; and published snapshots' dicts are never mutated in place (ADR 0009 D4 F4)."""
+    import threading as _t
+
+    from remote import serve
+
+    state = _serve_state(monkeypatch, tmp_path, models=["a"], routes={"a": "http://e1/v1"}, upstream={})
+    snap_a = state.snapshot()
+    snap_b = serve._Snapshot.build(routes={"a": "http://e1/v1", "b": "http://e2/v1"}, upstream={},
+                                   models=["a", "b"], capabilities={}, meta={}, pricing={}, max_concurrency=1)
+    errors = []
+    iters = 5000  # fixed count → deterministic, can't hang
+
+    def swapper():
+        for i in range(iters):
+            state.apply(snap_b if i % 2 else snap_a, [])
+
+    def router():
+        for _ in range(iters):
+            try:
+                result = state.route("b")
+            except Exception as exc:  # a torn read would KeyError here
+                errors.append(exc)
+                return
+            if result not in ("http://e1/v1", "http://e2/v1"):  # both valid; never garbage/None/torn
+                errors.append(result)
+                return
+
+    threads = [_t.Thread(target=swapper, daemon=True)] + [_t.Thread(target=router, daemon=True) for _ in range(3)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(10)
+
+    assert errors == []                                                  # never raised, never torn
+    assert snap_a.routes == {"a": "http://e1/v1"}                        # published snapshots not mutated
+    assert snap_b.routes == {"a": "http://e1/v1", "b": "http://e2/v1"}
+
+
+def test_serve_start_reload_watcher_installs_handler_and_thread(monkeypatch, tmp_path):
+    """_start_reload_watcher retains the reload state, installs a SIGHUP handler that ONLY sets the
+    reload flag (never raises), and starts a live reload daemon (ADR 0009 C4)."""
+    import signal as _sig
+
+    from remote import serve
+
+    state = _serve_state(monkeypatch, tmp_path)
+    monkeypatch.setattr(serve, "_reload_loop", lambda s, e: s.stop.wait(5))  # keep the thread alive, no-op
+    orig = _sig.getsignal(_sig.SIGHUP) if hasattr(_sig, "SIGHUP") else None
+    thread = serve._start_reload_watcher(
+        state, "remote", [("http://e1/v1", ["a"], ["a"], {})], ["comfyui:x"],
+        {"media": True, "media_bundles": ["x"]})
+    try:
+        assert state.engine_results() == [("http://e1/v1", ["a"], ["a"], {})]
+        assert state.media_models == ["comfyui:x"]
+        assert state.media_signature == serve._media_signature({"media": True, "media_bundles": ["x"]})
+        assert thread.is_alive()
+        if hasattr(_sig, "SIGHUP"):
+            _sig.getsignal(_sig.SIGHUP)(_sig.SIGHUP, None)  # simulate signal delivery on the main thread
+            assert state.reload_requested.is_set()          # the handler only sets the flag
+    finally:
+        state.stop.set()
+        thread.join(2)
+        if hasattr(_sig, "SIGHUP"):
+            _sig.signal(_sig.SIGHUP, orig)
+
+
+def test_run_remote_engine_starts_reload_thread_with_sighup_blocked(monkeypatch, tmp_path):
+    """C4: the reload/heartbeat daemons start while SIGHUP is blocked (so they inherit the block and the
+    signal only lands on the main thread), and main unblocks SIGHUP last, before the poll loop."""
+    import signal as _sig
+
+    from remote import relay, serve
+
+    if not hasattr(_sig, "SIGHUP"):
+        pytest.skip("no SIGHUP on this platform")
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    record = {"grid_id": "n1", "signaling_url": "https://relay.example", "media": False,
+              "engines": [{"endpoint_url": "http://e1/v1", "models": ["a"], "engine_label": None}]}
+    monkeypatch.setattr(serve.run_records, "read_record", lambda g, e: record)
+    monkeypatch.setattr(serve, "_load_tokens", lambda net: ("AT", "RT"))
+    monkeypatch.setattr(serve, "_node_id_from_token", lambda t: "node-1")
+    monkeypatch.setattr(serve, "_bring_up_engines",
+                        lambda rec: ([("http://e1/v1", ["a"], ["a"], {"schema_version": 1, "models": {"a": {}}})], [], None))
+    registered = []
+    monkeypatch.setattr(serve, "register_once", lambda s: registered.append(s))
+    monkeypatch.setattr(serve, "_heartbeat_loop", lambda s: None)
+    monkeypatch.setattr(relay, "unregister_node", lambda *a, **k: None)
+
+    reload_seen = {}
+    done = threading.Event()
+
+    def fake_reload_loop(s, eid):
+        reload_seen["blocked"] = _sig.SIGHUP in _sig.pthread_sigmask(_sig.SIG_BLOCK, [])  # the thread's own mask
+        reload_seen["engine_id"] = eid
+        done.set()
+
+    poll_mask = {}
+
+    def fake_poll(s):
+        poll_mask["unblocked"] = _sig.SIGHUP not in _sig.pthread_sigmask(_sig.SIG_BLOCK, [])  # main's mask
+        done.wait(2)  # let the reload daemon run and record before we return
+
+    monkeypatch.setattr(serve, "_reload_loop", fake_reload_loop)
+    monkeypatch.setattr(serve, "_poll_loop", fake_poll)
+
+    orig_handler = _sig.getsignal(_sig.SIGHUP)
+    orig_blocked = _sig.SIGHUP in _sig.pthread_sigmask(_sig.SIG_BLOCK, [])
+    try:
+        rc = serve.run_remote_engine_from_record("n1", "remote")
+    finally:
+        _sig.signal(_sig.SIGHUP, orig_handler)
+        _sig.pthread_sigmask(_sig.SIG_BLOCK if orig_blocked else _sig.SIG_UNBLOCK, {_sig.SIGHUP})
+
+    assert rc == 0 and registered                   # startup registered the identity
+    assert reload_seen["blocked"] is True           # the reload daemon inherited the SIGHUP block (C4)
+    assert reload_seen["engine_id"] == "remote"
+    assert poll_mask["unblocked"] is True            # main unblocked SIGHUP before the poll loop
 
 
 def test_serve_handle_job_non_stream_forwards_then_submits(monkeypatch, tmp_path):
@@ -2729,7 +3403,7 @@ def test_serve_heartbeat_once_re_registers_when_pruned(monkeypatch, tmp_path):
     state = _serve_state(monkeypatch, tmp_path)
     monkeypatch.setattr(relay, "heartbeat", lambda url, tok, *, load: "missing")
     calls = []
-    monkeypatch.setattr(serve, "register", lambda s: calls.append(s))
+    monkeypatch.setattr(serve, "register_once", lambda s: calls.append(s))
     assert serve.heartbeat_once(state) == "missing"
     assert calls == [state]  # 404 → re-register with the cached payload
 
@@ -2971,6 +3645,26 @@ def test_meta_uses_meta_name_for_grid_page_name(monkeypatch, tmp_path):
     assert serve._meta({"meta_name": "mybox", "endpoint_url": "http://h/v1"}, "remote")["name"] == "mybox"
     # Fallback to engine_id when no display name was stored (defensive; join always sets meta_name).
     assert serve._meta({"endpoint_url": "http://h/v1"}, "remote")["name"] == "remote"
+
+
+def test_meta_labels_all_external_union_as_external(monkeypatch, tmp_path):
+    """A union of external --at engines (each engine_label=None) shows engine='external' on the grid page,
+    not the built-in 'llama.cpp' default; only a built-in --serve spec (no endpoint_url) is 'llama.cpp'
+    (ADR 0009 _meta fix)."""
+    from remote import serve
+
+    multi_external = {"meta_name": "mybox", "endpoint_url": None, "models": ["a", "b"], "engines": [
+        {"endpoint_url": "http://e1/v1", "models": ["a"], "engine_label": None},
+        {"endpoint_url": "http://e2/v1", "models": ["b"], "engine_label": None},
+    ]}
+    assert serve._meta(multi_external, "remote") == {"name": "mybox", "engine": "external"}
+
+    single_external = {"endpoint_url": "http://h/v1", "models": ["a"]}  # flat single external → external
+    assert serve._meta(single_external, "remote")["engine"] == "external"
+
+    builtin = {"endpoint_url": None, "models": ["m"],
+               "engines": [{"endpoint_url": None, "models": ["m"], "engine_label": None}]}
+    assert serve._meta(builtin, "remote")["engine"] == "llama.cpp"  # built-in --serve still labels llama.cpp
 
 
 def test_bring_up_engines_external_multi_probes_each(monkeypatch, tmp_path):

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -1129,6 +1129,43 @@ def test_engine_label_is_deprecated_but_still_recorded(monkeypatch, tmp_path, ca
     assert cli.provider._read_records("n1")["remote"]["engine_label"] == "rig"
 
 
+def test_engine_ls_and_list_route_to_cmd_engine_list():
+    parser = cli.build_parser()
+    assert parser.parse_args(["engine", "ls"]).handler is cli.cmd_engine_list
+    assert parser.parse_args(["engine", "list"]).handler is cli.cmd_engine_list
+
+
+def test_engine_ls_accepts_grid_and_json():
+    args = cli.build_parser().parse_args(["engine", "ls", "home", "--json"])
+    assert args.grid == "home" and args.json is True
+
+
+def test_engine_ls_local_delegates_to_cmd_engines(monkeypatch, tmp_path):
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    seen = {}
+
+    def fake_engines(args):
+        seen["grid"] = args.grid
+        return 0
+
+    monkeypatch.setattr(cli.provider, "cmd_engines", fake_engines)
+    assert cli.main(["engine", "ls", "home"]) == 0  # default mode is local
+    assert seen["grid"] == "home"
+
+
+def test_engine_ls_remote_delegates_to_remote_engines(monkeypatch, tmp_path):
+    _seed_remote(monkeypatch, tmp_path)
+    seen = {}
+
+    def fake_remote_engines(args):
+        seen["hit"] = True
+        return 0
+
+    monkeypatch.setattr(cli.remote_overview, "cmd_remote_engines", fake_remote_engines)
+    assert cli.main(["engine", "ls"]) == 0
+    assert seen.get("hit") is True
+
+
 _FAKE_ENGINES = [
     {"name": "mac", "endpoint_url": "http://192.168.1.10:8080/v1", "models": ["gemma4-31b"]},
     {"name": "gpu", "endpoint_url": "http://192.168.1.20:8000/v1", "models": ["devstral", "gemma4-31b"]},

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -983,6 +983,12 @@ def test_ls_shows_grid_id_local(monkeypatch, tmp_path, capsys):
     assert json.loads(capsys.readouterr().out)[0]["id"] == cfg["grid_id"]
 
 
+def test_join_kind_flag_with_engine_alias():
+    parser = cli.build_parser()
+    assert parser.parse_args(["join", "--kind", "ollama"]).kind == "ollama"
+    assert parser.parse_args(["join", "--engine", "vllm"]).kind == "vllm"  # --engine is a back-compat alias
+
+
 _FAKE_ENGINES = [
     {"name": "mac", "endpoint_url": "http://192.168.1.10:8080/v1", "models": ["gemma4-31b"]},
     {"name": "gpu", "endpoint_url": "http://192.168.1.20:8000/v1", "models": ["devstral", "gemma4-31b"]},

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -922,6 +922,74 @@ def test_leave_all_removes_records(monkeypatch, tmp_path):
     assert cli.provider._read_records(grid_id) == {}
 
 
+def _seed_local_engine(grid_id, engine_id, *, endpoint_url=None, models=None):
+    cli.provider._write_record(grid_id, engine_id, {
+        "engine_id": engine_id, "node_id": engine_id, "grid_id": grid_id, "pid": 0,
+        "endpoint_url": endpoint_url, "models": models or [],
+    })
+
+
+def _leave(*argv):
+    return cli.cmd_leave(cli.build_parser().parse_args(["leave", *argv]))
+
+
+def test_leave_local_matches_by_endpoint_url(monkeypatch, tmp_path):
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    grid_id = runtime.init_grid_config(name="home", port=8090)["grid_id"]
+    _seed_local_engine(grid_id, "mac", endpoint_url="http://h:8000/v1", models=["mistral"])
+    _seed_local_engine(grid_id, "gpu", endpoint_url="http://h:9000/v1", models=["devstral"])
+    assert _leave("home", "--engine", "http://h:8000/v1") == 0
+    assert set(cli.provider._read_records(grid_id)) == {"gpu"}
+
+
+def test_leave_local_matches_by_served_model(monkeypatch, tmp_path):
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    grid_id = runtime.init_grid_config(name="home", port=8090)["grid_id"]
+    _seed_local_engine(grid_id, "mac", endpoint_url="http://h:8000/v1", models=["mistral"])
+    _seed_local_engine(grid_id, "gpu", endpoint_url="http://h:9000/v1", models=["devstral"])
+    assert _leave("home", "--engine", "devstral") == 0
+    assert set(cli.provider._read_records(grid_id)) == {"mac"}
+
+
+def test_leave_local_matches_by_url_fragment(monkeypatch, tmp_path):
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    grid_id = runtime.init_grid_config(name="home", port=8090)["grid_id"]
+    _seed_local_engine(grid_id, "mac", endpoint_url="http://h:8000/v1", models=["mistral"])
+    _seed_local_engine(grid_id, "gpu", endpoint_url="http://h:9000/v1", models=["devstral"])
+    assert _leave("home", "--engine", ":9000") == 0
+    assert set(cli.provider._read_records(grid_id)) == {"mac"}
+
+
+def test_leave_local_exact_id_wins_over_url_substring(monkeypatch, tmp_path):
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    grid_id = runtime.init_grid_config(name="home", port=8090)["grid_id"]
+    _seed_local_engine(grid_id, "mac", endpoint_url="http://h:8000/v1", models=["m1"])
+    _seed_local_engine(grid_id, "gpu", endpoint_url="http://mac-host:9000/v1", models=["m2"])
+    assert _leave("home", "--engine", "mac") == 0  # exact id, not the substring of gpu's URL
+    assert set(cli.provider._read_records(grid_id)) == {"gpu"}
+
+
+def test_leave_local_ambiguous_model_lists_ids(monkeypatch, tmp_path):
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    grid_id = runtime.init_grid_config(name="home", port=8090)["grid_id"]
+    _seed_local_engine(grid_id, "mac", endpoint_url="http://h:8000/v1", models=["shared"])
+    _seed_local_engine(grid_id, "gpu", endpoint_url="http://h:9000/v1", models=["shared"])
+    with pytest.raises(SystemExit) as exc:
+        _leave("home", "--engine", "shared")
+    msg = str(exc.value)
+    assert "several" in msg.lower() and "mac" in msg and "gpu" in msg
+
+
+def test_leave_local_unknown_selector_errors(monkeypatch, tmp_path):
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    grid_id = runtime.init_grid_config(name="home", port=8090)["grid_id"]
+    _seed_local_engine(grid_id, "mac", endpoint_url="http://h:8000/v1", models=["mistral"])
+    with pytest.raises(SystemExit) as exc:
+        _leave("home", "--engine", "ghost")
+    assert "ghost" in str(exc.value)
+    assert set(cli.provider._read_records(grid_id)) == {"mac"}  # nothing dropped on a miss
+
+
 def test_cli_accepts_engines_and_json_and_aliases():
     parser = cli.build_parser()
 

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -807,6 +807,29 @@ def test_join_all_joins_every_detected_engine(monkeypatch, tmp_path):
     assert set(records) == {"ollama", "vllm"}
 
 
+def test_join_kind_filters_to_one_engine(monkeypatch, tmp_path):
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    grid_id = runtime.init_grid_config(name="home", port=8090)["grid_id"]
+    monkeypatch.setattr(
+        cli.provider,
+        "_detect",
+        lambda host: [
+            detect.DetectedEngine(label="ollama", endpoint_url="http://h:11434/v1", models=["llama3"]),
+            detect.DetectedEngine(label="vllm", endpoint_url="http://h:8000/v1", models=["mistral"]),
+        ],
+    )
+    monkeypatch.setattr(cli.provider.subprocess, "Popen", lambda cmd, **kw: type("P", (), {"pid": 1})())
+    monkeypatch.setattr(cli.provider, "_await_engine_start", lambda *a, **k: "registered")
+
+    assert cli.cmd_join(cli.build_parser().parse_args(["join", "home", "--kind", "vllm"])) == 0
+    assert set(cli.provider._read_records(grid_id)) == {"vllm"}  # only the vllm engine joined
+    # the --engine alias drives the same filter (and errors on no match)
+    assert cli.cmd_join(cli.build_parser().parse_args(["join", "home", "--engine", "ollama"])) == 0
+    assert set(cli.provider._read_records(grid_id)) == {"vllm", "ollama"}
+    with pytest.raises(SystemExit):
+        cli.cmd_join(cli.build_parser().parse_args(["join", "home", "--kind", "nope"]))
+
+
 def test_join_cleans_up_record_when_engine_dies(monkeypatch, tmp_path, capsys):
     monkeypatch.setenv("GRID_HOME", str(tmp_path))
     cfg = runtime.init_grid_config(name="home", port=8090)
@@ -1110,6 +1133,19 @@ def test_serve_rejects_inline_equals():
     assert "--advertise-as" in str(exc.value)
 
 
+def test_serve_rejects_extra_model_flag():
+    # --serve serves one built-in model; a separate -m (aliased or not) would be silently dropped.
+    for argv in (["--serve", "modelY", "-m", "real=pub"], ["--serve", "modelY", "-m", "foo"]):
+        with pytest.raises(SystemExit) as exc:
+            cli.cmd_join(_parse_join(*argv))
+        assert "--serve" in str(exc.value)
+
+
+def test_inline_alias_rejects_multiple_equals():
+    with pytest.raises(SystemExit):
+        cli.provider._apply_inline_aliases(_parse_join("--at", "u", "-m", "a=b=c"))
+
+
 def test_remote_join_inline_alias_desugars_into_record(monkeypatch, tmp_path):
     _seed_running_remote_grid(monkeypatch, tmp_path)
     _mock_remote_spawn(monkeypatch)
@@ -1194,6 +1230,17 @@ def test_up_starts_existing_grid_by_id(monkeypatch, tmp_path):
     cfg = runtime.init_grid_config(name="home", port=8090)
     monkeypatch.setattr(cli.grid.runtime, "start_grid", lambda cfg: None)
     assert cli.main(["up", cfg["grid_id"]]) == 0  # found by id → guard skipped
+
+
+def test_up_rejects_known_remote_grid_in_local_mode(monkeypatch, tmp_path):
+    _seed_remote(monkeypatch, tmp_path, networks=[{"network_id": "n1", "name": "team"}])
+    state.set_mode("local")  # the remote grid is known via credentials, but we're in local mode
+    from local import config as local_config
+    for arg in ("team", "n1"):  # matched by name and by network_id
+        with pytest.raises(SystemExit) as exc:
+            cli.main(["up", arg])
+        assert "remote" in str(exc.value).lower()
+    assert local_config.iter_grid_configs() == []  # nothing created
 
 
 _FAKE_ENGINES = [
@@ -4843,6 +4890,7 @@ def test_remote_ls_lists_local_without_network_call(monkeypatch, tmp_path, capsy
     out = capsys.readouterr().out
     assert "team" in out and "permissioned-public" in out
     assert "lab" in out and "permissioned-providers" in out
+    assert "n1" in out and "n2" in out  # network_id column (ADR 0010 item 9b)
 
 
 def test_remote_ls_json_emits_grid_and_type(monkeypatch, tmp_path, capsys):

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -6,6 +6,7 @@ import json
 import os
 import stat
 import subprocess
+import threading
 import tomllib
 from pathlib import Path
 from types import SimpleNamespace
@@ -1008,6 +1009,91 @@ def test_atomic_write_bytes_is_0600_even_under_hostile_umask(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# cross-process file lock (shared/filelock.py)
+# ---------------------------------------------------------------------------
+
+def test_file_lock_is_mutually_exclusive_and_reusable(tmp_path):
+    """`file_lock` serializes a read-merge-write across processes: while held, another holder's
+    non-blocking acquire fails; after the block, it is free again (no deadlock on re-entry)."""
+    import fcntl
+
+    from shared.filelock import file_lock
+
+    target = tmp_path / "engines" / "n1" / "remote.json"  # parent dirs don't exist yet — lock must create them
+    with file_lock(target):
+        fd = os.open(str(target) + ".lock", os.O_CREAT | os.O_RDWR, 0o600)
+        try:
+            with pytest.raises(BlockingIOError):
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)  # a rival can't take it while we hold it
+        finally:
+            os.close(fd)
+    with file_lock(target):  # released → reacquirable
+        pass
+    assert (target.parent / "remote.json.lock").exists()
+
+
+def test_terminate_pid_sigterms_but_does_not_touch_the_record(monkeypatch, tmp_path):
+    """`terminate_pid` stops a detached child (SIGTERM) without removing its record — the caller keeps
+    the record for a respawn that rewrites it, unlike `stop_engine` which unlinks."""
+    import signal as signal_mod
+
+    from shared import run_records
+
+    sent = []
+    alive = {"v": True}
+    monkeypatch.setattr(run_records, "pid_alive", lambda pid: alive["v"])
+    monkeypatch.setattr(run_records.os, "kill", lambda pid, sig: (sent.append((pid, sig)), alive.__setitem__("v", False)))
+    monkeypatch.setattr(run_records.time, "sleep", lambda s: None)
+
+    record_file = run_records.record_path("n1", "remote")
+    record_file.parent.mkdir(parents=True, exist_ok=True)
+    record_file.write_text("{}")
+
+    run_records.terminate_pid(4242)
+    assert sent == [(4242, signal_mod.SIGTERM)]  # graceful stop
+    assert record_file.exists()  # record left intact for the caller to rewrite
+
+
+def test_terminate_pid_escalates_to_sigkill_group_when_stubborn(monkeypatch):
+    """A child that ignores SIGTERM past the grace window is SIGKILL'd by process group, and
+    `terminate_pid` reports False because it could not confirm the process died."""
+    from shared import run_records
+
+    killed = []
+    clock = {"v": 1000.0}
+    monkeypatch.setattr(run_records, "pid_alive", lambda pid: True)  # never dies on its own
+    monkeypatch.setattr(run_records, "kill_group", lambda pid: killed.append(pid))
+    monkeypatch.setattr(run_records.os, "kill", lambda pid, sig: None)
+    monkeypatch.setattr(run_records.time, "time", lambda: clock["v"])
+    monkeypatch.setattr(run_records.time, "sleep", lambda s: clock.__setitem__("v", clock["v"] + 10))
+
+    assert run_records.terminate_pid(4242) is False  # could not confirm it died
+    assert killed == [4242]
+
+
+def test_terminate_pid_reports_true_when_process_exits(monkeypatch):
+    from shared import run_records
+
+    alive = {"v": True}
+    monkeypatch.setattr(run_records, "pid_alive", lambda pid: alive["v"])
+    monkeypatch.setattr(run_records.os, "kill", lambda pid, sig: alive.__setitem__("v", False))
+    monkeypatch.setattr(run_records.time, "sleep", lambda s: None)
+    assert run_records.terminate_pid(4242) is True  # SIGTERM took → confirmed dead
+
+
+def test_pid_alive_treats_permission_error_as_alive(monkeypatch):
+    """A process owned by another uid answers `os.kill(pid, 0)` with EPERM — it EXISTS, so it is alive.
+    Reporting it dead would let a join spawn a clobbering second node under the same token id."""
+    from shared import run_records
+
+    def raise_eperm(pid, sig):
+        raise PermissionError()
+
+    monkeypatch.setattr(run_records.os, "kill", raise_eperm)
+    assert run_records.pid_alive(4242) is True
+
+
+# ---------------------------------------------------------------------------
 # Mode state kernel (shared/state.py)
 # ---------------------------------------------------------------------------
 
@@ -1250,8 +1336,9 @@ def test_remote_join_at_serves_external_engine(monkeypatch, tmp_path):
     _mock_remote_spawn(monkeypatch)
 
     assert cli.main(["join", "--at", "http://192.168.1.9:11434/v1", "-m", "llama3", "--name", "ext"]) == 0
-    record = cli.provider._read_records("n1")["ext"]
+    record = cli.provider._read_records("n1")["remote"]  # remote is a singleton identity per grid
     assert record["endpoint_url"] == "http://192.168.1.9:11434/v1" and record["models"] == ["llama3"]
+    assert record["meta_name"] == "ext"  # --name in remote is the grid-page display name, not the record key
 
 
 def test_remote_join_member_falls_back_to_bundle_url_when_status_forbidden(monkeypatch, tmp_path):
@@ -1430,16 +1517,252 @@ def test_remote_join_died_cleans_up_record(monkeypatch, tmp_path):
     assert cli.provider._read_records("n1") == {}  # stale record removed on a failed start
 
 
-def test_remote_leave_stops_and_removes_record(monkeypatch, tmp_path, capsys):
+def test_remote_join_appends_via_respawn(monkeypatch, tmp_path):
+    """A second `grid join` on a remote grid is ADDITIVE: it merges into the one singleton identity and
+    respawns it (stopping the prior process first, since both share the token-pinned node_id)."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_remote_spawn(monkeypatch)
+    terminated = []
+    monkeypatch.setattr(cli.remote_provider.run_records, "terminate_pid", lambda pid: terminated.append(pid) or True)
+
+    assert cli.main(["join", "--at", "http://h:11434/v1", "-m", "llama3"]) == 0
+    # The first identity is now live — make its recorded pid look alive so the 2nd join appends to it.
+    monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
+    assert cli.main(["join", "--at", "http://h:8000/v1", "-m", "mistral"]) == 0
+
+    records = cli.provider._read_records("n1")
+    assert list(records) == ["remote"]  # exactly one singleton identity per grid
+    rec = records["remote"]
+    assert [e["endpoint_url"] for e in rec["engines"]] == ["http://h:11434/v1", "http://h:8000/v1"]  # union
+    assert rec["models"] == ["llama3", "mistral"] and rec["endpoint_url"] is None
+    assert terminated == [4242]  # the 2nd join stopped the 1st process before respawning the union
+
+
+def test_remote_join_appending_same_url_is_noop(monkeypatch, tmp_path, capsys):
+    """Re-joining an engine already in the union adds nothing and does not respawn (idempotent)."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_remote_spawn(monkeypatch)
+    respawned = []
+    monkeypatch.setattr(cli.remote_provider.run_records, "terminate_pid", lambda pid: respawned.append(pid))
+
+    assert cli.main(["join", "--at", "http://h:11434/v1", "-m", "llama3"]) == 0
+    monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
+    assert cli.main(["join", "--at", "http://h:11434/v1", "-m", "llama3"]) == 0  # same engine again
+
+    rec = cli.provider._read_records("n1")["remote"]
+    assert len(rec["engines"]) == 1  # deduped by endpoint_url
+    assert respawned == []  # nothing new → no restart
+    assert "already serving" in capsys.readouterr().out.lower()
+
+
+def test_remote_join_appending_builtin_into_external_union_is_rejected(monkeypatch, tmp_path):
+    """The built-in `--serve` engine serves one model and cannot join a multi-engine union (external-only)."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_remote_spawn(monkeypatch)
+    monkeypatch.setattr(cli.remote_provider.run_records, "terminate_pid", lambda pid: None)
+
+    assert cli.main(["join", "--at", "http://h:11434/v1", "-m", "llama3"]) == 0
+    monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["join", "--serve", "qwen"])
+    assert "leave" in str(exc.value).lower()  # guidance: leave then re-join all as --at
+
+
+def test_remote_join_adopts_and_stops_legacy_live_record(monkeypatch, tmp_path):
+    """Migration: a pre-singleton `engine-<uuid>` record that is still live gets its engines adopted into
+    the singleton and its process stopped, so two children never share the token node_id."""
+    from shared import run_records
+
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_remote_spawn(monkeypatch)
+    terminated = []
+    monkeypatch.setattr(cli.remote_provider.run_records, "terminate_pid", lambda pid: terminated.append(pid) or True)
+    monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
+    run_records.write_record("n1", "engine-abc123", {
+        "engine_id": "engine-abc123", "grid_id": "n1", "pid": 999, "media": False,
+        "engines": [{"endpoint_url": "http://legacy:11434/v1", "models": ["llama3"], "engine_label": "ollama"}],
+        "models": ["llama3"], "endpoint_url": "http://legacy:11434/v1",
+    })
+
+    assert cli.main(["join", "--at", "http://new:8000/v1", "-m", "mistral"]) == 0
+
+    records = cli.provider._read_records("n1")
+    assert list(records) == ["remote"]  # legacy file removed; one singleton remains
+    assert [e["endpoint_url"] for e in records["remote"]["engines"]] == [
+        "http://legacy:11434/v1", "http://new:8000/v1",  # adopted legacy engine + the new one
+    ]
+    assert 999 in terminated  # legacy process stopped so it can't clobber the token node_id
+
+
+def test_remote_join_same_url_new_model_is_added(monkeypatch, tmp_path):
+    """Re-joining an engine already in the union but with an extra `-m` model ADDS the model (additive),
+    rather than dedup-skipping the whole spec and silently dropping the new model."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_remote_spawn(monkeypatch)
+    monkeypatch.setattr(cli.remote_provider.run_records, "terminate_pid", lambda pid: True)
+
+    assert cli.main(["join", "--at", "http://h:11434/v1", "-m", "llama3"]) == 0
+    monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
+    assert cli.main(["join", "--at", "http://h:11434/v1", "-m", "llama3", "-m", "mistral"]) == 0
+
+    rec = cli.provider._read_records("n1")["remote"]
+    assert len(rec["engines"]) == 1  # still one engine (same URL)
+    assert rec["engines"][0]["models"] == ["llama3", "mistral"]  # the new model was merged in, not dropped
+    assert rec["models"] == ["llama3", "mistral"]
+
+
+def test_remote_join_serve_rejoin_same_model_is_noop(monkeypatch, tmp_path, capsys):
+    """Re-running `grid join --serve <model>` (built-in, endpoint_url=None) with the same model is a
+    no-op, not a bogus 'multiple engines' rejection."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_remote_spawn(monkeypatch)
+    respawned = []
+    monkeypatch.setattr(cli.remote_provider.run_records, "terminate_pid", lambda pid: respawned.append(pid) or True)
+
+    assert cli.main(["join", "--serve", "qwen"]) == 0
+    monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
+    assert cli.main(["join", "--serve", "qwen"]) == 0  # same built-in model again
+
+    assert respawned == []  # nothing new → no restart, no SystemExit
+    assert "already serving" in capsys.readouterr().out.lower()
+
+
+def test_remote_join_rename_respawns_to_apply_meta_name(monkeypatch, tmp_path):
+    """A re-join that only changes --name is not silently dropped: it respawns so the new display name
+    actually takes effect (there is no other way to rename in Slice 1)."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_remote_spawn(monkeypatch)
+    respawned = []
+    monkeypatch.setattr(cli.remote_provider.run_records, "terminate_pid", lambda pid: respawned.append(pid) or True)
+
+    assert cli.main(["join", "--at", "http://h:11434/v1", "-m", "llama3", "--name", "first"]) == 0
+    monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
+    assert cli.main(["join", "--at", "http://h:11434/v1", "-m", "llama3", "--name", "second"]) == 0
+
+    assert cli.provider._read_records("n1")["remote"]["meta_name"] == "second"  # rename applied
+    assert respawned == [4242]  # respawned to apply it
+
+
+def test_remote_join_append_onto_aliased_identity_is_rejected(monkeypatch, tmp_path):
+    """Appending a 2nd engine onto a single-engine identity that uses --advertise-as is rejected (aliases
+    are single-engine only, ADR 0007 D4) instead of silently dropping the alias."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_remote_spawn(monkeypatch)
+    monkeypatch.setattr(cli.remote_provider.run_records, "terminate_pid", lambda pid: True)
+
+    assert cli.main(["join", "--at", "http://h:11434/v1", "-m", "real", "--advertise-as", "public"]) == 0
+    monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["join", "--at", "http://h:8000/v1", "-m", "mistral"])
+    assert "advertise-as" in str(exc.value).lower()
+
+
+def test_remote_join_aborts_when_prior_process_wont_die(monkeypatch, tmp_path):
+    """If a prior engine can't be confirmed stopped, the join aborts BEFORE spawning — spawning anyway
+    would put two processes on the same token node_id (the original clobber bug)."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_remote_spawn(monkeypatch)
+    monkeypatch.setattr(cli.remote_provider.run_records, "terminate_pid", lambda pid: False)  # won't die
+
+    assert cli.main(["join", "--at", "http://h:11434/v1", "-m", "llama3"]) == 0  # first join: no prior to stop
+    monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
+    spawns = []
+    monkeypatch.setattr(cli.remote_provider, "_spawn_remote_engine",
+                        lambda *a, **k: spawns.append(a) or type("P", (), {"pid": 1})())
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["join", "--at", "http://h:8000/v1", "-m", "mistral"])
+    assert "could not stop" in str(exc.value).lower()
+    assert spawns == []  # never spawned the clobbering second process
+
+
+def _seed_remote_identity(monkeypatch, tmp_path, engines, *, pid=4242, media=False):
     from shared import run_records
 
     _seed_remote(monkeypatch, tmp_path,
                 networks=[{"network_id": "n1", "name": "team", "access_token": "AT"}], active="team")
-    run_records.write_record("n1", "rig", {"engine_id": "rig", "node_id": "node-x", "grid_id": "n1", "pid": 0})
+    run_records.write_record("n1", "remote", {
+        "engine_id": "remote", "grid_id": "n1", "pid": pid, "media": media,
+        "signaling_url": "https://relay.example", "meta_name": "mybox",
+        "engines": engines,
+        "models": list(dict.fromkeys(m for e in engines for m in e.get("models") or [])),
+        "endpoint_url": engines[0]["endpoint_url"] if len(engines) == 1 else None,
+    })
 
-    assert cli.main(["leave", "--engine", "rig"]) == 0
+
+def test_remote_leave_tears_down_the_identity(monkeypatch, tmp_path, capsys):
+    _seed_remote_identity(monkeypatch, tmp_path,
+                          [{"endpoint_url": "http://h:11434/v1", "models": ["llama3"], "engine_label": "ollama"}], pid=0)
+
+    assert cli.main(["leave"]) == 0  # bare leave tears down the whole singleton identity
     assert cli.provider._read_records("n1") == {}
-    assert "Left engine rig" in capsys.readouterr().out
+    assert "Left team" in capsys.readouterr().out
+
+
+def test_remote_leave_engine_shrinks_union(monkeypatch, tmp_path):
+    _seed_remote_identity(monkeypatch, tmp_path, [
+        {"endpoint_url": "http://h:11434/v1", "models": ["llama3"], "engine_label": "ollama"},
+        {"endpoint_url": "http://h:8000/v1", "models": ["mistral"], "engine_label": "vllm"},
+    ])
+    _mock_remote_spawn(monkeypatch)  # the reduced union is respawned
+    terminated = []
+    monkeypatch.setattr(cli.remote_provider.run_records, "terminate_pid", lambda pid: terminated.append(pid) or True)
+    monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
+
+    assert cli.main(["leave", "--engine", "http://h:11434/v1"]) == 0  # drop one engine by endpoint URL
+    rec = cli.provider._read_records("n1")["remote"]
+    assert [e["endpoint_url"] for e in rec["engines"]] == ["http://h:8000/v1"]  # only the survivor remains
+    assert rec["models"] == ["mistral"] and rec["endpoint_url"] == "http://h:8000/v1"
+    assert terminated == [4242]  # respawned with the reduced union
+
+
+def test_remote_leave_engine_last_tears_down(monkeypatch, tmp_path, capsys):
+    _seed_remote_identity(monkeypatch, tmp_path,
+                          [{"endpoint_url": "http://h:11434/v1", "models": ["llama3"], "engine_label": "ollama"}], pid=0)
+
+    assert cli.main(["leave", "--engine", "http://h:11434/v1"]) == 0  # the only engine
+    assert cli.provider._read_records("n1") == {}  # last engine removed → whole identity torn down
+    assert "last engine" in capsys.readouterr().out.lower()
+
+
+def test_remote_leave_engine_unknown_errors(monkeypatch, tmp_path):
+    _seed_remote_identity(monkeypatch, tmp_path,
+                          [{"endpoint_url": "http://h:11434/v1", "models": ["llama3"], "engine_label": "ollama"}], pid=0)
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["leave", "--engine", "http://nope:9999/v1"])
+    assert "no engine" in str(exc.value).lower()
+
+
+def test_remote_leave_shrink_preserves_media(monkeypatch, tmp_path):
+    """Dropping a text engine from an identity that also serves media keeps media on in the respawn."""
+    _seed_remote_identity(monkeypatch, tmp_path, [
+        {"endpoint_url": "http://h:11434/v1", "models": ["llama3"], "engine_label": "ollama"},
+        {"endpoint_url": "http://h:8000/v1", "models": ["mistral"], "engine_label": "vllm"},
+    ], media=True)
+    _mock_remote_spawn(monkeypatch)
+    monkeypatch.setattr(cli.remote_provider.run_records, "terminate_pid", lambda pid: True)
+    monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
+
+    assert cli.main(["leave", "--engine", "http://h:11434/v1"]) == 0
+    rec = cli.provider._read_records("n1")["remote"]
+    assert rec["media"] is True  # media survives an engine drop
+    assert [e["endpoint_url"] for e in rec["engines"]] == ["http://h:8000/v1"]
+
+
+def test_remote_leave_shrink_reports_a_dead_respawn(monkeypatch, tmp_path):
+    """A shrink whose respawn dies must surface an error, not print 're-serving N engine(s)' success while
+    the grid serves nothing."""
+    _seed_remote_identity(monkeypatch, tmp_path, [
+        {"endpoint_url": "http://h:11434/v1", "models": ["llama3"], "engine_label": "ollama"},
+        {"endpoint_url": "http://h:8000/v1", "models": ["mistral"], "engine_label": "vllm"},
+    ])
+    monkeypatch.setattr(cli.remote_provider.subprocess, "Popen", lambda cmd, **kw: type("P", (), {"pid": 7})())
+    monkeypatch.setattr(cli.remote_provider, "_await_remote_engine_start", lambda *a, **k: "died")
+    monkeypatch.setattr(cli.remote_provider.run_records, "terminate_pid", lambda pid: True)
+    monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["leave", "--engine", "http://h:11434/v1"])
+    assert "not serving" in str(exc.value).lower() or "exited" in str(exc.value).lower()
 
 
 def test_dispatch_runs_agnostic_command_in_remote(monkeypatch, tmp_path, capsys):
@@ -2638,6 +2961,16 @@ def test_build_routing_maps_alias_to_upstream_real_name(monkeypatch, tmp_path):
     assert union == ["ollama-model"]
     assert caps == {"schema_version": 1, "models": {"ollama-model": {"x": 1}}}
     assert warns == []
+
+
+def test_meta_uses_meta_name_for_grid_page_name(monkeypatch, tmp_path):
+    """The grid-page node name comes from the record's ``meta_name`` (--name, or hostname when omitted),
+    not the singleton record key ``engine_id`` (which is the constant "remote")."""
+    from remote import serve
+
+    assert serve._meta({"meta_name": "mybox", "endpoint_url": "http://h/v1"}, "remote")["name"] == "mybox"
+    # Fallback to engine_id when no display name was stored (defensive; join always sets meta_name).
+    assert serve._meta({"endpoint_url": "http://h/v1"}, "remote")["name"] == "remote"
 
 
 def test_bring_up_engines_external_multi_probes_each(monkeypatch, tmp_path):
@@ -4580,3 +4913,52 @@ def test_capabilities_threads_ctx_size_into_envelope(monkeypatch):
         "json_object": False, "json_schema": False})
     env = probe.capabilities("http://h:8081/v1", "qwen3.5:0.8b", context_window=200000)
     assert env["models"]["qwen3.5:0.8b"]["context_window"] == 200000
+
+
+def _poll_loop_state_and_poll(job_then_none):
+    """A minimal serve state + a poll_once double that yields `job_then_none` then stops the loop."""
+    from remote import serve
+
+    state = SimpleNamespace(stop=threading.Event())
+    queue = list(job_then_none)
+
+    def fake_poll(_state, **_kwargs):
+        if queue:
+            return queue.pop(0)
+        _state.stop.set()  # nothing left to serve — let the loop exit
+        return None
+
+    monkey_targets = {"poll_once": fake_poll, "handle_job": lambda _s, _job: None}
+    return serve, state, monkey_targets
+
+
+def test_poll_loop_is_silent_on_success_by_default(monkeypatch, capsys):
+    # A healthy poll (a served job, then an empty 204) must not write to the engine log — only
+    # errors and job failures are recorded, so the log stays quiet unless something is wrong.
+    serve, state, targets = _poll_loop_state_and_poll(
+        [{"transaction_id": "txn-1", "body": {"model": "qwen3:0.6b"}}, None]
+    )
+    monkeypatch.setattr(serve, "_DEBUG", False)
+    for name, fn in targets.items():
+        monkeypatch.setattr(serve, name, fn)
+
+    serve._poll_loop(state)
+
+    assert "[engine]" not in capsys.readouterr().err
+
+
+def test_poll_loop_traces_each_cycle_when_debug_enabled(monkeypatch, capsys):
+    # With GRID_ENGINE_DEBUG set, every cycle is traced: a claimed job (with its txn + model) and
+    # an empty 204 both emit an `[engine]` line so the poll loop is visible while debugging.
+    serve, state, targets = _poll_loop_state_and_poll(
+        [{"transaction_id": "txn-1", "body": {"model": "qwen3:0.6b"}}, None]
+    )
+    monkeypatch.setattr(serve, "_DEBUG", True)
+    for name, fn in targets.items():
+        monkeypatch.setattr(serve, name, fn)
+
+    serve._poll_loop(state)
+
+    err = capsys.readouterr().err
+    assert "[engine] poll: job txn=txn-1 model='qwen3:0.6b' handled" in err
+    assert "[engine] poll: no job (204)" in err

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -1166,6 +1166,36 @@ def test_engine_ls_remote_delegates_to_remote_engines(monkeypatch, tmp_path):
     assert seen.get("hit") is True
 
 
+def test_looks_like_grid_id_detector():
+    assert cli.grid._looks_like_grid_id("ag-home-deadbeef") is True
+    assert cli.grid._looks_like_grid_id("workshop") is False
+    assert cli.grid._looks_like_grid_id("ag-team") is False  # no hex8 suffix → still a creatable name
+
+
+def test_up_rejects_unknown_grid_id_without_creating(monkeypatch, tmp_path):
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["up", "ag-home-deadbeef"])
+    assert "grid ls" in str(exc.value)
+    from local import config as local_config
+    assert local_config.iter_grid_configs() == []  # nothing created, nothing spawned
+
+
+def test_up_creates_for_human_name(monkeypatch, tmp_path):
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    monkeypatch.setattr(cli.grid.runtime, "start_grid", lambda cfg: None)
+    assert cli.main(["up", "workshop"]) == 0
+    from local import config as local_config
+    assert any(c["name"] == "workshop" for c in local_config.iter_grid_configs())
+
+
+def test_up_starts_existing_grid_by_id(monkeypatch, tmp_path):
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    cfg = runtime.init_grid_config(name="home", port=8090)
+    monkeypatch.setattr(cli.grid.runtime, "start_grid", lambda cfg: None)
+    assert cli.main(["up", cfg["grid_id"]]) == 0  # found by id → guard skipped
+
+
 _FAKE_ENGINES = [
     {"name": "mac", "endpoint_url": "http://192.168.1.10:8080/v1", "models": ["gemma4-31b"]},
     {"name": "gpu", "endpoint_url": "http://192.168.1.20:8000/v1", "models": ["devstral", "gemma4-31b"]},

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -1051,6 +1051,16 @@ def test_remote_join_inline_alias_desugars_into_record(monkeypatch, tmp_path):
     assert rec["advertise_as"] == ["pub-a"]
 
 
+def test_engine_label_is_deprecated_but_still_recorded(monkeypatch, tmp_path, capsys):
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_remote_spawn(monkeypatch)
+    assert cli.main(["join", "--serve", "m", "--engine-label", "rig"]) == 0
+    err = capsys.readouterr().err
+    assert "engine-label" in err and "deprecated" in err.lower()
+    # still stored so `grid leave --engine <label>` keeps matching (ADR 0010 D-c)
+    assert cli.provider._read_records("n1")["remote"]["engine_label"] == "rig"
+
+
 _FAKE_ENGINES = [
     {"name": "mac", "endpoint_url": "http://192.168.1.10:8080/v1", "models": ["gemma4-31b"]},
     {"name": "gpu", "endpoint_url": "http://192.168.1.20:8000/v1", "models": ["devstral", "gemma4-31b"]},

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -989,6 +989,68 @@ def test_join_kind_flag_with_engine_alias():
     assert parser.parse_args(["join", "--engine", "vllm"]).kind == "vllm"  # --engine is a back-compat alias
 
 
+def _parse_join(*argv):
+    return cli.build_parser().parse_args(["join", *argv])
+
+
+def test_join_inline_alias_desugars_into_record(monkeypatch, tmp_path):
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    cfg = runtime.init_grid_config(name="home", port=8090)
+
+    class FakePopen:
+        def __init__(self, cmd, **kwargs):
+            self.pid = 4321
+
+    monkeypatch.setattr(cli.provider.subprocess, "Popen", FakePopen)
+    monkeypatch.setattr(cli.provider, "_await_engine_start", lambda *a, **k: "registered")
+    args = _parse_join("home", "--at", "http://h:11434/v1", "-m", "real-a=pub-a", "--name", "mac")
+    assert cli.cmd_join(args) == 0
+    rec = cli.provider._read_records(cfg["grid_id"])["mac"]
+    assert rec["models"] == ["real-a"]
+    assert rec["advertise_as"] == ["pub-a"]
+
+
+def test_inline_alias_rejects_mixing_with_advertise_as():
+    args = _parse_join("--at", "u", "-m", "real=pub", "--advertise-as", "x")
+    with pytest.raises(SystemExit) as exc:
+        cli.provider._apply_inline_aliases(args)
+    assert "not both" in str(exc.value)
+
+
+def test_inline_alias_all_or_nothing():
+    args = _parse_join("--at", "u", "-m", "real=pub", "-m", "plain")
+    with pytest.raises(SystemExit):
+        cli.provider._apply_inline_aliases(args)
+
+
+def test_inline_alias_rejects_empty_side():
+    for bad in ("=pub", "real="):
+        with pytest.raises(SystemExit):
+            cli.provider._apply_inline_aliases(_parse_join("--at", "u", "-m", bad))
+
+
+def test_inline_alias_no_equals_is_untouched():
+    args = _parse_join("--at", "u", "-m", "qwen3:0.6b")
+    cli.provider._apply_inline_aliases(args)
+    assert args.models == ["qwen3:0.6b"] and args.advertise_as == []
+
+
+def test_serve_rejects_inline_equals():
+    args = _parse_join("--serve", "real=pub")
+    with pytest.raises(SystemExit) as exc:
+        cli.provider._apply_inline_aliases(args)
+    assert "--advertise-as" in str(exc.value)
+
+
+def test_remote_join_inline_alias_desugars_into_record(monkeypatch, tmp_path):
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_remote_spawn(monkeypatch)
+    assert cli.main(["join", "--at", "http://h:11434/v1", "-m", "real-a=pub-a"]) == 0
+    rec = cli.provider._read_records("n1")["remote"]
+    assert rec["models"] == ["real-a"]
+    assert rec["advertise_as"] == ["pub-a"]
+
+
 _FAKE_ENGINES = [
     {"name": "mac", "endpoint_url": "http://192.168.1.10:8080/v1", "models": ["gemma4-31b"]},
     {"name": "gpu", "endpoint_url": "http://192.168.1.20:8000/v1", "models": ["devstral", "gemma4-31b"]},

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -936,6 +936,53 @@ def test_cli_accepts_engines_and_json_and_aliases():
     assert parser.parse_args(["remove", "m.gguf"]).handler is cli.cmd_rm
 
 
+# ---------------------------------------------------------------------------
+# CLI UX overhaul (ADR 0010): help text, join flag groups, `grid ls` id column
+# ---------------------------------------------------------------------------
+
+def _subcmd_help(cmd: str) -> str:
+    """Whitespace-collapsed --help text for a subcommand. argparse re-wraps help to the terminal
+    width, so collapsing runs of whitespace lets substring asserts survive line breaks."""
+    parser = cli.build_parser()
+    sub = next(a for a in parser._actions if isinstance(a, argparse._SubParsersAction))
+    return " ".join(sub.choices[cmd].format_help().split())
+
+
+def test_leave_help_lists_all_match_kinds():
+    help_text = _subcmd_help("leave")
+    for kind in ("engine id", "endpoint URL", "served model", "URL fragment"):
+        assert kind in help_text, f"leave --engine help should mention {kind!r}"
+
+
+def test_leave_all_help_states_multi_engine_needs_all():
+    assert "multi-engine" in _subcmd_help("leave")
+
+
+def test_join_help_groups_flags():
+    help_text = _subcmd_help("join")
+    for title in ("Choose an engine", "Name & display", "Media", "Built-in", "Local only", "Remote only"):
+        assert title in help_text, f"join -h should have a {title!r} group"
+
+
+def test_join_help_marks_mode_scoped_flags():
+    help_text = _subcmd_help("join")
+    assert "(local only)" in help_text and "(remote only)" in help_text
+
+
+def test_positional_grid_help_present():
+    assert "Grid name or id" in _subcmd_help("up")
+    assert "Grid name or id" in _subcmd_help("join")
+
+
+def test_ls_shows_grid_id_local(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    cfg = runtime.init_grid_config(name="home", port=8090)
+    assert cli.cmd_ls(cli.build_parser().parse_args(["ls"])) == 0
+    assert cfg["grid_id"] in capsys.readouterr().out  # id column present in human output
+    assert cli.cmd_ls(cli.build_parser().parse_args(["ls", "--json"])) == 0
+    assert json.loads(capsys.readouterr().out)[0]["id"] == cfg["grid_id"]
+
+
 _FAKE_ENGINES = [
     {"name": "mac", "endpoint_url": "http://192.168.1.10:8080/v1", "models": ["gemma4-31b"]},
     {"name": "gpu", "endpoint_url": "http://192.168.1.20:8000/v1", "models": ["devstral", "gemma4-31b"]},
@@ -4589,7 +4636,8 @@ def test_remote_ls_json_emits_grid_and_type(monkeypatch, tmp_path, capsys):
     _seed_remote(monkeypatch, tmp_path, networks=[
         {"network_id": "n1", "name": "team", "network_type": "permissioned-public"}])
     assert cli.main(["ls", "--json"]) == 0
-    assert json.loads(capsys.readouterr().out) == [{"grid": "team", "type": "permissioned-public"}]
+    assert json.loads(capsys.readouterr().out) == [
+        {"grid": "team", "type": "permissioned-public", "id": "n1"}]
 
 
 def test_remote_list_alias_lists_like_ls(monkeypatch, tmp_path, capsys):


### PR DESCRIPTION
## What

Merge `fix/remote-join` into `main`. These are two sibling branches that both grew
`remote/` from merge-base `3c2bdd8` in different directions, so this is a **design
integration**, not a text merge — the hard part is `remote/serve.py`, which now runs
**both** remote-provider designs at once.

## The two designs (both kept)

| Branch | ADR | What it adds |
|---|---|---|
| `main` | 0009 concurrency | `--max-concurrency` = N daemon poll workers + heartbeat under `_supervise`; main thread is a pure waiter (SIGTERM can't kill an in-flight job); single bounded `_DRAIN_TIMEOUT` drain; `max_concurrency` clamp |
| `fix/remote-join` | 0009-append → **0010** | additive `grid join` (one identity/grid, singleton record); SIGHUP hot-reload via a reload daemon + immutable `_Snapshot` swap + `register_once` under `_register_lock` |

## How they coexist in `remote/serve.py`

- SIGHUP is **blocked before any thread spawns**. The reload daemon, heartbeat, and all N
  poll workers inherit the block; `_serve_loop` unblocks it on the **main thread last**, so a
  `grid join`/`leave` signal can only land on main and EINTR its park — never on a poll worker
  mid-forward (ADR 0010 C4).
- `_serve_loop` owns the pool + bounded drain. The reload daemon is a separate self-guarding
  thread (a failed reload keeps the old routing, so it is deliberately **not** `_supervise`d).
- `_ServeState` is the snapshot-based version; the `_MAX_CONCURRENCY` clamp moved into
  `_Snapshot.build` (sole normalization site) so reloads clamp too; main's richer `load()`
  (GPU/host VRAM roll-up) preserved.
- Submit path: main's 401-refreshing `_submit_response`/`_try_submit_error` (a token expiring
  mid-job still delivers a terminal signal) + join's `_traced_stream`. `_bring_up_engines`
  keeps main's per-model probe; `_advertise_as` keeps main's `comfyui:` guard; `_meta` keeps
  join's `meta_name` + auto-derived `external` label.

## Other resolved files

- **`cli/remote_provider.py`** — join's singleton `cmd_remote_leave` + `_leave_one_engine`
  (hot-reload/respawn union shrink), with main's robust teardown re-applied: the whole-identity
  teardown routes through `provider._stop_engine` (reaps a ComfyUI the engine started).
- **`shared/run_records.py`** — main's `update_record` + join's `match_engine` + `media_signature`.
- **`tests/test_local_cli.py`** — union of both suites (no name collisions).
- **`README.md` / `docs/cli.md`** — both edits merged (`--engine-label` documented as deprecated
  per the CLI-UX overhaul; `--max-concurrency` described per the concurrency work).
- **ADR renumber** — two `0009` files after the merge: kept `0009-remote-provider-concurrency`;
  `0009-remote-join-append` → **0010**, `0010-cli-ux-vocabulary` → **0011**; all in-repo refs updated.

## Testing

- `pytest tests/test_local_cli.py` — **433 passed** (union suite + 2 new regression tests).
- `ruff check cli shared local remote tests` — clean.
- Three independent reviewers (python-reviewer / code-reviewer / silent-failure-hunter) ran on the
  serve.py concurrency integration. They cleared the SIGHUP-only-on-main ordering, `_ServeState` lock
  discipline (no torn reads / no cycle), and the refresh/401 path as correct.

## Post-review hardening (issues the integration introduced or activated)

- **Multi-model reload probe** — extracted `_probe_spec_caps`, shared by startup (`_bring_up_engines`)
  and hot-reload (`_reload_once`), so a newly-appended multi-model `--at` engine advertises caps for
  ALL its models on both paths (previously reload probed only the first — silent capability loss for
  models 2..N). *+regression test.*
- **Reload↔unregister race** — the reload daemon is now joined in `_serve_loop`'s bounded drain (like
  the heartbeat, since both can `register_once`), and `_reload_once` skips re-registering once `stop`
  is set, so a reload's PUT can't resurrect a node the teardown just unregistered.
- **`max_concurrency` dropped on additive join** — an additive `grid join` now preserves the live
  identity's `--max-concurrency` (it sizes the poll-worker pool) instead of silently resetting it to 1.
  *+regression test.*
- **Reload advertised the wrong capacity** — a reload now pins advertised `max_concurrency` to the
  actual live pool size (the pool is sized once at startup and a reload can't resize it).

## Known pre-existing (surfaced by review; NOT introduced by this merge — follow-ups, not fixed here)

Each verified against the parent blobs; kept out of the merge to preserve scope discipline.

- **`shared/run_records.stop_engine`** discards `terminate_pid`'s "confirmed gone" bool and deletes the
  record unconditionally — a SIGKILL-surviving child could be clobbered by a later re-join (from `fix/remote-join`).
- **`shared/engine/comfyui.stop_running`** fires one SIGTERM with no wait/verify/escalation (from `main`).
- **`_reload_once`** post-swap re-register `except Exception` doesn't include `SystemExit`, so a corrupt
  `credentials.toml` during a reload skips the bounded retry (daemon still survives via `_reload_loop`'s
  `(Exception, SystemExit)` catch) (from `fix/remote-join`).
- **`_submit_response`** doesn't refresh on a streamed 401 (single-use iterator — intentional) and
  `_try_submit_error`'s `RelayError` branch has no retry → narrow consumer-hang if BOTH submit paths hit a
  down relay (from `main`).
- **`_meta`** still honors `record["engine_label"]` while the CLI documents `--engine-label` as deprecated/inert
  — a contradiction `fix/remote-join` created (deprecated the flag without neutralizing `_meta`); `_meta` is
  byte-identical in both parents.
- Minor: `rc=0` when all poll workers die (indistinguishable from clean exit); `_reload_loop` `.clear()`
  outside its try; `_STOP_GRACE_SECONDS=8` vs longer ComfyUI/relay teardown budgets.

## Residual risk

The N-worker × SIGHUP-reload interaction is concurrency-critical and **not fully verifiable single-host**
— a real append-`--at`-during-stream assertion needs 2 hosts. Flagged, not blocked.
