### PR TITLE
feat: API engines — join a grid with an OpenAI API key (ADR 0012)

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,35 @@ grid join http://192.168.1.25:8090 --media --bundle image_generation
 grid image "a compact walnut desk beside a sunlit window" --grid http://192.168.1.25:8090   # --grid: use-commands take the grid as a flag (positional = prompt)
 ```
 
+### No GPU at all? Join with an API key
+
+No capable hardware anywhere? A provider can still contribute capacity with just a paid **OpenAI**
+account. `grid join --api openai` serves OpenAI's models to your grid under your own key — an **API
+engine**, **remote only**. See what a join would serve first (no key, no network call):
+
+```bash
+grid catalog --api openai
+# Models a `grid join --api openai` would serve (verified 2026-07-08):
+#   openai:gpt-5.5           1,050,000 ctx   tools, vision, json, structured
+#   openai:gpt-5.4-mini        400,000 ctx   tools, vision, json, structured
+#   …
+```
+
+Then join. The key comes from `OPENAI_API_KEY` (or a hidden prompt) — never a command-line flag — and
+is stored `0o600` for later joins; it survives `grid logout` (it's your vendor credential, not your
+grid sign-in). With no `-m` you serve every whitelisted model your key can see:
+
+```bash
+export OPENAI_API_KEY=sk-…
+grid join research --api openai                       # or -m openai:gpt-5.4-mini to narrow
+grid chat -m openai:gpt-5.4-mini "hello from the grid"
+```
+
+Requests to `openai:*` models **leave the grid for OpenAI**, under your key and your own account's
+terms — the `openai:` prefix keeps that visible in every model list. There's no grid-side spend cap;
+put a budget limit on the key's OpenAI project if you want one. Full contract, key store, and rotation
+in [docs/cli.md](docs/cli.md#engines).
+
 ## How it works
 
 Grid sits **above** your computers — like an API gateway above your services, or Tailscale above

--- a/cli/models.py
+++ b/cli/models.py
@@ -1,4 +1,5 @@
-"""`grid catalog` / `grid pull` / `grid rm`: manage local GGUF model files."""
+"""`grid catalog` / `grid pull` / `grid rm`: manage local GGUF model files,
+plus the static API-engine whitelist (`grid catalog --api <kind>`)."""
 from __future__ import annotations
 
 import argparse
@@ -6,6 +7,11 @@ import json
 
 
 def cmd_catalog(args: argparse.Namespace) -> int:
+    # `is not None`, not truthiness: `--api ""` must reach the unknown-kind error,
+    # not silently fall through to the GGUF catalog.
+    if getattr(args, "api", None) is not None:
+        return _catalog_api(args)
+
     from shared.models import catalog, store
 
     if getattr(args, "json", False):
@@ -33,6 +39,48 @@ def cmd_catalog(args: argparse.Namespace) -> int:
         print(catalog.format_catalog_entry(entry))
     print()
     print("Also: `grid pull <hf-repo>:<file>` for any GGUF on Hugging Face.")
+    return 0
+
+
+def _catalog_api(args: argparse.Namespace) -> int:
+    from shared.models import api_catalog
+
+    kind = args.api
+    whitelist = api_catalog.WHITELISTS.get(kind)
+    if whitelist is None or not whitelist.entries:
+        supported = ", ".join(api_catalog.supported_kinds())
+        raise SystemExit(f"Unknown API kind {kind!r}. Supported: {supported}")
+
+    if getattr(args, "json", False):
+        # Explicit keys: this is the stable machine-readable contract (ADR 0012);
+        # renaming an ApiModelEntry field must not silently rename a JSON key.
+        print(json.dumps({
+            "kind": kind,
+            "last_verified": whitelist.last_verified,
+            "models": [
+                {
+                    "advertised": api_catalog.advertised_name(kind, entry),
+                    "vendor_name": entry.vendor_name,
+                    "context_window": entry.context_window,
+                    "supports_tools": entry.supports_tools,
+                    "supports_vision": entry.supports_vision,
+                    "supports_json_mode": entry.supports_json_mode,
+                    "supports_structured_outputs": entry.supports_structured_outputs,
+                    "notes": entry.notes,
+                }
+                for entry in whitelist.entries
+            ],
+        }, indent=2))
+        return 0
+
+    print(
+        f"Models a `grid join --api {kind}` would serve "
+        f"(verified {whitelist.last_verified}):"
+    )
+    for entry in whitelist.entries:
+        print(api_catalog.format_api_entry(kind, entry))
+    print()
+    print(f"No key needed to view. Requests to {kind}:* models leave the grid for the vendor.")
     return 0
 
 

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -207,6 +207,11 @@ def _add_engines(sub) -> None:
 def _add_models(sub) -> None:
     catalog = sub.add_parser("catalog", help="Models Grid can pull")
     catalog.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    catalog.add_argument(
+        "--api",
+        metavar="KIND",
+        help="Show the API-engine whitelist for a service kind (e.g. openai).",
+    )
     catalog.set_defaults(handler=cmd_catalog)
 
     pull = sub.add_parser("pull", help="Download a model (catalog label or '<hf-repo>:<file>')")

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -132,6 +132,13 @@ def _add_engines(sub) -> None:
     choose.add_argument("--all", action="store_true", help="Join every detected engine.")
     choose.add_argument("--kind", "--engine", dest="kind", default=None,
                         help="Join only the detected engine of this kind (e.g. ollama, vllm).")
+    choose.add_argument(
+        "--api",
+        metavar="KIND",
+        default=None,
+        help="Join a third-party API engine of this service kind (e.g. openai). "
+             "Remote only; requires -m with whitelisted models (see `grid catalog --api`).",
+    )
 
     naming = join.add_argument_group("Name & display")
     naming.add_argument("--name", default=None,

--- a/cli/provider.py
+++ b/cli/provider.py
@@ -33,6 +33,7 @@ from local import runtime
 # Remote-only `grid join` flags (DECISIONS D6/D8): rejected in local mode, where the concept
 # doesn't exist. (attr on args, surface flag) — kept here next to the local handler that guards them.
 _REMOTE_ONLY_JOIN_FLAGS = (
+    ("api", "--api"),
     ("engine_label", "--engine-label"),
     ("pricing_input", "--pricing-input"),
     ("pricing_output", "--pricing-output"),

--- a/cli/remote_provider.py
+++ b/cli/remote_provider.py
@@ -24,6 +24,7 @@ import uuid
 
 from shared import paths, run_records
 from shared.filelock import file_lock
+from shared.models import api_catalog
 
 # Remote has exactly ONE identity per grid: the relay node_id is pinned to the per-grid access token
 # (remote/serve._node_id_from_token), so two `grid join`s on a grid would register the same node and
@@ -31,6 +32,9 @@ from shared.filelock import file_lock
 # engines_dir(<network_id>)/remote.json — and repeated joins are additive (ADR 0010). `--name` no longer
 # keys the record (it can't mint a second identity); it is the grid-page display name (record["meta_name"]).
 _REMOTE_IDENTITY = "remote"
+
+# One-shot vendor model-listing call at `join --api` (key validation + whitelist intersection).
+_VENDOR_LIST_TIMEOUT = 15.0
 
 
 def _reject_local_only_flags(args: argparse.Namespace) -> None:
@@ -50,12 +54,48 @@ def _warn_deprecated(triggered: bool, message: str) -> None:
         print(message, file=sys.stderr)
 
 
+def _reject_api_conflicts(args: argparse.Namespace) -> None:
+    """Grammar for ``grid join --api <kind>`` (ADR 0012): one API engine per invocation. The
+    hardware/media selectors don't combine with it (additive joins cover serving both), and
+    aliasing never applies — the namespaced whitelist names ARE the advertised names."""
+    kind = args.api
+    if kind not in api_catalog.WHITELISTS:
+        supported = ", ".join(api_catalog.supported_kinds())
+        raise SystemExit(f"Unknown API kind {kind!r}. Supported: {supported}")
+    conflicts = (
+        ("at", "--at"),
+        ("serve", "--serve"),
+        ("advertise_as", "--advertise-as"),
+        ("media", "--media"),
+        ("bundles", "--bundle"),
+    )
+    used = [flag for attr, flag in conflicts if getattr(args, attr, None)]
+    if used:
+        raise SystemExit(
+            f"--api joins one API engine and can't combine with {', '.join(used)} in the same "
+            "invocation. Join other engines with a separate `grid join`."
+        )
+    models = list(getattr(args, "models", []) or [])
+    if not models:
+        raise SystemExit(
+            f"--api {kind} requires -m with the whitelisted models to serve "
+            f"(see `grid catalog --api {kind}`)."
+        )
+    if any("=" in model for model in models):
+        raise SystemExit(
+            "API-engine models are advertised under their whitelist names — inline `-m real=alias` "
+            "aliasing doesn't apply with --api."
+        )
+
+
 def cmd_remote_join(args: argparse.Namespace) -> int:
     from remote import credentials
 
     from . import provider, remote_grid
 
     _reject_local_only_flags(args)
+    if getattr(args, "api", None) is not None:  # `--api ""` must error, not fall through to hardware
+        _reject_api_conflicts(args)
     if args.serve and args.models:
         raise SystemExit("--serve serves one built-in model; drop -m/--model (alias a built-in with --advertise-as).")
     provider._apply_inline_aliases(args)
@@ -85,7 +125,10 @@ def cmd_remote_join(args: argparse.Namespace) -> int:
     # member can't pre-check fails later at register). See remote_grid.resolve_relay_base.
     signaling_url, _status = remote_grid.resolve_relay_base(session, rec, network_id, label)
 
-    specs, media_detected = _resolve_serve_targets(args)
+    if getattr(args, "api", None) is not None:
+        specs, media_detected = _resolve_api_targets(args), False
+    else:
+        specs, media_detected = _resolve_serve_targets(args)
     media = bool(getattr(args, "media", False)) or media_detected
     if not specs and not media:  # engines detected and the operator declined, or nothing to serve
         print("Nothing joined.")
@@ -154,6 +197,81 @@ def cmd_remote_join(args: argparse.Namespace) -> int:
     return 0
 
 
+def _resolve_api_targets(args: argparse.Namespace) -> list[dict[str, object]]:
+    """The single API-engine spec for ``join --api <kind>``: ``-m`` validated against the static
+    whitelist first (no key, no network), then the key from the kind's env var, then the vendor's
+    model listing — the ONLY place the CLI itself calls the vendor (ADR 0012) — which doubles as
+    key validation and as the whitelist ∩ visible-models filter. The spec is kind-generic and
+    never carries the key; the vendor model names are derived from the advertised names at serve
+    time (a stored map would go stale on an additive re-join, which unions models only)."""
+    kind = args.api
+    whitelist = api_catalog.WHITELISTS[kind]  # kind already validated by _reject_api_conflicts
+    if getattr(args, "advertise_as", None):
+        # Defence in depth: inline `-m real=alias` desugars into advertise_as after the early guard.
+        raise SystemExit("--advertise-as aliasing doesn't apply with --api.")
+    valid = {api_catalog.advertised_name(kind, entry): entry for entry in whitelist.entries}
+    chosen = list(dict.fromkeys(args.models))  # dedupe up front so errors don't repeat a model
+    unknown = [model for model in chosen if model not in valid]
+    if unknown:
+        raise SystemExit(
+            f"Not in the {kind} whitelist: {', '.join(unknown)}. "
+            f"Valid models: {', '.join(valid)}."
+        )
+    key = os.environ.get(whitelist.env_var)
+    if not key:
+        raise SystemExit(
+            f"--api {kind} needs your API key in {whitelist.env_var}. "
+            f"Export it and re-run: export {whitelist.env_var}=..."
+        )
+    visible = _list_vendor_models(kind, whitelist.base_url, key)
+    served = [model for model in chosen if valid[model].vendor_name in visible]
+    skipped = [model for model in chosen if model not in served]
+    if not served:
+        raise SystemExit(
+            f"None of the requested models are available to this {kind} key: {', '.join(skipped)}."
+        )
+    if skipped:
+        print(f"Skipping (not available to this {kind} key): {', '.join(skipped)}", file=sys.stderr)
+    return [{
+        "endpoint_url": whitelist.base_url,
+        "models": served,
+        "engine_label": kind,
+        "api_kind": kind,
+    }]
+
+
+def _list_vendor_models(kind: str, base_url: str, key: str) -> set[str]:
+    """The vendor model ids this key can see (``GET {base_url}/models``). A rejected key or an
+    unreachable/malformed vendor is a terminal error — nothing is spawned. Never echoes the key."""
+    import httpx  # lazy: only stdlib + shared.* at module top (see module docstring)
+
+    try:
+        with httpx.Client(timeout=_VENDOR_LIST_TIMEOUT) as client:
+            resp = client.get(f"{base_url}/models", headers={"Authorization": f"Bearer {key}"})
+    except httpx.HTTPError as exc:
+        raise SystemExit(f"Could not reach {kind} at {base_url}: {exc}") from None
+    if resp.status_code in (401, 403):
+        raise SystemExit(
+            f"{kind} rejected the API key (HTTP {resp.status_code}): {resp.text[:200]}"
+        )
+    if resp.status_code != 200:  # an outage/redirect is not a key problem — don't blame the key
+        raise SystemExit(f"{kind} returned HTTP {resp.status_code}: {resp.text[:200]}")
+    try:
+        data = resp.json()
+    except ValueError:
+        raise SystemExit(f"{kind} returned a malformed model listing (not JSON).") from None
+    # A 200 that isn't the documented {"data": [...]} shape must be its own diagnostic error —
+    # returning an empty set here would masquerade as "your key can't see these models".
+    items = data.get("data") if isinstance(data, dict) else None
+    if not isinstance(items, list):
+        raise SystemExit(f"{kind} returned an unexpected model listing shape: {resp.text[:200]}")
+    return {
+        str(item["id"])
+        for item in items
+        if isinstance(item, dict) and item.get("id")
+    }
+
+
 def _live_records(network_id: str) -> list[dict[str, object]]:
     """Every remote run record for this grid whose detached process is still alive. Normally that's just
     the singleton ``remote.json``; on upgrade it also catches legacy ``engine-<uuid>`` records so the join
@@ -166,7 +284,9 @@ def _live_records(network_id: str) -> list[dict[str, object]]:
 
 def _flat_spec(record: dict[str, object]) -> dict[str, object]:
     """One engine spec synthesised from a record written before the multi-engine ``engines`` field
-    (mirrors ``remote/serve._flat_spec``) so an old-format live record is still adopted, not dropped."""
+    (mirrors ``remote/serve._flat_spec``) so an old-format live record is still adopted, not dropped.
+    Never carries ``api_kind``: api specs postdate the ``engines`` array, so a flat record can't
+    hold one — if that invariant ever breaks, the spec would silently degrade to a hardware engine."""
     return {
         "endpoint_url": record.get("endpoint_url"),
         "models": list(record.get("models") or []),
@@ -273,6 +393,15 @@ def _hot_reloadable(
     if singleton.get("reload_signal") != "sighup":  # a pre-Slice-2 process has no SIGHUP handler (C1)
         return False
     if any(not spec.get("endpoint_url") for spec in merged_specs):  # a built-in --serve needs a launch
+        return False
+    # A NEW API engine needs the vendor key from this CLI's environment, which a SIGHUP can't
+    # inject into the live process — respawn so the child inherits the just-validated key.
+    # Known gap until issue 03's key store: a re-join of an ALREADY-live api spec (idempotent
+    # no-op, or a model append that hot-reloads below) can't deliver a ROTATED env key to the
+    # live process — its bearer is fixed at spawn. Rotation is issue 03's acceptance; `grid
+    # leave` + re-join is the interim path.
+    live_api = {_spec_key(spec) for spec in _engine_union(live) if spec.get("api_kind")}
+    if any(spec.get("api_kind") and _spec_key(spec) not in live_api for spec in merged_specs):
         return False
     return _media_key(record) == _media_key(singleton)  # a media/bundle change needs a bring-up (C3)
 

--- a/cli/remote_provider.py
+++ b/cli/remote_provider.py
@@ -141,10 +141,10 @@ def cmd_remote_join(args: argparse.Namespace) -> int:
     with file_lock(run_records.record_path(network_id, engine_id)):
         live = _live_records(network_id)  # normally just the singleton; also legacy `engine-<uuid>` on upgrade
         merged_specs, changed = _merge_engines(_engine_union(live), specs)
-        # A rotated key only matters when this kind's API spec is already LIVE: its bearer map is
-        # fixed at spawn (remote/serve._ServeState.bearer_by_url), so the new key can only be
-        # delivered by a respawn — never a no-op, never SIGHUP. Kept at the call sites (not inside
-        # `_hot_reloadable`) because leave-shrink shares that gate and rotation never applies there.
+        # A rotated key only matters when this kind's API spec is already LIVE. A reload WOULD re-read the
+        # key store and swap the bearer in place (issue 05), but rotation deliberately RESPAWNS so the
+        # operator has certainty the new key is live — never a no-op, never SIGHUP. Kept at the call sites
+        # (not inside `_hot_reloadable`) because leave-shrink shares that gate and rotation never applies there.
         rotated_live = key_rotated and any(
             spec.get("api_kind") == args.api for spec in _engine_union(live)
         )
@@ -160,6 +160,15 @@ def cmd_remote_join(args: argparse.Namespace) -> int:
             and meta_name == _identity_field(live, "meta_name") and not rotated_live
         ):
             print(f"Already serving on {label}; nothing to append.")
+            # The serve process records a hot-reload that failed AFTER the CLI reported success (the
+            # SIGHUP is fire-and-forget) — surface it here, or the no-op compounds the false success.
+            stale = _identity_field(live, "last_reload_error")
+            if stale:
+                print(
+                    f"Warning: the engine's last hot-reload failed and it kept its previous engines: "
+                    f"{stale}\n(see log={paths.engines_dir(network_id) / f'{engine_id}.log'})",
+                    file=sys.stderr,
+                )
             return 0
         _reject_unserveable_union(merged_specs, args, live)
         _warn_shadowed_models(merged_specs)  # the serve loop logs this too; show it on the operator's terminal
@@ -175,9 +184,10 @@ def cmd_remote_join(args: argparse.Namespace) -> int:
         # advertised, and the reload pins the advertised capacity to the actual live pool anyway).
         if getattr(args, "max_concurrency", None) is None and live:
             record["max_concurrency"] = _identity_field(live, "max_concurrency")
-        # Zero-drop when we can: SIGHUP the live singleton to hot-reload the union in place. Fall back to
-        # stop-respawn for a first join, a legacy/pre-handler process, a launch, a media change, or a
-        # rotated key (the live process's bearer can't be swapped in place).
+        # Zero-drop when we can: SIGHUP the live singleton to hot-reload the union in place — an appended
+        # API engine reloads too now that its bearer is re-read from the key store (issue 05). Fall back to
+        # stop-respawn for a first join, a legacy/pre-handler process, a launch, a media change, a
+        # concurrency-default flip, or a rotated key (respawned by policy so the operator knows it's live).
         if rotated_live:
             print(f"Rotated the stored {args.api} key — restarting the engine to apply it.")
         reloaded = (not rotated_live) and _hot_reloadable(live, merged_specs, record)
@@ -440,14 +450,10 @@ def _hot_reloadable(
     # explicit --max-concurrency pinning both sides — only a respawn applies the new size.
     if run_records.effective_max_concurrency(record) != run_records.effective_max_concurrency(singleton):
         return False
-    # A NEW API engine needs a vendor bearer, and the live process's bearer map is fixed at
-    # startup (remote/serve._ServeState.bearer_by_url — deliberately not on the reload-swappable
-    # snapshot) — respawn so the fresh process reads the just-stored key from the key store. A
-    # ROTATED key for an already-live api spec is handled by the caller (`rotated_live` in
-    # cmd_remote_join), not here: leave-shrink shares this gate and rotation never applies there.
-    live_api = {_spec_key(spec) for spec in _engine_union(live) if spec.get("api_kind")}
-    if any(spec.get("api_kind") and _spec_key(spec) not in live_api for spec in merged_specs):
-        return False
+    # A NEW API engine is hot-reloadable now that the reload re-reads the key store and swaps the vendor
+    # bearer atomically with routing (issue 05 — remote/serve._assemble_snapshot → _api_bearers), so it
+    # is NOT gated here. A ROTATED key for an already-live api spec is still a respawn, forced by the
+    # caller (`rotated_live` in cmd_remote_join) for operator certainty — a policy choice, not a limit.
     return _media_key(record) == _media_key(singleton)  # a media/bundle change needs a bring-up (C3)
 
 
@@ -749,11 +755,16 @@ def _leave_one_engine(
     record["endpoint_url"] = remaining[0]["endpoint_url"] if len(remaining) == 1 else None
     record["media"] = media  # recompute from the survivors, don't inherit the arbitrary template's flag
     record["media_bundles"] = list(dict.fromkeys(b for rec in survivors for b in (rec.get("media_bundles") or [])))
+    record.pop("last_reload_error", None)  # a fresh lifecycle attempt shouldn't inherit a stale failure
     if _hot_reloadable(survivors, remaining, record):
-        _hot_reload_identity(network_id, record, survivors)  # SIGHUP the survivor — zero-drop shrink
+        reloaded = _hot_reload_identity(network_id, record, survivors)  # SIGHUP the survivor — zero-drop shrink
     else:
         _respawn_identity(network_id, record, survivors)  # aborts on a stuck prior / raises on a dead respawn
-    print(f"Dropped {args.engine!r} from {label}; re-serving {len(remaining)} engine(s).")
+        reloaded = False
+    # Report honestly, like cmd_remote_join: _hot_reload_identity returns False when it fell back to a
+    # respawn (the pid vanished in the TOCTOU window), and a respawn is not a zero-drop shrink.
+    how = "hot-reloaded — no in-flight requests dropped" if reloaded else "restarted the engine to apply it"
+    print(f"Dropped {args.engine!r} from {label}; re-serving {len(remaining)} engine(s) ({how}).")
     return 0
 
 

--- a/cli/remote_provider.py
+++ b/cli/remote_provider.py
@@ -14,6 +14,7 @@ while the `cli` package is still initialising.
 from __future__ import annotations
 
 import argparse
+import getpass
 import os
 import signal
 import socket
@@ -57,7 +58,8 @@ def _warn_deprecated(triggered: bool, message: str) -> None:
 def _reject_api_conflicts(args: argparse.Namespace) -> None:
     """Grammar for ``grid join --api <kind>`` (ADR 0012): one API engine per invocation. The
     hardware/media selectors don't combine with it (additive joins cover serving both), and
-    aliasing never applies — the namespaced whitelist names ARE the advertised names."""
+    aliasing never applies — the namespaced whitelist names ARE the advertised names. ``-m`` is
+    optional: omitted, the join serves the whole whitelist the key can see (zero-config default)."""
     kind = args.api
     if kind not in api_catalog.WHITELISTS:
         supported = ", ".join(api_catalog.supported_kinds())
@@ -76,11 +78,6 @@ def _reject_api_conflicts(args: argparse.Namespace) -> None:
             "invocation. Join other engines with a separate `grid join`."
         )
     models = list(getattr(args, "models", []) or [])
-    if not models:
-        raise SystemExit(
-            f"--api {kind} requires -m with the whitelisted models to serve "
-            f"(see `grid catalog --api {kind}`)."
-        )
     if any("=" in model for model in models):
         raise SystemExit(
             "API-engine models are advertised under their whitelist names — inline `-m real=alias` "
@@ -125,8 +122,10 @@ def cmd_remote_join(args: argparse.Namespace) -> int:
     # member can't pre-check fails later at register). See remote_grid.resolve_relay_base.
     signaling_url, _status = remote_grid.resolve_relay_base(session, rec, network_id, label)
 
+    key_rotated = False  # a `join --api` that stored a NEW key must reach a live identity via respawn
     if getattr(args, "api", None) is not None:
-        specs, media_detected = _resolve_api_targets(args), False
+        specs, key_rotated = _resolve_api_targets(args)
+        media_detected = False
     else:
         specs, media_detected = _resolve_serve_targets(args)
     media = bool(getattr(args, "media", False)) or media_detected
@@ -142,6 +141,13 @@ def cmd_remote_join(args: argparse.Namespace) -> int:
     with file_lock(run_records.record_path(network_id, engine_id)):
         live = _live_records(network_id)  # normally just the singleton; also legacy `engine-<uuid>` on upgrade
         merged_specs, changed = _merge_engines(_engine_union(live), specs)
+        # A rotated key only matters when this kind's API spec is already LIVE: its bearer map is
+        # fixed at spawn (remote/serve._ServeState.bearer_by_url), so the new key can only be
+        # delivered by a respawn — never a no-op, never SIGHUP. Kept at the call sites (not inside
+        # `_hot_reloadable`) because leave-shrink shares that gate and rotation never applies there.
+        rotated_live = key_rotated and any(
+            spec.get("api_kind") == args.api for spec in _engine_union(live)
+        )
         base_media = any(bool(rec.get("media")) for rec in live)
         media = base_media or media
         base_bundles = list(dict.fromkeys(b for rec in live for b in (rec.get("media_bundles") or [])))
@@ -151,7 +157,7 @@ def cmd_remote_join(args: argparse.Namespace) -> int:
         # it — there is no other way to rename or add a bundle in Slice 1.
         if (
             live and not changed and media == base_media and bundles == base_bundles
-            and meta_name == _identity_field(live, "meta_name")
+            and meta_name == _identity_field(live, "meta_name") and not rotated_live
         ):
             print(f"Already serving on {label}; nothing to append.")
             return 0
@@ -170,8 +176,11 @@ def cmd_remote_join(args: argparse.Namespace) -> int:
         if getattr(args, "max_concurrency", None) is None and live:
             record["max_concurrency"] = _identity_field(live, "max_concurrency")
         # Zero-drop when we can: SIGHUP the live singleton to hot-reload the union in place. Fall back to
-        # stop-respawn for a first join, a legacy/pre-handler process, a launch, or a media change.
-        reloaded = _hot_reloadable(live, merged_specs, record)
+        # stop-respawn for a first join, a legacy/pre-handler process, a launch, a media change, or a
+        # rotated key (the live process's bearer can't be swapped in place).
+        if rotated_live:
+            print(f"Rotated the stored {args.api} key — restarting the engine to apply it.")
+        reloaded = (not rotated_live) and _hot_reloadable(live, merged_specs, record)
         if reloaded:
             reloaded = _hot_reload_identity(network_id, record, live)  # False if it fell back to a respawn
         else:
@@ -197,38 +206,62 @@ def cmd_remote_join(args: argparse.Namespace) -> int:
     return 0
 
 
-def _resolve_api_targets(args: argparse.Namespace) -> list[dict[str, object]]:
-    """The single API-engine spec for ``join --api <kind>``: ``-m`` validated against the static
-    whitelist first (no key, no network), then the key from the kind's env var, then the vendor's
-    model listing — the ONLY place the CLI itself calls the vendor (ADR 0012) — which doubles as
-    key validation and as the whitelist ∩ visible-models filter. The spec is kind-generic and
-    never carries the key; the vendor model names are derived from the advertised names at serve
-    time (a stored map would go stale on an additive re-join, which unions models only)."""
+def _resolve_api_targets(args: argparse.Namespace) -> tuple[list[dict[str, object]], bool]:
+    """The single API-engine spec for ``join --api <kind>``, plus whether the stored key rotated:
+    ``-m`` validated against the static whitelist first (no key, no network), then the key resolved
+    (env var, else key store, else hidden prompt), then the vendor's model listing — the ONLY place
+    the CLI itself calls the vendor (ADR 0012) — which doubles as key validation and as the
+    whitelist ∩ visible-models filter. The spec is kind-generic and never carries the key; the
+    vendor model names are derived from the advertised names at serve time (a stored map would go
+    stale on an additive re-join, which unions models only)."""
     kind = args.api
     whitelist = api_catalog.WHITELISTS[kind]  # kind already validated by _reject_api_conflicts
     if getattr(args, "advertise_as", None):
         # Defence in depth: inline `-m real=alias` desugars into advertise_as after the early guard.
         raise SystemExit("--advertise-as aliasing doesn't apply with --api.")
     valid = {api_catalog.advertised_name(kind, entry): entry for entry in whitelist.entries}
-    chosen = list(dict.fromkeys(args.models))  # dedupe up front so errors don't repeat a model
+    # No -m = the whole whitelist (zero-config default); `valid` preserves whitelist order.
+    chosen = list(dict.fromkeys(args.models or [])) or list(valid)  # dedupe so errors don't repeat
     unknown = [model for model in chosen if model not in valid]
     if unknown:
         raise SystemExit(
             f"Not in the {kind} whitelist: {', '.join(unknown)}. "
             f"Valid models: {', '.join(valid)}."
         )
-    key = os.environ.get(whitelist.env_var)
+    from remote import api_keys  # lazy: only stdlib + shared.* at module top (see module docstring)
+
+    from . import provider
+
+    # Key precedence (ADR 0012): env var, else the machine-local key store, else a hidden
+    # interactive prompt. Never a flag — a key on the command line leaks into shell history.
+    # The env value is stripped like the prompt's, so accidental whitespace can't make an
+    # identical key look rotated on the `key != stored` check below.
+    stored = api_keys.load_key(kind)
+    key = (os.environ.get(whitelist.env_var) or "").strip() or stored
+    if not key and provider._interactive():
+        key = _prompt_api_key(kind, whitelist.env_var)
+        if not key:
+            raise SystemExit(f"No {kind} API key entered.")
     if not key:
         raise SystemExit(
-            f"--api {kind} needs your API key in {whitelist.env_var}. "
-            f"Export it and re-run: export {whitelist.env_var}=..."
+            f"--api {kind} needs your API key in {whitelist.env_var} "
+            f"(export {whitelist.env_var}=... and re-run), or run interactively to be prompted."
         )
     visible = _list_vendor_models(kind, whitelist.base_url, key)
+    # The listing call above proved the key valid — only now persist it to the machine-local key
+    # store, so a mistyped/revoked key is never stored for later joins (and the detached serve
+    # process) to reuse silently. A reused stored key skips the no-op rewrite; any NEW key (env or
+    # prompted) counts as a rotation the caller must deliver to a live identity via respawn.
+    key_rotated = key != stored
+    if key_rotated:
+        api_keys.store_key(kind, key)
     served = [model for model in chosen if valid[model].vendor_name in visible]
     skipped = [model for model in chosen if model not in served]
     if not served:
+        # Wording must fit both the -m subset and the no--m default (nothing was "requested" then),
+        # and must keep the model names — they are the actionable part of the diagnostic.
         raise SystemExit(
-            f"None of the requested models are available to this {kind} key: {', '.join(skipped)}."
+            f"None of these {kind} whitelist models are available to this key: {', '.join(skipped)}."
         )
     if skipped:
         print(f"Skipping (not available to this {kind} key): {', '.join(skipped)}", file=sys.stderr)
@@ -237,7 +270,13 @@ def _resolve_api_targets(args: argparse.Namespace) -> list[dict[str, object]]:
         "models": served,
         "engine_label": kind,
         "api_kind": kind,
-    }]
+    }], key_rotated
+
+
+def _prompt_api_key(kind: str, env_var: str) -> str:
+    """Hidden interactive prompt for one kind's API key — input is never echoed (getpass). Split
+    out so the CLI-seam tests can monkeypatch it (getpass reads the controlling tty)."""
+    return getpass.getpass(f"Enter your {kind} API key (input hidden; or export {env_var}): ").strip()
 
 
 def _list_vendor_models(kind: str, base_url: str, key: str) -> set[str]:
@@ -381,9 +420,10 @@ def _hot_reloadable(
 ) -> bool:
     """Whether this update can be SIGHUP-hot-reloaded into the live singleton (zero-drop) instead of a
     stop-respawn. True only when the SOLE live process is the singleton, it was started by a build that
-    installs the SIGHUP reload handler (``reload_signal``), the merged union is external-only, and the
-    media config is unchanged. Everything else — a first join, a legacy/pre-handler sibling, a built-in
-    ``--serve`` launch, or any media/bundle change — still respawns (ADR 0010 D3 / C1 / C3).
+    installs the SIGHUP reload handler (``reload_signal``), the merged union is external-only, the
+    media config is unchanged, and the effective poll-worker count doesn't flip. Everything else — a
+    first join, a legacy/pre-handler sibling, a built-in ``--serve`` launch, any media/bundle change,
+    or a concurrency-default flip — still respawns (ADR 0010 D3 / C1 / C3).
     """
     if len(live) != 1:
         return False
@@ -394,12 +434,17 @@ def _hot_reloadable(
         return False
     if any(not spec.get("endpoint_url") for spec in merged_specs):  # a built-in --serve needs a launch
         return False
-    # A NEW API engine needs the vendor key from this CLI's environment, which a SIGHUP can't
-    # inject into the live process — respawn so the child inherits the just-validated key.
-    # Known gap until issue 03's key store: a re-join of an ALREADY-live api spec (idempotent
-    # no-op, or a model append that hot-reloads below) can't deliver a ROTATED env key to the
-    # live process — its bearer is fixed at spawn. Rotation is issue 03's acceptance; `grid
-    # leave` + re-join is the interim path.
+    # The poll-worker pool is sized once at spawn and a reload can't resize it (remote/serve
+    # `_assemble_snapshot` pins the advertised capacity to the live pool). When this update flips
+    # the EFFECTIVE concurrency — the api-only default 8 vs the hardware default 1, with no
+    # explicit --max-concurrency pinning both sides — only a respawn applies the new size.
+    if run_records.effective_max_concurrency(record) != run_records.effective_max_concurrency(singleton):
+        return False
+    # A NEW API engine needs a vendor bearer, and the live process's bearer map is fixed at
+    # startup (remote/serve._ServeState.bearer_by_url — deliberately not on the reload-swappable
+    # snapshot) — respawn so the fresh process reads the just-stored key from the key store. A
+    # ROTATED key for an already-live api spec is handled by the caller (`rotated_live` in
+    # cmd_remote_join), not here: leave-shrink shares this gate and rotation never applies there.
     live_api = {_spec_key(spec) for spec in _engine_union(live) if spec.get("api_kind")}
     if any(spec.get("api_kind") and _spec_key(spec) not in live_api for spec in merged_specs):
         return False

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -203,14 +203,20 @@ of `__engine`. That subprocess (`remote/serve.py:run_remote_engine_from_record`)
    workflows the host's VRAM gates in, and forwards `media/*` jobs to the media server on loopback
    (always streamed SSE) — media-only or alongside a text engine. See
    [ADR 0008](adr/0008-remote-media-serve.md).
-6. `grid join --api <kind>` serves an **API engine** (v1: `openai`): the join validates the key
-   from the kind's env var against the vendor's model listing, the record's spec carries kind +
-   vendor base URL + advertised `openai:*` names (never the key), and the loop registers those
-   models with **static** whitelist capabilities (`shared/models/api_catalog.py` — the vendor is
-   never probed) and forwards their `chat/completions` jobs to the vendor with a
-   `Authorization: Bearer` header and the advertised→vendor model rewrite. A vendor 401 is a job
-   error in a separate auth domain — it never triggers the relay-token refresh in step 3. See
-   [ADR 0012](adr/0012-api-engines.md).
+6. `grid join --api <kind>` serves an **API engine** (v1: `openai`): the join resolves the key
+   (env var → machine-local key store → hidden prompt), validates it against the vendor's model
+   listing, and stores it in `~/.grid/api_keys.toml` (`0o600`, survives `grid logout`; a new env
+   value overwrites it — rotation restarts the engine). With no `-m` it serves the whole whitelist
+   ∩ key-visible models. The record's spec carries kind + vendor base URL + advertised `openai:*`
+   names (never the key — the detached loop reads the key store at startup), and the loop registers
+   those models with **static** whitelist capabilities (`shared/models/api_catalog.py` — the vendor
+   is never probed, and only `chat/completions` is advertised/served: a legacy `completions` job
+   gets a structured error, never a forward) and forwards their `chat/completions` jobs to the
+   vendor with a `Authorization: Bearer` header and the advertised→vendor model rewrite. A vendor
+   401 is a job error in a separate auth domain — it never triggers the relay-token refresh in
+   step 3, never unregisters the engine, and (like 403/429) warns on the engine log. An API-only
+   identity defaults to 8 poll workers (`--max-concurrency` still wins); any hardware engine in the
+   union keeps the default of 1. See [ADR 0012](adr/0012-api-engines.md).
 7. `grid leave` SIGTERMs the subprocess, which flips the node back to `consumer` so the relay
    drains queued work, and stops anything it launched. See
    [ADR 0004](adr/0004-remote-provider-serve.md).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -203,7 +203,15 @@ of `__engine`. That subprocess (`remote/serve.py:run_remote_engine_from_record`)
    workflows the host's VRAM gates in, and forwards `media/*` jobs to the media server on loopback
    (always streamed SSE) — media-only or alongside a text engine. See
    [ADR 0008](adr/0008-remote-media-serve.md).
-6. `grid leave` SIGTERMs the subprocess, which flips the node back to `consumer` so the relay
+6. `grid join --api <kind>` serves an **API engine** (v1: `openai`): the join validates the key
+   from the kind's env var against the vendor's model listing, the record's spec carries kind +
+   vendor base URL + advertised `openai:*` names (never the key), and the loop registers those
+   models with **static** whitelist capabilities (`shared/models/api_catalog.py` — the vendor is
+   never probed) and forwards their `chat/completions` jobs to the vendor with a
+   `Authorization: Bearer` header and the advertised→vendor model rewrite. A vendor 401 is a job
+   error in a separate auth domain — it never triggers the relay-token refresh in step 3. See
+   [ADR 0012](adr/0012-api-engines.md).
+7. `grid leave` SIGTERMs the subprocess, which flips the node back to `consumer` so the relay
    drains queued work, and stops anything it launched. See
    [ADR 0004](adr/0004-remote-provider-serve.md).
 

--- a/docs/adr/0010-remote-join-append.md
+++ b/docs/adr/0010-remote-join-append.md
@@ -4,7 +4,11 @@ Status: accepted (2026-07-02) — supersedes **ADR 0007 Decision 1 for remote mo
 (singleton + additive append via **stop-respawn** + leave + migration), then **Slice 2** (SIGHUP hot-reload
 for zero-drop append/shrink/rename, Decisions 3 & 4). Slice 2's gate — a live append-during-stream test —
 was **CLEARED 2026-07-03** on the hosted relay (see "On the zero-drop claim" below); it is now implemented,
-with the concurrency/correctness fixes recorded in **"Slice 2 as built"**.
+with the concurrency/correctness fixes recorded in **"Slice 2 as built"**. An **API engine** appended to a
+live identity became hot-reload-eligible in **issue 05** ([ADR 0012](./0012-api-engines.md)): its vendor
+bearer moved onto the reload-swappable snapshot and is re-read from the durable key store on reload, so
+`grid join --api openai` onto a running identity re-advertises the union with no respawn (a rotated key
+still respawns, by CLI policy). The concurrency-flip and media-change respawn gates are unchanged.
 
 ## Context
 

--- a/docs/adr/0012-api-engines.md
+++ b/docs/adr/0012-api-engines.md
@@ -1,0 +1,78 @@
+# ADR 0012 — API engines (v1: OpenAI): catalog, namespacing, key store
+
+Status: accepted (2026-07-08). Scope: the API-engines feature (`grid join --api openai`,
+PRD in the feature branch's `.scratch/api-engines/`). This ADR records the three
+decisions that become hard to reverse once consumers and scripts depend on them; the
+full feature ships across several slices, of which the whitelist + `grid catalog --api`
+surface is the first.
+
+## Context
+
+A provider with no capable hardware but a paid OpenAI account has no way to contribute
+capacity to a grid. The fix is an **API engine**: an engine that is a third-party LLM
+API service, joined by supplying its API key (`grid join --api openai`). Requests flow
+consumer → relay → poll as usual; the serving machine forwards each job to OpenAI with
+the provider's key. Three design points shape everything downstream and would each be
+breaking to change later: where the model whitelist lives, what the advertised model
+names look like, and where the vendor key is stored.
+
+Constraints: remote mode only (the flow needs the relay); membership semantics are
+unchanged (the human is the member, OpenAI is merely their engine); no relay or
+control-plane changes (model registration already accepts arbitrary names).
+
+## Decisions
+
+**D-a (CLI-direct catalog — no hosted catalog API).** The curated whitelist of OpenAI
+chat models ships as static data inside the CLI (`shared/models/api_catalog.py`), keyed
+by service kind from day one. `grid catalog --api openai` prints it with per-model
+capabilities and a last-verified date — no key, no network call (the same "Grid can
+pull" discovery posture as the GGUF catalog). At join time the CLI calls OpenAI's
+model-listing endpoint with the provider's key, which doubles as key validation and as
+the intersection filter (whitelist ∩ models the key can see) — join-time validation is
+the only place the CLI itself calls OpenAI. Rejected: a control-plane catalog API
+(needless moving part for a small curated table; keeping it current is a data edit
+verified against vendor docs, not a live probing subsystem).
+
+Curation rule: the current flagship family plus mini/nano variants and the reasoning
+series (which, as of the GPT-5.x lineup, is folded into the flagship family rather than
+a separate o-series); excludes audio/realtime, embeddings, image, moderation, and
+legacy chat models.
+As verified 2026-07-08 against live OpenAI docs this yields four models (`gpt-5.5`,
+`gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`) — fewer than the ~8–10 the PRD anticipated,
+because OpenAI folded reasoning into the GPT-5.x family and deprecated the o-series and
+gpt-5.2. The **pro tiers are deliberately excluded**: they do not stream and answer in
+minutes, the wrong fit for relay-polled chat serving. The rule wins over the count.
+
+**D-b (`openai:*` model namespacing).** API-engine models are advertised as
+`openai:<vendor-name>` (`openai:gpt-5.5`), the `comfyui:*` precedent. The
+advertised→real rewrite before forwarding reuses the existing advertised/upstream
+mapping mechanism (the one `--advertise-as` uses). Provenance is deliberately visible:
+every model list shows consumers that requests to these models leave the grid for a
+third party. Rejected: advertising bare vendor names (indistinguishable from local
+models, and a name collision with a hardware engine serving the same model would be
+silent).
+
+**D-c (kind-keyed key store that survives `grid logout`).** Vendor keys live in a
+separate TOML file in the grid home directory, keyed by service kind (`openai`, later
+`anthropic`, …), mode `0o600`, written through the existing hardened atomic writer. It
+is **not** part of the sign-in credential store: `grid logout` destroys the autonomous
+session, not the provider's own vendor credential. Input precedence: env var
+(`OPENAI_API_KEY`) → stored key → hidden interactive prompt; a supplied env value
+overwrites the stored key (rotation is one re-join). No `--api-key` flag exists — keys
+must never enter shell history or process listings. The detached serve process reads
+the key store at startup; run records never carry the key. Rejected: storing the key in
+`credentials.toml` (couples a vendor credential to sign-in lifecycle), or per-grid
+storage (the key belongs to the machine's operator, not to any one grid).
+
+## Consequences
+
+- Adding `anthropic`/`gemini` or an OpenAI-compatible base URL later is a data edit
+  plus a kind guard — no on-disk, record, or catalog format change (each new kind still
+  gets its own ADR).
+- The whitelist is maintenance-by-data-edit: bump entries and the last-verified date
+  against vendor docs; an integrity test guards shape (non-empty, unique names, dated).
+- Consumers can rely on the `openai:` prefix as a stable privacy signal; scripts can
+  rely on `grid catalog --api openai --json` as a stable machine-readable surface.
+- A revoked/rotated upstream key is invisible to the grid until serve-time job errors
+  surface it (upstream 401 is a job error + stderr warning, never a relay-token refresh,
+  never an auto-eject in v1) — accepted; auto-eject is a deferred observability slice.

--- a/docs/adr/0012-api-engines.md
+++ b/docs/adr/0012-api-engines.md
@@ -76,3 +76,9 @@ storage (the key belongs to the machine's operator, not to any one grid).
 - A revoked/rotated upstream key is invisible to the grid until serve-time job errors
   surface it (upstream 401 is a job error + stderr warning, never a relay-token refresh,
   never an auto-eject in v1) — accepted; auto-eject is a deferred observability slice.
+- Because the key lives in a durable store the serve process re-reads on **reload** (not
+  only at startup), appending an API engine to a live identity **hot-reloads in place**
+  (issue 05): the vendor bearer joins the reload-swappable routing snapshot, so `grid join
+  --api openai` onto a running identity — and `grid leave --engine openai` — re-advertise
+  the union with no respawn and no dropped in-flight requests, reusing static caps (never a
+  probe). A *rotated* key still respawns, by CLI policy (operator certainty), not mechanism.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -175,6 +175,7 @@ grid join [grid] --all                                # join every detected engi
 grid join [grid] --at <url> -m <model>... [--name <id>]
 grid join [grid] --serve <model> [--name <id>]
 grid join [grid] --media [--bundle <bundle>]... [--name <id>]
+grid join [grid] --api <kind> -m <model>...           # remote only: join a third-party API engine (v1: openai)
 grid leave [grid] [--engine <sel>] [--all]            # <sel>: engine id, endpoint URL, served model, or :port fragment
 grid engine ls [grid] [--json]                        # live engines joined to a grid (legacy alias: grid engines)
 ```
@@ -225,6 +226,21 @@ up ComfyUI + the media server, registers the `comfyui:*` workflows the host's VR
 relay forwards `media/*` jobs to the media server on loopback; the SSE (progress + base64 result
 files) streams back exactly as in local mode.
 
+`grid join --api <kind> -m <model>...` (v1: `openai`) joins an **API engine** — a third-party LLM
+API service served through your own key ([ADR 0012](./adr/0012-api-engines.md)). The key is read
+from `OPENAI_API_KEY` (there is deliberately no `--api-key` flag) and validated at join time
+against the vendor's model listing — an invalid key is a terminal error and nothing is spawned.
+`-m` names whitelisted `openai:*` models (`grid catalog --api openai` shows them); a whitelisted
+model your key can't see is skipped with a note, and a name outside the whitelist errors listing
+the valid names. The serve loop registers the models with their **static** whitelist capabilities —
+the vendor is never probed or benchmarked — and forwards each `chat/completions` job to the vendor
+with your key, rewriting the advertised `openai:<name>` to the vendor's `<name>`; SSE streams pass
+through unchanged, and a vendor error (401/429/5xx) surfaces as that job's error, never touching
+your grid sign-in. **Requests to `openai:*` models leave the grid for the vendor**, under your key
+and your own OpenAI account's terms. `--api` is mutually exclusive with
+`--at`/`--serve`/`--advertise-as`/`--media`/`--bundle` in one invocation — join other engines with
+a separate (additive) `grid join`.
+
 The `grid join` flag set is the union of both modes, gated by mode:
 
 - **Both modes:** `--at` / `--serve` / `-m,--model` / `--kind <kind>` (alias `--engine`) / `--name`
@@ -233,7 +249,8 @@ The `grid join` flag set is the union of both modes, gated by mode:
   and the media flags `--media` / `--bundle <bundle>` / `--comfyui-port` / `--media-port`.
 - **local-only:** `--advertise-host` (a remote engine polls the relay outbound — there is no inbound
   endpoint to advertise).
-- **Remote-only:** `--max-concurrency` (how many requests this engine serves at once; default 1 —
+- **Remote-only:** `--api <kind>` (join a third-party API engine; requires `-m` with whitelisted
+  models), and `--max-concurrency` (how many requests this engine serves at once; default 1 —
   the provider runs one poll worker per slot).
 - **Deprecated:** `--engine-label` — the grid page now derives the engine kind automatically, so it is
   accepted but inert (still matched by `grid leave --engine <label>`); `--pricing-input` /

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -250,6 +250,7 @@ is rejected with `--all`.) See [ADR 0004](./adr/0004-remote-provider-serve.md),
 ```
 grid models [grid] [--verbose] [--json] # live models the grid can run now
 grid catalog [--json]                   # models Grid can pull
+grid catalog --api <kind> [--json]      # API-engine whitelist for a service kind (v1: openai)
 grid pull <model>                       # pull a model for the default text engine
 grid rm <model> [--yes]                 # remove a pulled model
 ```
@@ -284,6 +285,27 @@ In `remote` mode `grid models` and `grid engines` read the grid's live overview 
 relay endpoint (no token needed, so they work even before `grid sync`). The output is the same
 shape, but `--verbose` shows the **node** serving each model instead of a local `WHERE` URL —
 remote engines sit behind the relay, not at an address you call directly.
+
+`grid catalog --api <kind>` answers the discovery question for **API engines**: which models
+would a `grid join --api <kind>` serve? It prints a curated, static whitelist with each model's
+capabilities and context window — no key needed, no network call (the same posture as the
+"Grid can pull" catalog). The table carries the date it was last verified against the vendor's
+documentation, and an unknown kind is a clear error listing the supported kinds. Models are
+advertised under namespaced names (`openai:gpt-5.5`), so it is visible in every model list that
+requests to them leave the grid for the vendor. `--json` emits the same table machine-readable.
+
+```text
+Models a `grid join --api openai` would serve (verified 2026-07-08):
+  openai:gpt-5.5           1,050,000 ctx   tools, vision, json, structured
+  openai:gpt-5.4           1,050,000 ctx   tools, vision, json, structured
+  openai:gpt-5.4-mini        400,000 ctx   tools, vision, json, structured
+  openai:gpt-5.4-nano        400,000 ctx   tools, vision, json, structured
+
+No key needed to view. Requests to openai:* models leave the grid for the vendor.
+```
+
+See [ADR 0012](./adr/0012-api-engines.md) for the decisions behind the CLI-shipped whitelist,
+the `openai:*` namespacing, and the key-store lifecycle.
 
 ## Use
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -175,7 +175,7 @@ grid join [grid] --all                                # join every detected engi
 grid join [grid] --at <url> -m <model>... [--name <id>]
 grid join [grid] --serve <model> [--name <id>]
 grid join [grid] --media [--bundle <bundle>]... [--name <id>]
-grid join [grid] --api <kind> -m <model>...           # remote only: join a third-party API engine (v1: openai)
+grid join [grid] --api <kind> [-m <model>...]         # remote only: join a third-party API engine (v1: openai)
 grid leave [grid] [--engine <sel>] [--all]            # <sel>: engine id, endpoint URL, served model, or :port fragment
 grid engine ls [grid] [--json]                        # live engines joined to a grid (legacy alias: grid engines)
 ```
@@ -226,20 +226,33 @@ up ComfyUI + the media server, registers the `comfyui:*` workflows the host's VR
 relay forwards `media/*` jobs to the media server on loopback; the SSE (progress + base64 result
 files) streams back exactly as in local mode.
 
-`grid join --api <kind> -m <model>...` (v1: `openai`) joins an **API engine** — a third-party LLM
-API service served through your own key ([ADR 0012](./adr/0012-api-engines.md)). The key is read
-from `OPENAI_API_KEY` (there is deliberately no `--api-key` flag) and validated at join time
-against the vendor's model listing — an invalid key is a terminal error and nothing is spawned.
-`-m` names whitelisted `openai:*` models (`grid catalog --api openai` shows them); a whitelisted
-model your key can't see is skipped with a note, and a name outside the whitelist errors listing
-the valid names. The serve loop registers the models with their **static** whitelist capabilities —
-the vendor is never probed or benchmarked — and forwards each `chat/completions` job to the vendor
-with your key, rewriting the advertised `openai:<name>` to the vendor's `<name>`; SSE streams pass
-through unchanged, and a vendor error (401/429/5xx) surfaces as that job's error, never touching
-your grid sign-in. **Requests to `openai:*` models leave the grid for the vendor**, under your key
-and your own OpenAI account's terms. `--api` is mutually exclusive with
-`--at`/`--serve`/`--advertise-as`/`--media`/`--bundle` in one invocation — join other engines with
-a separate (additive) `grid join`.
+`grid join --api <kind> [-m <model>...]` (v1: `openai`) joins an **API engine** — a third-party LLM
+API service served through your own key ([ADR 0012](./adr/0012-api-engines.md)). The key is
+resolved in order: the `OPENAI_API_KEY` env var, else the machine-local key store, else a hidden
+interactive prompt (there is deliberately no `--api-key` flag; non-interactive with no key anywhere
+is a clear error). It is validated at join time against the vendor's model listing — an invalid key
+is a terminal error and nothing is spawned or stored. A validated key is saved to
+`~/.grid/api_keys.toml` (`0o600`, keyed by service kind): later joins and the detached serve
+process read it from there, and `grid logout` leaves it intact (it belongs to your vendor account,
+not your grid sign-in). Re-joining with a new env value overwrites the stored key and restarts the
+engine — **rotation is one command**. A bare `grid join` (auto-detect) never joins an API engine
+just because a key file exists; `--api` is always explicit.
+
+With no `-m` the join serves the **whole whitelist ∩ the models your key can see** (skipped
+whitelist models are reported; an empty intersection errors). `-m` narrows to whitelisted
+`openai:*` models (`grid catalog --api openai` shows them); a whitelisted model your key can't see
+is skipped with a note, and a name outside the whitelist errors listing the valid names. The serve
+loop registers the models with their **static** whitelist capabilities — the vendor is never probed
+or benchmarked — and forwards each `chat/completions` job to the vendor with your key, rewriting
+the advertised `openai:<name>` to the vendor's `<name>`; SSE streams pass through unchanged. An API
+engine serves `chat/completions` **only** — a legacy `completions` job gets a structured "not
+served" error and is never forwarded. A vendor error (401/429/5xx) surfaces as that job's error
+with the upstream status, never touching your grid sign-in and never unregistering the engine; an
+auth/quota failure (401/403/429) additionally warns in the engine's log so a revoked key or
+exhausted quota is visible to you, not just to consumers. **Requests to `openai:*` models leave the
+grid for the vendor**, under your key and your own OpenAI account's terms. `--api` is mutually
+exclusive with `--at`/`--serve`/`--advertise-as`/`--media`/`--bundle` in one invocation — join
+other engines with a separate (additive) `grid join`.
 
 The `grid join` flag set is the union of both modes, gated by mode:
 
@@ -249,9 +262,10 @@ The `grid join` flag set is the union of both modes, gated by mode:
   and the media flags `--media` / `--bundle <bundle>` / `--comfyui-port` / `--media-port`.
 - **local-only:** `--advertise-host` (a remote engine polls the relay outbound — there is no inbound
   endpoint to advertise).
-- **Remote-only:** `--api <kind>` (join a third-party API engine; requires `-m` with whitelisted
-  models), and `--max-concurrency` (how many requests this engine serves at once; default 1 —
-  the provider runs one poll worker per slot).
+- **Remote-only:** `--api <kind>` (join a third-party API engine; `-m` optionally narrows the
+  whitelist, omitted = every whitelisted model the key can see), and `--max-concurrency` (how many
+  requests this engine serves at once; the provider runs one poll worker per slot — default 1, or
+  8 when the identity serves only API engines).
 - **Deprecated:** `--engine-label` — the grid page now derives the engine kind automatically, so it is
   accepted but inert (still matched by `grid leave --engine <label>`); `--pricing-input` /
   `--pricing-output` — kept so old invocations don't hard-error, but they no longer advertise a price.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -254,6 +254,14 @@ grid for the vendor**, under your key and your own OpenAI account's terms. `--ap
 exclusive with `--at`/`--serve`/`--advertise-as`/`--media`/`--bundle` in one invocation — join
 other engines with a separate (additive) `grid join`.
 
+An API engine merges into your grid's **one serving identity** exactly like a hardware engine.
+`grid join --api openai` onto an identity already serving other engines appends to the union and
+**hot-reloads in place** — no restart, no dropped in-flight requests (the vendor key is re-read from
+the key store on reload, so the appended engine forwards with auth immediately). `grid leave
+--engine openai` drops just the API engine and re-advertises the survivors; removing the last engine
+tears the identity down. To **narrow** an already-served set, `grid leave --engine openai` then
+re-join with the `-m` subset you want — a join only ever adds models to the union, never removes them.
+
 The `grid join` flag set is the union of both modes, gated by mode:
 
 - **Both modes:** `--at` / `--serve` / `-m,--model` / `--kind <kind>` (alias `--engine`) / `--name`

--- a/remote/api_keys.py
+++ b/remote/api_keys.py
@@ -1,0 +1,46 @@
+"""Machine-local API-engine key store: one vendor key per service kind (ADR 0012).
+
+Persists to ``~/.grid/api_keys.toml`` (TOML, ``0o600``) through the same hardened writer as the
+credential store, but is deliberately NOT part of it: ``grid logout`` deletes credentials.toml and
+must leave the vendor key intact (the key belongs to the provider's vendor account, not to the
+autonomous sign-in). One ``[<kind>]`` table per service kind with the key under ``key``, so later
+per-kind metadata (e.g. an OpenAI-compatible ``base_url``) is a field addition, not a format change.
+
+``store_key``'s read-merge-write is serialized under its own ``file_lock`` (the ADR 0010 pattern):
+without it, two overlapping ``join --api`` runs for DIFFERENT kinds could each read before the
+other's write landed and the loser's key would silently vanish from the whole-file rewrite. Reads
+stay lock-free — the write is an atomic rename, so a read never sees a torn file. The
+vendor-validation network call happens before the run-record lock is taken, so this store never
+nests inside that lock (no ordering hazard).
+"""
+from __future__ import annotations
+
+import contextlib
+
+from shared import paths
+from shared.filelock import file_lock
+
+from . import credentials
+
+
+def load_key(kind: str) -> str | None:
+    """The stored key for one service kind, or None (no file / no entry)."""
+    entry = credentials.load_toml(paths.api_keys_file()).get(kind)
+    key = entry.get("key") if isinstance(entry, dict) else None
+    return str(key) if key else None
+
+
+def store_key(kind: str, key: str) -> None:
+    """Persist one kind's key (0o600), preserving every other kind and future per-kind fields.
+
+    Immutable update: a fresh dict is written, never the loaded one mutated in place.
+    """
+    with file_lock(paths.api_keys_file()):  # serialize the read-merge-write (see module docstring)
+        data = credentials.load_toml(paths.api_keys_file())
+        existing = data.get(kind)
+        merged_kind = {**(existing if isinstance(existing, dict) else {}), "key": key}
+        credentials.atomic_write_toml(paths.api_keys_file(), {**data, kind: merged_kind})
+    # Best-effort: keep the home dir owner-only (mirrors credentials.save_credentials), so a local
+    # user can't even list that a key file exists — even when THIS write is what created ~/.grid.
+    with contextlib.suppress(OSError):
+        paths.grid_home().chmod(0o700)

--- a/remote/probe.py
+++ b/remote/probe.py
@@ -403,14 +403,18 @@ def probe_llama_capabilities(llm_url: str, llm_model: str) -> dict[str, bool]:
 DEFAULT_CONTEXT_WINDOW = 128000
 
 
-def capability_entry(probed: dict[str, bool], context_window: int | None = None) -> dict[str, Any]:
+def capability_entry(
+    probed: dict[str, bool], context_window: int | None = None,
+    endpoints: list[str] | None = None,
+) -> dict[str, Any]:
     """Render one model's capability entry (matches the desktop/relay shape). ``context_window`` reflects
     the engine's ``--ctx-size`` when known (the master reads it into the model catalog); it falls back to
-    the default when unknown."""
+    the default when unknown. ``endpoints`` defaults to the hardware-engine pair; an API engine passes
+    ``["chat/completions"]`` — it never serves legacy completions (ADR 0012)."""
     input_modalities = ["text", "image"] if probed["vision"] else ["text"]
     ctx = int(context_window) if context_window else DEFAULT_CONTEXT_WINDOW
     return {
-        "endpoints": ["chat/completions", "completions"],
+        "endpoints": list(endpoints) if endpoints is not None else ["chat/completions", "completions"],
         "input_modalities": input_modalities,
         "output_modalities": ["text"],
         "context_window": ctx,
@@ -435,9 +439,15 @@ def capability_entry(probed: dict[str, bool], context_window: int | None = None)
     }
 
 
-def envelope(model_name: str, probed: dict[str, bool], context_window: int | None = None) -> dict[str, Any]:
+def envelope(
+    model_name: str, probed: dict[str, bool], context_window: int | None = None,
+    endpoints: list[str] | None = None,
+) -> dict[str, Any]:
     """Wrap a probed-features dict in the ``{schema_version, models}`` envelope the relay requires."""
-    return {"schema_version": 1, "models": {model_name: capability_entry(probed, context_window)}}
+    return {
+        "schema_version": 1,
+        "models": {model_name: capability_entry(probed, context_window, endpoints=endpoints)},
+    }
 
 
 # --- throughput benchmark ---

--- a/remote/serve.py
+++ b/remote/serve.py
@@ -27,6 +27,7 @@ from typing import Any, Callable
 
 from remote import api_keys, control_plane, credentials, probe, relay
 from shared import run_records
+from shared.filelock import file_lock
 from shared.models import api_catalog
 
 # One engine's probe result: (normalized llm_url, advertised models, upstream models, caps envelope).
@@ -557,6 +558,7 @@ def _assemble_snapshot(
         meta=_meta(record, engine_id), pricing=_pricing(record),
         max_concurrency=max_concurrency,
         api_kind_by_url=_api_kinds_by_url(record),
+        bearer_by_url=_api_bearers(record),  # re-read the key store so an appended api engine forwards with auth
     )
 
 
@@ -647,6 +649,7 @@ class _Snapshot:
     pricing: dict[str, float]     # always {} today (advertised pricing is deprecated)
     max_concurrency: int
     api_kind_by_url: dict[str, str]  # vendor base URL -> service kind (endpoint gating); {} = none
+    bearer_by_url: dict[str, str]    # vendor base URL -> API key (forward auth); {} = none
 
     @staticmethod
     def build(
@@ -659,6 +662,7 @@ class _Snapshot:
         pricing: dict[str, float],
         max_concurrency: int,
         api_kind_by_url: dict[str, str] | None = None,
+        bearer_by_url: dict[str, str] | None = None,
     ) -> "_Snapshot":
         return _Snapshot(
             routes={model: url.rstrip("/") for model, url in routes.items()},
@@ -668,6 +672,7 @@ class _Snapshot:
             meta=dict(meta or {}),
             pricing=dict(pricing or {}),
             api_kind_by_url={url.rstrip("/"): kind for url, kind in (api_kind_by_url or {}).items()},
+            bearer_by_url={url.rstrip("/"): key for url, key in (bearer_by_url or {}).items()},
             # Clamp to [1, _MAX_CONCURRENCY]: each slot becomes a real poll-worker thread in `_serve_loop`,
             # so an absurd `--max-concurrency` can't exhaust threads/sockets. This is the sole clamp site,
             # so a reload that changes max_concurrency is bounded the same way as startup.
@@ -700,11 +705,10 @@ class _ServeState:
         self.node_id = node_id
         self.network_id = network_id
         self.llm_url = llm_url.rstrip("/")
-        # {vendor base URL: API key} for the API engines this identity serves — read from the key
-        # store (env fallback) at startup, never from the run record. Fixed for the process
-        # lifetime (like media_url), so it lives here and not on the reload-swappable snapshot —
-        # a rotated key reaches jobs via the respawn `grid join` forces, never via SIGHUP.
-        self.bearer_by_url = {url.rstrip("/"): key for url, key in (bearer_by_url or {}).items()}
+        # `bearer_by_url` and `api_kind_by_url` are resolved from the key store / record and live on the
+        # reload-swappable snapshot built below (NOT as fixed attributes — see the `bearer_by_url`
+        # property), so a SIGHUP hot-reload re-reads the key store and swaps them atomically WITH routing
+        # (issue 05). A rotated key still respawns, by CLI policy, not because the mechanism can't swap it.
         # This box's media server base (`http://127.0.0.1:<media_port>`) when the identity serves
         # media, else None. `media/*` jobs forward here instead of an LLM engine; all media models
         # share the one server, so a single URL (not a per-model route) is enough.
@@ -717,7 +721,7 @@ class _ServeState:
         self._snapshot = _Snapshot.build(
             routes=route_map, upstream=upstream or {}, models=models, capabilities=capabilities,
             meta=meta, pricing=pricing, max_concurrency=max_concurrency,
-            api_kind_by_url=api_kind_by_url,
+            api_kind_by_url=api_kind_by_url, bearer_by_url=bearer_by_url,
         )
         # The probe results the live snapshot was built from, kept so a reload probes only newly-added
         # engines (ADR 0010 D4 F6). Reload-owned: set at startup, thereafter only the reload loop writes.
@@ -757,6 +761,12 @@ class _ServeState:
     def max_concurrency(self) -> int:
         return self._snapshot.max_concurrency
 
+    @property
+    def bearer_by_url(self) -> dict[str, str]:
+        """The vendor bearers for the live snapshot — a hot-reload swaps these WITH routing (issue 05),
+        so a forward binding one snapshot never pairs a route with another union's bearer (D4 F4)."""
+        return self._snapshot.bearer_by_url
+
     def snapshot(self) -> _Snapshot:
         """The current routing snapshot — one atomic reference load (no lock). Bind it ONCE per
         operation, then read fields off the result, so a concurrent reload swap is never seen
@@ -776,7 +786,7 @@ class _ServeState:
         only newly-added engines (ADR 0010 D4 F6)."""
         return self._engine_results
 
-    def route_and_kind(self, model: str | None) -> tuple[str | None, str | None]:
+    def route_and_kind(self, model: str | None, snap: _Snapshot | None = None) -> tuple[str | None, str | None]:
         """The local engine URL serving ``model``, plus its API service kind (None = hardware/media).
 
         Exact match wins. Otherwise, when every model points at the **same single engine** (one
@@ -788,7 +798,7 @@ class _ServeState:
         One method for both lookups so they read the SAME snapshot: a separate kind read could bind
         a torn pair across a concurrent reload swap (ADR 0010 D4 F4 — bind once).
         """
-        snap = self._snapshot  # bind once — a concurrent reload swap is never seen half-applied
+        snap = snap if snap is not None else self._snapshot  # bind once — a concurrent reload swap is never seen half-applied
         target = None
         if model and model in snap.routes:
             target = snap.routes[model]
@@ -804,12 +814,13 @@ class _ServeState:
         """The local engine URL serving ``model`` (see ``route_and_kind``)."""
         return self.route_and_kind(model)[0]
 
-    def upstream_model(self, model: str | None) -> str | None:
+    def upstream_model(self, model: str | None, snap: _Snapshot | None = None) -> str | None:
         """The name the local engine answers to for an advertised ``model`` (``--advertise-as`` maps the
         consumer-facing alias back to the engine's real model name). ``None`` when unmapped — the caller
         then forwards the body's model unchanged (single-engine fallback / built-in, where they match).
+        ``snap`` lets one job bind a single union for route + upstream + bearer (D4 F4 — bind once).
         """
-        snap = self._snapshot
+        snap = snap if snap is not None else self._snapshot
         if model and model in snap.upstream:
             return snap.upstream[model]
         return None
@@ -945,6 +956,26 @@ def heartbeat_once(state: _ServeState, *, _allow_refresh: bool = True) -> str:
     return result
 
 
+def _set_last_reload_error(state: _ServeState, engine_id: str, message: str | None) -> None:
+    """Persist (``str``) or clear (``None``) a reload failure on the run record so the NEXT CLI command
+    can surface it: the CLI prints success as soon as the SIGHUP is delivered, so a failure inside this
+    process would otherwise be visible only in this log. Locked read-modify-write — the CLI merges
+    joins under the same lock, so an unlocked write here could lose a concurrent join's union (ADR
+    0010 F3). Best-effort bookkeeping that never raises: a raise inside ``_reload_loop``'s except
+    would kill the watcher, and one after a successful swap would mislabel the reload as failed."""
+    try:
+        with file_lock(run_records.record_path(state.network_id, engine_id)):
+            record = run_records.read_record(state.network_id, engine_id)
+            if not record or (message is None and "last_reload_error" not in record):
+                return
+            updated = {k: v for k, v in record.items() if k != "last_reload_error"}
+            if message is not None:
+                updated["last_reload_error"] = message[:300]  # a trace, not a transcript (never the key)
+            run_records.write_record(state.network_id, engine_id, updated)
+    except (Exception, SystemExit) as exc:
+        _warn(f"could not update last_reload_error on the run record (ignoring): {exc!r}")
+
+
 def _reload_once(state: _ServeState, engine_id: str) -> None:
     """Rebuild routing from the (re-read) record and re-advertise the union in place — the body of the
     SIGHUP hot-reload (ADR 0010 D3). External-only and probe-only: reuse retained caps for engines
@@ -999,6 +1030,8 @@ def _reload_once(state: _ServeState, engine_id: str) -> None:
 
     snapshot = _assemble_snapshot(reassembled, state.media_models, record, engine_id, state.max_concurrency)
     state.apply(snapshot, reassembled)  # atomic swap; in-flight requests were unaffected until here
+    if record.get("last_reload_error"):
+        _set_last_reload_error(state, engine_id, None)  # the union applied — a previous failure healed
     if state.stop.is_set():
         # A concurrent teardown (grid leave / SIGTERM) already set stop and the outer `finally` will
         # `unregister_node`; re-advertising now would resurrect a node that is exiting (a zombie the relay
@@ -1066,8 +1099,12 @@ def handle_job(state: _ServeState, job: dict[str, Any]) -> None:
         _try_submit_error(state, txn, f"unsupported endpoint: {endpoint!r}")
         return
 
+    # Bind ONE routing snapshot for this whole job: route + kind + upstream + bearer all come from the
+    # same union, so a concurrent leave/append hot-reload swap is all-or-nothing per job — never a route
+    # from one union paired with a bearer from another (ADR 0010 D4 F4 — bind once; issue 05).
+    snap = state.snapshot()
     model = body.get("model")  # body is already `job.get("body") or {}`, so it is a dict
-    target, api_kind = state.route_and_kind(model)  # which local engine serves this model (DECISIONS D9)
+    target, api_kind = state.route_and_kind(model, snap)  # which local engine serves this model (DECISIONS D9)
     if target is None:
         _try_submit_error(state, txn, f"no engine serves model {model!r}")
         return
@@ -1084,12 +1121,12 @@ def handle_job(state: _ServeState, job: dict[str, Any]) -> None:
     # Consumers address the model by its advertised name; an external engine behind ``--advertise-as``
     # only knows its real name, so rewrite the body's model before forwarding (a new dict — never
     # mutate the job). No mapping / already-equal → forward unchanged (built-in + single-engine paths).
-    upstream_model = state.upstream_model(model)
+    upstream_model = state.upstream_model(model, snap)
     forward_body = {**body, "model": upstream_model} if upstream_model and upstream_model != model else body
 
     state.enter_inference()
     try:
-        headers = _forward_headers(state, target)
+        headers = _forward_headers(state, target, snap)
         if is_stream:
             _forward_stream(state, txn, endpoint, forward_body, read_timeout, target, headers=headers,
                             api_kind=api_kind)
@@ -1153,12 +1190,15 @@ def _warn_api_auth_failure(api_kind: str | None, status: int) -> None:
               f"(jobs will keep erroring until it is fixed; the engine stays registered)")
 
 
-def _forward_headers(state: _ServeState, target_url: str) -> dict[str, str]:
+def _forward_headers(state: _ServeState, target_url: str, snap: _Snapshot | None = None) -> dict[str, str]:
     """Forward headers for one target: the API key rides ONLY on an API engine's own vendor URL —
     hardware-engine (and media) forwards stay bearer-free, and an upstream 401 is a job error in a
-    different auth domain from the relay token (it can never trigger the relay-token refresh)."""
+    different auth domain from the relay token (it can never trigger the relay-token refresh). ``snap``
+    binds the SAME union the route came from, so a hot-reload swap can't leave an in-flight vendor job
+    bearer-less mid-forward (issue 05 / D4 F4)."""
     headers = {"Content-Type": "application/json"}
-    key = state.bearer_by_url.get(target_url.rstrip("/"))
+    bearers = (snap if snap is not None else state.snapshot()).bearer_by_url
+    key = bearers.get(target_url.rstrip("/"))
     if key:
         headers["Authorization"] = f"Bearer {key}"
     return headers
@@ -1368,6 +1408,9 @@ def _reload_loop(state: _ServeState, engine_id: str) -> None:
                 # thread, silently disabling hot-reload for the process's life (ADR 0010 D4 F6). Mirrors
                 # run_remote_engine_from_record's own (Exception, SystemExit) handler.
                 _warn(f"reload failed (keeping current routing): {exc!r}")
+                # Leave a trace the CLI can surface: it printed success on SIGHUP delivery, so this log
+                # line alone would leave the operator believing the new union is advertised (issue 05).
+                _set_last_reload_error(state, engine_id, str(exc) or repr(exc))
 
 
 def _start_reload_watcher(

--- a/remote/serve.py
+++ b/remote/serve.py
@@ -27,6 +27,7 @@ from typing import Any, Callable
 
 from remote import control_plane, credentials, probe, relay
 from shared import run_records
+from shared.models import api_catalog
 
 # One engine's probe result: (normalized llm_url, advertised models, upstream models, caps envelope).
 _EngineResults = list[tuple[str, list[str], list[str], dict[str, Any]]]
@@ -99,6 +100,10 @@ def run_remote_engine_from_record(grid_id: str, engine_id: str) -> int:
             "This grid's access token carries no node identity; run `grid login` to refresh your "
             "tokens, then re-join."
         )
+    # API-engine keys come from the environment (issue 03 moves them to a key store) — resolve them
+    # up front so a keyless respawn dies naming the env var instead of advertising models whose
+    # every job would 401 upstream. Never read from the record; the record never carries a key.
+    bearer_by_url = _api_bearers(record)
 
     def _on_term(_signum, _frame):  # noqa: ANN001
         raise KeyboardInterrupt
@@ -170,6 +175,7 @@ def run_remote_engine_from_record(grid_id: str, engine_id: str) -> int:
             routes=routes,
             upstream=upstream,
             media_url=media_url,
+            bearer_by_url=bearer_by_url,
         )
         register_once(state)
         registered = True
@@ -264,7 +270,9 @@ def _bring_up_engines(
                 launcher_mod = mod
             # Probe EVERY model this spec serves (not just the first), so a multi-model `--at` advertises
             # caps for all of them — shared with the hot-reload path (`_reload_once`) so the two can't drift.
-            caps = _probe_spec_caps(llm_url, advertised, upstream, record.get("ctx_size"))
+            caps = _probe_spec_caps(
+                llm_url, advertised, upstream, record.get("ctx_size"), api_kind=spec.get("api_kind"),
+            )
             results.append((llm_url, advertised, upstream, caps))
     except BaseException:  # a later spec failed — don't orphan a server an earlier spec already launched
         if launcher_mod is not None:
@@ -275,7 +283,9 @@ def _bring_up_engines(
 
 
 def _flat_spec(record: dict[str, Any]) -> dict[str, Any]:
-    """A record written before multi-engine (no ``engines``) → one spec from its flat fields."""
+    """A record written before multi-engine (no ``engines``) → one spec from its flat fields.
+    Never carries ``api_kind``: api specs postdate the ``engines`` array, so a flat record can't
+    hold one — if that invariant ever breaks, the spec would silently degrade to a hardware engine."""
     return {
         "endpoint_url": record.get("endpoint_url"),
         "models": list(record.get("models") or []),
@@ -296,6 +306,12 @@ def _bring_up_one(
     comes from the record's top-level fields — only the single built-in path consumes them.
     """
     models = list(spec.get("models") or [])
+    api_kind = spec.get("api_kind")
+    if api_kind:
+        # API engine: the advertised names ARE the namespaced whitelist names (aliases never touch
+        # them) and the upstream names are the vendor names they embed; nothing is launched.
+        upstream = [_api_upstream_name(api_kind, model) for model in models]
+        return (spec.get("endpoint_url") or "").rstrip("/"), None, None, list(models), upstream
     advertised = _advertised_models(models, aliases)
     endpoint_url = spec.get("endpoint_url")
     if endpoint_url:  # external engine: forward to it (by its real model name), launch nothing
@@ -351,8 +367,68 @@ def _advertised_models(models: list[str], aliases: list[str]) -> list[str]:
     return cleaned
 
 
+def _api_bearers(record: dict[str, Any]) -> dict[str, str]:
+    """{vendor base URL: API key} for every API spec in the record, from each kind's env var.
+
+    A missing key is terminal: the join validated the key pre-spawn, so a keyless start is a
+    respawn in an environment that lost it — better to die naming the variable than to serve
+    models whose every job errors upstream. The key never appears in the message.
+    """
+    bearers: dict[str, str] = {}
+    for spec in record.get("engines") or []:
+        kind = spec.get("api_kind")
+        if not kind:
+            continue
+        whitelist = api_catalog.WHITELISTS.get(kind)
+        env_var = whitelist.env_var if whitelist else f"{kind.upper()}_API_KEY"
+        key = os.environ.get(env_var)
+        if not key:
+            raise SystemExit(
+                f"This engine serves --api {kind} models but {env_var} is not set. "
+                f"Export {env_var} and re-run `grid join --api {kind}`."
+            )
+        bearers[(spec.get("endpoint_url") or "").rstrip("/")] = key
+    return bearers
+
+
+def _api_upstream_name(api_kind: str, advertised: str) -> str:
+    """The vendor model name behind an advertised ``<kind>:<vendor>`` name. Whitelist-first (the
+    single source of truth); prefix-strip as the fallback so a catalog edit between join and respawn
+    degrades to a sane rewrite instead of forwarding the namespaced name verbatim."""
+    entry = api_catalog.find_advertised(api_kind, advertised)
+    if entry is not None:
+        return entry.vendor_name
+    return advertised.partition(":")[2] or advertised
+
+
+def _static_api_caps(api_kind: str, advertised: list[str]) -> dict[str, Any]:
+    """An API engine's caps envelope from the static whitelist — API engines are never live-probed
+    or benchmarked (ADR 0012); the vendor sees no traffic until a real job forwards. A model missing
+    from the whitelist (catalog edited between join and respawn) degrades like a failed probe: an
+    all-False entry, never a crash."""
+    no_features = dict.fromkeys(
+        ("vision", "tools", "parallel_tool_calls", "json_object", "json_schema"), False
+    )
+    caps_models: dict[str, Any] = {}
+    for advertised_model in advertised:
+        entry = api_catalog.find_advertised(api_kind, advertised_model)
+        if entry is None:
+            # A local data-integrity condition, not a transient probe failure — leave a trace, or
+            # tool/vision consumers break with no diagnostic trail (matches the reload _warn style).
+            _warn(
+                f"{advertised_model!r} is no longer in the {api_kind} whitelist "
+                "(catalog changed since join) — advertising it with no capabilities"
+            )
+        probed = api_catalog.probed_features(entry) if entry else no_features
+        ctx = entry.context_window if entry else None
+        env = probe.envelope(advertised_model, probed, ctx)
+        caps_models.update((env or {}).get("models") or {})
+    return {"schema_version": 1, "models": caps_models} if caps_models else {}
+
+
 def _probe_spec_caps(
-    llm_url: str, advertised: list[str], upstream: list[str], ctx_size: Any
+    llm_url: str, advertised: list[str], upstream: list[str], ctx_size: Any,
+    api_kind: str | None = None,
 ) -> dict[str, Any]:
     """Probe EVERY model a spec serves into one caps envelope — keyed by the advertised name, probed by
     the upstream name (Ollama/vLLM only know that). Shared by startup (`_bring_up_engines`) and the
@@ -360,8 +436,11 @@ def _probe_spec_caps(
     BOTH paths, not just the first (main's 5078c8c fix, kept in ONE place so the two can't drift). N
     sequential probes at join/reload (one-time; N is small). A failed probe returns an all-False entry for
     that one model (`probe.capabilities` never raises), so one bad model can't sink the node; ``{}`` only
-    when the spec serves no models.
+    when the spec serves no models. An API spec (``api_kind``) takes its caps from the static whitelist
+    instead — no probe ever targets the vendor — via the same seam so startup and reload can't drift.
     """
+    if api_kind:
+        return _static_api_caps(api_kind, advertised)
     caps_models: dict[str, Any] = {}
     for advertised_model, upstream_model in zip(advertised, upstream, strict=True):
         env = probe.capabilities(
@@ -589,11 +668,16 @@ class _ServeState:
         routes: dict[str, str] | None = None,
         upstream: dict[str, str] | None = None,
         media_url: str | None = None,
+        bearer_by_url: dict[str, str] | None = None,
     ) -> None:
         self.signaling_url = signaling_url
         self.node_id = node_id
         self.network_id = network_id
         self.llm_url = llm_url.rstrip("/")
+        # {vendor base URL: API key} for the API engines this identity serves — read from the
+        # environment at startup, never from the run record. Env-fixed for the process lifetime
+        # (like media_url), so it lives here and not on the reload-swappable snapshot.
+        self.bearer_by_url = {url.rstrip("/"): key for url, key in (bearer_by_url or {}).items()}
         # This box's media server base (`http://127.0.0.1:<media_port>`) when the identity serves
         # media, else None. `media/*` jobs forward here instead of an LLM engine; all media models
         # share the one server, so a single URL (not a per-model route) is enough.
@@ -855,17 +939,24 @@ def _reload_once(state: _ServeState, engine_id: str) -> None:
     for spec in specs:
         url = (spec.get("endpoint_url") or "").rstrip("/")
         models = list(spec.get("models") or [])
-        advertised = _advertised_models(models, aliases)
+        api_kind = spec.get("api_kind")
+        # An api spec's advertised names ARE its record models; its upstream names are the vendor
+        # names they embed — on BOTH branches below, or a reload would forward `openai:*` verbatim.
+        advertised = list(models) if api_kind else _advertised_models(models, aliases)
+        upstream = [_api_upstream_name(api_kind, m) for m in models] if api_kind else list(models)
         prev = retained.get(url)
         if prev is not None and prev[1][:1] == advertised[:1]:
             # Already serving this engine: reuse ONLY its probed caps. advertised/upstream come from the
             # record, so a model appended to this engine is still picked up, not dropped (ADR 0010 C2).
-            reassembled.append((url, advertised, list(models), prev[3]))
+            reassembled.append((url, advertised, upstream, prev[3]))
         else:  # a genuinely new engine (or a changed first model) → probe EVERY model it serves, so a
             # newly-appended multi-model `--at` advertises caps for all of them, exactly like startup
             # (`_probe_spec_caps` is the shared site, so startup and reload can't drift — ADR 0009 C2).
-            caps = _probe_spec_caps(url, advertised, list(models), record.get("ctx_size")) if models else {}
-            reassembled.append((url, advertised, list(models), caps))
+            caps = (
+                _probe_spec_caps(url, advertised, upstream, record.get("ctx_size"), api_kind=api_kind)
+                if models else {}
+            )
+            reassembled.append((url, advertised, upstream, caps))
 
     snapshot = _assemble_snapshot(reassembled, state.media_models, record, engine_id, state.max_concurrency)
     state.apply(snapshot, reassembled)  # atomic swap; in-flight requests were unaffected until here
@@ -921,7 +1012,8 @@ def handle_job(state: _ServeState, job: dict[str, Any]) -> None:
             return
         state.enter_inference()
         try:
-            _forward_stream(state, txn, endpoint, body, read_timeout, state.media_url)
+            _forward_stream(state, txn, endpoint, body, read_timeout, state.media_url,
+                            headers=_forward_headers(state, state.media_url))
         except Exception as exc:  # one bad media job must not kill the loop
             print(f"\nMedia job {txn} failed: {exc!r}", file=sys.stderr)
             _try_submit_error(state, txn, str(exc))
@@ -949,10 +1041,11 @@ def handle_job(state: _ServeState, job: dict[str, Any]) -> None:
 
     state.enter_inference()
     try:
+        headers = _forward_headers(state, target)
         if is_stream:
-            _forward_stream(state, txn, endpoint, forward_body, read_timeout, target)
+            _forward_stream(state, txn, endpoint, forward_body, read_timeout, target, headers=headers)
         else:
-            _forward_whole(state, txn, endpoint, forward_body, read_timeout, target)
+            _forward_whole(state, txn, endpoint, forward_body, read_timeout, target, headers=headers)
     except Exception as exc:  # one bad job must not kill the loop
         print(f"\nJob {txn} failed: {exc!r}", file=sys.stderr)
         _try_submit_error(state, txn, str(exc))
@@ -993,16 +1086,26 @@ def _submit_response(state: _ServeState, txn: str, *, content: Any, stream: bool
         relay.submit_response(state.signaling_url, state.token(), txn, content=content, stream=stream)
 
 
+def _forward_headers(state: _ServeState, target_url: str) -> dict[str, str]:
+    """Forward headers for one target: the API key rides ONLY on an API engine's own vendor URL —
+    hardware-engine (and media) forwards stay bearer-free, and an upstream 401 is a job error in a
+    different auth domain from the relay token (it can never trigger the relay-token refresh)."""
+    headers = {"Content-Type": "application/json"}
+    key = state.bearer_by_url.get(target_url.rstrip("/"))
+    if key:
+        headers["Authorization"] = f"Bearer {key}"
+    return headers
+
+
 def _forward_whole(
-    state: _ServeState, txn: str, endpoint: str, body: dict[str, Any], read_timeout: float, target_url: str
+    state: _ServeState, txn: str, endpoint: str, body: dict[str, Any], read_timeout: float, target_url: str,
+    headers: dict[str, str],
 ) -> None:
     import httpx
 
     timeout = httpx.Timeout(connect=10, read=read_timeout, write=30, pool=10)
     with httpx.Client(timeout=timeout) as client:
-        resp = client.post(
-            f"{target_url}/{endpoint}", json=body, headers={"Content-Type": "application/json"}
-        )
+        resp = client.post(f"{target_url}/{endpoint}", json=body, headers=headers)
     if resp.status_code != 200:
         _try_submit_error(state, txn, f"engine error {resp.status_code}: {resp.text[:200]}")
         return
@@ -1010,14 +1113,15 @@ def _forward_whole(
 
 
 def _forward_stream(
-    state: _ServeState, txn: str, endpoint: str, body: dict[str, Any], read_timeout: float, target_url: str
+    state: _ServeState, txn: str, endpoint: str, body: dict[str, Any], read_timeout: float, target_url: str,
+    headers: dict[str, str],
 ) -> None:
     import httpx
 
     timeout = httpx.Timeout(connect=10, read=read_timeout, write=None, pool=10)
     with httpx.Client(timeout=timeout) as client:
         with client.stream(
-            "POST", f"{target_url}/{endpoint}", json=body, headers={"Content-Type": "application/json"}
+            "POST", f"{target_url}/{endpoint}", json=body, headers=headers,
         ) as engine_resp:
             if engine_resp.status_code != 200:
                 engine_resp.read()

--- a/remote/serve.py
+++ b/remote/serve.py
@@ -25,7 +25,7 @@ from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from typing import Any, Callable
 
-from remote import control_plane, credentials, probe, relay
+from remote import api_keys, control_plane, credentials, probe, relay
 from shared import run_records
 from shared.models import api_catalog
 
@@ -100,11 +100,6 @@ def run_remote_engine_from_record(grid_id: str, engine_id: str) -> int:
             "This grid's access token carries no node identity; run `grid login` to refresh your "
             "tokens, then re-join."
         )
-    # API-engine keys come from the environment (issue 03 moves them to a key store) — resolve them
-    # up front so a keyless respawn dies naming the env var instead of advertising models whose
-    # every job would 401 upstream. Never read from the record; the record never carries a key.
-    bearer_by_url = _api_bearers(record)
-
     def _on_term(_signum, _frame):  # noqa: ANN001
         raise KeyboardInterrupt
 
@@ -125,6 +120,12 @@ def run_remote_engine_from_record(grid_id: str, engine_id: str) -> int:
     registered = False
     rc = 0
     try:
+        # API-engine keys come from the machine-local key store (env var as fallback) — resolve
+        # them up front so a keyless respawn dies naming the fix instead of advertising models
+        # whose every job would 401 upstream. Never read from the record; the record never carries
+        # a key. Inside the try so this death reaps the record like any died-before-registering
+        # engine (the `finally` below).
+        bearer_by_url = _api_bearers(record)
         # Bring up text engines only when the record names some — a media-only join (`grid join
         # --media`) has no text spec, and `_bring_up_engines` would otherwise error on the empty spec.
         has_text = bool(record.get("engines")) or bool(record.get("models")) or bool(record.get("endpoint_url"))
@@ -171,11 +172,14 @@ def run_remote_engine_from_record(grid_id: str, engine_id: str) -> int:
             capabilities=capabilities,
             meta=_meta(record, engine_id),
             pricing=_pricing(record),
-            max_concurrency=int(record.get("max_concurrency") or 1),
+            # Explicit --max-concurrency wins; else 8 for an API-only union, 1 otherwise — one
+            # shared rule with the CLI's hot-reload gate (run_records.effective_max_concurrency).
+            max_concurrency=run_records.effective_max_concurrency(record),
             routes=routes,
             upstream=upstream,
             media_url=media_url,
             bearer_by_url=bearer_by_url,
+            api_kind_by_url=_api_kinds_by_url(record),
         )
         register_once(state)
         registered = True
@@ -368,11 +372,12 @@ def _advertised_models(models: list[str], aliases: list[str]) -> list[str]:
 
 
 def _api_bearers(record: dict[str, Any]) -> dict[str, str]:
-    """{vendor base URL: API key} for every API spec in the record, from each kind's env var.
+    """{vendor base URL: API key} for every API spec in the record — the machine-local key store
+    first (the join validated and stored the key pre-spawn, so the store is the resolved truth),
+    each kind's env var as fallback (a pre-store record respawned in a key-bearing environment).
 
-    A missing key is terminal: the join validated the key pre-spawn, so a keyless start is a
-    respawn in an environment that lost it — better to die naming the variable than to serve
-    models whose every job errors upstream. The key never appears in the message.
+    A key missing from BOTH is terminal: better to die naming the fix than to serve models whose
+    every job errors upstream. The key never appears in the message.
     """
     bearers: dict[str, str] = {}
     for spec in record.get("engines") or []:
@@ -381,14 +386,28 @@ def _api_bearers(record: dict[str, Any]) -> dict[str, str]:
             continue
         whitelist = api_catalog.WHITELISTS.get(kind)
         env_var = whitelist.env_var if whitelist else f"{kind.upper()}_API_KEY"
-        key = os.environ.get(env_var)
+        key = api_keys.load_key(kind) or os.environ.get(env_var)
         if not key:
             raise SystemExit(
-                f"This engine serves --api {kind} models but {env_var} is not set. "
-                f"Export {env_var} and re-run `grid join --api {kind}`."
+                f"This engine serves --api {kind} models but no key is stored and {env_var} is "
+                f"not set. Re-run `grid join --api {kind}` to store a key (or export {env_var})."
             )
         bearers[(spec.get("endpoint_url") or "").rstrip("/")] = key
     return bearers
+
+
+def _api_kinds_by_url(record: dict[str, Any]) -> dict[str, str]:
+    """{vendor base URL: service kind} for every API spec in the record — the endpoint-gating map.
+
+    Derived from the record (not the probe results) at startup AND on every reload, so it follows
+    `grid leave --engine <kind>` hot-reloads. Unlike the bearers it lives on the reload-swappable
+    snapshot: it must never mark a URL an engine no longer serves.
+    """
+    return {
+        (spec.get("endpoint_url") or "").rstrip("/"): str(spec.get("api_kind"))
+        for spec in record.get("engines") or []
+        if spec.get("api_kind")
+    }
 
 
 def _api_upstream_name(api_kind: str, advertised: str) -> str:
@@ -421,7 +440,9 @@ def _static_api_caps(api_kind: str, advertised: list[str]) -> dict[str, Any]:
             )
         probed = api_catalog.probed_features(entry) if entry else no_features
         ctx = entry.context_window if entry else None
-        env = probe.envelope(advertised_model, probed, ctx)
+        # chat/completions only: the gate in handle_job refuses legacy completions, so the relay
+        # must not be told this model serves it (honest advertisement, ADR 0012).
+        env = probe.envelope(advertised_model, probed, ctx, endpoints=["chat/completions"])
         caps_models.update((env or {}).get("models") or {})
     return {"schema_version": 1, "models": caps_models} if caps_models else {}
 
@@ -535,6 +556,7 @@ def _assemble_snapshot(
         routes=routes, upstream=upstream, models=union_models, capabilities=capabilities,
         meta=_meta(record, engine_id), pricing=_pricing(record),
         max_concurrency=max_concurrency,
+        api_kind_by_url=_api_kinds_by_url(record),
     )
 
 
@@ -624,6 +646,7 @@ class _Snapshot:
     meta: dict[str, Any]          # grid-page {name, engine}
     pricing: dict[str, float]     # always {} today (advertised pricing is deprecated)
     max_concurrency: int
+    api_kind_by_url: dict[str, str]  # vendor base URL -> service kind (endpoint gating); {} = none
 
     @staticmethod
     def build(
@@ -635,6 +658,7 @@ class _Snapshot:
         meta: dict[str, Any],
         pricing: dict[str, float],
         max_concurrency: int,
+        api_kind_by_url: dict[str, str] | None = None,
     ) -> "_Snapshot":
         return _Snapshot(
             routes={model: url.rstrip("/") for model, url in routes.items()},
@@ -643,6 +667,7 @@ class _Snapshot:
             capabilities=dict(capabilities or {}),
             meta=dict(meta or {}),
             pricing=dict(pricing or {}),
+            api_kind_by_url={url.rstrip("/"): kind for url, kind in (api_kind_by_url or {}).items()},
             # Clamp to [1, _MAX_CONCURRENCY]: each slot becomes a real poll-worker thread in `_serve_loop`,
             # so an absurd `--max-concurrency` can't exhaust threads/sockets. This is the sole clamp site,
             # so a reload that changes max_concurrency is bounded the same way as startup.
@@ -669,14 +694,16 @@ class _ServeState:
         upstream: dict[str, str] | None = None,
         media_url: str | None = None,
         bearer_by_url: dict[str, str] | None = None,
+        api_kind_by_url: dict[str, str] | None = None,
     ) -> None:
         self.signaling_url = signaling_url
         self.node_id = node_id
         self.network_id = network_id
         self.llm_url = llm_url.rstrip("/")
-        # {vendor base URL: API key} for the API engines this identity serves — read from the
-        # environment at startup, never from the run record. Env-fixed for the process lifetime
-        # (like media_url), so it lives here and not on the reload-swappable snapshot.
+        # {vendor base URL: API key} for the API engines this identity serves — read from the key
+        # store (env fallback) at startup, never from the run record. Fixed for the process
+        # lifetime (like media_url), so it lives here and not on the reload-swappable snapshot —
+        # a rotated key reaches jobs via the respawn `grid join` forces, never via SIGHUP.
         self.bearer_by_url = {url.rstrip("/"): key for url, key in (bearer_by_url or {}).items()}
         # This box's media server base (`http://127.0.0.1:<media_port>`) when the identity serves
         # media, else None. `media/*` jobs forward here instead of an LLM engine; all media models
@@ -690,6 +717,7 @@ class _ServeState:
         self._snapshot = _Snapshot.build(
             routes=route_map, upstream=upstream or {}, models=models, capabilities=capabilities,
             meta=meta, pricing=pricing, max_concurrency=max_concurrency,
+            api_kind_by_url=api_kind_by_url,
         )
         # The probe results the live snapshot was built from, kept so a reload probes only newly-added
         # engines (ADR 0010 D4 F6). Reload-owned: set at startup, thereafter only the reload loop writes.
@@ -748,22 +776,33 @@ class _ServeState:
         only newly-added engines (ADR 0010 D4 F6)."""
         return self._engine_results
 
-    def route(self, model: str | None) -> str | None:
-        """The local engine URL serving ``model``.
+    def route_and_kind(self, model: str | None) -> tuple[str | None, str | None]:
+        """The local engine URL serving ``model``, plus its API service kind (None = hardware/media).
 
         Exact match wins. Otherwise, when every model points at the **same single engine** (one
         distinct URL — even if that one engine serves several models), fall back to it: a job with a
         missing/unknown ``model`` still forwards as it did before multi-engine (the proxy forwarded the
         body unchanged, letting the engine answer). With several distinct engines and no match, return
         ``None`` so the caller reports "no engine serves" instead of guessing.
+
+        One method for both lookups so they read the SAME snapshot: a separate kind read could bind
+        a torn pair across a concurrent reload swap (ADR 0010 D4 F4 — bind once).
         """
         snap = self._snapshot  # bind once — a concurrent reload swap is never seen half-applied
+        target = None
         if model and model in snap.routes:
-            return snap.routes[model]
-        distinct = set(snap.routes.values())
-        if len(distinct) == 1:
-            return next(iter(distinct))
-        return None
+            target = snap.routes[model]
+        else:
+            distinct = set(snap.routes.values())
+            if len(distinct) == 1:
+                target = next(iter(distinct))
+        if target is None:
+            return None, None
+        return target, snap.api_kind_by_url.get(target)  # both maps are URL-normalized by `build`
+
+    def route(self, model: str | None) -> str | None:
+        """The local engine URL serving ``model`` (see ``route_and_kind``)."""
+        return self.route_and_kind(model)[0]
 
     def upstream_model(self, model: str | None) -> str | None:
         """The name the local engine answers to for an advertised ``model`` (``--advertise-as`` maps the
@@ -1028,9 +1067,18 @@ def handle_job(state: _ServeState, job: dict[str, Any]) -> None:
         return
 
     model = body.get("model")  # body is already `job.get("body") or {}`, so it is a dict
-    target = state.route(model)  # which local engine serves this model (DECISIONS D9)
+    target, api_kind = state.route_and_kind(model)  # which local engine serves this model (DECISIONS D9)
     if target is None:
         _try_submit_error(state, txn, f"no engine serves model {model!r}")
+        return
+    # Endpoint gating per kind (ADR 0012): an API engine serves chat/completions ONLY. A legacy
+    # `completions` job routed to it — including via the single-URL fallback above — is refused
+    # with a structured error BEFORE any upstream call, never blind-forwarded to the vendor.
+    if api_kind and endpoint != "chat/completions":
+        _try_submit_error(
+            state, txn,
+            f"API engine {api_kind!r} serves chat/completions only (endpoint {endpoint!r} not served)",
+        )
         return
 
     # Consumers address the model by its advertised name; an external engine behind ``--advertise-as``
@@ -1043,9 +1091,11 @@ def handle_job(state: _ServeState, job: dict[str, Any]) -> None:
     try:
         headers = _forward_headers(state, target)
         if is_stream:
-            _forward_stream(state, txn, endpoint, forward_body, read_timeout, target, headers=headers)
+            _forward_stream(state, txn, endpoint, forward_body, read_timeout, target, headers=headers,
+                            api_kind=api_kind)
         else:
-            _forward_whole(state, txn, endpoint, forward_body, read_timeout, target, headers=headers)
+            _forward_whole(state, txn, endpoint, forward_body, read_timeout, target, headers=headers,
+                           api_kind=api_kind)
     except Exception as exc:  # one bad job must not kill the loop
         print(f"\nJob {txn} failed: {exc!r}", file=sys.stderr)
         _try_submit_error(state, txn, str(exc))
@@ -1086,6 +1136,23 @@ def _submit_response(state: _ServeState, txn: str, *, content: Any, stream: bool
         relay.submit_response(state.signaling_url, state.token(), txn, content=content, stream=stream)
 
 
+# Upstream statuses that point at the provider's key or quota (401/403 auth, 429 rate/quota) —
+# these earn a stderr warn on top of the per-job error; a 5xx says nothing about the key.
+_API_AUTH_QUOTA_STATUSES = frozenset({401, 403, 429})
+
+
+def _warn_api_auth_failure(api_kind: str | None, status: int) -> None:
+    """Warn the engine's stderr log when an API engine's upstream rejects for auth/quota reasons.
+
+    The per-job error reaches only the consumer; without this line the operator whose key was
+    revoked or quota exhausted has no signal in the engine log. Never includes the key. The loop
+    stays alive and the engine stays registered — each job errors, nothing auto-ejects (ADR 0012).
+    """
+    if api_kind and status in _API_AUTH_QUOTA_STATUSES:
+        _warn(f"{api_kind} upstream returned {status} — check your API key / quota "
+              f"(jobs will keep erroring until it is fixed; the engine stays registered)")
+
+
 def _forward_headers(state: _ServeState, target_url: str) -> dict[str, str]:
     """Forward headers for one target: the API key rides ONLY on an API engine's own vendor URL —
     hardware-engine (and media) forwards stay bearer-free, and an upstream 401 is a job error in a
@@ -1099,7 +1166,7 @@ def _forward_headers(state: _ServeState, target_url: str) -> dict[str, str]:
 
 def _forward_whole(
     state: _ServeState, txn: str, endpoint: str, body: dict[str, Any], read_timeout: float, target_url: str,
-    headers: dict[str, str],
+    headers: dict[str, str], api_kind: str | None = None,
 ) -> None:
     import httpx
 
@@ -1107,6 +1174,7 @@ def _forward_whole(
     with httpx.Client(timeout=timeout) as client:
         resp = client.post(f"{target_url}/{endpoint}", json=body, headers=headers)
     if resp.status_code != 200:
+        _warn_api_auth_failure(api_kind, resp.status_code)
         _try_submit_error(state, txn, f"engine error {resp.status_code}: {resp.text[:200]}")
         return
     _submit_response(state, txn, content=resp.content, stream=False)
@@ -1114,7 +1182,7 @@ def _forward_whole(
 
 def _forward_stream(
     state: _ServeState, txn: str, endpoint: str, body: dict[str, Any], read_timeout: float, target_url: str,
-    headers: dict[str, str],
+    headers: dict[str, str], api_kind: str | None = None,
 ) -> None:
     import httpx
 
@@ -1125,6 +1193,7 @@ def _forward_stream(
         ) as engine_resp:
             if engine_resp.status_code != 200:
                 engine_resp.read()
+                _warn_api_auth_failure(api_kind, engine_resp.status_code)
                 _try_submit_error(state, txn, f"engine error {engine_resp.status_code}: {engine_resp.text[:200]}")
                 return
             # Pass the engine's SSE bytes straight through while its stream is open. A streamed 401 can't

--- a/shared/models/api_catalog.py
+++ b/shared/models/api_catalog.py
@@ -25,6 +25,8 @@ class ApiModelEntry:
 @dataclass(frozen=True)
 class ApiWhitelist:
     last_verified: str  # ISO date the table was last checked against the vendor's docs
+    base_url: str  # the vendor endpoint jobs forward to, no trailing slash
+    env_var: str  # the environment variable the provider's key is read from
     entries: tuple[ApiModelEntry, ...]
 
 
@@ -79,7 +81,12 @@ OPENAI_WHITELIST: tuple[ApiModelEntry, ...] = (
 
 # One structure per kind: the verified-date and the entries can't drift apart.
 WHITELISTS: dict[str, ApiWhitelist] = {
-    "openai": ApiWhitelist(last_verified=OPENAI_LAST_VERIFIED, entries=OPENAI_WHITELIST),
+    "openai": ApiWhitelist(
+        last_verified=OPENAI_LAST_VERIFIED,
+        base_url="https://api.openai.com/v1",
+        env_var="OPENAI_API_KEY",
+        entries=OPENAI_WHITELIST,
+    ),
 }
 
 
@@ -89,6 +96,33 @@ def supported_kinds() -> tuple[str, ...]:
 
 def advertised_name(kind: str, entry: ApiModelEntry) -> str:
     return f"{kind}:{entry.vendor_name}"
+
+
+def find_advertised(kind: str, advertised: str) -> ApiModelEntry | None:
+    """The whitelist entry advertised under ``advertised`` (e.g. ``openai:gpt-5.5``), or None.
+
+    Only the namespaced form resolves — a bare vendor name is not an advertised name.
+    """
+    whitelist = WHITELISTS.get(kind)
+    if whitelist is None:
+        return None
+    for entry in whitelist.entries:
+        if advertised_name(kind, entry) == advertised:
+            return entry
+    return None
+
+
+def probed_features(entry: ApiModelEntry) -> dict[str, bool]:
+    """The entry's capabilities in the probed-dict shape ``remote.probe.capability_entry``
+    consumes — API engines register these statically, never via a live probe."""
+    return {
+        "vision": entry.supports_vision,
+        "tools": entry.supports_tools,
+        # OpenAI models that support tools support parallel tool calls.
+        "parallel_tool_calls": entry.supports_tools,
+        "json_object": entry.supports_json_mode,
+        "json_schema": entry.supports_structured_outputs,
+    }
 
 
 def format_api_entry(kind: str, entry: ApiModelEntry) -> str:

--- a/shared/models/api_catalog.py
+++ b/shared/models/api_catalog.py
@@ -1,0 +1,108 @@
+"""Curated whitelists of API-engine models, keyed by service kind.
+
+An API engine (`grid join --api <kind>`) serves third-party models through the
+provider's own API key. Each kind's whitelist is static data: capabilities are
+copied from the vendor's documentation, never live-probed, and the table carries
+the date it was last checked against those docs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ApiModelEntry:
+    vendor_name: str  # the id sent upstream, e.g. "gpt-5.5"
+    context_window: int
+    supports_tools: bool
+    supports_vision: bool
+    supports_json_mode: bool  # response_format {"type": "json_object"}
+    supports_structured_outputs: bool  # response_format {"type": "json_schema"}
+    notes: str = ""
+
+
+@dataclass(frozen=True)
+class ApiWhitelist:
+    last_verified: str  # ISO date the table was last checked against the vendor's docs
+    entries: tuple[ApiModelEntry, ...]
+
+
+# Verified against https://platform.openai.com/docs/models (which 301-redirects to
+# https://developers.openai.com/api/docs/models) on 2026-07-08.
+# Curation: the current flagship family plus mini/nano variants; reasoning is built
+# into the GPT-5.x family (the separate o-series is deprecated, removal 2026-12-11).
+# Excluded: pro tiers (no streaming, multi-minute answers — wrong fit for relay-polled
+# chat), gpt-5.3-codex (agentic coding specialty), gpt-4.1 family (outside the flagship
+# family), gpt-5.2 and earlier (deprecated), and all audio/realtime/image/embedding/
+# moderation models.
+OPENAI_LAST_VERIFIED = "2026-07-08"
+
+OPENAI_WHITELIST: tuple[ApiModelEntry, ...] = (
+    ApiModelEntry(
+        vendor_name="gpt-5.5",
+        context_window=1_050_000,
+        supports_tools=True,
+        supports_vision=True,
+        supports_json_mode=True,
+        supports_structured_outputs=True,
+        notes="Flagship model for coding and professional work.",
+    ),
+    ApiModelEntry(
+        vendor_name="gpt-5.4",
+        context_window=1_050_000,
+        supports_tools=True,
+        supports_vision=True,
+        supports_json_mode=True,
+        supports_structured_outputs=True,
+        notes="More affordable flagship-family model.",
+    ),
+    ApiModelEntry(
+        vendor_name="gpt-5.4-mini",
+        context_window=400_000,
+        supports_tools=True,
+        supports_vision=True,
+        supports_json_mode=True,
+        supports_structured_outputs=True,
+        notes="Strongest mini model for high-volume work.",
+    ),
+    ApiModelEntry(
+        vendor_name="gpt-5.4-nano",
+        context_window=400_000,
+        supports_tools=True,
+        supports_vision=True,
+        supports_json_mode=True,
+        supports_structured_outputs=True,
+        notes="Cheapest GPT-5.4-class model for simple tasks.",
+    ),
+)
+
+# One structure per kind: the verified-date and the entries can't drift apart.
+WHITELISTS: dict[str, ApiWhitelist] = {
+    "openai": ApiWhitelist(last_verified=OPENAI_LAST_VERIFIED, entries=OPENAI_WHITELIST),
+}
+
+
+def supported_kinds() -> tuple[str, ...]:
+    return tuple(sorted(WHITELISTS))
+
+
+def advertised_name(kind: str, entry: ApiModelEntry) -> str:
+    return f"{kind}:{entry.vendor_name}"
+
+
+def format_api_entry(kind: str, entry: ApiModelEntry) -> str:
+    caps = ", ".join(
+        name
+        for name, supported in (
+            ("tools", entry.supports_tools),
+            ("vision", entry.supports_vision),
+            ("json", entry.supports_json_mode),
+            ("structured", entry.supports_structured_outputs),
+        )
+        if supported
+    )
+    return (
+        f"  {advertised_name(kind, entry):<24} {entry.context_window:>9,} ctx   "
+        f"{caps or 'text only'}"
+    )

--- a/shared/paths.py
+++ b/shared/paths.py
@@ -22,6 +22,12 @@ def device_file() -> Path:
     return grid_home() / "device.toml"
 
 
+def api_keys_file() -> Path:
+    """Machine-local API-engine key store (TOML, 0o600), keyed by service kind. Survives logout —
+    deliberately separate from the sign-in credential store (like device.toml)."""
+    return grid_home() / "api_keys.toml"
+
+
 def grids_dir() -> Path:
     return grid_home() / "grids"
 

--- a/shared/run_records.py
+++ b/shared/run_records.py
@@ -111,6 +111,29 @@ def media_signature(record: dict[str, Any]) -> tuple[bool, tuple[str, ...], int,
     )
 
 
+# Poll-worker default for an identity that serves ONLY API engines: the upstream is a hosted API,
+# so several consumers must not queue behind one worker while it sits idle (ADR 0012). Any hardware
+# engine (or media) in the union keeps the conservative default of 1.
+API_ONLY_DEFAULT_CONCURRENCY = 8
+
+
+def effective_max_concurrency(record: dict[str, Any]) -> int:
+    """The poll-worker count a record's identity runs and advertises.
+
+    An explicit ``--max-concurrency`` (stored truthy on the record) always wins; otherwise the
+    default is derived from the union: 8 when every engine spec is an API engine and the identity
+    serves no media, else 1. Like ``media_signature``, this is the ONE definition shared by the
+    CLI's hot-reload-vs-respawn choice and the serve loop's startup, so the two can never desync
+    (ADR 0010 C3). A legacy flat record (no ``engines`` field) keeps the default of 1.
+    """
+    explicit = record.get("max_concurrency")
+    if explicit:
+        return int(explicit)
+    engines = record.get("engines") or []
+    api_only = bool(engines) and all(spec.get("api_kind") for spec in engines)
+    return API_ONLY_DEFAULT_CONCURRENCY if api_only and not record.get("media") else 1
+
+
 def pid_alive(pid: int) -> bool:
     if not pid:
         return False

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -2675,10 +2675,11 @@ def test_remote_join_appends_via_hot_reload(monkeypatch, tmp_path):
     assert terminated == []                             # never stopped the live process (zero-drop)
 
 
-def test_remote_join_api_append_onto_live_hardware_respawns_not_reloads(monkeypatch, tmp_path):
-    """Appending an API engine must RESPAWN, not SIGHUP: the live process's bearer map is fixed at
-    startup, so a hot-reload would advertise openai:* models with no vendor bearer. The respawned
-    process reads the just-validated key from the key store at startup."""
+def test_remote_join_api_append_onto_live_hardware_hot_reloads(monkeypatch, tmp_path):
+    """Appending an API engine onto a live hardware identity is ZERO-DROP: the vendor key now lives in
+    the durable key store, so the reload re-reads it and swaps the bearer in place — SIGHUP, no respawn,
+    no dropped in-flight requests (issue 05; closes issue 02's respawn caveat). Rotation and the
+    concurrency-flip reverse order still respawn (separate tests)."""
     import signal as _sig
 
     _seed_running_remote_grid(monkeypatch, tmp_path)
@@ -2690,19 +2691,20 @@ def test_remote_join_api_append_onto_live_hardware_respawns_not_reloads(monkeypa
 
     assert cli.main(["join", "--at", "http://h:11434/v1", "-m", "llama3"]) == 0  # first join spawns
     monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
-    assert cli.main(["join", "--api", "openai", "-m", "openai:gpt-5.5"]) == 0
+    assert cli.main(["join", "--api", "openai", "-m", "openai:gpt-5.5"]) == 0  # api-append hot-reloads
 
     rec = cli.provider._read_records("n1")["remote"]
     assert [e["endpoint_url"] for e in rec["engines"]] == ["http://h:11434/v1", "https://api.openai.com/v1"]
     assert rec["models"] == ["llama3", "openai:gpt-5.5"]
-    assert terminated == [4242]  # stopped the keyless live process...
-    assert (4242, _sig.SIGHUP) not in spawned["signals"]  # ...instead of hot-reloading it
+    assert spawned["signals"] == [(4242, _sig.SIGHUP)]  # hot-reloaded the live singleton in place
+    assert terminated == []                             # never stopped the live process (zero-drop)
 
 
 def test_remote_join_api_rotated_env_key_overwrites_store_and_respawns(monkeypatch, tmp_path, capsys):
     """Rotation is one command: a re-join with a NEW env key overwrites the stored key and RESPAWNS
-    the live identity (never a silent no-op, never SIGHUP) — the live process's bearer is fixed at
-    spawn, so only a fresh process picks up the rotated key."""
+    the live identity (never a silent no-op, never SIGHUP). Not because the mechanism can't hot-swap
+    the bearer — it now can (issue 05) — but because rotation is a deliberate policy: a fresh process
+    gives the operator certainty the new key is live, never a silent in-place swap."""
     import signal as _sig
 
     _seed_running_remote_grid(monkeypatch, tmp_path)
@@ -2744,6 +2746,25 @@ def test_remote_join_api_rejoin_with_same_stored_key_is_noop(monkeypatch, tmp_pa
 
     assert "nothing to append" in capsys.readouterr().out  # the no-op message
     assert terminated == []
+
+
+def test_remote_join_noop_surfaces_last_reload_error(monkeypatch, tmp_path, capsys):
+    """The idempotent no-op re-join WARNS when the engine's last hot-reload failed inside the detached
+    process (`last_reload_error` on the record): the operator's earlier join printed success while the
+    old union kept serving, so a bare 'nothing to append' would compound the false success
+    (issue 05 follow-up — reload failures were signaled only in the engine's log)."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_remote_spawn(monkeypatch)
+
+    assert cli.main(["join", "--at", "http://h:11434/v1", "-m", "llama3"]) == 0
+    monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
+    # The detached process recorded a reload failure (e.g. its key store was tampered with mid-flight).
+    cli.remote_provider.run_records.update_record("n1", "remote", last_reload_error="no key is stored for openai")
+
+    assert cli.main(["join", "--at", "http://h:11434/v1", "-m", "llama3"]) == 0  # identical → no-op
+    out_err = capsys.readouterr()
+    assert "nothing to append" in out_err.out
+    assert "no key is stored for openai" in out_err.err  # the failure is surfaced, not silent
 
 
 def test_remote_join_hardware_onto_api_only_respawns_for_concurrency_flip(monkeypatch, tmp_path):
@@ -3111,6 +3132,64 @@ def test_remote_leave_engine_shrinks_union(monkeypatch, tmp_path):
     assert rec["models"] == ["mistral"] and rec["endpoint_url"] == "http://h:8000/v1"
     assert spawned["signals"] == [(4242, _sig.SIGHUP)]  # hot-reloaded the reduced union
     assert terminated == []                             # never stopped the live process
+
+
+def test_remote_leave_engine_reports_respawn_fallback(monkeypatch, tmp_path, capsys):
+    """If the SIGHUP finds the singleton's pid gone (the TOCTOU window), the shrink falls back to a
+    respawn — and the message says so instead of claiming zero-drop, mirroring cmd_remote_join's
+    honest reporting (issue 05 follow-up: the return of _hot_reload_identity was discarded here)."""
+    _seed_remote_identity(monkeypatch, tmp_path, [
+        {"endpoint_url": "http://h:11434/v1", "models": ["llama3"], "engine_label": "ollama"},
+        {"endpoint_url": "http://h:8000/v1", "models": ["mistral"], "engine_label": "vllm"},
+    ])
+    _mock_remote_spawn(monkeypatch)
+    monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
+    monkeypatch.setattr(cli.remote_provider.run_records, "terminate_pid", lambda pid: True)
+
+    def gone(pid):  # the singleton died between the liveness check and the signal
+        raise ProcessLookupError(pid)
+
+    monkeypatch.setattr(cli.remote_provider, "_signal_reload", gone)
+
+    assert cli.main(["leave", "--engine", "http://h:11434/v1"]) == 0
+    out = capsys.readouterr().out
+    assert "Dropped 'http://h:11434/v1'" in out and "re-serving 1 engine(s)" in out
+    assert "restarted" in out          # honest: it fell back to a respawn...
+    assert "hot-reload" not in out     # ...and never claims a zero-drop reload
+
+
+def test_remote_leave_engine_openai_drops_only_api_reserves_survivors(monkeypatch, tmp_path):
+    """`grid leave --engine openai` drops ONLY the API engine (matched by its `openai` kind label) and
+    hot-reloads the surviving hardware engine in place — the hardware keeps serving, zero-drop (issue 05)."""
+    import signal as _sig
+
+    _seed_remote_identity(monkeypatch, tmp_path, [
+        {"endpoint_url": "http://h:11434/v1", "models": ["llama3"], "engine_label": "ollama"},
+        {"endpoint_url": "https://api.openai.com/v1", "models": ["openai:gpt-5.5"],
+         "engine_label": "openai", "api_kind": "openai"},
+    ])
+    spawned = _mock_remote_spawn(monkeypatch)
+    terminated = []
+    monkeypatch.setattr(cli.remote_provider.run_records, "terminate_pid", lambda pid: terminated.append(pid) or True)
+    monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
+
+    assert cli.main(["leave", "--engine", "openai"]) == 0  # drop the API engine by its kind label
+    rec = cli.provider._read_records("n1")["remote"]
+    assert [e["endpoint_url"] for e in rec["engines"]] == ["http://h:11434/v1"]  # only the hardware survivor
+    assert rec["models"] == ["llama3"] and rec["endpoint_url"] == "http://h:11434/v1"
+    assert spawned["signals"] == [(4242, _sig.SIGHUP)]  # hot-reloaded the reduced union in place
+    assert terminated == []                             # never stopped the live process (zero-drop)
+
+
+def test_remote_leave_engine_openai_last_tears_down(monkeypatch, tmp_path, capsys):
+    """Leaving the API engine when it is the ONLY engine tears the identity down (never reload-to-empty)."""
+    _seed_remote_identity(monkeypatch, tmp_path, [
+        {"endpoint_url": "https://api.openai.com/v1", "models": ["openai:gpt-5.5"],
+         "engine_label": "openai", "api_kind": "openai"}], pid=0)
+
+    assert cli.main(["leave", "--engine", "openai"]) == 0
+    assert cli.provider._read_records("n1") == {}  # last engine removed → the whole identity is torn down
+    assert "last engine" in capsys.readouterr().out.lower()
 
 
 def test_remote_leave_engine_last_tears_down(monkeypatch, tmp_path, capsys):
@@ -4504,7 +4583,7 @@ def _seed_reload_state(monkeypatch, tmp_path, engines, *, retained, media_models
     is the ``[(url, advertised, upstream, caps), ...]`` the live snapshot was built from; the state's
     ``media_signature`` reflects the STARTUP media config (``startup_bundles``), which the reload
     compares the re-read record against."""
-    from remote import serve
+    from remote import api_keys, serve
     from shared import run_records
 
     monkeypatch.setenv("GRID_HOME", str(tmp_path))
@@ -4522,6 +4601,10 @@ def _seed_reload_state(monkeypatch, tmp_path, engines, *, retained, media_models
         "media_bundles": list(record_bundles if record_bundles is not None else (startup_bundles or [])),
         "engines": engines,
     })
+    # A record with an api spec makes the reload read the key store (issue 05); seed a deterministic
+    # key per kind so `_api_bearers` resolves instead of raising, and the bearer is assertable.
+    for kind in dict.fromkeys(s.get("api_kind") for s in engines if s.get("api_kind")):
+        api_keys.store_key(kind, f"sk-test-{kind}")
     return state
 
 
@@ -4599,8 +4682,9 @@ def test_serve_reload_appended_model_kept_no_reprobe(monkeypatch, tmp_path):
 def test_serve_reload_new_api_spec_static_caps_and_vendor_upstream(monkeypatch, tmp_path):
     """A hot-reload that gains an API spec must take its caps from the static whitelist (no probe
     ever targets the vendor) and derive vendor upstream names — the same `_probe_spec_caps` seam as
-    startup, so the two can't drift. (Reachable via leave-shrink; a NEW api join respawns instead,
-    since the live process's bearer map is fixed at startup.)"""
+    startup, so the two can't drift. `grid join --api` onto a live identity reaches this path now
+    that the bearer is rebuilt from the key store on reload (issue 05); the bearer itself is covered
+    by `test_serve_reload_new_api_spec_attaches_vendor_bearer`."""
     from remote import probe, relay, serve
 
     state = _seed_reload_state(monkeypatch, tmp_path, retained=[
@@ -4624,6 +4708,61 @@ def test_serve_reload_new_api_spec_static_caps_and_vendor_upstream(monkeypatch, 
     # the hardware route stays unmarked.
     assert state.route_and_kind("openai:gpt-5.5") == ("https://api.openai.com/v1", "openai")
     assert state.route_and_kind("a") == ("http://e1/v1", None)
+
+
+def test_serve_reload_new_api_spec_attaches_vendor_bearer(monkeypatch, tmp_path):
+    """A hot-reload that gains an API spec must attach that engine's vendor bearer to its forwards:
+    the key is re-read from the machine-local store on reload (not fixed at spawn), so `grid join
+    --api` onto a live identity hot-reloads a WORKING engine instead of respawning (issue 05 — the
+    key store closes issue 02's respawn caveat). Hardware forwards stay bearer-free."""
+    from remote import probe, relay, serve
+
+    state = _seed_reload_state(monkeypatch, tmp_path, retained=[
+        ("http://e1/v1", ["a"], ["a"], {"schema_version": 1, "models": {"a": {}}}),
+    ], engines=[
+        {"endpoint_url": "http://e1/v1", "models": ["a"], "engine_label": None},
+        {"endpoint_url": "https://api.openai.com/v1", "models": ["openai:gpt-5.5"],
+         "engine_label": "openai", "api_kind": "openai"},
+    ])
+    monkeypatch.setattr(probe, "capabilities",
+                        lambda *a, **k: pytest.fail("api engines are never probed, reload included"))
+    monkeypatch.setattr(relay, "register_node", lambda *a, **kw: None)
+
+    serve._reload_once(state, "remote")
+
+    # The appended vendor engine now forwards WITH the bearer (seeded by the harness as sk-test-openai);
+    # the hardware engine stays bearer-free — the API key rides only its own vendor URL.
+    assert serve._forward_headers(state, "https://api.openai.com/v1").get("Authorization") == "Bearer sk-test-openai"
+    assert "Authorization" not in serve._forward_headers(state, "http://e1/v1")
+
+
+def test_serve_reload_dropping_api_spec_removes_its_bearer(monkeypatch, tmp_path):
+    """The vendor bearer follows the union: a `leave --engine openai` shrink drops the bearer on the same
+    swap that drops the route, so the departed vendor URL is bearer-free afterwards — no in-flight job can
+    forward to a vendor this identity no longer serves (issue 05, the leave-direction of the bind-once seam)."""
+    from remote import probe, relay, serve
+    from shared import run_records
+
+    state = _seed_reload_state(monkeypatch, tmp_path, retained=[
+        ("http://e1/v1", ["a"], ["a"], {"schema_version": 1, "models": {"a": {}}}),
+    ], engines=[
+        {"endpoint_url": "http://e1/v1", "models": ["a"], "engine_label": None},
+        {"endpoint_url": "https://api.openai.com/v1", "models": ["openai:gpt-5.5"],
+         "engine_label": "openai", "api_kind": "openai"},
+    ])
+    monkeypatch.setattr(probe, "capabilities", lambda *a, **k: {"schema_version": 1, "models": {}})
+    monkeypatch.setattr(relay, "register_node", lambda *a, **kw: None)
+
+    serve._reload_once(state, "remote")  # append the api engine → its vendor bearer is now live
+    assert serve._forward_headers(state, "https://api.openai.com/v1").get("Authorization") == "Bearer sk-test-openai"
+
+    run_records.write_record("n1", "remote", {  # `leave --engine openai` rewrites the record to hardware-only
+        "engine_id": "remote", "grid_id": "n1",
+        "engines": [{"endpoint_url": "http://e1/v1", "models": ["a"], "engine_label": None}]})
+    serve._reload_once(state, "remote")
+
+    assert "openai:gpt-5.5" not in state.models                         # the vendor engine left the advertised union...
+    assert "Authorization" not in serve._forward_headers(state, "https://api.openai.com/v1")  # ...and its bearer with it
 
 
 def test_serve_reload_retained_api_spec_keeps_vendor_upstream(monkeypatch, tmp_path):
@@ -4822,6 +4961,48 @@ def test_serve_reload_loop_survives_a_systemexit_reload(monkeypatch, tmp_path):
     assert calls == ["remote", "remote"]  # kept looping after the first reload raised SystemExit
 
 
+def test_serve_reload_loop_persists_failure_on_the_record(monkeypatch, tmp_path):
+    """A failed reload leaves a trace the CLI can surface: `last_reload_error` on the run record. The
+    CLI already printed success when it delivered the SIGHUP, so without this the only signal that the
+    union was NOT re-advertised is this process's log (issue 05 follow-up)."""
+    from remote import serve
+    from shared import run_records
+
+    state = _seed_reload_state(monkeypatch, tmp_path, retained=[], engines=[
+        {"endpoint_url": "http://e1/v1", "models": ["a"], "engine_label": None},
+    ])
+
+    def failing_reload(s, eid):
+        s.stop.set()  # one iteration is enough
+        raise SystemExit("This engine serves --api openai models but no key is stored")
+
+    monkeypatch.setattr(serve, "_reload_once", failing_reload)
+    state.reload_requested.set()
+    serve._reload_loop(state, "remote")
+
+    rec = run_records.read_record("n1", "remote")
+    assert "no key is stored" in rec["last_reload_error"]  # the failure survived the process's log
+
+
+def test_serve_reload_success_clears_last_reload_error(monkeypatch, tmp_path):
+    """A successful reload clears a previous failure's `last_reload_error`, so the CLI stops warning
+    about a condition that healed."""
+    from remote import relay, serve
+    from shared import run_records
+
+    state = _seed_reload_state(monkeypatch, tmp_path, retained=[
+        ("http://e1/v1", ["a"], ["a"], {"schema_version": 1, "models": {"a": {}}}),
+    ], engines=[
+        {"endpoint_url": "http://e1/v1", "models": ["a"], "engine_label": None},
+    ])
+    run_records.update_record("n1", "remote", last_reload_error="previous failure")
+    monkeypatch.setattr(relay, "register_node", lambda *a, **k: None)
+
+    serve._reload_once(state, "remote")
+
+    assert "last_reload_error" not in (run_records.read_record("n1", "remote") or {})
+
+
 def test_serve_reload_rearms_on_post_swap_register_failure(monkeypatch, tmp_path):
     """Swap succeeds but the re-register fails (transient) → the reload re-arms reload_requested so a
     later tick retries; the new union is not left unadvertised (ADR 0010 C5)."""
@@ -4896,6 +5077,32 @@ def test_serve_reload_failing_probe_keeps_old_routing(monkeypatch, tmp_path):
     assert state.snapshot() is before           # no partial apply — the old routing is untouched
 
 
+def test_serve_reload_missing_api_key_keeps_old_routing(monkeypatch, tmp_path):
+    """If an appended API spec's key is in neither the store nor the env, the reload aborts BEFORE the
+    swap: `_api_bearers` raises, the old snapshot keeps serving, and nothing is registered — the loop's
+    guard then logs and survives (issue 05, mirrors the failed-probe abort). Never a partial union with a
+    bearer-less openai:* engine advertised to the relay."""
+    from remote import api_keys, probe, relay, serve
+
+    state = _seed_reload_state(monkeypatch, tmp_path, retained=[
+        ("http://e1/v1", ["a"], ["a"], {"schema_version": 1, "models": {"a": {}}}),
+    ], engines=[
+        {"endpoint_url": "http://e1/v1", "models": ["a"], "engine_label": None},
+        {"endpoint_url": "https://api.openai.com/v1", "models": ["openai:gpt-5.5"],
+         "engine_label": "openai", "api_kind": "openai"},
+    ])
+    # The key the harness seeded is gone (revoked/deleted out of band) and there is no env fallback.
+    monkeypatch.setattr(api_keys, "load_key", lambda kind: None)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(probe, "capabilities", lambda *a, **k: pytest.fail("api engines are never probed"))
+    monkeypatch.setattr(relay, "register_node", lambda *a, **k: pytest.fail("must not register a partial union"))
+    before = state.snapshot()
+
+    with pytest.raises(SystemExit, match="OPENAI_API_KEY"):
+        serve._reload_once(state, "remote")     # propagates; _reload_loop's guard catches + logs in production
+    assert state.snapshot() is before           # no partial apply — the old routing keeps serving untouched
+
+
 def test_serve_route_survives_concurrent_swap(monkeypatch, tmp_path):
     """route() binds the snapshot once, so a reload swapping mid-call never raises or returns a torn
     result; and published snapshots' dicts are never mutated in place (ADR 0010 D4 F4)."""
@@ -4934,6 +5141,47 @@ def test_serve_route_survives_concurrent_swap(monkeypatch, tmp_path):
     assert errors == []                                                  # never raised, never torn
     assert snap_a.routes == {"a": "http://e1/v1"}                        # published snapshots not mutated
     assert snap_b.routes == {"a": "http://e1/v1", "b": "http://e2/v1"}
+
+
+def test_serve_handle_job_pairs_route_and_bearer_from_one_snapshot(monkeypatch, tmp_path):
+    """Bind-once (issue 05): a job reads its route AND its vendor bearer from ONE snapshot, so a reload
+    swapping mid-job can never pair a route from one union with a bearer from another. Two generations
+    give the SAME model different vendor URLs+keys; a torn pair would surface as a target URL whose key
+    isn't in the bound snapshot (no Authorization) — asserted absent under a concurrent swapper."""
+    import threading as _t
+
+    from remote import serve
+
+    state = _serve_state(monkeypatch, tmp_path, models=["m"], routes={"m": "http://a/v1"}, upstream={},
+                         bearer_by_url={"http://a/v1": "KEY-A"})
+    snap_a = state.snapshot()
+    snap_b = serve._Snapshot.build(routes={"m": "http://b/v1"}, upstream={}, models=["m"], capabilities={},
+                                   meta={}, pricing={}, max_concurrency=1,
+                                   bearer_by_url={"http://b/v1": "KEY-B"})
+    expected = {"http://a/v1": "Bearer KEY-A", "http://b/v1": "Bearer KEY-B"}
+    errors = []
+    iters = 5000  # fixed count → deterministic, can't hang
+
+    def swapper():
+        for i in range(iters):
+            state.apply(snap_b if i % 2 else snap_a, [])
+
+    def reader():
+        for _ in range(iters):
+            snap = state.snapshot()                       # bind once, exactly as handle_job does
+            target = state.route_and_kind("m", snap)[0]
+            auth = serve._forward_headers(state, target, snap).get("Authorization")
+            if auth != expected.get(target):              # a torn (route, bearer) pair → wrong/absent key
+                errors.append((target, auth))
+                return
+
+    threads = [_t.Thread(target=swapper, daemon=True)] + [_t.Thread(target=reader, daemon=True) for _ in range(3)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(10)
+
+    assert errors == []   # route and bearer always came from the same snapshot generation
 
 
 def test_serve_start_reload_watcher_installs_handler_and_thread(monkeypatch, tmp_path):
@@ -7279,6 +7527,19 @@ def test_remote_engines_lists_nodes_with_engine_device_and_models(monkeypatch, t
     assert "glm-5.2,qwen-3" in out  # the MLX node's models, joined
 
 
+def test_remote_engines_renders_api_engine_kind_openai(monkeypatch, tmp_path, capsys):
+    """An API engine surfaces on the grid page with kind `openai`: the overview renderer prints whatever
+    `node.engine` the relay returns, and an API join advertises engine `openai` (issue 05 / AC#4)."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_overview(monkeypatch, {"nodes": [
+        {"name": "keybox", "device": "Linux x86_64", "engine": "openai",
+         "models": ["openai:gpt-5.5"], "online": True},
+    ]})
+    assert cli.main(["engines"]) == 0
+    out = capsys.readouterr().out
+    assert "openai" in out and "openai:gpt-5.5" in out  # the API engine's kind label + its namespaced model
+
+
 def test_remote_engines_json_passes_through_nodes_verbatim(monkeypatch, tmp_path, capsys):
     _seed_running_remote_grid(monkeypatch, tmp_path)
     _mock_overview(monkeypatch, _OVERVIEW_2NODES)
@@ -7977,6 +8238,30 @@ def test_relay_delete_model_price_encodes_model(monkeypatch, tmp_path):
     assert "/relay/v1/grid/models/z-ai%2Fglm-5.1" in seen["url"]
 
 
+def test_relay_model_price_roundtrips_namespaced_openai_name(monkeypatch, tmp_path):
+    """A namespaced `openai:*` price rides the wire correctly: the colon is verbatim in the PUT body and
+    percent-encodes to ONE safe path segment on DELETE — API-engine models are priced like any other
+    (issue 05 / AC#5; the colon is treated exactly like the slash case above)."""
+    from remote import relay
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    seen = {}
+
+    def handler(request):
+        seen.setdefault("urls", []).append(str(request.url))
+        if request.method == "PUT":
+            seen["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"model": "openai:gpt-5.5"})
+
+    _mock_relay(monkeypatch, handler)
+    relay.set_model_price("https://relay.example", "AT", model="openai:gpt-5.5", modality="chat",
+                          input_rate=2.0, output_rate=8.0, cache_rate=0.5)
+    relay.delete_model_price("https://relay.example", "AT", "openai:gpt-5.5")
+
+    assert seen["body"]["model"] == "openai:gpt-5.5"                                # verbatim in the PUT body
+    assert any("/relay/v1/grid/models/openai%3Agpt-5.5" in u for u in seen["urls"])  # one encoded path segment
+
+
 def test_relay_set_model_price_includes_metadata_when_given(monkeypatch, tmp_path):
     from remote import relay
 
@@ -8043,6 +8328,23 @@ def test_price_set_end_to_end_through_cli_main(monkeypatch, tmp_path):
         "input_rate": 0.3, "output_rate": 1.0, "cache_rate": 0.05,
         "name": "GLM 5.1", "maker": "Z.ai", "status": "available", "context_length": 200000,
     }
+
+
+def test_price_set_accepts_namespaced_openai_model_through_cli_main(monkeypatch, tmp_path):
+    """`grid price set -m openai:gpt-5.5` is accepted verbatim through the whole CLI path — the per-model
+    price command puts the namespaced API-engine name on the wire with no colon rejection (issue 05 / AC#5)."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    state.set_mode("remote")
+    seen = {}
+
+    def handler(request):
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"model": "openai:gpt-5.5"})
+
+    _mock_relay(monkeypatch, handler)
+    rc = cli.main(["price", "set", "-m", "openai:gpt-5.5", "--input", "2.0", "--output", "8.0", "--cache", "0.5"])
+    assert rc == 0
+    assert seen["body"]["model"] == "openai:gpt-5.5"  # the colon-namespaced name rides through unchanged
 
 
 def test_price_set_403_maps_to_join_first_through_cli_main(monkeypatch, tmp_path):

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -694,6 +694,33 @@ def test_api_whitelist_integrity():
             assert entry.context_window > 0
             assert api_catalog.advertised_name(kind, entry) == f"{kind}:{entry.vendor_name}"
         date.fromisoformat(whitelist.last_verified)  # dated, ISO format
+        assert whitelist.base_url.startswith("https://"), f"{kind} needs a vendor base URL"
+        assert not whitelist.base_url.endswith("/"), f"{kind} base URL must not end with '/'"
+        assert whitelist.env_var, f"{kind} needs the env var its key is read from"
+
+
+def test_api_whitelist_carries_base_url_and_env_var():
+    openai = api_catalog.WHITELISTS["openai"]
+    assert openai.base_url == "https://api.openai.com/v1"
+    assert openai.env_var == "OPENAI_API_KEY"
+
+
+def test_api_catalog_find_advertised_and_probed_features():
+    entry = api_catalog.find_advertised("openai", "openai:gpt-5.5")
+    assert entry is not None and entry.vendor_name == "gpt-5.5"
+    # Only the advertised (namespaced) form resolves — a bare vendor name does not.
+    assert api_catalog.find_advertised("openai", "gpt-5.5") is None
+    assert api_catalog.find_advertised("openai", "openai:nope") is None
+    assert api_catalog.find_advertised("anthropic", "anthropic:claude") is None
+
+    features = api_catalog.probed_features(entry)
+    # Exactly the probed-dict shape remote/probe.capability_entry consumes.
+    assert set(features) == {"vision", "tools", "parallel_tool_calls", "json_object", "json_schema"}
+    assert features["tools"] is entry.supports_tools
+    assert features["parallel_tool_calls"] is entry.supports_tools
+    assert features["vision"] is entry.supports_vision
+    assert features["json_object"] is entry.supports_json_mode
+    assert features["json_schema"] is entry.supports_structured_outputs
 
 
 def test_catalog_api_json_roundtrips(capsys):
@@ -1207,6 +1234,22 @@ def test_join_local_rejects_remote_only_flags(monkeypatch, tmp_path):
     with pytest.raises(SystemExit) as exc:
         cli.cmd_join(args)  # local handler rejects a remote-only flag before doing any work
     assert "--max-concurrency" in str(exc.value) and "remote" in str(exc.value).lower()
+
+
+def test_join_parser_accepts_api_kind(monkeypatch, tmp_path):
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    args = cli.build_parser().parse_args(["join", "--api", "openai", "-m", "openai:gpt-5.5"])
+    assert args.api == "openai"
+    assert cli.build_parser().parse_args(["join"]).api is None
+
+
+def test_join_local_rejects_api_flag(monkeypatch, tmp_path):
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    runtime.init_grid_config(name="home", port=8090)
+    args = cli.build_parser().parse_args(["join", "home", "--api", "openai", "-m", "openai:gpt-5.5"])
+    with pytest.raises(SystemExit) as exc:
+        cli.cmd_join(args)  # API engines live in remote mode; local points the user there
+    assert "--api" in str(exc.value) and "remote" in str(exc.value).lower()
 
 
 def test_await_engine_start_distinguishes_died_registered_starting(monkeypatch):
@@ -2102,6 +2145,194 @@ def test_remote_join_at_serves_external_engine(monkeypatch, tmp_path):
     assert record["meta_name"] == "ext"  # --name in remote is the grid-page display name, not the record key
 
 
+def test_remote_join_api_unknown_kind_lists_supported(monkeypatch, tmp_path):
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_remote_spawn(monkeypatch)
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["join", "--api", "anthropic", "-m", "anthropic:claude"])
+    assert "anthropic" in str(exc.value)  # the kind that was rejected
+    assert "openai" in str(exc.value)  # ... and the supported kinds, so the fix is one edit away
+
+    # `--api ""` (e.g. an unset shell variable) must error too, not silently join hardware.
+    with pytest.raises(SystemExit):
+        cli.main(["join", "--api", "", "-m", "openai:gpt-5.5"])
+    assert cli.provider._read_records("n1") == {}
+
+
+def test_remote_join_api_mutually_exclusive_flags(monkeypatch, tmp_path):
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_remote_spawn(monkeypatch)
+
+    conflicts = [
+        (["--at", "http://h:11434/v1"], "--at"),
+        (["--serve", "m"], "--serve"),
+        (["--advertise-as", "alias"], "--advertise-as"),
+        (["--media"], "--media"),
+        (["--bundle", "image_generation"], "--bundle"),
+    ]
+    for extra, flag in conflicts:
+        with pytest.raises(SystemExit) as exc:
+            cli.main(["join", "--api", "openai", "-m", "openai:gpt-5.5", *extra])
+        assert flag in str(exc.value), f"{flag} must be named in the error"
+        assert "--api" in str(exc.value)
+    assert cli.provider._read_records("n1") == {}
+
+
+def test_remote_join_api_requires_model_flag(monkeypatch, tmp_path):
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_remote_spawn(monkeypatch)
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["join", "--api", "openai"])
+    msg = str(exc.value)
+    assert "-m" in msg and "grid catalog --api openai" in msg
+    assert cli.provider._read_records("n1") == {}
+
+
+def test_remote_join_api_rejects_inline_alias(monkeypatch, tmp_path):
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_remote_spawn(monkeypatch)
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["join", "--api", "openai", "-m", "openai:gpt-5.5=alias"])
+    assert "advertise" in str(exc.value).lower() or "alias" in str(exc.value).lower()
+    assert cli.provider._read_records("n1") == {}
+
+
+def test_remote_join_api_model_outside_whitelist_lists_valid_names(monkeypatch, tmp_path):
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    spawned = _mock_remote_spawn(monkeypatch)
+    # No env key on purpose: the whitelist is static data, checked before the key or any network.
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(httpx, "Client", lambda *a, **k: pytest.fail("whitelist check must precede any vendor call"))
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["join", "--api", "openai", "-m", "openai:nope"])
+    msg = str(exc.value)
+    assert "openai:nope" in msg
+    for entry in api_catalog.WHITELISTS["openai"].entries:  # every valid name, so the fix is one edit away
+        assert api_catalog.advertised_name("openai", entry) in msg
+    assert cli.provider._read_records("n1") == {} and "cmd" not in spawned
+
+
+def test_remote_join_api_requires_env_key(monkeypatch, tmp_path):
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    spawned = _mock_remote_spawn(monkeypatch)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(httpx, "Client", lambda *a, **k: pytest.fail("no key, no vendor call"))
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["join", "--api", "openai", "-m", "openai:gpt-5.5"])
+    assert "OPENAI_API_KEY" in str(exc.value)
+    assert cli.provider._read_records("n1") == {} and "cmd" not in spawned
+
+
+def _mock_vendor(monkeypatch, handler, _real=httpx.Client):
+    """Serve the vendor's model-listing endpoint the `join --api` key validation calls, via
+    httpx.MockTransport (the `_mock_serve_engine` pattern). Returns what the vendor saw."""
+    seen = {}
+
+    def wrapped(request):
+        seen["url"] = str(request.url)
+        seen["auth"] = request.headers.get("authorization")
+        return handler(request)
+
+    monkeypatch.setattr(
+        httpx, "Client",
+        lambda *a, **k: _real(*a, **{**k, "transport": httpx.MockTransport(wrapped)}),
+    )
+    return seen
+
+
+def test_remote_join_api_invalid_key_is_terminal_no_spawn(monkeypatch, tmp_path):
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    spawned = _mock_remote_spawn(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-123")
+    seen = _mock_vendor(monkeypatch, lambda request: httpx.Response(401, text="invalid key"))
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["join", "--api", "openai", "-m", "openai:gpt-5.5"])
+    msg = str(exc.value)
+    assert "401" in msg
+    assert "sk-test-123" not in msg  # the key never appears in terminal output
+    assert seen["url"] == "https://api.openai.com/v1/models"
+    assert seen["auth"] == "Bearer sk-test-123"
+    assert cli.provider._read_records("n1") == {} and "cmd" not in spawned
+
+
+def test_remote_join_api_writes_kind_generic_record_and_spawns(monkeypatch, tmp_path, capsys):
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    spawned = _mock_remote_spawn(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-123")
+    _mock_vendor(monkeypatch, lambda request: httpx.Response(
+        200, json={"data": [{"id": "gpt-5.5"}, {"id": "gpt-5.4-mini"}]}
+    ))
+
+    assert cli.main(["join", "--api", "openai", "-m", "openai:gpt-5.5"]) == 0
+
+    record = cli.provider._read_records("n1")["remote"]
+    # Kind-generic spec: service kind + vendor base URL + advertised names — never the key.
+    assert record["engines"] == [{
+        "endpoint_url": "https://api.openai.com/v1",
+        "models": ["openai:gpt-5.5"],
+        "engine_label": "openai",
+        "api_kind": "openai",
+    }]
+    assert record["models"] == ["openai:gpt-5.5"]
+    assert record["endpoint_url"] == "https://api.openai.com/v1"
+    assert spawned["cmd"][-3:] == ["__remote-engine", "n1", "remote"]
+    # Secret hygiene: the key appears in no record, no terminal output.
+    from shared import run_records
+    record_text = run_records.record_path("n1", "remote").read_text()
+    assert "sk-test-123" not in record_text
+    out_err = capsys.readouterr()
+    assert "sk-test-123" not in out_err.out + out_err.err
+
+
+def test_remote_join_api_excludes_models_key_cannot_see(monkeypatch, tmp_path, capsys):
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_remote_spawn(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-123")
+    # The key sees gpt-5.5 but not gpt-5.4-mini: the whitelisted-but-unavailable model is excluded.
+    _mock_vendor(monkeypatch, lambda request: httpx.Response(200, json={"data": [{"id": "gpt-5.5"}]}))
+
+    assert cli.main(["join", "--api", "openai", "-m", "openai:gpt-5.5", "-m", "openai:gpt-5.4-mini"]) == 0
+
+    record = cli.provider._read_records("n1")["remote"]
+    assert record["models"] == ["openai:gpt-5.5"]
+    assert "openai:gpt-5.4-mini" in capsys.readouterr().err  # the exclusion is reported, not silent
+
+
+def test_remote_join_api_all_models_unavailable_errors(monkeypatch, tmp_path):
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    spawned = _mock_remote_spawn(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-123")
+    _mock_vendor(monkeypatch, lambda request: httpx.Response(200, json={"data": []}))
+
+    with pytest.raises(SystemExit) as exc:  # error rather than joining nothing
+        cli.main(["join", "--api", "openai", "-m", "openai:gpt-5.5"])
+    assert "openai:gpt-5.5" in str(exc.value)
+    assert cli.provider._read_records("n1") == {} and "cmd" not in spawned
+
+
+def test_remote_join_api_unexpected_listing_shape_is_diagnostic(monkeypatch, tmp_path):
+    """A 200 whose body isn't the documented {"data": [...]} shape must be its own diagnostic
+    error, not masquerade as 'your key can't see these models' (which points the operator at
+    permissions instead of the vendor/proxy)."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    spawned = _mock_remote_spawn(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-123")
+    _mock_vendor(monkeypatch, lambda request: httpx.Response(200, json=[{"id": "gpt-5.5"}]))
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["join", "--api", "openai", "-m", "openai:gpt-5.5"])
+    msg = str(exc.value)
+    assert "shape" in msg.lower() or "unexpected" in msg.lower()
+    assert "available to this" not in msg  # not the key-permissions message
+    assert cli.provider._read_records("n1") == {} and "cmd" not in spawned
+
+
 def test_remote_join_member_falls_back_to_bundle_url_when_status_forbidden(monkeypatch, tmp_path):
     """A provider MEMBER (not the grid creator) gets 403 from the creator-only status endpoint; join
     must fall back to the lan_signaling_url the login bundle carries instead of failing."""
@@ -2314,6 +2545,30 @@ def test_remote_join_appends_via_hot_reload(monkeypatch, tmp_path):
     assert rec["models"] == ["llama3", "mistral"] and rec["endpoint_url"] is None
     assert spawned["signals"] == [(4242, _sig.SIGHUP)]  # hot-reloaded the live singleton in place
     assert terminated == []                             # never stopped the live process (zero-drop)
+
+
+def test_remote_join_api_append_onto_live_hardware_respawns_not_reloads(monkeypatch, tmp_path):
+    """Appending an API engine must RESPAWN, not SIGHUP: the live process's environment has no
+    vendor key, so a hot-reload would advertise openai:* models whose every job 401s upstream.
+    The respawned process inherits the joining CLI's env — where the key was just validated."""
+    import signal as _sig
+
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    spawned = _mock_remote_spawn(monkeypatch)
+    terminated = []
+    monkeypatch.setattr(cli.remote_provider.run_records, "terminate_pid", lambda pid: terminated.append(pid) or True)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-123")
+    _mock_vendor(monkeypatch, lambda request: httpx.Response(200, json={"data": [{"id": "gpt-5.5"}]}))
+
+    assert cli.main(["join", "--at", "http://h:11434/v1", "-m", "llama3"]) == 0  # first join spawns
+    monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
+    assert cli.main(["join", "--api", "openai", "-m", "openai:gpt-5.5"]) == 0
+
+    rec = cli.provider._read_records("n1")["remote"]
+    assert [e["endpoint_url"] for e in rec["engines"]] == ["http://h:11434/v1", "https://api.openai.com/v1"]
+    assert rec["models"] == ["llama3", "openai:gpt-5.5"]
+    assert terminated == [4242]  # stopped the keyless live process...
+    assert (4242, _sig.SIGHUP) not in spawned["signals"]  # ...instead of hot-reloading it
 
 
 def test_remote_join_additive_preserves_max_concurrency(monkeypatch, tmp_path):
@@ -4101,6 +4356,61 @@ def test_serve_reload_appended_model_kept_no_reprobe(monkeypatch, tmp_path):
     assert state.route("b") == "http://e1/v1"
 
 
+def test_serve_reload_new_api_spec_static_caps_and_vendor_upstream(monkeypatch, tmp_path):
+    """A hot-reload that gains an API spec must take its caps from the static whitelist (no probe
+    ever targets the vendor) and derive vendor upstream names — the same `_probe_spec_caps` seam as
+    startup, so the two can't drift. (Reachable via leave-shrink; a NEW api join respawns instead,
+    for the env key.)"""
+    from remote import probe, relay, serve
+
+    state = _seed_reload_state(monkeypatch, tmp_path, retained=[
+        ("http://e1/v1", ["a"], ["a"], {"schema_version": 1, "models": {"a": {}}}),
+    ], engines=[
+        {"endpoint_url": "http://e1/v1", "models": ["a"], "engine_label": None},
+        {"endpoint_url": "https://api.openai.com/v1", "models": ["openai:gpt-5.5"],
+         "engine_label": "openai", "api_kind": "openai"},
+    ])
+    monkeypatch.setattr(probe, "capabilities",
+                        lambda *a, **k: pytest.fail("api engines are never probed, reload included"))
+    seen = {}
+    monkeypatch.setattr(relay, "register_node", lambda url, tok, node, **kw: seen.update(kw))
+
+    serve._reload_once(state, "remote")
+
+    assert seen["models"] == ["a", "openai:gpt-5.5"]
+    assert seen["capabilities"]["models"]["openai:gpt-5.5"]["context_window"] == 1_050_000
+    assert state.upstream_model("openai:gpt-5.5") == "gpt-5.5"  # vendor name, not the advertised name
+    assert state.route("openai:gpt-5.5") == "https://api.openai.com/v1"
+
+
+def test_serve_reload_retained_api_spec_keeps_vendor_upstream(monkeypatch, tmp_path):
+    """A reload triggered by an unrelated append must not break a LIVE api engine's rewrite: the
+    retained branch rebuilds upstream from the record's advertised names, which for an api spec must
+    re-derive the vendor names — and still never probe the vendor."""
+    from remote import probe, relay, serve
+
+    state = _seed_reload_state(monkeypatch, tmp_path, retained=[
+        ("https://api.openai.com/v1", ["openai:gpt-5.5"], ["gpt-5.5"],
+         {"schema_version": 1, "models": {"openai:gpt-5.5": {"context_window": 1_050_000}}}),
+    ], engines=[
+        {"endpoint_url": "https://api.openai.com/v1", "models": ["openai:gpt-5.5"],
+         "engine_label": "openai", "api_kind": "openai"},
+        {"endpoint_url": "http://e2/v1", "models": ["b"], "engine_label": None},
+    ])
+    probed = []
+    monkeypatch.setattr(probe, "capabilities",
+                        lambda url, model, **kw: probed.append((url, model))
+                        or {"schema_version": 1, "models": {model: {}}})
+    seen = {}
+    monkeypatch.setattr(relay, "register_node", lambda url, tok, node, **kw: seen.update(kw))
+
+    serve._reload_once(state, "remote")
+
+    assert probed == [("http://e2/v1", "b")]                    # only the new hardware engine probed
+    assert state.upstream_model("openai:gpt-5.5") == "gpt-5.5"  # the live api rewrite survives the reload
+    assert seen["models"] == ["openai:gpt-5.5", "b"]
+
+
 def test_serve_reload_drops_removed_engine(monkeypatch, tmp_path):
     """Leave-shrink: dropping an engine from the record removes it from the union on the next reload."""
     from remote import probe, relay, serve
@@ -4411,6 +4721,61 @@ def test_serve_start_reload_watcher_installs_handler_and_thread(monkeypatch, tmp
             _sig.signal(_sig.SIGHUP, orig)
 
 
+def test_remote_engine_startup_missing_api_env_key_exits_naming_var(monkeypatch, tmp_path):
+    """A respawned serve process whose record carries an API spec but whose environment lost the
+    key must exit naming the env var — not come up advertising models whose every job would 401."""
+    from remote import serve
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    record = {"grid_id": "n1", "signaling_url": "https://relay.example", "media": False,
+              "engines": [{"endpoint_url": "https://api.openai.com/v1", "models": ["openai:gpt-5.5"],
+                           "engine_label": "openai", "api_kind": "openai"}]}
+    monkeypatch.setattr(serve.run_records, "read_record", lambda g, e: record)
+    monkeypatch.setattr(serve, "_load_tokens", lambda net: ("AT", "RT"))
+    monkeypatch.setattr(serve, "_node_id_from_token", lambda t: "node-1")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    with pytest.raises(SystemExit) as exc:
+        serve.run_remote_engine_from_record("n1", "remote")
+    assert "OPENAI_API_KEY" in str(exc.value)
+
+
+def test_remote_engine_api_record_registers_static_caps_and_kind(monkeypatch, tmp_path):
+    """Startup-seam proof for the API-engine tracer bullet: a record with one api spec comes up with
+    whitelist caps (no probe), advertises the namespaced models, reports kind `openai` on the grid
+    page, and holds the env key ready for forwards — while the record itself stays key-free."""
+    from remote import probe, relay, serve
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-123")
+    record = {"grid_id": "n1", "signaling_url": "https://relay.example", "media": False,
+              "engines": [{"endpoint_url": "https://api.openai.com/v1", "models": ["openai:gpt-5.5"],
+                           "engine_label": "openai", "api_kind": "openai"}]}
+    monkeypatch.setattr(serve.run_records, "read_record", lambda g, e: record)
+    monkeypatch.setattr(serve, "_load_tokens", lambda net: ("AT", "RT"))
+    monkeypatch.setattr(serve, "_node_id_from_token", lambda t: "node-1")
+    monkeypatch.setattr(probe, "capabilities", lambda *a, **k: pytest.fail("api engines are never probed"))
+    seen = {}
+    monkeypatch.setattr(relay, "register_node", lambda url, tok, node, **kw: seen.update(kw, node=node))
+    monkeypatch.setattr(relay, "unregister_node", lambda *a, **k: None)
+    monkeypatch.setattr(serve, "_heartbeat_loop", lambda s: None)
+    state_seen = {}
+
+    def fake_poll(s):
+        state_seen["bearer_by_url"] = dict(s.bearer_by_url)
+        s.stop.set()
+
+    monkeypatch.setattr(serve, "_poll_loop", fake_poll)
+
+    assert serve.run_remote_engine_from_record("n1", "remote") == 0
+
+    assert seen["node"] == "node-1" and seen["models"] == ["openai:gpt-5.5"]
+    entry = seen["capabilities"]["models"]["openai:gpt-5.5"]
+    assert entry["context_window"] == 1_050_000 and entry["features"]["tools"] is True
+    assert seen["meta"]["engine"] == "openai"  # the grid page shows the API engine's kind
+    assert state_seen["bearer_by_url"] == {"https://api.openai.com/v1": "sk-test-123"}
+
+
 def test_run_remote_engine_starts_reload_thread_with_sighup_blocked(monkeypatch, tmp_path):
     """C4: every daemon — the reload watcher, the heartbeat, AND the N poll workers — starts while SIGHUP
     is blocked (so they inherit the block), then `_serve_loop` unblocks SIGHUP on the MAIN thread last.
@@ -4521,6 +4886,102 @@ def test_serve_handle_job_engine_error_submits_error(monkeypatch, tmp_path):
 
     serve.handle_job(state, {"transaction_id": "t1", "endpoint_path": "chat/completions", "body": {}, "is_stream": False})
     assert "500" in captured["error"] and "submitted" not in captured
+
+
+def _api_serve_state(monkeypatch, tmp_path, **overrides):
+    """A `_ServeState` serving one API-engine model: advertised `openai:gpt-5.5` routed to the vendor
+    base URL, vendor-name rewrite, and the key attached per target URL."""
+    kwargs = dict(
+        models=["openai:gpt-5.5"],
+        routes={"openai:gpt-5.5": "https://api.openai.com/v1"},
+        upstream={"openai:gpt-5.5": "gpt-5.5"},
+        bearer_by_url={"https://api.openai.com/v1": "sk-test-123"},
+    )
+    kwargs.update(overrides)
+    return _serve_state(monkeypatch, tmp_path, **kwargs)
+
+
+def test_serve_handle_job_api_forward_carries_bearer_and_vendor_model(monkeypatch, tmp_path):
+    from remote import relay, serve
+
+    state = _api_serve_state(monkeypatch, tmp_path)
+    captured = {}
+    monkeypatch.setattr(relay, "submit_response",
+                        lambda url, tok, txn, *, content, stream: captured.update(content=content, stream=stream))
+    monkeypatch.setattr(relay, "submit_error", lambda url, tok, txn, *, message, tokens_delivered=0: captured.update(error=message))
+
+    def vendor(request):
+        assert str(request.url) == "https://api.openai.com/v1/chat/completions"
+        assert request.headers["authorization"] == "Bearer sk-test-123"
+        assert json.loads(request.content)["model"] == "gpt-5.5"  # vendor name, not openai:gpt-5.5
+        return httpx.Response(200, json={"choices": [{"message": {"content": "hi"}}]})
+
+    _mock_serve_engine(monkeypatch, vendor)
+    serve.handle_job(state, {"transaction_id": "t1", "endpoint_path": "chat/completions",
+                             "body": {"model": "openai:gpt-5.5"}, "is_stream": False})
+    assert captured["stream"] is False and b'"hi"' in captured["content"] and "error" not in captured
+
+
+def test_serve_handle_job_api_stream_passes_sse_with_bearer(monkeypatch, tmp_path):
+    from remote import relay, serve
+
+    state = _api_serve_state(monkeypatch, tmp_path)
+    captured = {}
+
+    def cap_submit(url, tok, txn, *, content, stream):
+        captured.update(stream=stream, body=b"".join(content))  # materialise the generator while open
+
+    monkeypatch.setattr(relay, "submit_response", cap_submit)
+
+    def vendor(request):
+        assert request.headers["authorization"] == "Bearer sk-test-123"
+        return httpx.Response(200, content=b"data: a\n\ndata: [DONE]\n\n")
+
+    _mock_serve_engine(monkeypatch, vendor)
+    serve.handle_job(state, {"transaction_id": "t1", "endpoint_path": "chat/completions",
+                             "body": {"model": "openai:gpt-5.5"}, "is_stream": True})
+    assert captured["stream"] is True and captured["body"] == b"data: a\n\ndata: [DONE]\n\n"
+
+
+def test_serve_handle_job_hardware_forward_has_no_bearer(monkeypatch, tmp_path):
+    """A hardware engine in the same identity as an API engine must never see the vendor key."""
+    from remote import relay, serve
+
+    state = _api_serve_state(
+        monkeypatch, tmp_path,
+        models=["llama3", "openai:gpt-5.5"],
+        routes={"llama3": "http://127.0.0.1:8081/v1", "openai:gpt-5.5": "https://api.openai.com/v1"},
+    )
+    captured = {}
+    monkeypatch.setattr(relay, "submit_response", lambda url, tok, txn, *, content, stream: captured.update(ok=True))
+
+    def engine(request):
+        assert request.url.host == "127.0.0.1"
+        assert "authorization" not in request.headers  # the key rides only to the vendor URL
+        return httpx.Response(200, json={})
+
+    _mock_serve_engine(monkeypatch, engine)
+    serve.handle_job(state, {"transaction_id": "t1", "endpoint_path": "chat/completions",
+                             "body": {"model": "llama3"}, "is_stream": False})
+    assert captured.get("ok") is True
+
+
+def test_serve_handle_job_api_upstream_401_is_job_error_not_token_refresh(monkeypatch, tmp_path):
+    """A vendor 401 is a JOB error in the vendor's auth domain: it must reach the consumer with the
+    upstream status and must never enter the relay-token refresh path (distinct auth domains)."""
+    from remote import relay, serve
+
+    state = _api_serve_state(monkeypatch, tmp_path)
+    monkeypatch.setattr(state, "refresh",
+                        lambda stale_token=None: pytest.fail("vendor 401 must not touch relay-token refresh"))
+    captured = {}
+    monkeypatch.setattr(relay, "submit_response", lambda *a, **k: captured.update(submitted=True))
+    monkeypatch.setattr(relay, "submit_error", lambda url, tok, txn, *, message, tokens_delivered=0: captured.update(error=message))
+    _mock_serve_engine(monkeypatch, lambda r: httpx.Response(401, text="invalid api key"))
+
+    serve.handle_job(state, {"transaction_id": "t1", "endpoint_path": "chat/completions",
+                             "body": {"model": "openai:gpt-5.5"}, "is_stream": False})
+    assert "401" in captured["error"] and "submitted" not in captured
 
 
 def test_serve_handle_job_media_without_media_url_submits_error(monkeypatch, tmp_path):
@@ -5092,6 +5553,85 @@ def test_bring_up_engines_single_spec_multi_model_probes_every_model(monkeypatch
     assert advertised == ["A", "B", "C"] and upstream == ["A", "B", "C"]
     assert set(caps["models"]) == {"A", "B", "C"}           # one merged envelope carries all models
     assert caps["models"]["B"] == {"f": "B"}                # later models keep their own probed entry
+
+
+def test_bring_up_engines_api_spec_static_caps_never_probes(monkeypatch, tmp_path):
+    """An API engine's caps come from the static whitelist — no probe or benchmark call may ever
+    target the vendor (ADR 0012). Upstream names are the vendor names derived from the advertised
+    `openai:*` form, so the forward rewrite sends what the vendor understands."""
+    from remote import probe, serve
+
+    record = {
+        "engines": [{
+            "endpoint_url": "https://api.openai.com/v1",
+            "models": ["openai:gpt-5.5", "openai:gpt-5.4-mini"],
+            "engine_label": "openai",
+            "api_kind": "openai",
+        }],
+        "advertise_as": [],
+    }
+    monkeypatch.setattr(probe, "capabilities",
+                        lambda *a, **k: pytest.fail("api engines are never probed"))
+
+    results, launched, launcher = serve._bring_up_engines(record)
+    assert launched == [] and launcher is None
+    (llm_url, advertised, upstream, caps), = results
+    assert llm_url == "https://api.openai.com/v1"
+    assert advertised == ["openai:gpt-5.5", "openai:gpt-5.4-mini"]
+    assert upstream == ["gpt-5.5", "gpt-5.4-mini"]          # vendor names, derived from the whitelist
+    assert caps["schema_version"] == 1
+    flagship = caps["models"]["openai:gpt-5.5"]
+    assert flagship["features"]["tools"] is True and flagship["features"]["vision"] is True
+    assert flagship["context_window"] == 1_050_000          # static caps straight from the whitelist
+
+
+def test_bring_up_engines_api_model_gone_from_whitelist_warns_and_degrades(monkeypatch, tmp_path, capsys):
+    """A model that left the whitelist between join and respawn degrades like a failed probe
+    (all-False caps, prefix-strip rewrite) — but the degrade must leave a stderr trace, like every
+    other serve-side degrade, so quietly broken tool/vision consumers are diagnosable."""
+    from remote import probe, serve
+
+    record = {
+        "engines": [{
+            "endpoint_url": "https://api.openai.com/v1",
+            "models": ["openai:gpt-5.5", "openai:gpt-legacy"],
+            "engine_label": "openai",
+            "api_kind": "openai",
+        }],
+        "advertise_as": [],
+    }
+    monkeypatch.setattr(probe, "capabilities", lambda *a, **k: pytest.fail("api engines are never probed"))
+
+    results, _launched, _launcher = serve._bring_up_engines(record)
+
+    (_url, _advertised, upstream, caps), = results
+    assert upstream == ["gpt-5.5", "gpt-legacy"]  # prefix-strip fallback still rewrites sanely
+    legacy = caps["models"]["openai:gpt-legacy"]
+    assert all(v is False for v in legacy["features"].values())  # degraded, not crashed
+    err = capsys.readouterr().err
+    assert "openai:gpt-legacy" in err and "whitelist" in err  # ...and the degrade is observable
+
+
+def test_bring_up_engines_mixed_union_probes_only_hardware(monkeypatch, tmp_path):
+    from remote import probe, serve
+
+    record = {
+        "engines": [
+            {"endpoint_url": "http://h:11434/v1", "models": ["llama3"], "engine_label": "ollama"},
+            {"endpoint_url": "https://api.openai.com/v1", "models": ["openai:gpt-5.5"],
+             "engine_label": "openai", "api_kind": "openai"},
+        ],
+        "advertise_as": [],
+    }
+    probed = []
+    monkeypatch.setattr(probe, "capabilities",
+                        lambda url, model, *, advertise_as=None, context_window=None: probed.append((url, model))
+                        or {"schema_version": 1, "models": {advertise_as or model: {}}})
+
+    results, launched, _ = serve._bring_up_engines(record)
+    assert launched == []
+    assert probed == [("http://h:11434/v1", "llama3")]      # only the hardware engine is probed
+    assert results[1][1] == ["openai:gpt-5.5"] and results[1][2] == ["gpt-5.5"]
 
 
 def test_bring_up_engines_external_alias_probes_real_name_keys_alias(monkeypatch, tmp_path):

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -2179,15 +2179,38 @@ def test_remote_join_api_mutually_exclusive_flags(monkeypatch, tmp_path):
     assert cli.provider._read_records("n1") == {}
 
 
-def test_remote_join_api_requires_model_flag(monkeypatch, tmp_path):
+def test_remote_join_api_no_model_flag_serves_whole_whitelist_intersection(monkeypatch, tmp_path, capsys):
+    """`grid join --api openai` with no -m is the zero-config default: it serves the whole
+    whitelist ∩ the models the key can see, and reports the skipped whitelist models."""
     _seed_running_remote_grid(monkeypatch, tmp_path)
     _mock_remote_spawn(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-123")
+    _mock_vendor(monkeypatch, lambda request: httpx.Response(
+        200, json={"data": [{"id": "gpt-5.5"}, {"id": "gpt-5.4"}]}
+    ))
+
+    assert cli.main(["join", "--api", "openai"]) == 0
+
+    record = cli.provider._read_records("n1")["remote"]
+    assert record["models"] == ["openai:gpt-5.5", "openai:gpt-5.4"]  # whitelist order, key-visible only
+    err = capsys.readouterr().err
+    assert "openai:gpt-5.4-mini" in err and "openai:gpt-5.4-nano" in err  # skipped models reported
+
+
+def test_remote_join_api_no_model_flag_empty_intersection_errors(monkeypatch, tmp_path):
+    """Default-all with a key that can see NO whitelisted model is an error naming the skipped
+    models — not a join that serves nothing, and not a message claiming they were 'requested'."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    spawned = _mock_remote_spawn(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-123")
+    _mock_vendor(monkeypatch, lambda request: httpx.Response(200, json={"data": [{"id": "other-model"}]}))
 
     with pytest.raises(SystemExit) as exc:
         cli.main(["join", "--api", "openai"])
     msg = str(exc.value)
-    assert "-m" in msg and "grid catalog --api openai" in msg
-    assert cli.provider._read_records("n1") == {}
+    assert "openai:gpt-5.5" in msg          # the unavailable whitelist models are named
+    assert "requested" not in msg.lower()   # nothing was requested — this is the default set
+    assert cli.provider._read_records("n1") == {} and "cmd" not in spawned
 
 
 def test_remote_join_api_rejects_inline_alias(monkeypatch, tmp_path):
@@ -2216,15 +2239,37 @@ def test_remote_join_api_model_outside_whitelist_lists_valid_names(monkeypatch, 
     assert cli.provider._read_records("n1") == {} and "cmd" not in spawned
 
 
-def test_remote_join_api_requires_env_key(monkeypatch, tmp_path):
+def test_remote_join_api_no_key_anywhere_non_interactive_errors(monkeypatch, tmp_path):
+    """No env var, empty key store, non-interactive (pytest is non-tty): a clear error naming the
+    env var — no vendor call, no hidden prompt."""
     _seed_running_remote_grid(monkeypatch, tmp_path)
     spawned = _mock_remote_spawn(monkeypatch)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.setattr(httpx, "Client", lambda *a, **k: pytest.fail("no key, no vendor call"))
+    monkeypatch.setattr(cli.remote_provider, "_prompt_api_key",
+                        lambda *a: pytest.fail("non-interactive must not prompt"))
 
     with pytest.raises(SystemExit) as exc:
         cli.main(["join", "--api", "openai", "-m", "openai:gpt-5.5"])
     assert "OPENAI_API_KEY" in str(exc.value)
+    assert cli.provider._read_records("n1") == {} and "cmd" not in spawned
+
+
+def test_remote_join_api_empty_prompt_input_is_terminal(monkeypatch, tmp_path):
+    """An interactive prompt answered with nothing is a clean error — not a vendor call with an
+    empty bearer, and nothing stored."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    spawned = _mock_remote_spawn(monkeypatch)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(cli.provider, "_interactive", lambda: True)
+    monkeypatch.setattr(cli.remote_provider, "_prompt_api_key", lambda kind, env_var: "")
+    monkeypatch.setattr(httpx, "Client", lambda *a, **k: pytest.fail("empty key, no vendor call"))
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["join", "--api", "openai", "-m", "openai:gpt-5.5"])
+    assert "key" in str(exc.value).lower()
+    from remote import api_keys
+    assert api_keys.load_key("openai") is None
     assert cli.provider._read_records("n1") == {} and "cmd" not in spawned
 
 
@@ -2259,6 +2304,9 @@ def test_remote_join_api_invalid_key_is_terminal_no_spawn(monkeypatch, tmp_path)
     assert seen["url"] == "https://api.openai.com/v1/models"
     assert seen["auth"] == "Bearer sk-test-123"
     assert cli.provider._read_records("n1") == {} and "cmd" not in spawned
+    # A key the vendor rejected is never persisted — later joins must not reuse it silently.
+    from remote import api_keys
+    assert api_keys.load_key("openai") is None
 
 
 def test_remote_join_api_writes_kind_generic_record_and_spawns(monkeypatch, tmp_path, capsys):
@@ -2288,6 +2336,68 @@ def test_remote_join_api_writes_kind_generic_record_and_spawns(monkeypatch, tmp_
     assert "sk-test-123" not in record_text
     out_err = capsys.readouterr()
     assert "sk-test-123" not in out_err.out + out_err.err
+
+
+def test_remote_join_api_env_key_persisted_to_key_store(monkeypatch, tmp_path):
+    """A validated env key lands in the machine-local key store (api_keys.toml, 0o600, keyed by
+    service kind) so later joins and the detached serve process can read it without the env var."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_remote_spawn(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-123")
+    _mock_vendor(monkeypatch, lambda request: httpx.Response(200, json={"data": [{"id": "gpt-5.5"}]}))
+
+    assert cli.main(["join", "--api", "openai", "-m", "openai:gpt-5.5"]) == 0
+
+    import tomllib
+
+    from remote import api_keys
+    from shared import paths
+    key_file = paths.api_keys_file()
+    assert key_file.exists()
+    assert (key_file.stat().st_mode & 0o777) == 0o600
+    assert api_keys.load_key("openai") == "sk-test-123"
+    # On-disk contract: one table per service kind, the key under a `key` field — room for
+    # future per-kind metadata (base_url etc.) without a format change.
+    data = tomllib.loads(key_file.read_text())
+    assert data["openai"]["key"] == "sk-test-123"
+
+
+def test_remote_join_api_reuses_stored_key_without_env(monkeypatch, tmp_path):
+    """A later join with no env var silently reuses the stored key: the vendor sees the stored
+    bearer, and `grid logout` beforehand doesn't matter (the store is not the credential store)."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_remote_spawn(monkeypatch)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    from remote import api_keys
+    api_keys.store_key("openai", "sk-stored-456")
+    seen = _mock_vendor(monkeypatch, lambda request: httpx.Response(200, json={"data": [{"id": "gpt-5.5"}]}))
+
+    assert cli.main(["join", "--api", "openai", "-m", "openai:gpt-5.5"]) == 0
+    assert seen["auth"] == "Bearer sk-stored-456"
+
+
+def test_remote_join_api_prompts_hidden_key_when_interactive(monkeypatch, tmp_path, capsys):
+    """First join with no env and no stored key on a TTY: the hidden prompt supplies the key,
+    which is validated, stored, and never echoed; the join proceeds."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_remote_spawn(monkeypatch)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(cli.provider, "_interactive", lambda: True)
+    prompts = []
+    monkeypatch.setattr(
+        cli.remote_provider, "_prompt_api_key",
+        lambda kind, env_var: (prompts.append(kind), "sk-prompted-789")[1],
+    )
+    seen = _mock_vendor(monkeypatch, lambda request: httpx.Response(200, json={"data": [{"id": "gpt-5.5"}]}))
+
+    assert cli.main(["join", "--api", "openai", "-m", "openai:gpt-5.5"]) == 0
+
+    from remote import api_keys
+    assert prompts == ["openai"]
+    assert seen["auth"] == "Bearer sk-prompted-789"
+    assert api_keys.load_key("openai") == "sk-prompted-789"
+    out_err = capsys.readouterr()
+    assert "sk-prompted-789" not in out_err.out + out_err.err
 
 
 def test_remote_join_api_excludes_models_key_cannot_see(monkeypatch, tmp_path, capsys):
@@ -2467,6 +2577,24 @@ def test_remote_join_detect_requires_confirmation_for_text_plus_media(monkeypatc
     assert "multiple engines" in str(exc.value).lower()
 
 
+def test_remote_join_bare_never_auto_joins_api_engine(monkeypatch, tmp_path):
+    """A bare `grid join` (auto-detect) must NEVER include an API engine just because a key file
+    exists on disk — API engines join only when --api is explicit (no surprise upstream spend)."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_remote_spawn(monkeypatch)
+    from remote import api_keys
+    api_keys.store_key("openai", "sk-on-disk")
+    monkeypatch.setattr(cli.provider, "_detect", lambda host: [
+        detect.DetectedEngine(label="ollama", endpoint_url="http://h:11434/v1", models=["llama3"]),
+    ])
+
+    assert cli.main(["join"]) == 0
+
+    record = cli.provider._read_records("n1")["remote"]
+    assert all(not spec.get("api_kind") for spec in record["engines"])  # hardware only
+    assert record["models"] == ["llama3"]
+
+
 def test_remote_join_rejects_advertise_host(monkeypatch, tmp_path):
     _seed_running_remote_grid(monkeypatch, tmp_path)
     _mock_remote_spawn(monkeypatch)
@@ -2548,9 +2676,9 @@ def test_remote_join_appends_via_hot_reload(monkeypatch, tmp_path):
 
 
 def test_remote_join_api_append_onto_live_hardware_respawns_not_reloads(monkeypatch, tmp_path):
-    """Appending an API engine must RESPAWN, not SIGHUP: the live process's environment has no
-    vendor key, so a hot-reload would advertise openai:* models whose every job 401s upstream.
-    The respawned process inherits the joining CLI's env — where the key was just validated."""
+    """Appending an API engine must RESPAWN, not SIGHUP: the live process's bearer map is fixed at
+    startup, so a hot-reload would advertise openai:* models with no vendor bearer. The respawned
+    process reads the just-validated key from the key store at startup."""
     import signal as _sig
 
     _seed_running_remote_grid(monkeypatch, tmp_path)
@@ -2569,6 +2697,118 @@ def test_remote_join_api_append_onto_live_hardware_respawns_not_reloads(monkeypa
     assert rec["models"] == ["llama3", "openai:gpt-5.5"]
     assert terminated == [4242]  # stopped the keyless live process...
     assert (4242, _sig.SIGHUP) not in spawned["signals"]  # ...instead of hot-reloading it
+
+
+def test_remote_join_api_rotated_env_key_overwrites_store_and_respawns(monkeypatch, tmp_path, capsys):
+    """Rotation is one command: a re-join with a NEW env key overwrites the stored key and RESPAWNS
+    the live identity (never a silent no-op, never SIGHUP) — the live process's bearer is fixed at
+    spawn, so only a fresh process picks up the rotated key."""
+    import signal as _sig
+
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    spawned = _mock_remote_spawn(monkeypatch)
+    terminated = []
+    monkeypatch.setattr(cli.remote_provider.run_records, "terminate_pid", lambda pid: terminated.append(pid) or True)
+    _mock_vendor(monkeypatch, lambda request: httpx.Response(200, json={"data": [{"id": "gpt-5.5"}]}))
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-old-111")
+    assert cli.main(["join", "--api", "openai", "-m", "openai:gpt-5.5"]) == 0
+    monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-new-222")
+    # Same models — without rotation this re-join would be the idempotent no-op.
+    assert cli.main(["join", "--api", "openai", "-m", "openai:gpt-5.5"]) == 0
+
+    from remote import api_keys
+    assert api_keys.load_key("openai") == "sk-new-222"    # rotated on disk
+    assert terminated == [4242]                           # stopped the stale-bearer process...
+    assert (4242, _sig.SIGHUP) not in spawned["signals"]  # ...instead of hot-reloading it
+    out_err = capsys.readouterr()
+    assert "rotat" in out_err.out.lower()                 # the operator sees why it restarted
+    assert "sk-new-222" not in out_err.out + out_err.err and "sk-old-111" not in out_err.out + out_err.err
+
+
+def test_remote_join_api_rejoin_with_same_stored_key_is_noop(monkeypatch, tmp_path, capsys):
+    """A re-join whose key resolves to the SAME stored value stays the idempotent no-op — rotation
+    must not turn every repeat join into a restart."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_remote_spawn(monkeypatch)
+    terminated = []
+    monkeypatch.setattr(cli.remote_provider.run_records, "terminate_pid", lambda pid: terminated.append(pid) or True)
+    _mock_vendor(monkeypatch, lambda request: httpx.Response(200, json={"data": [{"id": "gpt-5.5"}]}))
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-same-333")
+    assert cli.main(["join", "--api", "openai", "-m", "openai:gpt-5.5"]) == 0
+    monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
+    assert cli.main(["join", "--api", "openai", "-m", "openai:gpt-5.5"]) == 0
+
+    assert "nothing to append" in capsys.readouterr().out  # the no-op message
+    assert terminated == []
+
+
+def test_remote_join_hardware_onto_api_only_respawns_for_concurrency_flip(monkeypatch, tmp_path):
+    """Adding a hardware engine to an API-only identity flips the concurrency default (8 → 1). The
+    pool is sized once at spawn, so this join must RESPAWN — a SIGHUP would leave 8 workers
+    hammering a hardware engine sized for 1."""
+    import signal as _sig
+
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    spawned = _mock_remote_spawn(monkeypatch)
+    terminated = []
+    monkeypatch.setattr(cli.remote_provider.run_records, "terminate_pid", lambda pid: terminated.append(pid) or True)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-123")
+    _mock_vendor(monkeypatch, lambda request: httpx.Response(200, json={"data": [{"id": "gpt-5.5"}]}))
+
+    assert cli.main(["join", "--api", "openai", "-m", "openai:gpt-5.5"]) == 0  # api-only: default 8
+    monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
+    assert cli.main(["join", "--at", "http://h:11434/v1", "-m", "llama3"]) == 0  # union gains hardware
+
+    assert terminated == [4242]                           # respawned to resize the pool...
+    assert (4242, _sig.SIGHUP) not in spawned["signals"]  # ...not hot-reloaded at the old size
+
+
+def test_remote_leave_shrink_to_api_only_respawns_for_concurrency_flip(monkeypatch, tmp_path):
+    """The reverse flip: dropping the last hardware engine leaves an API-only union whose default
+    is 8 — the shrink must respawn so the pool can grow (a SIGHUP keeps the live pool of 1)."""
+    import signal as _sig
+
+    _seed_remote_identity(monkeypatch, tmp_path, [
+        {"endpoint_url": "http://h:11434/v1", "models": ["llama3"], "engine_label": "ollama"},
+        {"endpoint_url": "https://api.openai.com/v1", "models": ["openai:gpt-5.5"],
+         "engine_label": "openai", "api_kind": "openai"},
+    ])
+    spawned = _mock_remote_spawn(monkeypatch)
+    terminated = []
+    monkeypatch.setattr(cli.remote_provider.run_records, "terminate_pid", lambda pid: terminated.append(pid) or True)
+    monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
+
+    assert cli.main(["leave", "--engine", "http://h:11434/v1"]) == 0
+
+    rec = cli.provider._read_records("n1")["remote"]
+    assert [e["endpoint_url"] for e in rec["engines"]] == ["https://api.openai.com/v1"]
+    assert terminated == [4242]                           # respawned to grow the pool to 8...
+    assert (4242, _sig.SIGHUP) not in spawned["signals"]  # ...not left at 1 by a hot-reload
+
+
+def test_remote_join_api_additive_preserves_explicit_max_concurrency(monkeypatch, tmp_path):
+    """An explicit --max-concurrency on an API identity survives a re-join that omits it — exactly
+    the hardware-engine preserve rule (and no concurrency-flip respawn fires: 2 == 2)."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_remote_spawn(monkeypatch)
+    monkeypatch.setattr(cli.remote_provider.run_records, "terminate_pid", lambda pid: True)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-123")
+    _mock_vendor(monkeypatch, lambda request: httpx.Response(
+        200, json={"data": [{"id": "gpt-5.5"}, {"id": "gpt-5.4"}]}
+    ))
+
+    assert cli.main(["join", "--api", "openai", "-m", "openai:gpt-5.5", "--max-concurrency", "2"]) == 0
+    assert cli.provider._read_records("n1")["remote"]["max_concurrency"] == 2
+    monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
+    assert cli.main(["join", "--api", "openai", "-m", "openai:gpt-5.4"]) == 0  # no flag re-passed
+
+    rec = cli.provider._read_records("n1")["remote"]
+    assert rec["max_concurrency"] == 2  # preserved, not reset
+    assert rec["models"] == ["openai:gpt-5.5", "openai:gpt-5.4"]
 
 
 def test_remote_join_additive_preserves_max_concurrency(monkeypatch, tmp_path):
@@ -4360,7 +4600,7 @@ def test_serve_reload_new_api_spec_static_caps_and_vendor_upstream(monkeypatch, 
     """A hot-reload that gains an API spec must take its caps from the static whitelist (no probe
     ever targets the vendor) and derive vendor upstream names — the same `_probe_spec_caps` seam as
     startup, so the two can't drift. (Reachable via leave-shrink; a NEW api join respawns instead,
-    for the env key.)"""
+    since the live process's bearer map is fixed at startup.)"""
     from remote import probe, relay, serve
 
     state = _seed_reload_state(monkeypatch, tmp_path, retained=[
@@ -4380,7 +4620,10 @@ def test_serve_reload_new_api_spec_static_caps_and_vendor_upstream(monkeypatch, 
     assert seen["models"] == ["a", "openai:gpt-5.5"]
     assert seen["capabilities"]["models"]["openai:gpt-5.5"]["context_window"] == 1_050_000
     assert state.upstream_model("openai:gpt-5.5") == "gpt-5.5"  # vendor name, not the advertised name
-    assert state.route("openai:gpt-5.5") == "https://api.openai.com/v1"
+    # The endpoint-gating map follows the reload: the vendor route is marked as kind `openai`,
+    # the hardware route stays unmarked.
+    assert state.route_and_kind("openai:gpt-5.5") == ("https://api.openai.com/v1", "openai")
+    assert state.route_and_kind("a") == ("http://e1/v1", None)
 
 
 def test_serve_reload_retained_api_spec_keeps_vendor_upstream(monkeypatch, tmp_path):
@@ -4721,12 +4964,13 @@ def test_serve_start_reload_watcher_installs_handler_and_thread(monkeypatch, tmp
             _sig.signal(_sig.SIGHUP, orig)
 
 
-def test_remote_engine_startup_missing_api_env_key_exits_naming_var(monkeypatch, tmp_path):
-    """A respawned serve process whose record carries an API spec but whose environment lost the
-    key must exit naming the env var — not come up advertising models whose every job would 401."""
+def test_remote_engine_startup_missing_api_key_everywhere_exits_naming_fix(monkeypatch, tmp_path, capsys):
+    """A respawned serve process whose record carries an API spec but whose key is gone from BOTH
+    the key store and the environment must exit non-zero naming the re-join fix (in the engine log)
+    — not come up advertising models whose every job would 401 upstream."""
     from remote import serve
 
-    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))  # empty tmp home ⇒ empty key store
     record = {"grid_id": "n1", "signaling_url": "https://relay.example", "media": False,
               "engines": [{"endpoint_url": "https://api.openai.com/v1", "models": ["openai:gpt-5.5"],
                            "engine_label": "openai", "api_kind": "openai"}]}
@@ -4735,19 +4979,71 @@ def test_remote_engine_startup_missing_api_env_key_exits_naming_var(monkeypatch,
     monkeypatch.setattr(serve, "_node_id_from_token", lambda t: "node-1")
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
-    with pytest.raises(SystemExit) as exc:
-        serve.run_remote_engine_from_record("n1", "remote")
-    assert "OPENAI_API_KEY" in str(exc.value)
+    assert serve.run_remote_engine_from_record("n1", "remote") == 1
+    err = capsys.readouterr().err
+    assert "OPENAI_API_KEY" in err
+    assert "grid join --api openai" in err
+
+
+def test_api_key_store_preserves_other_kinds(monkeypatch, tmp_path):
+    """Storing one kind's key must never clobber another kind's entry — the store is a single file
+    holding every service kind (the read-merge-write is serialized under a file lock)."""
+    from remote import api_keys
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    api_keys.store_key("openai", "sk-openai")
+    api_keys.store_key("other", "sk-other")
+    api_keys.store_key("openai", "sk-openai-2")  # rotation of one kind...
+
+    assert api_keys.load_key("openai") == "sk-openai-2"
+    assert api_keys.load_key("other") == "sk-other"  # ...leaves the sibling intact
+
+
+def test_remote_engine_startup_missing_api_key_reaps_record(monkeypatch, tmp_path):
+    """A startup that dies before registering (key gone from store AND env) must reap its on-disk
+    run record like any other died-before-registering engine — not leave a stale singleton that
+    forces a `grid leave --all`."""
+    from remote import serve
+    from shared import run_records as rr
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    rr.write_record("n1", "remote", {
+        "engine_id": "remote", "grid_id": "n1", "signaling_url": "https://relay.example",
+        "media": False,
+        "engines": [{"endpoint_url": "https://api.openai.com/v1", "models": ["openai:gpt-5.5"],
+                     "engine_label": "openai", "api_kind": "openai"}],
+    })
+    monkeypatch.setattr(serve, "_load_tokens", lambda net: ("AT", "RT"))
+    monkeypatch.setattr(serve, "_node_id_from_token", lambda t: "node-1")
+
+    assert serve.run_remote_engine_from_record("n1", "remote") == 1  # died pre-register, non-zero
+    assert not rr.record_path("n1", "remote").exists()  # reaped, not stranded
+
+
+def test_remote_engine_startup_reads_api_key_from_env_when_store_empty(monkeypatch, tmp_path):
+    """Env fallback: a pre-store record respawned in a key-bearing environment still comes up (the
+    store is authoritative but its absence must not brick an upgraded install)."""
+    from remote import serve
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-env-999")
+    record = {"grid_id": "n1", "signaling_url": "https://relay.example", "media": False,
+              "engines": [{"endpoint_url": "https://api.openai.com/v1", "models": ["openai:gpt-5.5"],
+                           "engine_label": "openai", "api_kind": "openai"}]}
+    assert serve._api_bearers(record) == {"https://api.openai.com/v1": "sk-env-999"}
 
 
 def test_remote_engine_api_record_registers_static_caps_and_kind(monkeypatch, tmp_path):
     """Startup-seam proof for the API-engine tracer bullet: a record with one api spec comes up with
     whitelist caps (no probe), advertises the namespaced models, reports kind `openai` on the grid
-    page, and holds the env key ready for forwards — while the record itself stays key-free."""
-    from remote import probe, relay, serve
+    page, and holds the STORED key ready for forwards (env no longer required at serve time) —
+    while the record itself stays key-free."""
+    from remote import api_keys, probe, relay, serve
 
     monkeypatch.setenv("GRID_HOME", str(tmp_path))
-    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-123")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    api_keys.store_key("openai", "sk-test-123")
     record = {"grid_id": "n1", "signaling_url": "https://relay.example", "media": False,
               "engines": [{"endpoint_url": "https://api.openai.com/v1", "models": ["openai:gpt-5.5"],
                            "engine_label": "openai", "api_kind": "openai"}]}
@@ -4772,8 +5068,97 @@ def test_remote_engine_api_record_registers_static_caps_and_kind(monkeypatch, tm
     assert seen["node"] == "node-1" and seen["models"] == ["openai:gpt-5.5"]
     entry = seen["capabilities"]["models"]["openai:gpt-5.5"]
     assert entry["context_window"] == 1_050_000 and entry["features"]["tools"] is True
+    # Honest advertisement: an API engine never serves the legacy completions endpoint, so the
+    # relay must not be told it does (the serve-side gate stays as defense in depth).
+    assert entry["endpoints"] == ["chat/completions"]
     assert seen["meta"]["engine"] == "openai"  # the grid page shows the API engine's kind
     assert state_seen["bearer_by_url"] == {"https://api.openai.com/v1": "sk-test-123"}
+
+
+def test_remote_engine_startup_wires_api_endpoint_gating(monkeypatch, tmp_path):
+    """Startup derives the API-kind map from the record, so a legacy `completions` job is gated
+    from the very first poll — not only after a reload."""
+    from remote import api_keys, relay, serve
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    api_keys.store_key("openai", "sk-test-123")
+    record = {"grid_id": "n1", "signaling_url": "https://relay.example", "media": False,
+              "engines": [{"endpoint_url": "https://api.openai.com/v1", "models": ["openai:gpt-5.5"],
+                           "engine_label": "openai", "api_kind": "openai"}]}
+    monkeypatch.setattr(serve.run_records, "read_record", lambda g, e: record)
+    monkeypatch.setattr(serve, "_load_tokens", lambda net: ("AT", "RT"))
+    monkeypatch.setattr(serve, "_node_id_from_token", lambda t: "node-1")
+    monkeypatch.setattr(relay, "register_node", lambda *a, **k: None)
+    monkeypatch.setattr(relay, "unregister_node", lambda *a, **k: None)
+    monkeypatch.setattr(serve, "_heartbeat_loop", lambda s: None)
+    captured = {}
+    monkeypatch.setattr(relay, "submit_error",
+                        lambda url, tok, txn, *, message, tokens_delivered=0: captured.update(error=message))
+
+    def fake_poll(s):
+        serve.handle_job(s, {"transaction_id": "t1", "endpoint_path": "completions",
+                             "body": {"model": "openai:gpt-5.5"}})
+        s.stop.set()
+
+    monkeypatch.setattr(serve, "_poll_loop", fake_poll)
+
+    assert serve.run_remote_engine_from_record("n1", "remote") == 0
+    assert "chat/completions" in captured["error"]  # gated at the startup seam, no upstream call
+
+
+def test_effective_max_concurrency_default_rules():
+    """API-only union → 8; any hardware engine or media → 1; explicit value always wins; a legacy
+    flat record (no engines field) → 1. One shared rule for the CLI and the serve loop."""
+    from shared import run_records
+
+    api = {"endpoint_url": "https://api.openai.com/v1", "models": ["openai:gpt-5.5"], "api_kind": "openai"}
+    hw = {"endpoint_url": "http://h:11434/v1", "models": ["llama3"]}
+    assert run_records.effective_max_concurrency({"engines": [api]}) == 8
+    assert run_records.effective_max_concurrency({"engines": [api, hw]}) == 1
+    assert run_records.effective_max_concurrency({"engines": [hw]}) == 1
+    assert run_records.effective_max_concurrency({"engines": [api], "media": True}) == 1
+    assert run_records.effective_max_concurrency({"engines": [], "media": True}) == 1
+    assert run_records.effective_max_concurrency({}) == 1
+    assert run_records.effective_max_concurrency({"engines": [api], "max_concurrency": 3}) == 3
+    assert run_records.effective_max_concurrency({"engines": [hw], "max_concurrency": 8}) == 8
+
+
+def test_remote_engine_api_only_defaults_to_eight_workers(monkeypatch, tmp_path):
+    """An identity whose union is API-only defaults to 8 poll workers, advertised AND held by the
+    live state (the pool is sized from it) — several consumers must not queue behind one worker
+    while the vendor sits idle. An explicit --max-concurrency still wins."""
+    from remote import api_keys, relay, serve
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    api_keys.store_key("openai", "sk-test-123")
+    record = {"grid_id": "n1", "signaling_url": "https://relay.example", "media": False,
+              "engines": [{"endpoint_url": "https://api.openai.com/v1", "models": ["openai:gpt-5.5"],
+                           "engine_label": "openai", "api_kind": "openai"}]}
+    monkeypatch.setattr(serve.run_records, "read_record", lambda g, e: record)
+    monkeypatch.setattr(serve, "_load_tokens", lambda net: ("AT", "RT"))
+    monkeypatch.setattr(serve, "_node_id_from_token", lambda t: "node-1")
+    seen = {}
+    monkeypatch.setattr(relay, "register_node", lambda url, tok, node, **kw: seen.update(kw))
+    monkeypatch.setattr(relay, "unregister_node", lambda *a, **k: None)
+    monkeypatch.setattr(serve, "_heartbeat_loop", lambda s: None)
+    state_seen = {}
+
+    def fake_poll(s):
+        state_seen["max_concurrency"] = s.max_concurrency
+        s.stop.set()
+
+    monkeypatch.setattr(serve, "_poll_loop", fake_poll)
+
+    assert serve.run_remote_engine_from_record("n1", "remote") == 0
+    assert seen["max_concurrency"] == 8          # advertised to the relay
+    assert state_seen["max_concurrency"] == 8    # ... and sizing the real pool
+
+    # Explicit flag wins over the API-only default.
+    record = {**record, "max_concurrency": 3}
+    assert serve.run_remote_engine_from_record("n1", "remote") == 0
+    assert seen["max_concurrency"] == 3 and state_seen["max_concurrency"] == 3
 
 
 def test_run_remote_engine_starts_reload_thread_with_sighup_blocked(monkeypatch, tmp_path):
@@ -4890,15 +5275,71 @@ def test_serve_handle_job_engine_error_submits_error(monkeypatch, tmp_path):
 
 def _api_serve_state(monkeypatch, tmp_path, **overrides):
     """A `_ServeState` serving one API-engine model: advertised `openai:gpt-5.5` routed to the vendor
-    base URL, vendor-name rewrite, and the key attached per target URL."""
+    base URL, vendor-name rewrite, the key attached per target URL, and the target marked as an
+    API engine (endpoint gating)."""
     kwargs = dict(
         models=["openai:gpt-5.5"],
         routes={"openai:gpt-5.5": "https://api.openai.com/v1"},
         upstream={"openai:gpt-5.5": "gpt-5.5"},
         bearer_by_url={"https://api.openai.com/v1": "sk-test-123"},
+        api_kind_by_url={"https://api.openai.com/v1": "openai"},
     )
     kwargs.update(overrides)
     return _serve_state(monkeypatch, tmp_path, **kwargs)
+
+
+def test_serve_handle_job_api_completions_gated_without_upstream_call(monkeypatch, tmp_path):
+    """An API engine serves chat/completions ONLY: a legacy `completions` job routed to it submits
+    a structured 'not served' error to the relay and never forwards upstream."""
+    from remote import relay, serve
+
+    state = _api_serve_state(monkeypatch, tmp_path)
+    captured = {}
+    monkeypatch.setattr(relay, "submit_error",
+                        lambda url, tok, txn, *, message, tokens_delivered=0: captured.update(error=message))
+    monkeypatch.setattr(relay, "submit_response", lambda *a, **k: pytest.fail("a gated job has no response"))
+    _mock_serve_engine(monkeypatch, lambda request: pytest.fail("a gated job must never reach the vendor"))
+
+    serve.handle_job(state, {"transaction_id": "t1", "endpoint_path": "completions",
+                             "body": {"model": "openai:gpt-5.5"}})
+
+    assert "chat/completions" in captured["error"]  # names what IS served
+    assert "openai" in captured["error"]            # ... and which engine refused
+
+
+def test_serve_handle_job_api_completions_gated_on_single_url_fallback_too(monkeypatch, tmp_path):
+    """route() falls back to the single distinct URL for an unknown model — on an API-only identity
+    a `completions` job with ANY model name must still be gated, not blind-forwarded upstream."""
+    from remote import relay, serve
+
+    state = _api_serve_state(monkeypatch, tmp_path)
+    captured = {}
+    monkeypatch.setattr(relay, "submit_error",
+                        lambda url, tok, txn, *, message, tokens_delivered=0: captured.update(error=message))
+    _mock_serve_engine(monkeypatch, lambda request: pytest.fail("a gated job must never reach the vendor"))
+
+    serve.handle_job(state, {"transaction_id": "t2", "endpoint_path": "completions",
+                             "body": {"model": "some-unknown-model"}})
+
+    assert "chat/completions" in captured["error"]
+
+
+def test_serve_handle_job_hardware_completions_still_forwards(monkeypatch, tmp_path):
+    """The legacy `completions` endpoint stays served by hardware engines — the gate is per API
+    kind, not a blanket endpoint removal."""
+    from remote import relay, serve
+
+    state = _serve_state(monkeypatch, tmp_path)
+    captured = {}
+    monkeypatch.setattr(relay, "submit_response",
+                        lambda url, tok, txn, *, content, stream: captured.update(content=content))
+    monkeypatch.setattr(relay, "submit_error",
+                        lambda url, tok, txn, *, message, tokens_delivered=0: pytest.fail(f"unexpected error: {message}"))
+    _mock_serve_engine(monkeypatch, lambda request: httpx.Response(200, json={"choices": []}))
+
+    serve.handle_job(state, {"transaction_id": "t3", "endpoint_path": "completions", "body": {"model": "m"}})
+
+    assert captured["content"]  # forwarded and answered
 
 
 def test_serve_handle_job_api_forward_carries_bearer_and_vendor_model(monkeypatch, tmp_path):
@@ -4982,6 +5423,80 @@ def test_serve_handle_job_api_upstream_401_is_job_error_not_token_refresh(monkey
     serve.handle_job(state, {"transaction_id": "t1", "endpoint_path": "chat/completions",
                              "body": {"model": "openai:gpt-5.5"}, "is_stream": False})
     assert "401" in captured["error"] and "submitted" not in captured
+
+
+def test_serve_handle_job_api_auth_quota_failures_warn_on_stderr(monkeypatch, tmp_path, capsys):
+    """A vendor auth/quota failure (401/403/429) on an API engine additionally warns on the
+    engine's stderr log — the per-job error alone is invisible to the operator. The engine stays
+    registered and the loop stays alive (handle_job returns normally). No key in the warning."""
+    from remote import relay, serve
+
+    state = _api_serve_state(monkeypatch, tmp_path)
+    errors = []
+    monkeypatch.setattr(relay, "submit_error",
+                        lambda url, tok, txn, *, message, tokens_delivered=0: errors.append(message))
+    _mock_serve_engine(monkeypatch, lambda r: httpx.Response(429, text="rate limited"))
+
+    serve.handle_job(state, {"transaction_id": "t1", "endpoint_path": "chat/completions",
+                             "body": {"model": "openai:gpt-5.5"}, "is_stream": False})
+
+    assert errors and "429" in errors[0]          # the consumer sees status + snippet
+    err = capsys.readouterr().err
+    assert "openai" in err and "429" in err       # ... and the operator sees the warn
+    assert "sk-test-123" not in err               # never the key
+
+
+def test_serve_handle_job_api_5xx_is_job_error_without_auth_warn(monkeypatch, tmp_path, capsys):
+    """A vendor 5xx is an ordinary upstream failure: job error passes through, but no auth/quota
+    warning — 500s say nothing about the key."""
+    from remote import relay, serve
+
+    state = _api_serve_state(monkeypatch, tmp_path)
+    errors = []
+    monkeypatch.setattr(relay, "submit_error",
+                        lambda url, tok, txn, *, message, tokens_delivered=0: errors.append(message))
+    _mock_serve_engine(monkeypatch, lambda r: httpx.Response(500, text="server error"))
+
+    serve.handle_job(state, {"transaction_id": "t1", "endpoint_path": "chat/completions",
+                             "body": {"model": "openai:gpt-5.5"}, "is_stream": False})
+
+    assert errors and "500" in errors[0]
+    assert "quota" not in capsys.readouterr().err.lower()
+
+
+def test_serve_handle_job_hardware_401_has_no_api_warn(monkeypatch, tmp_path, capsys):
+    """A hardware engine's 401 is not a vendor-key event: job error only, no API warn."""
+    from remote import relay, serve
+
+    state = _serve_state(monkeypatch, tmp_path)
+    errors = []
+    monkeypatch.setattr(relay, "submit_error",
+                        lambda url, tok, txn, *, message, tokens_delivered=0: errors.append(message))
+    _mock_serve_engine(monkeypatch, lambda r: httpx.Response(401, text="denied"))
+
+    serve.handle_job(state, {"transaction_id": "t1", "endpoint_path": "chat/completions",
+                             "body": {"model": "m"}, "is_stream": False})
+
+    assert errors and "401" in errors[0]
+    assert "quota" not in capsys.readouterr().err.lower()
+
+
+def test_serve_handle_job_api_stream_429_warns_too(monkeypatch, tmp_path, capsys):
+    """The streamed forward path shares the auth/quota warn — a streaming consumer's 429 must not
+    be quieter than a whole-body one."""
+    from remote import relay, serve
+
+    state = _api_serve_state(monkeypatch, tmp_path)
+    errors = []
+    monkeypatch.setattr(relay, "submit_error",
+                        lambda url, tok, txn, *, message, tokens_delivered=0: errors.append(message))
+    _mock_serve_engine(monkeypatch, lambda r: httpx.Response(429, text="rate limited"))
+
+    serve.handle_job(state, {"transaction_id": "t1", "endpoint_path": "chat/completions",
+                             "body": {"model": "openai:gpt-5.5"}, "is_stream": True})
+
+    assert errors and "429" in errors[0]
+    assert "429" in capsys.readouterr().err
 
 
 def test_serve_handle_job_media_without_media_url_submits_error(monkeypatch, tmp_path):
@@ -5888,6 +6403,20 @@ def test_logout_clears_credentials_and_active(monkeypatch, tmp_path, capsys):
 
     assert cli.cmd_logout(cli.build_parser().parse_args(["logout"])) == 0  # idempotent
     assert "not signed in" in capsys.readouterr().out.lower()
+
+
+def test_logout_leaves_api_key_store_intact(monkeypatch, tmp_path, capsys):
+    """`grid logout` deletes the sign-in credential store but NEVER the vendor key store — the API
+    key belongs to the provider's vendor account, not to the autonomous session (ADR 0012)."""
+    from remote import api_keys, credentials
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    credentials.save_credentials({"session_token": "S"})
+    api_keys.store_key("openai", "sk-keep-me")
+
+    assert cli.cmd_logout(cli.build_parser().parse_args(["logout"])) == 0
+    assert not paths.credentials_file().exists()
+    assert api_keys.load_key("openai") == "sk-keep-me"
 
 
 def test_logout_json(monkeypatch, tmp_path, capsys):

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -24,7 +24,7 @@ from shared import paths
 from shared import state
 from local import runtime
 from shared.engine import comfyui, installer, launcher
-from shared.models import catalog, download, media_bundles
+from shared.models import api_catalog, catalog, download, media_bundles
 from local import media_server
 from local.server import create_app
 from shared.system import detect
@@ -239,6 +239,10 @@ def test_cli_accepts_engine_and_model_commands():
     assert source_install.from_source is True
 
     assert parser.parse_args(["catalog"]).handler is cli.cmd_catalog
+    assert parser.parse_args(["catalog"]).api is None
+    api_args = parser.parse_args(["catalog", "--api", "openai"])
+    assert api_args.handler is cli.cmd_catalog
+    assert api_args.api == "openai"
     assert parser.parse_args(["pull", "qwen36-35b-a3b-mtp"]).model == "qwen36-35b-a3b-mtp"
     rm = parser.parse_args(["rm", "your-model.gguf", "--yes"])
     assert rm.handler is cli.cmd_rm
@@ -627,6 +631,86 @@ def test_catalog_contains_reference_readme_qwen36_models():
     assert nvidia.hf_repo == "unsloth/Qwen3.6-27B-MTP-GGUF"
     assert nvidia.quantized_file == "Qwen3.6-27B-UD-Q5_K_XL.gguf"
     assert nvidia.target == catalog.TARGET_NVIDIA
+
+
+def test_catalog_api_openai_prints_whitelist(monkeypatch, capsys):
+    # The api catalog is static data: no key, and any network attempt is a bug.
+    def _no_network(*args, **kwargs):
+        raise AssertionError("`grid catalog --api` must not touch the network")
+
+    monkeypatch.setattr(httpx, "Client", _no_network)
+    monkeypatch.setattr(httpx, "request", _no_network)
+    monkeypatch.setattr(httpx, "stream", _no_network)
+
+    rc = cli.cmd_catalog(argparse.Namespace(api="openai", json=False))
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert api_catalog.OPENAI_LAST_VERIFIED in out
+    entries = api_catalog.WHITELISTS["openai"].entries
+    assert entries
+    for entry in entries:
+        assert api_catalog.advertised_name("openai", entry) in out
+        assert f"{entry.context_window:,}" in out
+    # Requests to these models leave the grid — the disclosure must be printed.
+    assert "leave the grid" in out
+
+
+def test_catalog_api_unknown_kind_errors():
+    with pytest.raises(SystemExit) as exc:
+        cli.cmd_catalog(argparse.Namespace(api="anthropic", json=False))
+
+    msg = str(exc.value)
+    assert "anthropic" in msg  # the kind that was rejected
+    assert "openai" in msg  # ... and the supported kinds, so the fix is one edit away
+
+    # `--api ""` (e.g. an unset shell variable) must error too, not silently
+    # fall through to the GGUF catalog.
+    with pytest.raises(SystemExit):
+        cli.cmd_catalog(argparse.Namespace(api="", json=False))
+
+
+def test_catalog_without_api_unchanged(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+
+    rc = cli.cmd_catalog(argparse.Namespace(api=None, json=False))
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Grid can pull:" in out
+    assert "openai:" not in out
+
+
+def test_api_whitelist_integrity():
+    from datetime import date
+
+    assert api_catalog.supported_kinds() == ("openai",)
+    for kind, whitelist in api_catalog.WHITELISTS.items():
+        assert whitelist.entries, f"{kind} whitelist must not be empty"
+        names = [entry.vendor_name for entry in whitelist.entries]
+        assert all(names), f"{kind} has an entry with an empty vendor name"
+        assert len(set(names)) == len(names), f"{kind} has duplicate vendor names"
+        for entry in whitelist.entries:
+            assert entry.context_window > 0
+            assert api_catalog.advertised_name(kind, entry) == f"{kind}:{entry.vendor_name}"
+        date.fromisoformat(whitelist.last_verified)  # dated, ISO format
+
+
+def test_catalog_api_json_roundtrips(capsys):
+    rc = cli.cmd_catalog(argparse.Namespace(api="openai", json=True))
+
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["kind"] == "openai"
+    assert payload["last_verified"] == api_catalog.OPENAI_LAST_VERIFIED
+    entries = api_catalog.WHITELISTS["openai"].entries
+    assert len(payload["models"]) == len(entries)
+    first, first_entry = payload["models"][0], entries[0]
+    assert first["advertised"] == api_catalog.advertised_name("openai", first_entry)
+    assert first["vendor_name"] == first_entry.vendor_name
+    assert first["context_window"] == first_entry.context_window
+    assert first["supports_tools"] is first_entry.supports_tools
+    assert first["supports_vision"] is first_entry.supports_vision
 
 
 def test_download_surfaces_non_2xx_as_clean_systemexit(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Adds **API engines** (ADR 0012): a provider with no capable hardware can contribute capacity to a remote grid by joining with a third-party LLM API key instead of running a local engine. v1 ships **OpenAI** — `grid join --api openai` validates the key, then serves a curated whitelist of OpenAI chat models under namespaced `openai:*` names; requests flow consumer → relay → poll → OpenAI → back, streaming included. Membership, additive joins, SIGHUP hot-reload, and leave all behave exactly as they do for hardware engines. **Remote-only**; local mode gates `--api` with switch-to-remote guidance.

No relay or control-plane changes — model registration already accepts arbitrary names.

## What's included (ADR 0012 slices)

- `84d48f6` — whitelist data + `grid catalog --api openai` (offline, static caps) + ADR 0012
- `6ea847a` — join & serve: `grid join --api openai`, key validation, bearer-on-forward, SSE streaming
- `287ff5f` — key store (`~/.grid/api_keys.toml`, `0600`, survives logout, rotation) + default-all join + serve hardening (endpoint gating, upstream-error passthrough, concurrency default 8 for API-only identities)
- `b9090ce` — union & lifecycle: append hot-reloads in place, `leave --engine openai`, honest reload reporting
- `00bc08c` — README: "No GPU at all? Join with an API key"

Whitelist (verified 2026-07-08): `openai:gpt-5.5`, `openai:gpt-5.4`, `openai:gpt-5.4-mini`, `openai:gpt-5.4-nano`. Key handling precedence: `OPENAI_API_KEY` env → stored key → hidden prompt (there is deliberately **no** `--api-key` flag). The key never reaches a run record, log, terminal, or the grid page.

## Docs

ADR `docs/adr/0012-api-engines.md`, `docs/cli.md` (Engines/Models), `docs/ARCHITECTURE.md` (serve step 6), and README.

## Test plan

- [x] Unit / CLI-seam tests: ~500 green across the 4 slices (TDD + 3-reviewer pass each)
- [x] Local-mode gating: `catalog --api openai` prints offline (no key/network); `join --api openai` rejected with switch-to-remote guidance; unknown kind errors
- [x] Remote real-key E2E (2026-07-08): provider joined `--api openai` (default-all 4 models); key absent from run record **and** serve log (grep = 0); relay rendered node kind `openai`
- [x] 2-host / 2-account round-trip: consumer on a separate account + Linux host ran `grid chat -m openai:gpt-5.4-nano` (no `--allow-self-provider`) → `PONG` in ~2.1s via the provider's OpenAI engine
- [x] Secret hygiene: key store `0600`; run-record spec carries kind + endpoint + models only

The real-key E2E spends OpenAI credit, so it is a manual runbook (`.claude/skills/test-grid-cli`), not automated.
