### PR TITLE
feat: auto-routing (model "auto") — Advisor ranking + probe fix (v0.1.15)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ dist/
 .codegraph/
 .scratch/
 docs/agents/
+
+CONTEXT-MAP.md
+remote/CONTEXT.md
+local/CONTEXT.md

--- a/README.md
+++ b/README.md
@@ -284,6 +284,27 @@ terms — the `openai:` prefix keeps that visible in every model list. There's n
 put a budget limit on the key's OpenAI project if you want one. Full contract, key store, and rotation
 in [docs/cli.md](docs/cli.md#engines).
 
+### Don't know which model to ask for? Send `auto`
+
+A grid's catalog is heterogeneous and shifts as engines join and leave. Instead of hardcoding a model
+name, an app can send the reserved name **`auto`** and the grid picks a capable model that's free — so
+requests don't queue behind a busy model while idle ones sit unused. The owner turns it on for a grid
+they own and points it at a **Ranker** (any OpenAI-compatible endpoint — start with OpenAI, move to
+OpenRouter or your own later):
+
+```bash
+export GRID_RANKER_API_KEY=sk-…
+grid router set-ranker research 1 --base-url https://api.openai.com/v1 --model gpt-5.4-mini
+grid router enable research
+grid chat -m auto "summarize this file in one line"   # the grid ranks its models and picks one
+```
+
+Only a **bounded excerpt** of each request — never the full conversation — goes to the Ranker (on the
+owner's key); a dead Ranker falls back to a deterministic pick, so `auto`'s availability equals the
+grid's, not a vendor's. The `model` field and `X-Grid-Routed-Model` header name whichever model
+actually answered. Full contract and the transparency table in
+[docs/cli.md](docs/cli.md#router); rationale in [ADR 0013](docs/adr/0013-auto-routing.md).
+
 ## How it works
 
 Grid sits **above** your computers — like an API gateway above your services, or Tailscale above

--- a/README.md
+++ b/README.md
@@ -289,18 +289,17 @@ in [docs/cli.md](docs/cli.md#engines).
 A grid's catalog is heterogeneous and shifts as engines join and leave. Instead of hardcoding a model
 name, an app can send the reserved name **`auto`** and the grid picks a capable model that's free — so
 requests don't queue behind a busy model while idle ones sit unused. The owner turns it on for a grid
-they own and points it at a **Ranker** (any OpenAI-compatible endpoint — start with OpenAI, move to
-OpenRouter or your own later):
+they own and points it at one or more **Advisors** — picked by name from the platform catalog
+(`grid router models` lists the choices); you supply no URL and no key, the platform carries both:
 
 ```bash
-export GRID_RANKER_API_KEY=sk-…
-grid router set-ranker research 1 --base-url https://api.openai.com/v1 --model gpt-5.4-mini
-grid router enable research
+grid router set-advisors openai:gpt-5-mini --grid research   # pick an advisor by name — no key, no URL
+grid router enable --grid research
 grid chat -m auto "summarize this file in one line"   # the grid ranks its models and picks one
 ```
 
-Only a **bounded excerpt** of each request — never the full conversation — goes to the Ranker (on the
-owner's key); a dead Ranker falls back to a deterministic pick, so `auto`'s availability equals the
+Only a **bounded excerpt** of each request — never the full conversation — goes to the Advisor (on the
+platform's key); a dead Advisor falls back to a deterministic pick, so `auto`'s availability equals the
 grid's, not a vendor's. The `model` field and `X-Grid-Routed-Model` header name whichever model
 actually answered. Full contract and the transparency table in
 [docs/cli.md](docs/cli.md#router); rationale in [ADR 0013](docs/adr/0013-auto-routing.md).

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -27,6 +27,7 @@ from .remote_request import (
     cmd_remote_image,
     cmd_remote_video,
 )
+from .remote_router import cmd_remote_router
 from .engine import (
     cmd_engine_install,
     cmd_engine_list,
@@ -78,6 +79,7 @@ __all__ = [
     "cmd_remote_info",
     "cmd_remote_members",
     "cmd_remote_price",
+    "cmd_remote_router",
     "cmd_remote_chat",
     "cmd_remote_image",
     "cmd_remote_edit",

--- a/cli/dispatch.py
+++ b/cli/dispatch.py
@@ -89,7 +89,7 @@ REMOTE_HANDLERS = {
 
 # Remote-only commands: they run their real handlers in remote mode and are gated with
 # guidance in local mode — the mirror image of ``remote_stub`` for the GATED commands.
-REMOTE_ONLY = frozenset({"login", "logout", "members", "sync", "price"})
+REMOTE_ONLY = frozenset({"login", "logout", "members", "sync", "price", "router"})
 
 
 def local_stub(command: str | None) -> NoReturn:

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -17,6 +17,7 @@ from ._constants import (
 from .auth import cmd_login, cmd_logout, cmd_sync
 from .remote_grid import cmd_remote_members
 from .remote_price import cmd_remote_price
+from .remote_router import RANKER_KEY_ENV, cmd_remote_router
 from .engine import (
     cmd_engine_install,
     cmd_engine_list,
@@ -67,6 +68,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_auth(sub)
     _add_members(sub)
     _add_price(sub)
+    _add_router(sub)
     _add_engine_setup(sub)
 
     return parser
@@ -392,6 +394,52 @@ def _add_price(sub) -> None:
     show.add_argument("--grid", default=None, help="Grid to act on (default: active grid).")
     show.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
     show.set_defaults(handler=cmd_remote_price)
+
+
+def _add_router(sub) -> None:
+    """Remote-only auto-routing config for a grid you own (model `auto`, ADR 0013):
+    `grid router status|enable|disable`, `grid router set-ranker <1|2|3> --base-url <url> --model
+    <name>`, and `grid router remove-ranker <1|2|3>`. Gated in local mode by dispatch (`router` is in
+    `REMOTE_ONLY`). `[grid]` is declared first (before the required `position`) so a lone positional
+    binds to `position`; omitting `[grid]` falls back to the active grid. The Ranker key for
+    `set-ranker` is NOT a flag — it comes from the GRID_RANKER_API_KEY env var or a hidden prompt, so
+    it never lands in argv, shell history, or process listings."""
+    router = sub.add_parser("router", help="Configure auto-routing (model `auto`) for a grid you own")
+    router_sub = router.add_subparsers(dest="subcommand", required=True)
+
+    # status / enable / disable share the same shape (an optional `[grid]` + `--json`); build them in
+    # a loop, mirroring `_add_price`'s rm/delete idiom.
+    for name, help_text in (
+        ("status", "Show routing state and configured rankers (no keys)"),
+        ("enable", "Enable auto-routing on the grid"),
+        ("disable", "Disable auto-routing on the grid"),
+    ):
+        simple = router_sub.add_parser(name, help=help_text)
+        simple.add_argument("grid", nargs="?", default=None)
+        simple.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+        simple.set_defaults(handler=cmd_remote_router)
+
+    set_ranker = router_sub.add_parser(
+        "set-ranker",
+        help=f"Set the ranker at position 1-3 (key from {RANKER_KEY_ENV} env or a hidden prompt)",
+        description=(
+            f"Set the ranker at a priority position (1-3). The Ranker API key is read from the "
+            f"{RANKER_KEY_ENV} environment variable, else a hidden interactive prompt — never a "
+            f"command-line flag, so it stays out of shell history and process listings."
+        ),
+    )
+    set_ranker.add_argument("grid", nargs="?", default=None)
+    set_ranker.add_argument("position", type=int, choices=(1, 2, 3), help="Ranker priority position (1-3).")
+    set_ranker.add_argument("--base-url", required=True, help="Ranker OpenAI-compatible base URL.")
+    set_ranker.add_argument("--model", required=True, help="Ranker model name.")
+    set_ranker.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    set_ranker.set_defaults(handler=cmd_remote_router)
+
+    remove_ranker = router_sub.add_parser("remove-ranker", help="Remove the ranker at position 1-3")
+    remove_ranker.add_argument("grid", nargs="?", default=None)
+    remove_ranker.add_argument("position", type=int, choices=(1, 2, 3), help="Ranker position to remove (1-3).")
+    remove_ranker.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    remove_ranker.set_defaults(handler=cmd_remote_router)
 
 
 def _add_engine_setup(sub) -> None:

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -17,7 +17,7 @@ from ._constants import (
 from .auth import cmd_login, cmd_logout, cmd_sync
 from .remote_grid import cmd_remote_members
 from .remote_price import cmd_remote_price
-from .remote_router import RANKER_KEY_ENV, cmd_remote_router
+from .remote_router import AdvisorsAction, MAX_ADVISORS, cmd_remote_router, parse_advisor_token
 from .engine import (
     cmd_engine_install,
     cmd_engine_list,
@@ -397,49 +397,64 @@ def _add_price(sub) -> None:
 
 
 def _add_router(sub) -> None:
-    """Remote-only auto-routing config for a grid you own (model `auto`, ADR 0013):
-    `grid router status|enable|disable`, `grid router set-ranker <1|2|3> --base-url <url> --model
-    <name>`, and `grid router remove-ranker <1|2|3>`. Gated in local mode by dispatch (`router` is in
-    `REMOTE_ONLY`). `[grid]` is declared first (before the required `position`) so a lone positional
-    binds to `position`; omitting `[grid]` falls back to the active grid. The Ranker key for
-    `set-ranker` is NOT a flag — it comes from the GRID_RANKER_API_KEY env var or a hidden prompt, so
-    it never lands in argv, shell history, or process listings."""
+    """Remote-only auto-routing config for a grid you own (model `auto`, ADR 0013, revised):
+    `grid router status|enable|disable [--grid <grid>]`, `grid router models`, `grid router set-advisors
+    <provider[:model]> …`, and `grid router remove-advisor <provider[:model]>`. Gated in local mode by
+    dispatch (`router` is in `REMOTE_ONLY`).
+
+    An Advisor is picked BY NAME from the platform catalog — there is NO key or URL input anywhere in this
+    group. Grid selection is a uniform `--grid` FLAG on every subcommand that acts on a grid (omit for the
+    active grid), matching `grid price`. The flag (not a positional `[grid]`) is forced by `set-advisors`,
+    whose `nargs="+"` advisor tokens make a leading positional `[grid]` ambiguous — is the first token a
+    grid or an advisor?; the other subcommands adopt it too so the whole group reads one way and a
+    positional-grid habit can't silently become an advisor token. `models` takes no grid at all (it reads
+    the account-level catalog)."""
     router = sub.add_parser("router", help="Configure auto-routing (model `auto`) for a grid you own")
     router_sub = router.add_subparsers(dest="subcommand", required=True)
 
-    # status / enable / disable share the same shape (an optional `[grid]` + `--json`); build them in
-    # a loop, mirroring `_add_price`'s rm/delete idiom.
+    # status / enable / disable share the same shape (`--grid` + `--json`); build them in a loop, mirroring
+    # `_add_price`'s rm/delete idiom. `--grid` (not a positional) keeps the whole group's selection uniform.
     for name, help_text in (
-        ("status", "Show routing state and configured rankers (no keys)"),
+        ("status", "Show routing state and the advisor chain (no keys)"),
         ("enable", "Enable auto-routing on the grid"),
         ("disable", "Disable auto-routing on the grid"),
     ):
         simple = router_sub.add_parser(name, help=help_text)
-        simple.add_argument("grid", nargs="?", default=None)
+        simple.add_argument("--grid", default=None, help="Grid to act on (default: active grid).")
         simple.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
         simple.set_defaults(handler=cmd_remote_router)
 
-    set_ranker = router_sub.add_parser(
-        "set-ranker",
-        help=f"Set the ranker at position 1-3 (key from {RANKER_KEY_ENV} env or a hidden prompt)",
+    # `models` lists the platform advisor catalog — account-level, needs no grid (and no grid running).
+    models = router_sub.add_parser(
+        "models", help="List the advisor catalog (providers + whitelisted models; no grid needed)")
+    models.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    models.set_defaults(handler=cmd_remote_router)
+
+    set_advisors = router_sub.add_parser(
+        "set-advisors",
+        help=f"Replace the advisor chain (up to {MAX_ADVISORS} `provider[:model]`, order = priority)",
         description=(
-            f"Set the ranker at a priority position (1-3). The Ranker API key is read from the "
-            f"{RANKER_KEY_ENV} environment variable, else a hidden interactive prompt — never a "
-            f"command-line flag, so it stays out of shell history and process listings."
+            f"Replace the whole advisor chain with 1-{MAX_ADVISORS} `provider[:model]` tokens, in priority "
+            "order. A bare `provider` uses the catalog's default model. Advisors are picked by name from the "
+            "platform catalog (`grid router models`) — there is no URL or key to supply."
         ),
     )
-    set_ranker.add_argument("grid", nargs="?", default=None)
-    set_ranker.add_argument("position", type=int, choices=(1, 2, 3), help="Ranker priority position (1-3).")
-    set_ranker.add_argument("--base-url", required=True, help="Ranker OpenAI-compatible base URL.")
-    set_ranker.add_argument("--model", required=True, help="Ranker model name.")
-    set_ranker.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
-    set_ranker.set_defaults(handler=cmd_remote_router)
+    set_advisors.add_argument(
+        "advisors", nargs="+", metavar="provider[:model]", type=parse_advisor_token, action=AdvisorsAction,
+        help=f"1-{MAX_ADVISORS} advisors in priority order, e.g. `openai:gpt-5-mini openai:gpt-4o-mini`.")
+    set_advisors.add_argument("--grid", default=None, help="Grid to act on (default: active grid).")
+    set_advisors.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    set_advisors.set_defaults(handler=cmd_remote_router)
 
-    remove_ranker = router_sub.add_parser("remove-ranker", help="Remove the ranker at position 1-3")
-    remove_ranker.add_argument("grid", nargs="?", default=None)
-    remove_ranker.add_argument("position", type=int, choices=(1, 2, 3), help="Ranker position to remove (1-3).")
-    remove_ranker.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
-    remove_ranker.set_defaults(handler=cmd_remote_router)
+    remove_advisor = router_sub.add_parser(
+        "remove-advisor",
+        help="Remove an advisor by name (exact `provider:model`, or bare `provider` for all its entries)")
+    remove_advisor.add_argument(
+        "advisor", metavar="provider[:model]", type=parse_advisor_token,
+        help="Exact `provider:model` removes one entry; bare `provider` removes all of its entries.")
+    remove_advisor.add_argument("--grid", default=None, help="Grid to act on (default: active grid).")
+    remove_advisor.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    remove_advisor.set_defaults(handler=cmd_remote_router)
 
 
 def _add_engine_setup(sub) -> None:

--- a/cli/remote_router.py
+++ b/cli/remote_router.py
@@ -1,49 +1,96 @@
-"""Remote-mode `grid router status|enable|disable|set-ranker|remove-ranker` — the network
-creator's surface for auto-routing (model `auto`, ADR 0013).
+"""Remote-mode `grid router status|enable|disable|set-advisors|remove-advisor|models` — the network
+creator's surface for auto-routing (model `auto`, ADR 0013, revised).
 
-Account-level, like `grid members`: it authenticates with the session token, resolves the grid
-locally via ``remote_grid._select``/``_network_id`` and calls the control-plane owner API — no
-relay, no running grid needed. The Ranker key for ``set-ranker`` is sourced from the
-``GRID_RANKER_API_KEY`` env var or a hidden prompt (never a flag, never printed); ``status`` never
-shows key material.
+Account-level, like `grid members`: it authenticates with the session token, resolves the grid locally via
+``remote_grid._select``/``_network_id`` and calls the control-plane owner API — no relay, no running grid
+needed. An **Advisor** is a ``provider[:model]`` pair picked BY NAME from the platform catalog; the platform
+carries the base URL and the key, so there is NO key input anywhere in this group — no env var, no prompt,
+no flag. ``grid router models`` prints the catalog and needs no grid at all.
 
-Remote-only — ``cli.dispatch`` gates it (``router`` is in ``REMOTE_ONLY``); local mode exits with
-guidance. Import rule mirrors the other remote handlers: stdlib only at module top; ``remote.*`` and
-sibling ``cli`` modules are imported lazily inside handlers (``cli.dispatch`` imports this module
-while the ``cli`` package is still initialising).
+Remote-only — ``cli.dispatch`` gates it (``router`` is in ``REMOTE_ONLY``); local mode exits with guidance.
+Import rule mirrors the other remote handlers: stdlib only at module top; ``remote.*`` and sibling ``cli``
+modules are imported lazily inside handlers (``cli.dispatch`` imports this module while the ``cli`` package
+is still initialising).
 """
 from __future__ import annotations
 
 import argparse
-import getpass
 import json
-import os
 from typing import Any
 
-# The Ranker API key for `set-ranker` is read from this env var (else a hidden prompt) — never a
-# flag. grid-apis documents the same name as the CLI's source (ADR 0013 / grid-apis handler).
-RANKER_KEY_ENV = "GRID_RANKER_API_KEY"
+# Max advisors in a chain — a client-side fast-fail cap. The control plane's ``_ROUTER_MAX_ADVISORS`` is the
+# real backstop (a stricter server just surfaces its own 400); this only spares an obviously-too-long request.
+MAX_ADVISORS = 3
 
-# Reply fields that must never be echoed. The control plane already masks ranker keys on every read
-# (they ride only the owner's snapshot channel); this is a client-side belt-and-suspenders scrub so
-# a future server-side masking regression can't turn `--json`/`status` into a key leak.
-_SECRET_KEYS = frozenset({"api_key", "apikey", "key", "secret", "token"})
+# Reply fields that must never be echoed. The control plane already masks any key AND base URL on every read
+# (the per-grid proxy key + advisor-proxy URL ride only the owner's snapshot channel, never a CLI reply);
+# this is a client-side belt-and-suspenders scrub so a future server-side masking regression can't turn
+# `--json`/`status` into a key OR URL leak — ADR 0013: "`status` returns neither key nor URL". The URL keys
+# (`base_url`/`endpoint_url`) match the vocabulary used elsewhere in the client (`cli/remote_provider.py`);
+# no v2 reply legitimately carries any of these fields, so nothing real is ever dropped.
+_SECRET_KEYS = frozenset(
+    {"api_key", "apikey", "key", "secret", "token", "base_url", "url", "endpoint_url"})
+
+
+def parse_advisor_token(token: str) -> tuple[str, str | None]:
+    """Parse one ``provider[:model]`` advisor token into ``(provider, model | None)``. A bare provider →
+    ``model is None`` (the control plane resolves the catalog default).
+
+    SHAPE validation only — the CLI never hardcodes the provider/model whitelist (that is the control plane's
+    catalog); an unknown provider or off-whitelist model is a server 400 listing the valid names. Raises
+    ``argparse.ArgumentTypeError`` (→ a clean parser error, never a traceback) on an empty token, empty
+    provider (``:model``), empty model (``provider:``), or a stray extra colon (``a:b:c``). The single ``:``
+    delimiter assumes catalog model names are colon-free — true for the v1 openai catalog (``gpt-5-mini`` &c.).
+    """
+    raw = token.strip()
+    if not raw:
+        raise argparse.ArgumentTypeError("empty advisor token")
+    if ":" not in raw:
+        return raw, None  # bare provider — the server resolves the catalog default model
+    parts = raw.split(":")
+    if len(parts) != 2:
+        raise argparse.ArgumentTypeError(
+            f"malformed advisor {token!r}: use 'provider' or 'provider:model'")
+    provider, model = parts[0].strip(), parts[1].strip()
+    if not provider:
+        raise argparse.ArgumentTypeError(f"malformed advisor {token!r}: empty provider")
+    if not model:
+        raise argparse.ArgumentTypeError(f"malformed advisor {token!r}: empty model after ':'")
+    return provider, model
+
+
+class AdvisorsAction(argparse.Action):
+    """Cap ``set-advisors`` at ``MAX_ADVISORS`` tokens at PARSE time, so a 4th token is a clean parser error
+    (``argparse`` exits 2) rather than a late runtime failure. ``nargs="+"`` already guarantees ≥1; this only
+    rejects the upper bound, then stores the parsed list exactly like the default ``store`` action (the
+    ``setattr`` is not optional — without it ``args.advisors`` would be unset)."""
+
+    def __call__(self, parser, namespace, values, option_string=None):  # noqa: ANN001
+        if len(values) > MAX_ADVISORS:
+            parser.error(f"set-advisors takes at most {MAX_ADVISORS} advisors (got {len(values)})")
+        setattr(namespace, self.dest, values)
 
 
 def cmd_remote_router(args: argparse.Namespace) -> int:
-    """`grid router status|enable|disable|set-ranker|remove-ranker` — configure auto-routing on a
+    """`grid router status|enable|disable|set-advisors|remove-advisor|models` — configure auto-routing on a
     grid you own.
 
-    Account-level (session token, like `grid members`): resolves the grid locally and never needs it
-    running, so there is no relay call. The control-plane reply is masked (position/base_url/model,
-    never a key) and echoed as-is for ``--json`` (after a defensive scrub); human output is built with
-    ``.get()`` and never indexes the reply shape. The Ranker key for ``set-ranker`` never touches this
-    function's output — it flows straight from env/prompt into the control-plane request body."""
+    Account-level (session token, like `grid members`): resolves the grid locally and never needs it running,
+    so there is no relay call. ``models`` is answered BEFORE grid resolution — it reads the account-level
+    catalog and needs no grid. Every control-plane reply is masked (``{provider, model}`` pairs, never a
+    key or URL) and echoed as-is for ``--json`` (after a defensive scrub); human output is built with
+    ``.get()`` and never indexes the reply shape. There is NO key input anywhere in this group."""
     from remote import control_plane, credentials
 
     from . import remote_grid
 
     session = credentials.require_session()
+
+    # `models` is account-level (catalog only) — resolve NO grid, so it works with none selected/running.
+    if args.subcommand == "models":
+        catalog = control_plane.get_router_catalog(session)
+        return _print_catalog(catalog, args.json)
+
     network_id = remote_grid._network_id(remote_grid._select(args.grid))
 
     if args.subcommand == "status":
@@ -58,32 +105,36 @@ def cmd_remote_router(args: argparse.Namespace) -> int:
         result = control_plane.disable_router(session, network_id)
         return _print_mutation(result, args.json, "Auto-routing disabled.")
 
-    if args.subcommand == "set-ranker":
-        key = _resolve_ranker_key()
-        result = control_plane.set_ranker(
-            session, network_id, args.position, args.base_url, args.model, key)
-        return _print_mutation(result, args.json, f"Set ranker {args.position} ({args.model}).")
+    if args.subcommand == "set-advisors":
+        result = control_plane.set_advisors(session, network_id, args.advisors)
+        chain = " ".join(_fmt_token(provider, model) for provider, model in args.advisors)
+        return _print_mutation(result, args.json, f"Set advisors: {chain}.")
 
-    if args.subcommand == "remove-ranker":
-        result = control_plane.remove_ranker(session, network_id, args.position)
-        return _print_mutation(result, args.json, f"Removed ranker {args.position}.")
+    if args.subcommand == "remove-advisor":
+        provider, model = args.advisor
+        result = control_plane.remove_advisor(session, network_id, provider, model)
+        return _print_mutation(result, args.json, f"Removed advisor {_fmt_token(provider, model)}.")
 
     raise SystemExit(f"Unknown router subcommand: {args.subcommand!r}")
 
 
+def _fmt_token(provider: str, model: str | None) -> str:
+    """Render an advisor as its ``provider[:model]`` token — bare provider when the model is unset/blank."""
+    return f"{provider}:{model}" if model else provider
+
+
 def _safe_reply(reply: Any) -> dict[str, Any]:
     """Guard + scrub a control-plane reply before it is formatted or echoed. A non-dict 2xx body is
-    off-contract — fail with a clean ``SystemExit`` rather than an ``AttributeError`` traceback (the
-    same "never a traceback" idiom as ``_send``/``_raise`` and ``cli/remote_provider.py``'s shape
-    check). Then strip any key-material field at any depth (defence in depth over the control plane's
-    own masking)."""
+    off-contract — fail with a clean ``SystemExit`` rather than an ``AttributeError`` traceback (the same
+    "never a traceback" idiom as ``_send``/``_raise`` and ``cli/remote_provider.py``'s shape check). Then
+    strip any key-material field at any depth (defence in depth over the control plane's own masking)."""
     if not isinstance(reply, dict):
         raise SystemExit(f"The control plane returned an unexpected router reply: {str(reply)[:200]}")
     return _strip_secrets(reply)
 
 
 def _strip_secrets(value: Any) -> Any:
-    """Recursively drop any ``_SECRET_KEYS`` field from a reply so key material can never be echoed."""
+    """Recursively drop any ``_SECRET_KEYS`` field from a reply so key or URL material can never be echoed."""
     if isinstance(value, dict):
         return {k: _strip_secrets(v) for k, v in value.items() if k.lower() not in _SECRET_KEYS}
     if isinstance(value, list):
@@ -92,62 +143,56 @@ def _strip_secrets(value: Any) -> Any:
 
 
 def _print_status(config: dict[str, Any], as_json: bool) -> int:
-    """Show routing state + each configured ranker. ``--json`` echoes the (scrubbed, already-masked)
-    reply; human output uses ``.get()`` throughout and never indexes the reply shape."""
+    """Show routing state + the advisor chain as ordered ``provider:model`` tokens. ``--json`` echoes the
+    (scrubbed, already-masked) reply; human output uses ``.get()`` throughout and never indexes the shape."""
     config = _safe_reply(config)
     if as_json:
         print(json.dumps(config, indent=2))
         return 0
     print(f"auto-routing: {'enabled' if config.get('enabled') else 'disabled'}")
-    rankers = config.get("rankers") or []
-    if not rankers:
-        print("(no rankers configured)")
+    advisors = config.get("advisors") or []
+    if not advisors:
+        print("(no advisors configured)")
         return 0
-    for ranker in rankers:
-        print(f"{ranker.get('position')}\t{ranker.get('base_url') or ''}\t{ranker.get('model') or ''}")
+    for advisor in advisors:
+        print(_fmt_token(advisor.get("provider") or "", advisor.get("model")))
+    return 0
+
+
+def _print_catalog(catalog: dict[str, Any], as_json: bool) -> int:
+    """Show the advisor catalog for ``grid router models`` — every provider's whitelisted models, with the
+    default marked. ``--json`` echoes the (scrubbed) reply; human output uses ``.get()`` throughout."""
+    catalog = _safe_reply(catalog)
+    if as_json:
+        print(json.dumps(catalog, indent=2))
+        return 0
+    providers = catalog.get("providers") or []
+    if not providers:
+        print("(no advisor providers available)")
+        return 0
+    for provider in providers:
+        name = provider.get("provider") or ""
+        default = provider.get("default_model")
+        for model in provider.get("models") or []:
+            suffix = "  (default)" if model == default else ""
+            print(f"{_fmt_token(name, model)}{suffix}")
     return 0
 
 
 def _print_mutation(result: dict[str, Any], as_json: bool, human: str) -> int:
-    """Confirm a router mutation. ``--json`` echoes the raw (scrubbed, masked) reply verbatim. On the
-    human path the confirmation is a fixed string; when the control plane reports ``synced: false``
-    (saved, but the best-effort push to the running master didn't land) a caveat is appended so the
-    creator isn't told it's live when the periodic snapshot hasn't applied it yet."""
+    """Confirm a router mutation. ``--json`` echoes the raw (scrubbed, masked) reply verbatim. On the human
+    path the confirmation is a fixed string; when the control plane reports ``synced: false`` (saved, but the
+    best-effort push to the running master didn't land) a caveat is appended so the creator isn't told it's
+    live when the periodic snapshot hasn't applied it yet."""
     result = _safe_reply(result)
     if as_json:
         print(json.dumps(result, indent=2))
         return 0
+    # Only an explicit ``synced: false`` appends the caveat. An absent key (older server) OR an empty ``{}``
+    # body (a 204-equivalent DELETE coerced by ``_json_or_empty``) reads as "no not-synced signal" → no
+    # caveat, so on that defensive empty-reply path an actually-unknown sync state prints as a plain
+    # confirmation. Accepted: the real mutation endpoints always return a full ``{…, synced}`` body.
     if result.get("synced") is False:
         human += " (saved; the running grid will apply it shortly)"
     print(human)
     return 0
-
-
-def _resolve_ranker_key() -> str:
-    """The Ranker API key for `set-ranker`: the ``GRID_RANKER_API_KEY`` env var, else a hidden prompt.
-    Deliberately never a flag — a key on the command line leaks into shell history and process
-    listings. An empty prompt, or non-interactive with no key, is a clear error naming the env var
-    (mirrors the API-engine key precedent in ``cli/remote_provider.py``). The resolved key goes
-    straight to the control plane (``set_ranker`` body); it is never stored locally, logged, or
-    printed."""
-    from . import provider  # lazy: for _interactive() (both stdin+stdout must be a tty)
-
-    key = (os.environ.get(RANKER_KEY_ENV) or "").strip()
-    if not key and provider._interactive():
-        key = _prompt_ranker_key()
-        if not key:
-            raise SystemExit("No Ranker API key entered.")
-    if not key:
-        raise SystemExit(
-            f"set-ranker needs your Ranker API key in {RANKER_KEY_ENV} "
-            f"(export {RANKER_KEY_ENV}=... and re-run), or run interactively to be prompted."
-        )
-    return key
-
-
-def _prompt_ranker_key() -> str:
-    """Hidden interactive prompt for the Ranker key — input is never echoed (getpass). Split out so
-    the CLI-seam tests can monkeypatch it (getpass reads the controlling tty)."""
-    return getpass.getpass(
-        f"Enter your Ranker API key (input hidden; or export {RANKER_KEY_ENV}): "
-    ).strip()

--- a/cli/remote_router.py
+++ b/cli/remote_router.py
@@ -1,0 +1,153 @@
+"""Remote-mode `grid router status|enable|disable|set-ranker|remove-ranker` — the network
+creator's surface for auto-routing (model `auto`, ADR 0013).
+
+Account-level, like `grid members`: it authenticates with the session token, resolves the grid
+locally via ``remote_grid._select``/``_network_id`` and calls the control-plane owner API — no
+relay, no running grid needed. The Ranker key for ``set-ranker`` is sourced from the
+``GRID_RANKER_API_KEY`` env var or a hidden prompt (never a flag, never printed); ``status`` never
+shows key material.
+
+Remote-only — ``cli.dispatch`` gates it (``router`` is in ``REMOTE_ONLY``); local mode exits with
+guidance. Import rule mirrors the other remote handlers: stdlib only at module top; ``remote.*`` and
+sibling ``cli`` modules are imported lazily inside handlers (``cli.dispatch`` imports this module
+while the ``cli`` package is still initialising).
+"""
+from __future__ import annotations
+
+import argparse
+import getpass
+import json
+import os
+from typing import Any
+
+# The Ranker API key for `set-ranker` is read from this env var (else a hidden prompt) — never a
+# flag. grid-apis documents the same name as the CLI's source (ADR 0013 / grid-apis handler).
+RANKER_KEY_ENV = "GRID_RANKER_API_KEY"
+
+# Reply fields that must never be echoed. The control plane already masks ranker keys on every read
+# (they ride only the owner's snapshot channel); this is a client-side belt-and-suspenders scrub so
+# a future server-side masking regression can't turn `--json`/`status` into a key leak.
+_SECRET_KEYS = frozenset({"api_key", "apikey", "key", "secret", "token"})
+
+
+def cmd_remote_router(args: argparse.Namespace) -> int:
+    """`grid router status|enable|disable|set-ranker|remove-ranker` — configure auto-routing on a
+    grid you own.
+
+    Account-level (session token, like `grid members`): resolves the grid locally and never needs it
+    running, so there is no relay call. The control-plane reply is masked (position/base_url/model,
+    never a key) and echoed as-is for ``--json`` (after a defensive scrub); human output is built with
+    ``.get()`` and never indexes the reply shape. The Ranker key for ``set-ranker`` never touches this
+    function's output — it flows straight from env/prompt into the control-plane request body."""
+    from remote import control_plane, credentials
+
+    from . import remote_grid
+
+    session = credentials.require_session()
+    network_id = remote_grid._network_id(remote_grid._select(args.grid))
+
+    if args.subcommand == "status":
+        config = control_plane.get_router_config(session, network_id)
+        return _print_status(config, args.json)
+
+    if args.subcommand == "enable":
+        result = control_plane.enable_router(session, network_id)
+        return _print_mutation(result, args.json, "Auto-routing enabled.")
+
+    if args.subcommand == "disable":
+        result = control_plane.disable_router(session, network_id)
+        return _print_mutation(result, args.json, "Auto-routing disabled.")
+
+    if args.subcommand == "set-ranker":
+        key = _resolve_ranker_key()
+        result = control_plane.set_ranker(
+            session, network_id, args.position, args.base_url, args.model, key)
+        return _print_mutation(result, args.json, f"Set ranker {args.position} ({args.model}).")
+
+    if args.subcommand == "remove-ranker":
+        result = control_plane.remove_ranker(session, network_id, args.position)
+        return _print_mutation(result, args.json, f"Removed ranker {args.position}.")
+
+    raise SystemExit(f"Unknown router subcommand: {args.subcommand!r}")
+
+
+def _safe_reply(reply: Any) -> dict[str, Any]:
+    """Guard + scrub a control-plane reply before it is formatted or echoed. A non-dict 2xx body is
+    off-contract — fail with a clean ``SystemExit`` rather than an ``AttributeError`` traceback (the
+    same "never a traceback" idiom as ``_send``/``_raise`` and ``cli/remote_provider.py``'s shape
+    check). Then strip any key-material field at any depth (defence in depth over the control plane's
+    own masking)."""
+    if not isinstance(reply, dict):
+        raise SystemExit(f"The control plane returned an unexpected router reply: {str(reply)[:200]}")
+    return _strip_secrets(reply)
+
+
+def _strip_secrets(value: Any) -> Any:
+    """Recursively drop any ``_SECRET_KEYS`` field from a reply so key material can never be echoed."""
+    if isinstance(value, dict):
+        return {k: _strip_secrets(v) for k, v in value.items() if k.lower() not in _SECRET_KEYS}
+    if isinstance(value, list):
+        return [_strip_secrets(item) for item in value]
+    return value
+
+
+def _print_status(config: dict[str, Any], as_json: bool) -> int:
+    """Show routing state + each configured ranker. ``--json`` echoes the (scrubbed, already-masked)
+    reply; human output uses ``.get()`` throughout and never indexes the reply shape."""
+    config = _safe_reply(config)
+    if as_json:
+        print(json.dumps(config, indent=2))
+        return 0
+    print(f"auto-routing: {'enabled' if config.get('enabled') else 'disabled'}")
+    rankers = config.get("rankers") or []
+    if not rankers:
+        print("(no rankers configured)")
+        return 0
+    for ranker in rankers:
+        print(f"{ranker.get('position')}\t{ranker.get('base_url') or ''}\t{ranker.get('model') or ''}")
+    return 0
+
+
+def _print_mutation(result: dict[str, Any], as_json: bool, human: str) -> int:
+    """Confirm a router mutation. ``--json`` echoes the raw (scrubbed, masked) reply verbatim. On the
+    human path the confirmation is a fixed string; when the control plane reports ``synced: false``
+    (saved, but the best-effort push to the running master didn't land) a caveat is appended so the
+    creator isn't told it's live when the periodic snapshot hasn't applied it yet."""
+    result = _safe_reply(result)
+    if as_json:
+        print(json.dumps(result, indent=2))
+        return 0
+    if result.get("synced") is False:
+        human += " (saved; the running grid will apply it shortly)"
+    print(human)
+    return 0
+
+
+def _resolve_ranker_key() -> str:
+    """The Ranker API key for `set-ranker`: the ``GRID_RANKER_API_KEY`` env var, else a hidden prompt.
+    Deliberately never a flag — a key on the command line leaks into shell history and process
+    listings. An empty prompt, or non-interactive with no key, is a clear error naming the env var
+    (mirrors the API-engine key precedent in ``cli/remote_provider.py``). The resolved key goes
+    straight to the control plane (``set_ranker`` body); it is never stored locally, logged, or
+    printed."""
+    from . import provider  # lazy: for _interactive() (both stdin+stdout must be a tty)
+
+    key = (os.environ.get(RANKER_KEY_ENV) or "").strip()
+    if not key and provider._interactive():
+        key = _prompt_ranker_key()
+        if not key:
+            raise SystemExit("No Ranker API key entered.")
+    if not key:
+        raise SystemExit(
+            f"set-ranker needs your Ranker API key in {RANKER_KEY_ENV} "
+            f"(export {RANKER_KEY_ENV}=... and re-run), or run interactively to be prompted."
+        )
+    return key
+
+
+def _prompt_ranker_key() -> str:
+    """Hidden interactive prompt for the Ranker key — input is never echoed (getpass). Split out so
+    the CLI-seam tests can monkeypatch it (getpass reads the controlling tty)."""
+    return getpass.getpass(
+        f"Enter your Ranker API key (input hidden; or export {RANKER_KEY_ENV}): "
+    ).strip()

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -183,7 +183,7 @@ engine ──GET /relay/v1/poll (long-poll)──▶ claims job ◀────�
    consume path does not refresh the token. See [ADR 0005](adr/0005-remote-consume.md).
 4. When the app sends the reserved model `model: "auto"` (and the owner enabled routing with
    `grid router`), the **relay** picks the real model *before* engine selection — its **Auto-router**
-   ranks the grid's live candidate models via an external Ranker and rewrites the body to the chosen
+   ranks the grid's live candidate models via an external Advisor and rewrites the body to the chosen
    name, then the normal engine selection above runs unchanged. This client only sends `auto` and
    reads the pick back from the `X-Grid-Routed-Model` / `X-Grid-Router` response headers; the routing
    logic itself lives server-side (see below). See [ADR 0013](adr/0013-auto-routing.md).
@@ -254,7 +254,7 @@ record and teardown are shared (`shared/run_records.py`).
   here is allowlist-only (`grid members`); richer management lives on the website (D13).
 - **Auto-routing (`auto`) decides server-side.** This repo ships only the owner CLI (`grid router`,
   which writes per-network config through the control plane) and the consumer's `auto` request. The
-  Auto-router itself — candidate ranking, the Ranker chain, circuit breakers, free-first pick, and the
+  Auto-router itself — candidate ranking, the Advisor chain, circuit breakers, free-first pick, and the
   bounded excerpt that is the only request data leaving the grid — lives in the relay/master (grid-src),
   consistent with "the backend stays out of this repo". Don't reimplement routing here. See
   [ADR 0013](adr/0013-auto-routing.md).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -60,6 +60,7 @@ command surface), `shared/` (used by both modes), `local/` (local mode), and `re
 │   ├── remote_grid.py     Remote `up` / `down` / `ls` / `info` + `members`.
 │   ├── remote_provider.py Remote `join` / `leave` (serve a remote grid).
 │   ├── remote_request.py  Remote `chat` / `image` / `edit` / `video` (consume via relay).
+│   ├── remote_router.py   Remote `grid router` — owner config for auto-routing (model `auto`).
 │   └── media_io.py          Shared media SSE/file IO used by local + remote request handlers.
 ├── shared/             Used by both modes.
 │   ├── state.py             Persisted mode pointer + per-mode active grid (~/.grid/state.json).
@@ -180,6 +181,12 @@ engine ──GET /relay/v1/poll (long-poll)──▶ claims job ◀────�
 3. The relay queues the job for a serving engine and returns the engine's result to the app
    (whole for chat, streamed SSE for media). A 401 is a clean "run `grid login`" — the one-shot
    consume path does not refresh the token. See [ADR 0005](adr/0005-remote-consume.md).
+4. When the app sends the reserved model `model: "auto"` (and the owner enabled routing with
+   `grid router`), the **relay** picks the real model *before* engine selection — its **Auto-router**
+   ranks the grid's live candidate models via an external Ranker and rewrites the body to the chosen
+   name, then the normal engine selection above runs unchanged. This client only sends `auto` and
+   reads the pick back from the `X-Grid-Routed-Model` / `X-Grid-Router` response headers; the routing
+   logic itself lives server-side (see below). See [ADR 0013](adr/0013-auto-routing.md).
 
 ### Engine lifecycle (`grid join` in remote mode)
 
@@ -245,6 +252,12 @@ record and teardown are shared (`shared/run_records.py`).
   and makes off-local calls to the relay, but the hosted backend — the relay service, its Postgres,
   billing — and heavy server dependencies stay out of this repo (DECISIONS D1, D14). Remote admin
   here is allowlist-only (`grid members`); richer management lives on the website (D13).
+- **Auto-routing (`auto`) decides server-side.** This repo ships only the owner CLI (`grid router`,
+  which writes per-network config through the control plane) and the consumer's `auto` request. The
+  Auto-router itself — candidate ranking, the Ranker chain, circuit breakers, free-first pick, and the
+  bounded excerpt that is the only request data leaving the grid — lives in the relay/master (grid-src),
+  consistent with "the backend stays out of this repo". Don't reimplement routing here. See
+  [ADR 0013](adr/0013-auto-routing.md).
 - **Vendored media stack.** Parts of `shared/media/` and `shared/engine/` are vendored from an
   upstream desktop app and annotated as such in their docstrings; keep vendored edits bracketed
   and minimal so they're easy to re-sync.

--- a/docs/adr/0013-auto-routing.md
+++ b/docs/adr/0013-auto-routing.md
@@ -1,0 +1,42 @@
+---
+status: accepted
+---
+
+# Auto routing: reserved `auto`, external Ranker chain, free-first pick
+
+An app that requests the reserved model name `auto` asks the grid to pick the model. The
+auto-router builds a candidate list from the models the grid currently serves (hard-filtered
+by the request's needs — vision, tools, json_schema), sends a **bounded excerpt** of the
+request — never the full conversation — to a **Ranker** (an external OpenAI-compatible LLM
+endpoint), and receives a fitness-ranked shortlist (≤7). It picks the first ranked model
+with a free engine; **busy never becomes refusal** (no model free → queue on the
+highest-ranked queueable one; every queue full → the existing 503). Remote mode ships first;
+local mode reuses the same portable pure-logic module against its in-memory registry.
+
+Choices a future reader will otherwise re-litigate:
+
+- **Bare `auto`, reserved, shadows any engine-advertised `auto` at dispatch.** Rejected
+  `grid:auto`: namespaces mean engine kind (`openai:`, `comfyui:`), not master features.
+- **Excerpt, not conversation** (~500-char system head + ~2000-char last-user tail + derived
+  features; images become markers). Full `messages` was rejected: every `auto` request would
+  ship the whole conversation to a third party, against the "models stay on your machines"
+  promise, with cost/latency growing with history. Metadata-only was rejected: the ranker
+  can't classify the task, and ranking degrades to capability matching.
+- **The Ranker sees capabilities only — no pricing, no live load.** Fitness is its one job;
+  cost and availability are decided locally at pick time, where the data is fresh.
+- **A model-level layer in front of the untouched engine-level selection.** After the
+  auto-router picks a model it rewrites the body to the real name and hands off; engine
+  choice, queueing, claiming, streaming, and billing are unchanged (an `auto` request bills
+  as the chosen model; the ranking call runs on the owner's own vendor key).
+- **Ranker chain is fixed priority, not round-robin** — up to 3 entries
+  `{base_url, api_key, model}`, tried in order per request, each behind a circuit breaker
+  (3 consecutive failures → skipped 60s → half-open probe). All rankers down → a
+  deterministic local fallback (most free capacity → price score → name) still serves the
+  request: `auto`'s availability equals the grid's, not any vendor's. The machine never
+  rewrites the configured order; removing a ranker is the owner's action.
+- **Per-network config owned by the network creator** (`router_enabled` + ranker triples),
+  managed through an owner-facing CLI command group following the membership pattern
+  (session token, account-level), stored on the control plane, and delivered to running
+  masters over the existing sync-snapshot — no restart, no epoch bump, works for
+  server-hosted and self-hosted masters. A VM-global env key was rejected (no per-grid
+  control); keys are never flags and are never printed.

--- a/docs/adr/0013-auto-routing.md
+++ b/docs/adr/0013-auto-routing.md
@@ -28,8 +28,26 @@ Choices a future reader will otherwise re-litigate:
   ship the whole conversation to a third party, against the "models stay on your machines"
   promise, with cost/latency growing with history. Metadata-only was rejected: the advisor
   can't classify the task, and ranking degrades to capability matching.
-- **The Advisor sees capabilities only — no pricing, no live load.** Fitness is its one job;
-  cost and availability are decided locally at pick time, where the data is fresh.
+- **The Advisor ranks on model facts, not names — but never on pricing or live load.** Each
+  candidate is rendered as its own line carrying the model name, its **context window**, and its
+  **capability names** (`tools`, `vision`, …) — owner-side facts about the grid's own engines, so the
+  Advisor ranks on data rather than guessing a model's strengths from its name. The system prompt
+  carries a **leanest-adequate rubric**: the grid owner pays for the compute, so the Advisor prefers
+  the smallest/cheapest candidate that still fits and escalates only when the request genuinely
+  demands it (fixing the observed over-ranking of big, well-known-named models on trivial requests).
+  Still never sent: per-engine **pricing**, **free capacity**, and **throughput** — cost and
+  availability are decided locally at pick time, where the data is fresh. The Advisor sees at most
+  **50 candidates** (a bounded, deterministically-ordered slice) so the prompt can't grow without
+  limit on a large grid. This is grid-side engine metadata (from whichever nodes registered as
+  providers), not consumer request data, so the **consumer privacy surface is unchanged** — the
+  excerpt (what leaves the grid *about the request*) is exactly as before; provider-supplied
+  capability names are additionally bounded to a known vocabulary so a node can't inject arbitrary
+  strings into the ranking prompt. A context window is included only when actually known: the probe
+  omits an unknown window rather than baking a default, and the master additionally treats a reported
+  `128000` as unknown — because that is both the CLI's own default `--ctx-size` and the old bake
+  value, so it is indistinguishable from "the operator never specified one." A real ctx signal thus
+  requires an explicit non-default `--ctx-size` (or a future probe of the engine's true window); it is
+  a standing rule, not a transitional one.
 - **A model-level layer in front of the untouched engine-level selection.** After the
   auto-router picks a model it rewrites the body to the real name and hands off; engine
   choice, queueing, claiming, streaming, and billing are unchanged (an `auto` request bills
@@ -38,7 +56,7 @@ Choices a future reader will otherwise re-litigate:
 - **Advisors come from a platform catalog, not from owner-supplied endpoints** *(revision)*.
   An advisor is a `{provider, model}` pair validated against a control-plane catalog
   (per-provider model whitelist + default model; v1: `openai` with bare model names —
-  `gpt-5-mini` default, `gpt-5-nano`, `gpt-4.1-mini`, `gpt-4o-mini`); the catalog maps the
+  `gpt-4o-mini` default, `gpt-5-mini`, `gpt-5-nano`, `gpt-4.1-mini`); the catalog maps the
   provider to the platform LLM proxy's URL (control-plane env). BYO `--base-url` was
   **dropped, not hidden**: no user-supplied advisor URLs means no owner key custody, no SSRF
   surface at the write path, and vendors/models are added server-side with no CLI release.

--- a/docs/adr/0013-auto-routing.md
+++ b/docs/adr/0013-auto-routing.md
@@ -2,16 +2,22 @@
 status: accepted
 ---
 
-# Auto routing: reserved `auto`, external Ranker chain, free-first pick
+# Auto routing: reserved `auto`, external Advisor chain, free-first pick
+
+> **Revised 2026-07-10, pre-merge** (nothing shipped): **Rankers became Advisors** — picked from a
+> platform catalog by `provider[:model]` name and called through the platform's LLM proxy on a
+> control-plane-allocated per-grid key. The owner no longer supplies a base URL or an API key.
+> Grill log: `.scratch/auto-router/regrill-2026-07-10-provider-spec.md`.
 
 An app that requests the reserved model name `auto` asks the grid to pick the model. The
 auto-router builds a candidate list from the models the grid currently serves (hard-filtered
 by the request's needs — vision, tools, json_schema), sends a **bounded excerpt** of the
-request — never the full conversation — to a **Ranker** (an external OpenAI-compatible LLM
-endpoint), and receives a fitness-ranked shortlist (≤7). It picks the first ranked model
-with a free engine; **busy never becomes refusal** (no model free → queue on the
-highest-ranked queueable one; every queue full → the existing 503). Remote mode ships first;
-local mode reuses the same portable pure-logic module against its in-memory registry.
+request — never the full conversation — to an **Advisor** (an external LLM picked from the
+platform's advisor catalog, called through the platform's LLM proxy), and receives a
+fitness-ranked shortlist (≤7). It picks the first ranked model with a free engine; **busy
+never becomes refusal** (no model free → queue on the highest-ranked queueable one; every
+queue full → the existing 503). Remote mode ships first; local mode reuses the same portable
+pure-logic module against its in-memory registry.
 
 Choices a future reader will otherwise re-litigate:
 
@@ -20,23 +26,45 @@ Choices a future reader will otherwise re-litigate:
 - **Excerpt, not conversation** (~500-char system head + ~2000-char last-user tail + derived
   features; images become markers). Full `messages` was rejected: every `auto` request would
   ship the whole conversation to a third party, against the "models stay on your machines"
-  promise, with cost/latency growing with history. Metadata-only was rejected: the ranker
+  promise, with cost/latency growing with history. Metadata-only was rejected: the advisor
   can't classify the task, and ranking degrades to capability matching.
-- **The Ranker sees capabilities only — no pricing, no live load.** Fitness is its one job;
+- **The Advisor sees capabilities only — no pricing, no live load.** Fitness is its one job;
   cost and availability are decided locally at pick time, where the data is fresh.
 - **A model-level layer in front of the untouched engine-level selection.** After the
   auto-router picks a model it rewrites the body to the real name and hands off; engine
   choice, queueing, claiming, streaming, and billing are unchanged (an `auto` request bills
-  as the chosen model; the ranking call runs on the owner's own vendor key).
-- **Ranker chain is fixed priority, not round-robin** — up to 3 entries
-  `{base_url, api_key, model}`, tried in order per request, each behind a circuit breaker
-  (3 consecutive failures → skipped 60s → half-open probe). All rankers down → a
-  deterministic local fallback (most free capacity → price score → name) still serves the
-  request: `auto`'s availability equals the grid's, not any vendor's. The machine never
-  rewrites the configured order; removing a ranker is the owner's action.
-- **Per-network config owned by the network creator** (`router_enabled` + ranker triples),
-  managed through an owner-facing CLI command group following the membership pattern
-  (session token, account-level), stored on the control plane, and delivered to running
-  masters over the existing sync-snapshot — no restart, no epoch bump, works for
-  server-hosted and self-hosted masters. A VM-global env key was rejected (no per-grid
-  control); keys are never flags and are never printed.
+  as the chosen model; the ranking call is billed to the platform's proxy key — not the
+  owner, not the consumer).
+- **Advisors come from a platform catalog, not from owner-supplied endpoints** *(revision)*.
+  An advisor is a `{provider, model}` pair validated against a control-plane catalog
+  (per-provider model whitelist + default model; v1: `openai` with bare model names —
+  `gpt-5-mini` default, `gpt-5-nano`, `gpt-4.1-mini`, `gpt-4o-mini`); the catalog maps the
+  provider to the platform LLM proxy's URL (control-plane env). BYO `--base-url` was
+  **dropped, not hidden**: no user-supplied advisor URLs means no owner key custody, no SSRF
+  surface at the write path, and vendors/models are added server-side with no CLI release.
+  `grid router models` lists the catalog; an off-whitelist model is a 400 naming the valid
+  models. The same provider may repeat in the chain with different models — with a
+  one-provider catalog that is the only route to a real failover chain.
+- **One per-grid proxy key, allocated by the control plane** *(revision)* — minted lazily on
+  the grid's first successful `set-advisors` through the proxy's key-management API, scoped
+  to the whitelisted advisor models, reused for the network's lifetime. Mint failure fails
+  the set cleanly (nothing saved). The owner never handles a key; it rides only the owner's
+  snapshot to the running master (which must hold it to dial the proxy) and is masked on
+  every other read. An owner *can* extract it there by design — accepted; damage is bounded
+  by the models scope (budget/rate caps at mint are a named follow-up, settable manually on
+  the proxy meanwhile).
+- **Advisor chain is fixed priority, not round-robin** — up to 3 entries, set
+  **replace-all** in one command (token order = priority), tried in order per request, each
+  behind a circuit breaker (3 consecutive failures → skipped 60s → half-open probe). All
+  advisors down → a deterministic local fallback (most free capacity → price score → name)
+  still serves the request: `auto`'s availability equals the grid's, not any vendor's. The
+  machine never rewrites the configured order; removing an advisor is the owner's action.
+- **Per-network config owned by the network creator** (`router_enabled` + advisor pairs +
+  the per-grid key), managed through an owner-facing CLI command group following the
+  membership pattern (session token, account-level), stored on the control plane, and
+  delivered to running masters over the existing sync-snapshot — no restart, no epoch bump,
+  works for server-hosted and self-hosted masters. The snapshot **materializes**
+  `{base_url, api_key, model}` triples from the catalog at read time, so the master-side
+  contract (and implementation) is unchanged by the revision and moving the proxy is an env
+  change, not a data migration. A VM-global env key was rejected (no per-grid control); keys
+  are never flags and are never printed — `status` returns neither key nor URL.

--- a/docs/adr/0013-auto-routing.md
+++ b/docs/adr/0013-auto-routing.md
@@ -35,12 +35,17 @@ Choices a future reader will otherwise re-litigate:
   candidate is rendered as its own line carrying the model name, its **context window**, and its
   **capability names** (`tools`, `vision`, …) — owner-side facts about the grid's own engines, so the
   Advisor ranks on data rather than guessing a model's strengths from its name. The system prompt
-  carries an **adequacy-first, efficiency-second rubric** *(revision — a leanest-first wording
-  under-provisioned hard requests onto tiny models in live testing)*: the top pick must be able to
-  answer the request WELL — a parameter size in the name (135m, 0.5b, 7b) is treated as a fact, and
-  doubt breaks toward the more capable candidate — then, among clearly-adequate candidates, prefer
-  the smallest/cheapest because the grid owner pays for the compute (still fixing the original
-  over-ranking of big, well-known-named models on trivial requests).
+  carries a **classification-first rubric** *(revision, converged via live A/B against the real
+  advisor proxy: a "prefer smallest" wording under-provisioned hard requests onto tiny models, and
+  an "adequacy first" wording over-provisioned trivial ones onto the API model)*: the Advisor first
+  classifies the request as SIMPLE (greetings, short factual questions — anything a small model
+  answers correctly) or DEMANDING (math/proofs, non-trivial code, multi-step reasoning, long or
+  specialized content), then maps the class to the candidate spectrum — SIMPLE → the
+  smallest/cheapest adequate candidate (the grid owner pays for every token), DEMANDING → the most
+  capable candidates, never a sub-billion model (a parameter size in the name is treated as a
+  fact). Candidate-list order is declared arbitrary (the free-capacity sort put the API engine
+  first, which biased rankings) and uncertainty breaks toward DEMANDING. Held stable across both
+  non-reasoning advisors (gpt-4.1-mini, gpt-4o-mini).
   Still never sent: per-engine **pricing**, **free capacity**, and **throughput** — cost and
   availability are decided locally at pick time, where the data is fresh. The Advisor sees at most
   **50 candidates** (a bounded, deterministically-ordered slice) so the prompt can't grow without

--- a/docs/adr/0013-auto-routing.md
+++ b/docs/adr/0013-auto-routing.md
@@ -35,9 +35,12 @@ Choices a future reader will otherwise re-litigate:
   candidate is rendered as its own line carrying the model name, its **context window**, and its
   **capability names** (`tools`, `vision`, …) — owner-side facts about the grid's own engines, so the
   Advisor ranks on data rather than guessing a model's strengths from its name. The system prompt
-  carries a **leanest-adequate rubric**: the grid owner pays for the compute, so the Advisor prefers
-  the smallest/cheapest candidate that still fits and escalates only when the request genuinely
-  demands it (fixing the observed over-ranking of big, well-known-named models on trivial requests).
+  carries an **adequacy-first, efficiency-second rubric** *(revision — a leanest-first wording
+  under-provisioned hard requests onto tiny models in live testing)*: the top pick must be able to
+  answer the request WELL — a parameter size in the name (135m, 0.5b, 7b) is treated as a fact, and
+  doubt breaks toward the more capable candidate — then, among clearly-adequate candidates, prefer
+  the smallest/cheapest because the grid owner pays for the compute (still fixing the original
+  over-ranking of big, well-known-named models on trivial requests).
   Still never sent: per-engine **pricing**, **free capacity**, and **throughput** — cost and
   availability are decided locally at pick time, where the data is fresh. The Advisor sees at most
   **50 candidates** (a bounded, deterministically-ordered slice) so the prompt can't grow without
@@ -59,7 +62,7 @@ Choices a future reader will otherwise re-litigate:
 - **Advisors come from a platform catalog, not from owner-supplied endpoints** *(revision)*.
   An advisor is a `{provider, model}` pair validated against a control-plane catalog
   (per-provider model whitelist + default model; v1: `openai` with bare model names —
-  `gpt-4o-mini` default, `gpt-5-mini`, `gpt-5-nano`, `gpt-4.1-mini`); the catalog maps the
+  `gpt-4.1-mini` default, `gpt-5-mini`, `gpt-5-nano`, `gpt-4o-mini`); the catalog maps the
   provider to the platform LLM proxy's URL (control-plane env). BYO `--base-url` was
   **dropped, not hidden**: no user-supplied advisor URLs means no owner key custody, no SSRF
   surface at the write path, and vendors/models are added server-side with no CLI release.

--- a/docs/adr/0013-auto-routing.md
+++ b/docs/adr/0013-auto-routing.md
@@ -23,11 +23,14 @@ Choices a future reader will otherwise re-litigate:
 
 - **Bare `auto`, reserved, shadows any engine-advertised `auto` at dispatch.** Rejected
   `grid:auto`: namespaces mean engine kind (`openai:`, `comfyui:`), not master features.
-- **Excerpt, not conversation** (~500-char system head + ~2000-char last-user tail + derived
-  features; images become markers). Full `messages` was rejected: every `auto` request would
-  ship the whole conversation to a third party, against the "models stay on your machines"
-  promise, with cost/latency growing with history. Metadata-only was rejected: the advisor
-  can't classify the task, and ranking degrades to capability matching.
+- **Excerpt, not conversation** (~500-char system head + the ~2000-char tails of the **last 3
+  user turns**, oldest→newest + derived features; images become markers). The last-3-user-turns
+  window (not just the final message) means a terse final turn ("continue", "fix that") still
+  carries the task/domain set in the turns leading up to it, without ever shipping assistant/tool
+  turns or older user turns. Full `messages` was rejected: every `auto` request would ship the whole
+  conversation to a third party, against the "models stay on your machines" promise, with cost/latency
+  growing with history. Metadata-only was rejected: the advisor can't classify the task, and ranking
+  degrades to capability matching.
 - **The Advisor ranks on model facts, not names — but never on pricing or live load.** Each
   candidate is rendered as its own line carrying the model name, its **context window**, and its
   **capability names** (`tools`, `vision`, …) — owner-side facts about the grid's own engines, so the

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -371,6 +371,12 @@ Check engines:
   grid engines
 ```
 
+**`-m auto`** lets the grid pick the model, when its owner has enabled auto-routing (`grid router`).
+`grid chat -m auto "…"` sends the reserved name `auto`; the reply comes back from whichever capable
+model the grid ranked and had free, and the `X-Grid-Routed-Model` response header (and the reply's
+`model` field) name it. On a grid without routing enabled, `auto` is a clear "not enabled" error. See
+[Router](#router).
+
 ## Members
 
 ```
@@ -434,6 +440,46 @@ The Ranker **API key** for `set-ranker` comes from the `GRID_RANKER_API_KEY` env
 hidden interactive prompt — **never a command-line flag** (so it stays out of shell history and process
 listings), and it is never printed or logged. A change that couldn't be pushed to the running grid yet is
 reported as saved and will apply shortly.
+
+**Chain + fallback.** The Rankers are tried strictly in position order (1 → 2 → 3, never reordered),
+advancing on failure. Each has a circuit breaker — 3 consecutive failures skip it for 60 s, then one
+half-open probe re-tries it — so a dead vendor doesn't tax every request. If every Ranker is down the
+grid still serves from a deterministic local pick (most free capacity → cheapest → name), stamped
+`X-Grid-Router: fallback`. The ranking call runs on **your** Ranker key; the served request bills the
+consumer as the chosen model.
+
+**Consuming `auto`.** An app requests the reserved model `auto` on `chat/completions` (streaming or
+not); the response `model` and the `X-Grid-Routed-Model` header carry the real model, and
+`X-Grid-Router` is `ranked` or `fallback`. `auto` appears in `/v1/models` (as `owned_by:
+"grid-router"`) only while routing is enabled; disabled → a clear "auto routing is not enabled" error.
+`auto` is chat-only — the legacy `completions` endpoint and a `--target-provider` header each reject
+it, and media models are never candidates.
+
+### Auto-routing transparency
+
+When routing is enabled, an `auto` request sends a **bounded excerpt** — and nothing else — to each
+Ranker in turn. This table is the complete set of what leaves the grid; the full conversation never
+does.
+
+| Field | What it is | Bound |
+|---|---|---|
+| system head | head of the first `system` message, truncated | ≤ 500 chars |
+| last-user tail | tail of the last `user` message, truncated | ≤ 2000 chars |
+| message count | number of messages in the request | integer |
+| approx input size | total characters across all message content | integer |
+| tool names | declared function **names** only — never arguments or JSON schemas | list of names |
+| images present | whether any image/binary part exists (each becomes a `[image]` marker) | yes / no |
+| requested output size | the request's `max_tokens`, if set | integer or unset |
+
+- **When** — only while `grid router` is **enabled**; a disabled grid makes no outbound Ranker call.
+- **To whom** — the Rankers you configured, in priority order (position 1, then 2, 3 on failure).
+- **On whose account** — the ranking call runs on **your** Ranker key; the served request is billed
+  to the consumer as the chosen model.
+- **Never sent** — the full conversation, mid-conversation turns, tool-call arguments or schemas, raw
+  image/audio bytes or URLs, or any API key.
+
+See [ADR 0013](./adr/0013-auto-routing.md) for the reserved-name, excerpt-not-conversation, and
+fixed-priority-chain decisions.
 
 ## Engine Setup
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -462,9 +462,9 @@ it, and media models are never candidates.
 
 ### Auto-routing transparency
 
-When routing is enabled, an `auto` request sends a **bounded excerpt** — and nothing else — to each
-Advisor in turn. This table is the complete set of what leaves the grid; the full conversation never
-does.
+When routing is enabled, an `auto` request sends a **bounded excerpt of the request** plus a
+**short list of your grid's own candidate models** to each Advisor in turn. This table is the complete
+set of request data that leaves the grid; the full conversation never does.
 
 | Field | What it is | Bound |
 |---|---|---|
@@ -476,13 +476,20 @@ does.
 | images present | whether any image/binary part exists (each becomes a `[image]` marker) | yes / no |
 | requested output size | the request's `max_tokens`, if set | integer or unset |
 
+- **Candidate metadata (grid-side, not request data)** — alongside the excerpt, the Advisor is given
+  one line per candidate model: the model **name**, its **capability names** (`tools`, `vision`, …,
+  bounded to a known vocabulary so a provider can't inject arbitrary text), and its **context window**
+  (included only when known). This is information about the **engines your grid's providers serve**,
+  not about the consumer's request, so it does not widen the request privacy surface above. It is
+  capped at **50 candidates**, and per-engine **pricing, free capacity, and throughput are never
+  included** — those stay on the grid and are used only for the local pick.
 - **When** — only while `grid router` is **enabled**; a disabled grid makes no outbound Advisor call.
 - **To whom** — the Advisors you configured, in priority order (advisor 1, then 2, 3 on failure), each
   reached **through the platform's LLM proxy** — you never hold, store, or hand out an advisor key or URL.
 - **On whose account** — the ranking call runs on the platform's advisor-proxy key (not your key, and
   not the consumer's); the served request is billed to the consumer as the chosen model.
 - **Never sent** — the full conversation, mid-conversation turns, tool-call arguments or schemas, raw
-  image/audio bytes or URLs, or any API key.
+  image/audio bytes or URLs, per-engine pricing/capacity/throughput, or any API key.
 
 See [ADR 0013](./adr/0013-auto-routing.md) for the reserved-name, excerpt-not-conversation, and
 fixed-priority-chain decisions.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -411,6 +411,30 @@ model you aren't currently serving (`grid join` first). `rm` does not (you can c
 `grid leave`). `show` lists the grid's models and prices. In `local` mode the command exits with
 guidance to switch.
 
+## Router
+
+```
+grid router status  [grid] [--json]
+grid router enable  [grid] [--json]
+grid router disable [grid] [--json]
+grid router set-ranker    [grid] <1|2|3> --base-url <url> --model <name> [--json]
+grid router remove-ranker [grid] <1|2|3> [--json]
+```
+
+**Remote-only.** Configure **auto-routing** for a grid you own: an app that requests the reserved model
+`auto` has the grid pick a model for the request, ranked by an external **Ranker** you configure (see
+[ADR 0013](./adr/0013-auto-routing.md)). `enable`/`disable` turn routing on and off; `set-ranker` sets one
+of up to three Rankers in priority order (each an OpenAI-compatible endpoint — `--base-url` + `--model`);
+`remove-ranker` drops one; `status` shows the enabled state and each position's base URL and model —
+**never a key**, in either human or `--json` output. `[grid]` follows the usual selection (active grid when
+omitted). Like membership, these authenticate with your account sign-in (not a per-grid token) and don't
+need the grid running; in `local` mode the command exits with guidance to switch.
+
+The Ranker **API key** for `set-ranker` comes from the `GRID_RANKER_API_KEY` environment variable, else a
+hidden interactive prompt — **never a command-line flag** (so it stays out of shell history and process
+listings), and it is never printed or logged. A change that couldn't be pushed to the running grid yet is
+reported as saved and will apply shortly.
+
 ## Engine Setup
 
 ```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -469,7 +469,7 @@ set of request data that leaves the grid; the full conversation never does.
 | Field | What it is | Bound |
 |---|---|---|
 | system head | head of the first `system` message, truncated | ≤ 500 chars |
-| last-user tail | tail of the last `user` message, truncated | ≤ 2000 chars |
+| recent user tails | tails of the **last 3 `user` messages** (oldest→newest), each truncated — so a terse final message still carries the task context set in the turns leading up to it | ≤ 2000 chars each |
 | message count | number of messages in the request | integer |
 | approx input size | total characters across all message content | integer |
 | tool names | declared function **names** only — never arguments or JSON schemas | list of names |
@@ -488,8 +488,9 @@ set of request data that leaves the grid; the full conversation never does.
   reached **through the platform's LLM proxy** — you never hold, store, or hand out an advisor key or URL.
 - **On whose account** — the ranking call runs on the platform's advisor-proxy key (not your key, and
   not the consumer's); the served request is billed to the consumer as the chosen model.
-- **Never sent** — the full conversation, mid-conversation turns, tool-call arguments or schemas, raw
-  image/audio bytes or URLs, per-engine pricing/capacity/throughput, or any API key.
+- **Never sent** — the full conversation, `assistant`/`tool` turns, `user` turns older than the last
+  three, tool-call arguments or schemas, raw image/audio bytes or URLs, per-engine
+  pricing/capacity/throughput, or any API key.
 
 See [ADR 0013](./adr/0013-auto-routing.md) for the reserved-name, excerpt-not-conversation, and
 fixed-priority-chain decisions.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -431,11 +431,13 @@ grid router remove-advisor <provider[:model]> [--grid <grid>] [--json]
 **Remote-only.** Configure **auto-routing** for a grid you own: an app that requests the reserved model
 `auto` has the grid pick a model for the request, ranked by an external **Advisor** (see
 [ADR 0013](./adr/0013-auto-routing.md)). An Advisor is a `provider[:model]` pair you pick **by name** from
-the platform catalog — `grid router models` lists the providers and their whitelisted models (the default
-marked), and a bare `provider` uses that default. You supply neither a URL nor a key: the platform carries
-both. `enable`/`disable` turn routing on and off; `set-advisors` **replaces the whole chain** with up to
-three advisors in priority order; `remove-advisor` drops one by name (an exact `provider:model`, or a bare
-`provider` to remove all of its entries); `status` shows the enabled state and the chain as ordered
+the platform catalog. **Start with `grid router models`** — it lists the providers and their whitelisted
+models (the default marked) — then name advisors from that list; a bare `provider` uses its default model.
+You supply neither a URL nor a key: the platform carries both. `enable`/`disable` turn routing on and off;
+`set-advisors` **replaces the whole chain** with up to three advisors in priority order (the same provider
+may repeat with a different model — with a one-provider catalog, the only route to a real failover chain —
+but a duplicated exact `provider:model` pair is rejected); `remove-advisor` drops one by name (an exact
+`provider:model`, or a bare `provider` to remove all of its entries); `status` shows the enabled state and the chain as ordered
 `provider:model` tokens — **never a key or URL**, in either human or `--json` output.
 
 Every subcommand that acts on a grid selects it with `--grid` (active grid when omitted); `set-advisors` and
@@ -475,7 +477,8 @@ does.
 | requested output size | the request's `max_tokens`, if set | integer or unset |
 
 - **When** — only while `grid router` is **enabled**; a disabled grid makes no outbound Advisor call.
-- **To whom** — the Advisors you configured, in priority order (advisor 1, then 2, 3 on failure).
+- **To whom** — the Advisors you configured, in priority order (advisor 1, then 2, 3 on failure), each
+  reached **through the platform's LLM proxy** — you never hold, store, or hand out an advisor key or URL.
 - **On whose account** — the ranking call runs on the platform's advisor-proxy key (not your key, and
   not the consumer's); the served request is billed to the consumer as the chosen model.
 - **Never sent** — the full conversation, mid-conversation turns, tool-call arguments or schemas, raw

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -420,45 +420,48 @@ guidance to switch.
 ## Router
 
 ```
-grid router status  [grid] [--json]
-grid router enable  [grid] [--json]
-grid router disable [grid] [--json]
-grid router set-ranker    [grid] <1|2|3> --base-url <url> --model <name> [--json]
-grid router remove-ranker [grid] <1|2|3> [--json]
+grid router status  [--grid <grid>] [--json]
+grid router enable  [--grid <grid>] [--json]
+grid router disable [--grid <grid>] [--json]
+grid router models  [--json]
+grid router set-advisors   <provider[:model]> [<provider[:model]> …] [--grid <grid>] [--json]
+grid router remove-advisor <provider[:model]> [--grid <grid>] [--json]
 ```
 
 **Remote-only.** Configure **auto-routing** for a grid you own: an app that requests the reserved model
-`auto` has the grid pick a model for the request, ranked by an external **Ranker** you configure (see
-[ADR 0013](./adr/0013-auto-routing.md)). `enable`/`disable` turn routing on and off; `set-ranker` sets one
-of up to three Rankers in priority order (each an OpenAI-compatible endpoint — `--base-url` + `--model`);
-`remove-ranker` drops one; `status` shows the enabled state and each position's base URL and model —
-**never a key**, in either human or `--json` output. `[grid]` follows the usual selection (active grid when
-omitted). Like membership, these authenticate with your account sign-in (not a per-grid token) and don't
-need the grid running; in `local` mode the command exits with guidance to switch.
+`auto` has the grid pick a model for the request, ranked by an external **Advisor** (see
+[ADR 0013](./adr/0013-auto-routing.md)). An Advisor is a `provider[:model]` pair you pick **by name** from
+the platform catalog — `grid router models` lists the providers and their whitelisted models (the default
+marked), and a bare `provider` uses that default. You supply neither a URL nor a key: the platform carries
+both. `enable`/`disable` turn routing on and off; `set-advisors` **replaces the whole chain** with up to
+three advisors in priority order; `remove-advisor` drops one by name (an exact `provider:model`, or a bare
+`provider` to remove all of its entries); `status` shows the enabled state and the chain as ordered
+`provider:model` tokens — **never a key or URL**, in either human or `--json` output.
 
-The Ranker **API key** for `set-ranker` comes from the `GRID_RANKER_API_KEY` environment variable, else a
-hidden interactive prompt — **never a command-line flag** (so it stays out of shell history and process
-listings), and it is never printed or logged. A change that couldn't be pushed to the running grid yet is
-reported as saved and will apply shortly.
+Every subcommand that acts on a grid selects it with `--grid` (active grid when omitted); `set-advisors` and
+`remove-advisor` take their advisor tokens positionally, and `models` needs no grid at all. Like membership,
+these authenticate with your account sign-in (not a per-grid token) and don't need the grid running; in
+`local` mode the command exits with guidance to switch. A change that couldn't be pushed to the running grid
+yet is reported as saved and will apply shortly.
 
-**Chain + fallback.** The Rankers are tried strictly in position order (1 → 2 → 3, never reordered),
+**Chain + fallback.** The Advisors are tried strictly in priority order (1 → 2 → 3, never reordered),
 advancing on failure. Each has a circuit breaker — 3 consecutive failures skip it for 60 s, then one
-half-open probe re-tries it — so a dead vendor doesn't tax every request. If every Ranker is down the
+half-open probe re-tries it — so a dead vendor doesn't tax every request. If every Advisor is down the
 grid still serves from a deterministic local pick (most free capacity → cheapest → name), stamped
-`X-Grid-Router: fallback`. The ranking call runs on **your** Ranker key; the served request bills the
-consumer as the chosen model.
+`X-Grid-Router: fallback`. The ranking call runs on the platform's advisor-proxy key (not your key, and not
+the consumer's); the served request bills the consumer as the chosen model.
 
 **Consuming `auto`.** An app requests the reserved model `auto` on `chat/completions` (streaming or
 not); the response `model` and the `X-Grid-Routed-Model` header carry the real model, and
 `X-Grid-Router` is `ranked` or `fallback`. `auto` appears in `/v1/models` (as `owned_by:
 "grid-router"`) only while routing is enabled; disabled → a clear "auto routing is not enabled" error.
-`auto` is chat-only — the legacy `completions` endpoint and a `--target-provider` header each reject
+`auto` is chat-only — the legacy `completions` endpoint and an `X-Target-Provider` header each reject
 it, and media models are never candidates.
 
 ### Auto-routing transparency
 
 When routing is enabled, an `auto` request sends a **bounded excerpt** — and nothing else — to each
-Ranker in turn. This table is the complete set of what leaves the grid; the full conversation never
+Advisor in turn. This table is the complete set of what leaves the grid; the full conversation never
 does.
 
 | Field | What it is | Bound |
@@ -471,10 +474,10 @@ does.
 | images present | whether any image/binary part exists (each becomes a `[image]` marker) | yes / no |
 | requested output size | the request's `max_tokens`, if set | integer or unset |
 
-- **When** — only while `grid router` is **enabled**; a disabled grid makes no outbound Ranker call.
-- **To whom** — the Rankers you configured, in priority order (position 1, then 2, 3 on failure).
-- **On whose account** — the ranking call runs on **your** Ranker key; the served request is billed
-  to the consumer as the chosen model.
+- **When** — only while `grid router` is **enabled**; a disabled grid makes no outbound Advisor call.
+- **To whom** — the Advisors you configured, in priority order (advisor 1, then 2, 3 on failure).
+- **On whose account** — the ranking call runs on the platform's advisor-proxy key (not your key, and
+  not the consumer's); the served request is billed to the consumer as the chosen model.
 - **Never sent** — the full conversation, mid-conversation turns, tool-call arguments or schemas, raw
   image/audio bytes or URLs, or any API key.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "grid"
-version = "0.1.14"
+version = "0.1.15"
 description = "Grid: one private OpenAI-compatible endpoint for the AI engines you already run."
 requires-python = ">=3.11"
 dependencies = [

--- a/remote/control_plane.py
+++ b/remote/control_plane.py
@@ -119,23 +119,25 @@ def list_members(
     return list(members or [])
 
 
-# --- Auto-router owner config (ADR 0013) ----------------------------------------------------------
+# --- Auto-router owner config (ADR 0013, revised) -------------------------------------------------
 # Account-level, session-token authorised, owner/admin-checked on the control plane. NOTE the
-# ``/networks/`` path prefix (NOT ``/managed-networks/`` like the calls above): the router routes are
-# registered only under ``/networks/{id}/router`` in grid-apis. Reads/writes return the *masked*
-# config (``{"enabled", "rankers": [{"position", "base_url", "model"}]}``, never a key); mutations add
-# ``"synced": bool``. Ranker keys ride only this owner channel, in the ``set_ranker`` request body.
+# ``/networks/`` path prefix (NOT ``/managed-networks/`` like the calls above): the per-grid router
+# routes are registered only under ``/networks/{id}/router`` in grid-apis (the catalog GET is
+# account-level under ``/router/catalog`` — no network). Reads/writes return the *masked* config
+# (``{"enabled", "advisors": [{"provider", "model"}]}``, never a key or URL); mutations add
+# ``"synced": bool``. Advisors are picked BY NAME from the platform catalog — the owner supplies
+# neither a base URL nor a key (the platform carries both), so nothing secret rides these requests.
 
 
 def get_router_config(session_token: str, network_id: str, api_url: str | None = None) -> dict[str, Any]:
-    """The grid's masked router config (enabled state + each ranker's position/base_url/model). Never
-    carries key material — the control plane strips it on every read."""
+    """The grid's masked router config: ``{"enabled", "advisors": [{"provider", "model"}]}`` in priority
+    order. Never a key or base URL — the control plane masks both on every read."""
     with _client(api_url, session_token) as client:
         return _json_or_empty(_send(client, "GET", f"/v1/grid/networks/{network_id}/router"))
 
 
 def enable_router(session_token: str, network_id: str, api_url: str | None = None) -> dict[str, Any]:
-    """Turn auto-routing on. The control plane rejects enabling with zero rankers (clear 400)."""
+    """Turn auto-routing on. The control plane rejects enabling with zero advisors (clear 400)."""
     with _client(api_url, session_token) as client:
         return _json_or_empty(_send(client, "POST", f"/v1/grid/networks/{network_id}/router/enable"))
 
@@ -146,27 +148,46 @@ def disable_router(session_token: str, network_id: str, api_url: str | None = No
         return _json_or_empty(_send(client, "POST", f"/v1/grid/networks/{network_id}/router/disable"))
 
 
-def set_ranker(
-    session_token: str, network_id: str, position: int, base_url: str, model: str, api_key: str,
+def set_advisors(
+    session_token: str, network_id: str, advisors: list[tuple[str, str | None]],
     api_url: str | None = None,
 ) -> dict[str, Any]:
-    """Set the ranker at ``position`` (1-3). ``api_key`` rides the body (sourced by the CLI from the
-    ``GRID_RANKER_API_KEY`` env var or a hidden prompt — never a flag). The control plane validates
-    scheme / non-empty model / key presence / contiguity and returns clear 400s."""
+    """Replace the whole advisor chain (1-3 ``{provider, model}`` pairs, order = priority). Each item is a
+    ``(provider, model | None)`` tuple; a bare provider (``model is None``) is sent provider-only so the
+    control plane resolves the catalog default. Replace-all — the posted list IS the chain. No key and no
+    URL ride this request (the platform carries both). Server 400s (unknown provider, off-whitelist model
+    listing the valid names, duplicate pair, >3) surface as a clean ``SystemExit`` via ``_send``."""
+    body = {"advisors": [
+        ({"provider": provider, "model": model} if model else {"provider": provider})
+        for provider, model in advisors
+    ]}
     with _client(api_url, session_token) as client:
         return _json_or_empty(_send(
-            client, "PUT", f"/v1/grid/networks/{network_id}/router/rankers/{position}",
-            json={"base_url": base_url, "model": model, "api_key": api_key},
-        ))
+            client, "PUT", f"/v1/grid/networks/{network_id}/router/advisors", json=body))
 
 
-def remove_ranker(
-    session_token: str, network_id: str, position: int, api_url: str | None = None
+def remove_advisor(
+    session_token: str, network_id: str, provider: str, model: str | None = None,
+    api_url: str | None = None,
 ) -> dict[str, Any]:
-    """Remove the ranker at ``position`` (1-3). Removing the last ranker while enabled is a clear 400."""
+    """Remove advisors by name: an exact ``provider`` + ``model`` removes one entry; a bare ``provider``
+    (``model is None``) removes all of that provider's entries. Name(s) ride the query string (httpx
+    percent-encodes them; there is no path segment to inject). A remove that matches nothing is a clear
+    400 from the control plane."""
+    params: dict[str, str] = {"provider": provider}
+    if model:
+        params["model"] = model
     with _client(api_url, session_token) as client:
         return _json_or_empty(_send(
-            client, "DELETE", f"/v1/grid/networks/{network_id}/router/rankers/{position}"))
+            client, "DELETE", f"/v1/grid/networks/{network_id}/router/advisors", params=params))
+
+
+def get_router_catalog(session_token: str, api_url: str | None = None) -> dict[str, Any]:
+    """The advisor catalog backing ``grid router models`` — each provider, its whitelisted models, and the
+    default. Account-level (any session token); no network, no admin, no grid running. Never a base URL or
+    key. Shape: ``{"providers": [{"provider", "models": [...], "default_model"}]}``."""
+    with _client(api_url, session_token) as client:
+        return _json_or_empty(_send(client, "GET", "/v1/grid/router/catalog"))
 
 
 def _send(client: httpx.Client, method: str, url: str, **kwargs: Any) -> httpx.Response:

--- a/remote/control_plane.py
+++ b/remote/control_plane.py
@@ -119,6 +119,56 @@ def list_members(
     return list(members or [])
 
 
+# --- Auto-router owner config (ADR 0013) ----------------------------------------------------------
+# Account-level, session-token authorised, owner/admin-checked on the control plane. NOTE the
+# ``/networks/`` path prefix (NOT ``/managed-networks/`` like the calls above): the router routes are
+# registered only under ``/networks/{id}/router`` in grid-apis. Reads/writes return the *masked*
+# config (``{"enabled", "rankers": [{"position", "base_url", "model"}]}``, never a key); mutations add
+# ``"synced": bool``. Ranker keys ride only this owner channel, in the ``set_ranker`` request body.
+
+
+def get_router_config(session_token: str, network_id: str, api_url: str | None = None) -> dict[str, Any]:
+    """The grid's masked router config (enabled state + each ranker's position/base_url/model). Never
+    carries key material — the control plane strips it on every read."""
+    with _client(api_url, session_token) as client:
+        return _json_or_empty(_send(client, "GET", f"/v1/grid/networks/{network_id}/router"))
+
+
+def enable_router(session_token: str, network_id: str, api_url: str | None = None) -> dict[str, Any]:
+    """Turn auto-routing on. The control plane rejects enabling with zero rankers (clear 400)."""
+    with _client(api_url, session_token) as client:
+        return _json_or_empty(_send(client, "POST", f"/v1/grid/networks/{network_id}/router/enable"))
+
+
+def disable_router(session_token: str, network_id: str, api_url: str | None = None) -> dict[str, Any]:
+    """Turn auto-routing off."""
+    with _client(api_url, session_token) as client:
+        return _json_or_empty(_send(client, "POST", f"/v1/grid/networks/{network_id}/router/disable"))
+
+
+def set_ranker(
+    session_token: str, network_id: str, position: int, base_url: str, model: str, api_key: str,
+    api_url: str | None = None,
+) -> dict[str, Any]:
+    """Set the ranker at ``position`` (1-3). ``api_key`` rides the body (sourced by the CLI from the
+    ``GRID_RANKER_API_KEY`` env var or a hidden prompt — never a flag). The control plane validates
+    scheme / non-empty model / key presence / contiguity and returns clear 400s."""
+    with _client(api_url, session_token) as client:
+        return _json_or_empty(_send(
+            client, "PUT", f"/v1/grid/networks/{network_id}/router/rankers/{position}",
+            json={"base_url": base_url, "model": model, "api_key": api_key},
+        ))
+
+
+def remove_ranker(
+    session_token: str, network_id: str, position: int, api_url: str | None = None
+) -> dict[str, Any]:
+    """Remove the ranker at ``position`` (1-3). Removing the last ranker while enabled is a clear 400."""
+    with _client(api_url, session_token) as client:
+        return _json_or_empty(_send(
+            client, "DELETE", f"/v1/grid/networks/{network_id}/router/rankers/{position}"))
+
+
 def _send(client: httpx.Client, method: str, url: str, **kwargs: Any) -> httpx.Response:
     """One request with both failure modes surfaced as a clean SystemExit (never a traceback):
     a transport/connection error before a response, and a >=400 status after one."""

--- a/remote/control_plane.py
+++ b/remote/control_plane.py
@@ -10,6 +10,7 @@ is reached in local mode (dispatch gates the remote commands to remote mode).
 """
 from __future__ import annotations
 
+import os
 from typing import Any
 from urllib.parse import quote
 
@@ -18,11 +19,18 @@ import httpx
 from . import credentials
 
 
+# Control-plane HTTP timeout (seconds). The default suits every fast call; managed-network *create* is
+# synchronous and can exceed it while the backend boots the master, so it is overridable via
+# ``GRID_CONTROL_PLANE_TIMEOUT`` (a too-short timeout aborts the client mid-create, leaving the backend
+# to finish on its own — a half-registered network).
+_TIMEOUT = float(os.getenv("GRID_CONTROL_PLANE_TIMEOUT", "30"))
+
+
 def _client(api_url: str | None = None, token: str | None = None) -> httpx.Client:
     headers = {"User-Agent": "grid-cli"}
     if token:
         headers["Authorization"] = f"Bearer {token}"
-    return httpx.Client(base_url=credentials.api_url(api_url), headers=headers, timeout=30.0)
+    return httpx.Client(base_url=credentials.api_url(api_url), headers=headers, timeout=_TIMEOUT)
 
 
 def start_device_login(api_url: str | None = None) -> dict[str, Any]:

--- a/remote/probe.py
+++ b/remote/probe.py
@@ -400,24 +400,23 @@ def probe_llama_capabilities(llm_url: str, llm_model: str) -> dict[str, bool]:
     return probed
 
 
-DEFAULT_CONTEXT_WINDOW = 128000
-
-
 def capability_entry(
     probed: dict[str, bool], context_window: int | None = None,
     endpoints: list[str] | None = None,
 ) -> dict[str, Any]:
-    """Render one model's capability entry (matches the desktop/relay shape). ``context_window`` reflects
-    the engine's ``--ctx-size`` when known (the master reads it into the model catalog); it falls back to
-    the default when unknown. ``endpoints`` defaults to the hardware-engine pair; an API engine passes
-    ``["chat/completions"]`` — it never serves legacy completions (ADR 0012)."""
+    """Render one model's capability entry (matches the desktop/relay shape). ``context_window`` is
+    included ONLY when actually known (the engine's ``--ctx-size`` or an API whitelist entry) — an
+    unknown window is omitted, never defaulted, so the master (and the auto-router Advisor) treats
+    absence as "unknown" rather than trusting a fabricated 128000. ``endpoints`` defaults to the
+    hardware-engine pair; an API engine passes ``["chat/completions"]`` — it never serves legacy
+    completions (ADR 0012)."""
     input_modalities = ["text", "image"] if probed["vision"] else ["text"]
-    ctx = int(context_window) if context_window else DEFAULT_CONTEXT_WINDOW
+    ctx = int(context_window) if context_window else None
     return {
         "endpoints": list(endpoints) if endpoints is not None else ["chat/completions", "completions"],
         "input_modalities": input_modalities,
         "output_modalities": ["text"],
-        "context_window": ctx,
+        **({"context_window": ctx} if ctx is not None else {}),
         "max_output_tokens": 64000,
         "features": {
             "vision": probed["vision"],
@@ -430,7 +429,7 @@ def capability_entry(
             "top_logprobs": False,
         },
         "limits": {
-            "max_context_tokens": ctx,
+            **({"max_context_tokens": ctx} if ctx is not None else {}),
             "max_output_tokens": 64000,
             "max_images": 8,
             "max_image_bytes": 4_000_000,

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -8945,7 +8945,7 @@ def test_price_is_gated_in_local_mode_through_cli_main(monkeypatch, tmp_path):
         cli.main(["price", "show"])
 
 
-def test_capability_entry_uses_ctx_size_when_given():
+def test_capability_entry_uses_ctx_size_and_omits_when_unknown():
     from remote import probe
 
     probed = {"vision": False, "tools": False, "parallel_tool_calls": False,
@@ -8953,9 +8953,12 @@ def test_capability_entry_uses_ctx_size_when_given():
     entry = probe.capability_entry(probed, 200000)
     assert entry["context_window"] == 200000
     assert entry["limits"]["max_context_tokens"] == 200000
-    # falls back to the default when unknown
+    # An unknown window is OMITTED, never defaulted — the master treats absence as "unknown" rather
+    # than being handed a fabricated 128000 that would mislead the auto-router's Advisor.
     default = probe.capability_entry(probed)
-    assert default["context_window"] == probe.DEFAULT_CONTEXT_WINDOW
+    assert "context_window" not in default
+    assert "max_context_tokens" not in default["limits"]
+    assert default["limits"]["max_output_tokens"] == 64000  # the other limits still present
 
 
 def test_capabilities_threads_ctx_size_into_envelope(monkeypatch):
@@ -8966,6 +8969,16 @@ def test_capabilities_threads_ctx_size_into_envelope(monkeypatch):
         "json_object": False, "json_schema": False})
     env = probe.capabilities("http://h:8081/v1", "qwen3.5:0.8b", context_window=200000)
     assert env["models"]["qwen3.5:0.8b"]["context_window"] == 200000
+
+
+def test_capabilities_envelope_omits_ctx_when_unknown(monkeypatch):
+    from remote import probe
+
+    monkeypatch.setattr(probe, "probe_llama_capabilities", lambda url, model: {
+        "vision": False, "tools": False, "parallel_tool_calls": False,
+        "json_object": False, "json_schema": False})
+    env = probe.capabilities("http://h:8081/v1", "qwen3.5:0.8b")  # no context_window known
+    assert "context_window" not in env["models"]["qwen3.5:0.8b"]
 
 
 # -- provider heartbeat VRAM (grid provider VRAM roll-up on the grid page) --

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -8112,218 +8112,361 @@ def test_control_plane_list_members_handles_no_content(monkeypatch, tmp_path):
 # Remote router — `grid router` command group (cli/remote_router.py, ADR 0013)
 # ---------------------------------------------------------------------------
 
-def _mock_router(monkeypatch, *, config=None, enable=None, disable=None, set_ranker=None, remove=None):
-    """Stub the five control-plane router calls; record what each was invoked with."""
+def _mock_router(monkeypatch, *, config=None, enable=None, disable=None,
+                 set_advisors=None, remove_advisor=None, catalog=None):
+    """Stub the six control-plane router calls; record what each was invoked with. Replies use the v2
+    ``advisors`` shape (``{provider, model}`` pairs) — never a key or base URL."""
     from remote import control_plane
 
     calls = {}
 
     def _get(session_token, network_id, api_url=None):
         calls["status"] = {"session": session_token, "network_id": network_id}
-        return config if config is not None else {"enabled": False, "rankers": []}
+        return config if config is not None else {"enabled": False, "advisors": []}
 
     def _enable(session_token, network_id, api_url=None):
         calls["enable"] = {"session": session_token, "network_id": network_id}
-        return enable if enable is not None else {"enabled": True, "rankers": [], "synced": True}
+        return enable if enable is not None else {"enabled": True, "advisors": [], "synced": True}
 
     def _disable(session_token, network_id, api_url=None):
         calls["disable"] = {"session": session_token, "network_id": network_id}
-        return disable if disable is not None else {"enabled": False, "rankers": [], "synced": True}
+        return disable if disable is not None else {"enabled": False, "advisors": [], "synced": True}
 
-    def _set(session_token, network_id, position, base_url, model, api_key, api_url=None):
-        calls["set_ranker"] = {
-            "session": session_token, "network_id": network_id, "position": position,
-            "base_url": base_url, "model": model, "api_key": api_key,
-        }
-        return set_ranker if set_ranker is not None else {
+    def _set(session_token, network_id, advisors, api_url=None):
+        calls["set_advisors"] = {
+            "session": session_token, "network_id": network_id, "advisors": advisors}
+        return set_advisors if set_advisors is not None else {
             "enabled": False,
-            "rankers": [{"position": position, "base_url": base_url, "model": model}],
+            "advisors": [{"provider": p, "model": m} for p, m in advisors],
             "synced": True,
         }
 
-    def _remove(session_token, network_id, position, api_url=None):
-        calls["remove_ranker"] = {"session": session_token, "network_id": network_id, "position": position}
-        return remove if remove is not None else {"enabled": False, "rankers": [], "synced": True}
+    def _remove(session_token, network_id, provider, model=None, api_url=None):
+        calls["remove_advisor"] = {
+            "session": session_token, "network_id": network_id, "provider": provider, "model": model}
+        return remove_advisor if remove_advisor is not None else {
+            "enabled": False, "advisors": [], "synced": True}
+
+    def _catalog(session_token, api_url=None):
+        calls["catalog"] = {"session": session_token}
+        return catalog if catalog is not None else {"providers": []}
 
     monkeypatch.setattr(control_plane, "get_router_config", _get)
     monkeypatch.setattr(control_plane, "enable_router", _enable)
     monkeypatch.setattr(control_plane, "disable_router", _disable)
-    monkeypatch.setattr(control_plane, "set_ranker", _set)
-    monkeypatch.setattr(control_plane, "remove_ranker", _remove)
+    monkeypatch.setattr(control_plane, "set_advisors", _set)
+    monkeypatch.setattr(control_plane, "remove_advisor", _remove)
+    monkeypatch.setattr(control_plane, "get_router_catalog", _catalog)
     return calls
 
+
+# -- enable / disable / status ----------------------------------------------
 
 def test_router_enable_calls_control_plane_and_confirms(monkeypatch, tmp_path, capsys):
     _seed_remote(monkeypatch, tmp_path,
                  networks=[{"network_id": "n1", "name": "team"}], active="team")
-    calls = _mock_router(monkeypatch, enable={"enabled": True, "rankers": [], "synced": True})
+    calls = _mock_router(monkeypatch, enable={"enabled": True, "advisors": [], "synced": True})
     assert cli.main(["router", "enable"]) == 0
     out = capsys.readouterr().out
     assert calls["enable"] == {"session": "sess-tok", "network_id": "n1"}
     assert "enabled" in out.lower()
 
 
-def test_router_status_shows_state_and_rankers_without_keys(monkeypatch, tmp_path, capsys):
-    _seed_remote(monkeypatch, tmp_path,
-                 networks=[{"network_id": "n1", "name": "team"}], active="team")
-    config = {"enabled": True, "rankers": [
-        {"position": 1, "base_url": "https://api.openai.com/v1", "model": "gpt-4o-mini"}]}
-    calls = _mock_router(monkeypatch, config=config)
-    assert cli.main(["router", "status"]) == 0
-    out = capsys.readouterr().out
-    assert calls["status"] == {"session": "sess-tok", "network_id": "n1"}
-    assert "enabled" in out.lower()
-    assert "gpt-4o-mini" in out and "https://api.openai.com/v1" in out
-
-
-def test_router_status_empty_reports_no_rankers(monkeypatch, tmp_path, capsys):
-    _seed_remote(monkeypatch, tmp_path,
-                 networks=[{"network_id": "n1", "name": "team"}], active="team")
-    _mock_router(monkeypatch, config={"enabled": False, "rankers": []})
-    assert cli.main(["router", "status"]) == 0
-    out = capsys.readouterr().out
-    assert "disabled" in out.lower()
-    assert "no rankers" in out.lower()
-
-
-def test_router_status_json_echoes_masked_config(monkeypatch, tmp_path, capsys):
-    _seed_remote(monkeypatch, tmp_path,
-                 networks=[{"network_id": "n1", "name": "team"}], active="team")
-    config = {"enabled": True, "rankers": [
-        {"position": 1, "base_url": "https://api.openai.com/v1", "model": "gpt-4o-mini"}]}
-    _mock_router(monkeypatch, config=config)
-    assert cli.main(["router", "status", "--json"]) == 0
-    assert json.loads(capsys.readouterr().out) == config
-
-
 def test_router_disable_calls_control_plane_and_confirms(monkeypatch, tmp_path, capsys):
     _seed_remote(monkeypatch, tmp_path,
                  networks=[{"network_id": "n1", "name": "team"}], active="team")
-    calls = _mock_router(monkeypatch, disable={"enabled": False, "rankers": [], "synced": True})
+    calls = _mock_router(monkeypatch, disable={"enabled": False, "advisors": [], "synced": True})
     assert cli.main(["router", "disable"]) == 0
     out = capsys.readouterr().out
     assert calls["disable"] == {"session": "sess-tok", "network_id": "n1"}
     assert "disabled" in out.lower()
 
 
-def test_router_remove_ranker_calls_control_plane_and_confirms(monkeypatch, tmp_path, capsys):
+def test_router_status_shows_state_and_advisors_as_tokens(monkeypatch, tmp_path, capsys):
     _seed_remote(monkeypatch, tmp_path,
                  networks=[{"network_id": "n1", "name": "team"}], active="team")
-    calls = _mock_router(monkeypatch, remove={"enabled": True, "rankers": [], "synced": True})
-    assert cli.main(["router", "remove-ranker", "2"]) == 0
+    config = {"enabled": True, "advisors": [
+        {"provider": "openai", "model": "gpt-5-mini"},
+        {"provider": "openai", "model": "gpt-4o-mini"}]}
+    calls = _mock_router(monkeypatch, config=config)
+    assert cli.main(["router", "status"]) == 0
     out = capsys.readouterr().out
-    assert calls["remove_ranker"] == {"session": "sess-tok", "network_id": "n1", "position": 2}
-    assert "2" in out
+    assert calls["status"] == {"session": "sess-tok", "network_id": "n1"}
+    assert "enabled" in out.lower()
+    assert "openai:gpt-5-mini" in out and "openai:gpt-4o-mini" in out
+    # order = priority: position 1 (gpt-5-mini) prints before position 2 (gpt-4o-mini)
+    assert out.index("gpt-5-mini") < out.index("gpt-4o-mini")
+    # no base_url / position leakage from the old shape
+    assert "https://" not in out
 
 
-def test_router_set_ranker_uses_env_key_and_never_prints_it(monkeypatch, tmp_path, capsys):
+def test_router_status_empty_reports_no_advisors(monkeypatch, tmp_path, capsys):
     _seed_remote(monkeypatch, tmp_path,
                  networks=[{"network_id": "n1", "name": "team"}], active="team")
-    monkeypatch.setenv("GRID_RANKER_API_KEY", "sk-secret-123")
-    calls = _mock_router(monkeypatch)
-    assert cli.main(["router", "set-ranker", "1",
-                     "--base-url", "https://api.openai.com/v1", "--model", "gpt-4o-mini"]) == 0
+    _mock_router(monkeypatch, config={"enabled": False, "advisors": []})
+    assert cli.main(["router", "status"]) == 0
     out = capsys.readouterr().out
-    assert calls["set_ranker"] == {
-        "session": "sess-tok", "network_id": "n1", "position": 1,
-        "base_url": "https://api.openai.com/v1", "model": "gpt-4o-mini", "api_key": "sk-secret-123",
-    }
-    assert "sk-secret-123" not in out  # the key is never echoed
+    assert "disabled" in out.lower()
+    assert "no advisors" in out.lower()
 
 
-def test_router_set_ranker_prompts_when_no_env_key(monkeypatch, tmp_path):
+def test_router_status_json_echoes_masked_config(monkeypatch, tmp_path, capsys):
     _seed_remote(monkeypatch, tmp_path,
                  networks=[{"network_id": "n1", "name": "team"}], active="team")
-    monkeypatch.delenv("GRID_RANKER_API_KEY", raising=False)
-    calls = _mock_router(monkeypatch)
-    monkeypatch.setattr(cli.provider, "_interactive", lambda: True)
-    monkeypatch.setattr(cli.remote_router, "_prompt_ranker_key", lambda: "sk-prompted")
-    assert cli.main(["router", "set-ranker", "1",
-                     "--base-url", "https://api.openai.com/v1", "--model", "gpt-4o-mini"]) == 0
-    assert calls["set_ranker"]["api_key"] == "sk-prompted"
+    config = {"enabled": True, "advisors": [{"provider": "openai", "model": "gpt-5-mini"}]}
+    _mock_router(monkeypatch, config=config)
+    assert cli.main(["router", "status", "--json"]) == 0
+    assert json.loads(capsys.readouterr().out) == config
 
 
-def test_router_set_ranker_errors_without_key_non_interactive(monkeypatch, tmp_path):
+def test_router_status_selects_grid_with_flag(monkeypatch, tmp_path):
     _seed_remote(monkeypatch, tmp_path,
-                 networks=[{"network_id": "n1", "name": "team"}], active="team")
-    monkeypatch.delenv("GRID_RANKER_API_KEY", raising=False)
-    _mock_router(monkeypatch)
-    monkeypatch.setattr(cli.provider, "_interactive", lambda: False)
-    with pytest.raises(SystemExit) as exc:
-        cli.main(["router", "set-ranker", "1",
-                  "--base-url", "https://api.openai.com/v1", "--model", "gpt-4o-mini"])
-    assert "GRID_RANKER_API_KEY" in str(exc.value)
+                 networks=[{"network_id": "n1", "name": "team"},
+                           {"network_id": "n2", "name": "other"}], active="team")
+    calls = _mock_router(monkeypatch, config={"enabled": False, "advisors": []})
+    assert cli.main(["router", "status", "--grid", "other"]) == 0
+    assert calls["status"]["network_id"] == "n2"  # --grid overrides the active grid
 
 
-def test_router_set_ranker_has_no_key_flag():
+def test_router_status_rejects_positional_grid():
+    # Uniform selection: after the v2 reshape a grid is named ONLY via --grid; a positional grid name is no
+    # longer accepted (guards the whole group from a mixed-idiom regression).
     parser = cli.build_parser()
-    with pytest.raises(SystemExit):  # a key flag does not exist — argparse rejects it
-        parser.parse_args(["router", "set-ranker", "1", "--base-url", "https://x/v1",
-                           "--model", "m", "--api-key", "sk-x"])
+    with pytest.raises(SystemExit):
+        parser.parse_args(["router", "status", "team"])
 
 
-def test_router_set_ranker_json_never_shows_key(monkeypatch, tmp_path, capsys):
+# -- set-advisors -----------------------------------------------------------
+
+def test_router_set_advisors_replaces_chain_and_confirms(monkeypatch, tmp_path, capsys):
     _seed_remote(monkeypatch, tmp_path,
                  networks=[{"network_id": "n1", "name": "team"}], active="team")
-    monkeypatch.setenv("GRID_RANKER_API_KEY", "sk-secret-123")
-    _mock_router(monkeypatch)
-    assert cli.main(["router", "set-ranker", "1", "--base-url", "https://api.openai.com/v1",
-                     "--model", "gpt-4o-mini", "--json"]) == 0
-    assert "sk-secret-123" not in capsys.readouterr().out
+    calls = _mock_router(monkeypatch)
+    assert cli.main(["router", "set-advisors", "openai:gpt-5-mini", "openai:gpt-4o-mini"]) == 0
+    out = capsys.readouterr().out
+    assert calls["set_advisors"] == {
+        "session": "sess-tok", "network_id": "n1",
+        "advisors": [("openai", "gpt-5-mini"), ("openai", "gpt-4o-mini")],  # order = priority, forwarded
+    }
+    assert "openai:gpt-5-mini" in out and "openai:gpt-4o-mini" in out
 
+
+def test_router_set_advisors_single_token(monkeypatch, tmp_path, capsys):
+    _seed_remote(monkeypatch, tmp_path,
+                 networks=[{"network_id": "n1", "name": "team"}], active="team")
+    calls = _mock_router(monkeypatch)
+    assert cli.main(["router", "set-advisors", "openai:gpt-5-mini"]) == 0
+    assert calls["set_advisors"]["advisors"] == [("openai", "gpt-5-mini")]
+
+
+def test_router_set_advisors_bare_provider_forwards_none(monkeypatch, tmp_path, capsys):
+    _seed_remote(monkeypatch, tmp_path,
+                 networks=[{"network_id": "n1", "name": "team"}], active="team")
+    calls = _mock_router(monkeypatch)
+    assert cli.main(["router", "set-advisors", "openai"]) == 0
+    # bare provider → model None; the control-plane client sends it provider-only (server resolves default)
+    assert calls["set_advisors"]["advisors"] == [("openai", None)]
+
+
+def test_router_set_advisors_uses_grid_flag_not_active(monkeypatch, tmp_path):
+    _seed_remote(monkeypatch, tmp_path,
+                 networks=[{"network_id": "n1", "name": "team"},
+                           {"network_id": "n2", "name": "other"}], active="team")
+    calls = _mock_router(monkeypatch)
+    assert cli.main(["router", "set-advisors", "openai:gpt-5-mini", "--grid", "other"]) == 0
+    assert calls["set_advisors"]["network_id"] == "n2"  # --grid overrides the active grid
+
+
+def test_router_set_advisors_rejects_fourth_token():
+    parser = cli.build_parser()
+    with pytest.raises(SystemExit):  # a 4th token is a clean parser rejection (AdvisorsAction cap)
+        parser.parse_args(["router", "set-advisors",
+                           "openai", "openai:gpt-5-nano", "openai:gpt-4o-mini", "openai:gpt-4.1-mini"])
+
+
+def test_router_set_advisors_accepts_exactly_three_max():
+    # The boundary: exactly MAX_ADVISORS (3) tokens must PARSE — guards a `>`→`>=` off-by-one regression in
+    # AdvisorsAction that the over-limit test alone wouldn't catch.
+    parser = cli.build_parser()
+    ns = parser.parse_args(["router", "set-advisors",
+                            "openai:gpt-5-mini", "openai:gpt-5-nano", "openai:gpt-4o-mini"])
+    assert len(ns.advisors) == 3
+
+
+@pytest.mark.parametrize("bad", [":m", "openai:", "a:b:c", ""])
+def test_router_set_advisors_rejects_malformed_token(bad):
+    parser = cli.build_parser()
+    with pytest.raises(SystemExit):  # malformed provider[:model] → parse_advisor_token ArgumentTypeError
+        parser.parse_args(["router", "set-advisors", bad])
+
+
+def test_router_set_advisors_json_scrubs_any_key(monkeypatch, tmp_path, capsys):
+    _seed_remote(monkeypatch, tmp_path,
+                 networks=[{"network_id": "n1", "name": "team"}], active="team")
+    _mock_router(monkeypatch, set_advisors={"enabled": False, "synced": True, "advisors": [
+        {"provider": "openai", "model": "gpt-5-mini", "api_key": "sk-should-not-appear"}]})
+    assert cli.main(["router", "set-advisors", "openai:gpt-5-mini", "--json"]) == 0
+    out = capsys.readouterr().out
+    assert "sk-should-not-appear" not in out and "api_key" not in out
+
+
+def test_router_set_advisors_surfaces_off_whitelist_400(monkeypatch, tmp_path):
+    # A real control-plane call (transport stubbed): an off-whitelist model is a 400 whose detail lists the
+    # valid names — the CLI surfaces that message verbatim, never a traceback.
+    _seed_remote(monkeypatch, tmp_path,
+                 networks=[{"network_id": "n1", "name": "team"}], active="team")
+    _mock_control_plane(monkeypatch, lambda r: httpx.Response(400, json={
+        "detail": "Invalid model 'gpt-9' for advisor 'openai'. Valid models: gpt-5-mini, gpt-5-nano"}))
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["router", "set-advisors", "openai:gpt-9"])
+    msg = str(exc.value)
+    assert "400" in msg and "Valid models" in msg
+
+
+# -- remove-advisor ---------------------------------------------------------
+
+def test_router_remove_advisor_exact_pair(monkeypatch, tmp_path, capsys):
+    _seed_remote(monkeypatch, tmp_path,
+                 networks=[{"network_id": "n1", "name": "team"}], active="team")
+    calls = _mock_router(monkeypatch, remove_advisor={"enabled": True, "advisors": [], "synced": True})
+    assert cli.main(["router", "remove-advisor", "openai:gpt-4o-mini"]) == 0
+    out = capsys.readouterr().out
+    assert calls["remove_advisor"] == {
+        "session": "sess-tok", "network_id": "n1", "provider": "openai", "model": "gpt-4o-mini"}
+    assert "openai:gpt-4o-mini" in out
+
+
+def test_router_remove_advisor_bare_provider_removes_all(monkeypatch, tmp_path, capsys):
+    _seed_remote(monkeypatch, tmp_path,
+                 networks=[{"network_id": "n1", "name": "team"}], active="team")
+    calls = _mock_router(monkeypatch)
+    assert cli.main(["router", "remove-advisor", "openai"]) == 0
+    assert calls["remove_advisor"] == {
+        "session": "sess-tok", "network_id": "n1", "provider": "openai", "model": None}
+
+
+def test_router_remove_advisor_empty_reply_is_clean(monkeypatch, tmp_path, capsys):
+    # Defensive: the real DELETE returns a full 200 body, but `_json_or_empty` coerces a 204/empty body to
+    # `{}`. That path must still print a clean confirmation and exit 0 — never crash on `.get()`.
+    _seed_remote(monkeypatch, tmp_path,
+                 networks=[{"network_id": "n1", "name": "team"}], active="team")
+    _mock_router(monkeypatch, remove_advisor={})  # 204-equivalent empty reply
+    assert cli.main(["router", "remove-advisor", "openai"]) == 0
+    assert "openai" in capsys.readouterr().out  # a confirmation still prints, no traceback
+
+
+# -- models (catalog) -------------------------------------------------------
+
+def test_router_models_renders_catalog_with_default_marked(monkeypatch, tmp_path, capsys):
+    _seed_remote(monkeypatch, tmp_path,
+                 networks=[{"network_id": "n1", "name": "team"}], active="team")
+    catalog = {"providers": [{"provider": "openai",
+                              "models": ["gpt-5-mini", "gpt-5-nano", "gpt-4o-mini"],
+                              "default_model": "gpt-5-mini"}]}
+    calls = _mock_router(monkeypatch, catalog=catalog)
+    assert cli.main(["router", "models"]) == 0
+    out = capsys.readouterr().out
+    assert calls["catalog"] == {"session": "sess-tok"}
+    assert "openai:gpt-5-mini" in out and "openai:gpt-5-nano" in out and "openai:gpt-4o-mini" in out
+    default_line = next(ln for ln in out.splitlines() if "gpt-5-mini" in ln)
+    assert "default" in default_line.lower()  # the default model is marked
+    nano_line = next(ln for ln in out.splitlines() if "gpt-5-nano" in ln)
+    assert "default" not in nano_line.lower()  # a non-default is not marked
+
+
+def test_router_models_json_echoes_reply(monkeypatch, tmp_path, capsys):
+    _seed_remote(monkeypatch, tmp_path,
+                 networks=[{"network_id": "n1", "name": "team"}], active="team")
+    catalog = {"providers": [
+        {"provider": "openai", "models": ["gpt-5-mini"], "default_model": "gpt-5-mini"}]}
+    _mock_router(monkeypatch, catalog=catalog)
+    assert cli.main(["router", "models", "--json"]) == 0
+    assert json.loads(capsys.readouterr().out) == catalog
+
+
+def test_router_models_works_without_grid_resolved(monkeypatch, tmp_path, capsys):
+    # No grids at all: `status` would error ("name a grid"), but `models` reads the account-level catalog
+    # and must still work — it never resolves a grid.
+    _seed_remote(monkeypatch, tmp_path, networks=[], active=None)
+    calls = _mock_router(monkeypatch, catalog={"providers": [
+        {"provider": "openai", "models": ["gpt-5-mini"], "default_model": "gpt-5-mini"}]})
+    assert cli.main(["router", "models"]) == 0
+    assert calls["catalog"] == {"session": "sess-tok"}
+    assert "openai:gpt-5-mini" in capsys.readouterr().out
+
+
+# -- no key path anywhere ---------------------------------------------------
+
+def test_router_module_has_no_key_path():
+    # The v2 reshape deletes every key path — env var, hidden prompt, and the resolver helpers.
+    import cli.remote_router as rr
+    for gone in ("RANKER_KEY_ENV", "_resolve_ranker_key", "_prompt_ranker_key"):
+        assert not hasattr(rr, gone)
+
+
+def test_router_set_advisors_has_no_key_or_url_flags():
+    parser = cli.build_parser()
+    for flag in (["--api-key", "sk-x"], ["--base-url", "https://x/v1"], ["--model", "m"]):
+        with pytest.raises(SystemExit):  # none of these flags exist on the v2 surface
+            parser.parse_args(["router", "set-advisors", "openai:gpt-5-mini", *flag])
+
+
+# -- secret scrub (belt-and-suspenders) -------------------------------------
 
 def test_router_status_json_scrubs_leaked_key(monkeypatch, tmp_path, capsys):
-    # Defence in depth: even if grid-apis ever regressed its masking and returned a key, the CLI must
-    # not echo it. The control plane is the source of truth for masking; this pins the client scrub.
+    # Defence in depth: even if grid-apis ever regressed its masking and returned a key, the CLI must not
+    # echo it. The control plane is the source of truth for masking; this pins the client scrub.
     _seed_remote(monkeypatch, tmp_path,
                  networks=[{"network_id": "n1", "name": "team"}], active="team")
-    leaked = {"enabled": True, "rankers": [
-        {"position": 1, "base_url": "https://api.openai.com/v1", "model": "gpt-4o-mini",
-         "api_key": "sk-leaked-999"}]}
+    leaked = {"enabled": True, "advisors": [
+        {"provider": "openai", "model": "gpt-5-mini", "api_key": "sk-leaked-999"}]}
     _mock_router(monkeypatch, config=leaked)
     assert cli.main(["router", "status", "--json"]) == 0
     out = capsys.readouterr().out
     assert "sk-leaked-999" not in out and "api_key" not in out
-    assert "gpt-4o-mini" in out  # the non-secret fields still print
+    assert "gpt-5-mini" in out  # the non-secret fields still print
 
+
+def test_router_status_json_scrubs_leaked_base_url(monkeypatch, tmp_path, capsys):
+    # The invariant is "never a key OR URL" (ADR 0013). The master-facing snapshot already materializes
+    # `{base_url, api_key, model}` triples; if a server regression ever leaked that shape onto the owner REST
+    # reply, the client scrub must drop the base_url too — not just the key.
+    _seed_remote(monkeypatch, tmp_path,
+                 networks=[{"network_id": "n1", "name": "team"}], active="team")
+    leaked = {"enabled": True, "advisors": [
+        {"provider": "openai", "model": "gpt-5-mini", "base_url": "https://internal-proxy.example/v1"}]}
+    _mock_router(monkeypatch, config=leaked)
+    assert cli.main(["router", "status", "--json"]) == 0
+    out = capsys.readouterr().out
+    assert "internal-proxy" not in out and "base_url" not in out
+    assert "gpt-5-mini" in out  # the non-secret fields still print
+
+
+def test_router_status_never_shows_key_material(monkeypatch, tmp_path, capsys):
+    _seed_remote(monkeypatch, tmp_path,
+                 networks=[{"network_id": "n1", "name": "team"}], active="team")
+    config = {"enabled": True, "advisors": [{"provider": "openai", "model": "gpt-5-mini"}]}
+    _mock_router(monkeypatch, config=config)
+    for argv in (["router", "status"], ["router", "status", "--json"]):
+        assert cli.main(argv) == 0
+        out = capsys.readouterr().out
+        assert "api_key" not in out and "sk-" not in out
+
+
+# -- mutation sync caveat ---------------------------------------------------
 
 def test_router_mutation_no_caveat_when_synced_absent(monkeypatch, tmp_path, capsys):
     _seed_remote(monkeypatch, tmp_path,
                  networks=[{"network_id": "n1", "name": "team"}], active="team")
-    _mock_router(monkeypatch, enable={"enabled": True, "rankers": []})  # reply omits `synced`
+    _mock_router(monkeypatch, enable={"enabled": True, "advisors": []})  # reply omits `synced`
     assert cli.main(["router", "enable"]) == 0
     assert "shortly" not in capsys.readouterr().out.lower()
-
-
-def test_router_set_ranker_whitespace_env_key_falls_through(monkeypatch, tmp_path):
-    _seed_remote(monkeypatch, tmp_path,
-                 networks=[{"network_id": "n1", "name": "team"}], active="team")
-    monkeypatch.setenv("GRID_RANKER_API_KEY", "   ")  # whitespace only → treated as absent
-    _mock_router(monkeypatch)
-    monkeypatch.setattr(cli.provider, "_interactive", lambda: False)
-    with pytest.raises(SystemExit) as exc:
-        cli.main(["router", "set-ranker", "1", "--base-url", "https://api.openai.com/v1",
-                  "--model", "gpt-4o-mini"])
-    assert "GRID_RANKER_API_KEY" in str(exc.value)
-
-
-def test_router_set_ranker_empty_prompt_is_terminal(monkeypatch, tmp_path):
-    _seed_remote(monkeypatch, tmp_path,
-                 networks=[{"network_id": "n1", "name": "team"}], active="team")
-    monkeypatch.delenv("GRID_RANKER_API_KEY", raising=False)
-    _mock_router(monkeypatch)
-    monkeypatch.setattr(cli.provider, "_interactive", lambda: True)
-    monkeypatch.setattr(cli.remote_router, "_prompt_ranker_key", lambda: "")  # user pressed Enter
-    with pytest.raises(SystemExit) as exc:
-        cli.main(["router", "set-ranker", "1", "--base-url", "https://api.openai.com/v1",
-                  "--model", "gpt-4o-mini"])
-    assert "entered" in str(exc.value).lower()
 
 
 def test_router_mutation_warns_when_not_synced(monkeypatch, tmp_path, capsys):
     _seed_remote(monkeypatch, tmp_path,
                  networks=[{"network_id": "n1", "name": "team"}], active="team")
-    _mock_router(monkeypatch, enable={"enabled": True, "rankers": [], "synced": False})
+    _mock_router(monkeypatch, enable={"enabled": True, "advisors": [], "synced": False})
     assert cli.main(["router", "enable"]) == 0
     out = capsys.readouterr().out.lower()
     assert "enabled" in out and "shortly" in out  # not-yet-synced caveat surfaced on the human line
@@ -8332,7 +8475,7 @@ def test_router_mutation_warns_when_not_synced(monkeypatch, tmp_path, capsys):
 def test_router_mutation_no_caveat_when_synced(monkeypatch, tmp_path, capsys):
     _seed_remote(monkeypatch, tmp_path,
                  networks=[{"network_id": "n1", "name": "team"}], active="team")
-    _mock_router(monkeypatch, enable={"enabled": True, "rankers": [], "synced": True})
+    _mock_router(monkeypatch, enable={"enabled": True, "advisors": [], "synced": True})
     assert cli.main(["router", "enable"]) == 0
     assert "shortly" not in capsys.readouterr().out.lower()
 
@@ -8340,22 +8483,10 @@ def test_router_mutation_no_caveat_when_synced(monkeypatch, tmp_path, capsys):
 def test_router_mutation_json_keeps_synced_verbatim(monkeypatch, tmp_path, capsys):
     _seed_remote(monkeypatch, tmp_path,
                  networks=[{"network_id": "n1", "name": "team"}], active="team")
-    reply = {"enabled": True, "rankers": [], "synced": False}
+    reply = {"enabled": True, "advisors": [], "synced": False}
     _mock_router(monkeypatch, enable=reply)
     assert cli.main(["router", "enable", "--json"]) == 0
     assert json.loads(capsys.readouterr().out) == reply
-
-
-def test_router_status_never_shows_key_material(monkeypatch, tmp_path, capsys):
-    _seed_remote(monkeypatch, tmp_path,
-                 networks=[{"network_id": "n1", "name": "team"}], active="team")
-    config = {"enabled": True, "rankers": [
-        {"position": 1, "base_url": "https://api.openai.com/v1", "model": "gpt-4o-mini"}]}
-    _mock_router(monkeypatch, config=config)
-    for argv in (["router", "status"], ["router", "status", "--json"]):
-        assert cli.main(argv) == 0
-        out = capsys.readouterr().out
-        assert "api_key" not in out and "sk-" not in out
 
 
 # -- gating / wiring --------------------------------------------------------
@@ -8376,9 +8507,9 @@ def test_router_gated_in_local_mode(monkeypatch, tmp_path):
 def test_router_parser_wires_subcommands_to_handler():
     parser = cli.build_parser()
     argvs = (
-        ["router", "status"], ["router", "enable"], ["router", "disable"],
-        ["router", "set-ranker", "1", "--base-url", "https://x/v1", "--model", "m"],
-        ["router", "remove-ranker", "1"],
+        ["router", "status"], ["router", "enable"], ["router", "disable"], ["router", "models"],
+        ["router", "set-advisors", "openai:gpt-5-mini"],
+        ["router", "remove-advisor", "openai"],
     )
     for argv in argvs:
         assert parser.parse_args(argv).handler is cli.cmd_remote_router
@@ -8394,7 +8525,7 @@ def test_router_requires_sign_in(monkeypatch, tmp_path):
     assert "signed in" in str(exc.value).lower()
 
 
-def test_router_requires_grid_resolution(monkeypatch, tmp_path):
+def test_router_status_requires_grid_resolution(monkeypatch, tmp_path):
     _seed_remote(monkeypatch, tmp_path, networks=[], active=None)  # signed in, no grids
     with pytest.raises(SystemExit) as exc:
         cli.main(["router", "status"])
@@ -8405,7 +8536,9 @@ def test_router_unknown_subcommand_errors(monkeypatch, tmp_path):
     _seed_remote(monkeypatch, tmp_path,
                  networks=[{"network_id": "n1", "name": "team"}], active="team")
     _mock_router(monkeypatch)
-    with pytest.raises(SystemExit) as exc:  # parser blocks this via the CLI; the guard catches misuse
+    # `grid=None` must be present: a bogus subcommand falls through the models short-circuit, resolves the
+    # active grid, then hits the final guard. The parser blocks this path; the guard catches direct misuse.
+    with pytest.raises(SystemExit) as exc:
         cli.cmd_remote_router(SimpleNamespace(subcommand="bogus", grid=None, json=False))
     assert "subcommand" in str(exc.value).lower()
 
@@ -8424,7 +8557,7 @@ def test_router_surfaces_validation_error(monkeypatch, tmp_path):
     _seed_remote(monkeypatch, tmp_path,
                  networks=[{"network_id": "n1", "name": "team"}], active="team")
     _mock_control_plane(monkeypatch,
-                        lambda r: httpx.Response(400, json={"detail": "configure a ranker first"}))
+                        lambda r: httpx.Response(400, json={"detail": "configure an advisor first"}))
     with pytest.raises(SystemExit) as exc:
         cli.main(["router", "enable"])
     assert "400" in str(exc.value)
@@ -8441,10 +8574,10 @@ def test_control_plane_get_router_config_gets_with_bearer(monkeypatch, tmp_path)
     def handler(request):
         seen["method"], seen["path"] = request.method, request.url.path
         seen["auth"] = request.headers.get("authorization")
-        return httpx.Response(200, json={"enabled": False, "rankers": []})
+        return httpx.Response(200, json={"enabled": False, "advisors": []})
 
     _mock_control_plane(monkeypatch, handler)
-    assert control_plane.get_router_config("sess-tok", "n1") == {"enabled": False, "rankers": []}
+    assert control_plane.get_router_config("sess-tok", "n1") == {"enabled": False, "advisors": []}
     assert (seen["method"], seen["path"]) == ("GET", "/v1/grid/networks/n1/router")
     assert seen["auth"] == "Bearer sess-tok"
 
@@ -8458,7 +8591,7 @@ def test_control_plane_enable_router_posts(monkeypatch, tmp_path):
     def handler(request):
         seen["method"], seen["path"] = request.method, request.url.path
         seen["auth"] = request.headers.get("authorization")
-        return httpx.Response(200, json={"enabled": True, "rankers": [], "synced": True})
+        return httpx.Response(200, json={"enabled": True, "advisors": [], "synced": True})
 
     _mock_control_plane(monkeypatch, handler)
     control_plane.enable_router("sess-tok", "n1")
@@ -8474,14 +8607,14 @@ def test_control_plane_disable_router_posts(monkeypatch, tmp_path):
 
     def handler(request):
         seen["method"], seen["path"] = request.method, request.url.path
-        return httpx.Response(200, json={"enabled": False, "rankers": [], "synced": True})
+        return httpx.Response(200, json={"enabled": False, "advisors": [], "synced": True})
 
     _mock_control_plane(monkeypatch, handler)
     control_plane.disable_router("sess-tok", "n1")
     assert (seen["method"], seen["path"]) == ("POST", "/v1/grid/networks/n1/router/disable")
 
 
-def test_control_plane_set_ranker_puts_with_body_and_bearer(monkeypatch, tmp_path):
+def test_control_plane_set_advisors_puts_with_body_and_bearer(monkeypatch, tmp_path):
     from remote import control_plane
 
     monkeypatch.setenv("GRID_HOME", str(tmp_path))
@@ -8491,17 +8624,20 @@ def test_control_plane_set_ranker_puts_with_body_and_bearer(monkeypatch, tmp_pat
         seen["method"], seen["path"] = request.method, request.url.path
         seen["auth"] = request.headers.get("authorization")
         seen["body"] = json.loads(request.content)
-        return httpx.Response(200, json={"enabled": False, "rankers": [], "synced": True})
+        return httpx.Response(200, json={"enabled": False, "advisors": [], "synced": True})
 
     _mock_control_plane(monkeypatch, handler)
-    control_plane.set_ranker("sess-tok", "n1", 2, "https://api.openai.com/v1", "gpt-4o-mini", "sk-key")
-    assert (seen["method"], seen["path"]) == ("PUT", "/v1/grid/networks/n1/router/rankers/2")
+    # A full pair AND a bare provider in one replace-all chain (order = priority).
+    control_plane.set_advisors("sess-tok", "n1", [("openai", "gpt-5-mini"), ("openai", None)])
+    assert (seen["method"], seen["path"]) == ("PUT", "/v1/grid/networks/n1/router/advisors")
     assert seen["auth"] == "Bearer sess-tok"
-    assert seen["body"] == {
-        "base_url": "https://api.openai.com/v1", "model": "gpt-4o-mini", "api_key": "sk-key"}
+    assert seen["body"] == {"advisors": [
+        {"provider": "openai", "model": "gpt-5-mini"},
+        {"provider": "openai"},  # bare provider → model omitted; the server resolves the catalog default
+    ]}
 
 
-def test_control_plane_remove_ranker_deletes(monkeypatch, tmp_path):
+def test_control_plane_remove_advisor_deletes_with_query(monkeypatch, tmp_path):
     from remote import control_plane
 
     monkeypatch.setenv("GRID_HOME", str(tmp_path))
@@ -8509,11 +8645,50 @@ def test_control_plane_remove_ranker_deletes(monkeypatch, tmp_path):
 
     def handler(request):
         seen["method"], seen["path"] = request.method, request.url.path
+        seen["params"] = dict(request.url.params)
+        return httpx.Response(200, json={"enabled": False, "advisors": [], "synced": True})
+
+    _mock_control_plane(monkeypatch, handler)
+    # Exact pair → both query params; the path stays clean (no position segment).
+    control_plane.remove_advisor("sess-tok", "n1", "openai", "gpt-5-mini")
+    assert (seen["method"], seen["path"]) == ("DELETE", "/v1/grid/networks/n1/router/advisors")
+    assert seen["params"] == {"provider": "openai", "model": "gpt-5-mini"}
+
+
+def test_control_plane_remove_advisor_bare_provider_omits_model_param(monkeypatch, tmp_path):
+    from remote import control_plane
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    seen = {}
+
+    def handler(request):
+        seen["params"] = dict(request.url.params)
         return httpx.Response(204)  # a successful DELETE may answer 204
 
     _mock_control_plane(monkeypatch, handler)
-    assert control_plane.remove_ranker("sess-tok", "n1", 2) == {}  # no JSON-decode crash on empty body
-    assert (seen["method"], seen["path"]) == ("DELETE", "/v1/grid/networks/n1/router/rankers/2")
+    # Bare provider → only `provider`; 204 must not crash `.json()`.
+    assert control_plane.remove_advisor("sess-tok", "n1", "openai") == {}
+    assert seen["params"] == {"provider": "openai"}
+
+
+def test_control_plane_get_router_catalog_gets_with_bearer(monkeypatch, tmp_path):
+    from remote import control_plane
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    seen = {}
+    catalog = {"providers": [
+        {"provider": "openai", "models": ["gpt-5-mini", "gpt-5-nano"], "default_model": "gpt-5-mini"}]}
+
+    def handler(request):
+        seen["method"], seen["path"] = request.method, request.url.path
+        seen["auth"] = request.headers.get("authorization")
+        return httpx.Response(200, json=catalog)
+
+    _mock_control_plane(monkeypatch, handler)
+    # No network id in the path — the catalog is account-level (session token only).
+    assert control_plane.get_router_catalog("sess-tok") == catalog
+    assert (seen["method"], seen["path"]) == ("GET", "/v1/grid/router/catalog")
+    assert seen["auth"] == "Bearer sess-tok"
 
 
 def _build_gguf(kvs: list[tuple[str, int, object]]) -> bytes:

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -8108,6 +8108,414 @@ def test_control_plane_list_members_handles_no_content(monkeypatch, tmp_path):
     assert control_plane.list_members("sess-tok", "n1") == []
 
 
+# ---------------------------------------------------------------------------
+# Remote router — `grid router` command group (cli/remote_router.py, ADR 0013)
+# ---------------------------------------------------------------------------
+
+def _mock_router(monkeypatch, *, config=None, enable=None, disable=None, set_ranker=None, remove=None):
+    """Stub the five control-plane router calls; record what each was invoked with."""
+    from remote import control_plane
+
+    calls = {}
+
+    def _get(session_token, network_id, api_url=None):
+        calls["status"] = {"session": session_token, "network_id": network_id}
+        return config if config is not None else {"enabled": False, "rankers": []}
+
+    def _enable(session_token, network_id, api_url=None):
+        calls["enable"] = {"session": session_token, "network_id": network_id}
+        return enable if enable is not None else {"enabled": True, "rankers": [], "synced": True}
+
+    def _disable(session_token, network_id, api_url=None):
+        calls["disable"] = {"session": session_token, "network_id": network_id}
+        return disable if disable is not None else {"enabled": False, "rankers": [], "synced": True}
+
+    def _set(session_token, network_id, position, base_url, model, api_key, api_url=None):
+        calls["set_ranker"] = {
+            "session": session_token, "network_id": network_id, "position": position,
+            "base_url": base_url, "model": model, "api_key": api_key,
+        }
+        return set_ranker if set_ranker is not None else {
+            "enabled": False,
+            "rankers": [{"position": position, "base_url": base_url, "model": model}],
+            "synced": True,
+        }
+
+    def _remove(session_token, network_id, position, api_url=None):
+        calls["remove_ranker"] = {"session": session_token, "network_id": network_id, "position": position}
+        return remove if remove is not None else {"enabled": False, "rankers": [], "synced": True}
+
+    monkeypatch.setattr(control_plane, "get_router_config", _get)
+    monkeypatch.setattr(control_plane, "enable_router", _enable)
+    monkeypatch.setattr(control_plane, "disable_router", _disable)
+    monkeypatch.setattr(control_plane, "set_ranker", _set)
+    monkeypatch.setattr(control_plane, "remove_ranker", _remove)
+    return calls
+
+
+def test_router_enable_calls_control_plane_and_confirms(monkeypatch, tmp_path, capsys):
+    _seed_remote(monkeypatch, tmp_path,
+                 networks=[{"network_id": "n1", "name": "team"}], active="team")
+    calls = _mock_router(monkeypatch, enable={"enabled": True, "rankers": [], "synced": True})
+    assert cli.main(["router", "enable"]) == 0
+    out = capsys.readouterr().out
+    assert calls["enable"] == {"session": "sess-tok", "network_id": "n1"}
+    assert "enabled" in out.lower()
+
+
+def test_router_status_shows_state_and_rankers_without_keys(monkeypatch, tmp_path, capsys):
+    _seed_remote(monkeypatch, tmp_path,
+                 networks=[{"network_id": "n1", "name": "team"}], active="team")
+    config = {"enabled": True, "rankers": [
+        {"position": 1, "base_url": "https://api.openai.com/v1", "model": "gpt-4o-mini"}]}
+    calls = _mock_router(monkeypatch, config=config)
+    assert cli.main(["router", "status"]) == 0
+    out = capsys.readouterr().out
+    assert calls["status"] == {"session": "sess-tok", "network_id": "n1"}
+    assert "enabled" in out.lower()
+    assert "gpt-4o-mini" in out and "https://api.openai.com/v1" in out
+
+
+def test_router_status_empty_reports_no_rankers(monkeypatch, tmp_path, capsys):
+    _seed_remote(monkeypatch, tmp_path,
+                 networks=[{"network_id": "n1", "name": "team"}], active="team")
+    _mock_router(monkeypatch, config={"enabled": False, "rankers": []})
+    assert cli.main(["router", "status"]) == 0
+    out = capsys.readouterr().out
+    assert "disabled" in out.lower()
+    assert "no rankers" in out.lower()
+
+
+def test_router_status_json_echoes_masked_config(monkeypatch, tmp_path, capsys):
+    _seed_remote(monkeypatch, tmp_path,
+                 networks=[{"network_id": "n1", "name": "team"}], active="team")
+    config = {"enabled": True, "rankers": [
+        {"position": 1, "base_url": "https://api.openai.com/v1", "model": "gpt-4o-mini"}]}
+    _mock_router(monkeypatch, config=config)
+    assert cli.main(["router", "status", "--json"]) == 0
+    assert json.loads(capsys.readouterr().out) == config
+
+
+def test_router_disable_calls_control_plane_and_confirms(monkeypatch, tmp_path, capsys):
+    _seed_remote(monkeypatch, tmp_path,
+                 networks=[{"network_id": "n1", "name": "team"}], active="team")
+    calls = _mock_router(monkeypatch, disable={"enabled": False, "rankers": [], "synced": True})
+    assert cli.main(["router", "disable"]) == 0
+    out = capsys.readouterr().out
+    assert calls["disable"] == {"session": "sess-tok", "network_id": "n1"}
+    assert "disabled" in out.lower()
+
+
+def test_router_remove_ranker_calls_control_plane_and_confirms(monkeypatch, tmp_path, capsys):
+    _seed_remote(monkeypatch, tmp_path,
+                 networks=[{"network_id": "n1", "name": "team"}], active="team")
+    calls = _mock_router(monkeypatch, remove={"enabled": True, "rankers": [], "synced": True})
+    assert cli.main(["router", "remove-ranker", "2"]) == 0
+    out = capsys.readouterr().out
+    assert calls["remove_ranker"] == {"session": "sess-tok", "network_id": "n1", "position": 2}
+    assert "2" in out
+
+
+def test_router_set_ranker_uses_env_key_and_never_prints_it(monkeypatch, tmp_path, capsys):
+    _seed_remote(monkeypatch, tmp_path,
+                 networks=[{"network_id": "n1", "name": "team"}], active="team")
+    monkeypatch.setenv("GRID_RANKER_API_KEY", "sk-secret-123")
+    calls = _mock_router(monkeypatch)
+    assert cli.main(["router", "set-ranker", "1",
+                     "--base-url", "https://api.openai.com/v1", "--model", "gpt-4o-mini"]) == 0
+    out = capsys.readouterr().out
+    assert calls["set_ranker"] == {
+        "session": "sess-tok", "network_id": "n1", "position": 1,
+        "base_url": "https://api.openai.com/v1", "model": "gpt-4o-mini", "api_key": "sk-secret-123",
+    }
+    assert "sk-secret-123" not in out  # the key is never echoed
+
+
+def test_router_set_ranker_prompts_when_no_env_key(monkeypatch, tmp_path):
+    _seed_remote(monkeypatch, tmp_path,
+                 networks=[{"network_id": "n1", "name": "team"}], active="team")
+    monkeypatch.delenv("GRID_RANKER_API_KEY", raising=False)
+    calls = _mock_router(monkeypatch)
+    monkeypatch.setattr(cli.provider, "_interactive", lambda: True)
+    monkeypatch.setattr(cli.remote_router, "_prompt_ranker_key", lambda: "sk-prompted")
+    assert cli.main(["router", "set-ranker", "1",
+                     "--base-url", "https://api.openai.com/v1", "--model", "gpt-4o-mini"]) == 0
+    assert calls["set_ranker"]["api_key"] == "sk-prompted"
+
+
+def test_router_set_ranker_errors_without_key_non_interactive(monkeypatch, tmp_path):
+    _seed_remote(monkeypatch, tmp_path,
+                 networks=[{"network_id": "n1", "name": "team"}], active="team")
+    monkeypatch.delenv("GRID_RANKER_API_KEY", raising=False)
+    _mock_router(monkeypatch)
+    monkeypatch.setattr(cli.provider, "_interactive", lambda: False)
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["router", "set-ranker", "1",
+                  "--base-url", "https://api.openai.com/v1", "--model", "gpt-4o-mini"])
+    assert "GRID_RANKER_API_KEY" in str(exc.value)
+
+
+def test_router_set_ranker_has_no_key_flag():
+    parser = cli.build_parser()
+    with pytest.raises(SystemExit):  # a key flag does not exist — argparse rejects it
+        parser.parse_args(["router", "set-ranker", "1", "--base-url", "https://x/v1",
+                           "--model", "m", "--api-key", "sk-x"])
+
+
+def test_router_set_ranker_json_never_shows_key(monkeypatch, tmp_path, capsys):
+    _seed_remote(monkeypatch, tmp_path,
+                 networks=[{"network_id": "n1", "name": "team"}], active="team")
+    monkeypatch.setenv("GRID_RANKER_API_KEY", "sk-secret-123")
+    _mock_router(monkeypatch)
+    assert cli.main(["router", "set-ranker", "1", "--base-url", "https://api.openai.com/v1",
+                     "--model", "gpt-4o-mini", "--json"]) == 0
+    assert "sk-secret-123" not in capsys.readouterr().out
+
+
+def test_router_status_json_scrubs_leaked_key(monkeypatch, tmp_path, capsys):
+    # Defence in depth: even if grid-apis ever regressed its masking and returned a key, the CLI must
+    # not echo it. The control plane is the source of truth for masking; this pins the client scrub.
+    _seed_remote(monkeypatch, tmp_path,
+                 networks=[{"network_id": "n1", "name": "team"}], active="team")
+    leaked = {"enabled": True, "rankers": [
+        {"position": 1, "base_url": "https://api.openai.com/v1", "model": "gpt-4o-mini",
+         "api_key": "sk-leaked-999"}]}
+    _mock_router(monkeypatch, config=leaked)
+    assert cli.main(["router", "status", "--json"]) == 0
+    out = capsys.readouterr().out
+    assert "sk-leaked-999" not in out and "api_key" not in out
+    assert "gpt-4o-mini" in out  # the non-secret fields still print
+
+
+def test_router_mutation_no_caveat_when_synced_absent(monkeypatch, tmp_path, capsys):
+    _seed_remote(monkeypatch, tmp_path,
+                 networks=[{"network_id": "n1", "name": "team"}], active="team")
+    _mock_router(monkeypatch, enable={"enabled": True, "rankers": []})  # reply omits `synced`
+    assert cli.main(["router", "enable"]) == 0
+    assert "shortly" not in capsys.readouterr().out.lower()
+
+
+def test_router_set_ranker_whitespace_env_key_falls_through(monkeypatch, tmp_path):
+    _seed_remote(monkeypatch, tmp_path,
+                 networks=[{"network_id": "n1", "name": "team"}], active="team")
+    monkeypatch.setenv("GRID_RANKER_API_KEY", "   ")  # whitespace only → treated as absent
+    _mock_router(monkeypatch)
+    monkeypatch.setattr(cli.provider, "_interactive", lambda: False)
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["router", "set-ranker", "1", "--base-url", "https://api.openai.com/v1",
+                  "--model", "gpt-4o-mini"])
+    assert "GRID_RANKER_API_KEY" in str(exc.value)
+
+
+def test_router_set_ranker_empty_prompt_is_terminal(monkeypatch, tmp_path):
+    _seed_remote(monkeypatch, tmp_path,
+                 networks=[{"network_id": "n1", "name": "team"}], active="team")
+    monkeypatch.delenv("GRID_RANKER_API_KEY", raising=False)
+    _mock_router(monkeypatch)
+    monkeypatch.setattr(cli.provider, "_interactive", lambda: True)
+    monkeypatch.setattr(cli.remote_router, "_prompt_ranker_key", lambda: "")  # user pressed Enter
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["router", "set-ranker", "1", "--base-url", "https://api.openai.com/v1",
+                  "--model", "gpt-4o-mini"])
+    assert "entered" in str(exc.value).lower()
+
+
+def test_router_mutation_warns_when_not_synced(monkeypatch, tmp_path, capsys):
+    _seed_remote(monkeypatch, tmp_path,
+                 networks=[{"network_id": "n1", "name": "team"}], active="team")
+    _mock_router(monkeypatch, enable={"enabled": True, "rankers": [], "synced": False})
+    assert cli.main(["router", "enable"]) == 0
+    out = capsys.readouterr().out.lower()
+    assert "enabled" in out and "shortly" in out  # not-yet-synced caveat surfaced on the human line
+
+
+def test_router_mutation_no_caveat_when_synced(monkeypatch, tmp_path, capsys):
+    _seed_remote(monkeypatch, tmp_path,
+                 networks=[{"network_id": "n1", "name": "team"}], active="team")
+    _mock_router(monkeypatch, enable={"enabled": True, "rankers": [], "synced": True})
+    assert cli.main(["router", "enable"]) == 0
+    assert "shortly" not in capsys.readouterr().out.lower()
+
+
+def test_router_mutation_json_keeps_synced_verbatim(monkeypatch, tmp_path, capsys):
+    _seed_remote(monkeypatch, tmp_path,
+                 networks=[{"network_id": "n1", "name": "team"}], active="team")
+    reply = {"enabled": True, "rankers": [], "synced": False}
+    _mock_router(monkeypatch, enable=reply)
+    assert cli.main(["router", "enable", "--json"]) == 0
+    assert json.loads(capsys.readouterr().out) == reply
+
+
+def test_router_status_never_shows_key_material(monkeypatch, tmp_path, capsys):
+    _seed_remote(monkeypatch, tmp_path,
+                 networks=[{"network_id": "n1", "name": "team"}], active="team")
+    config = {"enabled": True, "rankers": [
+        {"position": 1, "base_url": "https://api.openai.com/v1", "model": "gpt-4o-mini"}]}
+    _mock_router(monkeypatch, config=config)
+    for argv in (["router", "status"], ["router", "status", "--json"]):
+        assert cli.main(argv) == 0
+        out = capsys.readouterr().out
+        assert "api_key" not in out and "sk-" not in out
+
+
+# -- gating / wiring --------------------------------------------------------
+
+def test_router_classified_remote_only():
+    assert "router" in dispatch.REMOTE_ONLY
+    assert not (set(dispatch.AGNOSTIC) & set(dispatch.REMOTE_ONLY))
+    assert not (set(dispatch.REMOTE_HANDLERS) & set(dispatch.REMOTE_ONLY))
+
+
+def test_router_gated_in_local_mode(monkeypatch, tmp_path):
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))  # default local mode
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["router", "status"])
+    assert "remote" in str(exc.value).lower()
+
+
+def test_router_parser_wires_subcommands_to_handler():
+    parser = cli.build_parser()
+    argvs = (
+        ["router", "status"], ["router", "enable"], ["router", "disable"],
+        ["router", "set-ranker", "1", "--base-url", "https://x/v1", "--model", "m"],
+        ["router", "remove-ranker", "1"],
+    )
+    for argv in argvs:
+        assert parser.parse_args(argv).handler is cli.cmd_remote_router
+
+
+# -- error passthrough ------------------------------------------------------
+
+def test_router_requires_sign_in(monkeypatch, tmp_path):
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    state.set_mode("remote")  # remote, but no credentials on disk
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["router", "status"])
+    assert "signed in" in str(exc.value).lower()
+
+
+def test_router_requires_grid_resolution(monkeypatch, tmp_path):
+    _seed_remote(monkeypatch, tmp_path, networks=[], active=None)  # signed in, no grids
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["router", "status"])
+    assert "name a grid" in str(exc.value).lower()
+
+
+def test_router_unknown_subcommand_errors(monkeypatch, tmp_path):
+    _seed_remote(monkeypatch, tmp_path,
+                 networks=[{"network_id": "n1", "name": "team"}], active="team")
+    _mock_router(monkeypatch)
+    with pytest.raises(SystemExit) as exc:  # parser blocks this via the CLI; the guard catches misuse
+        cli.cmd_remote_router(SimpleNamespace(subcommand="bogus", grid=None, json=False))
+    assert "subcommand" in str(exc.value).lower()
+
+
+def test_router_surfaces_control_plane_rejection(monkeypatch, tmp_path):
+    _seed_remote(monkeypatch, tmp_path,
+                 networks=[{"network_id": "n1", "name": "team"}], active="team")
+    _mock_control_plane(monkeypatch,
+                        lambda r: httpx.Response(403, json={"detail": "Network admin role required"}))
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["router", "enable"])
+    assert "403" in str(exc.value)
+
+
+def test_router_surfaces_validation_error(monkeypatch, tmp_path):
+    _seed_remote(monkeypatch, tmp_path,
+                 networks=[{"network_id": "n1", "name": "team"}], active="team")
+    _mock_control_plane(monkeypatch,
+                        lambda r: httpx.Response(400, json={"detail": "configure a ranker first"}))
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["router", "enable"])
+    assert "400" in str(exc.value)
+
+
+# -- control-plane wire contract (pins the /networks/ prefix, not /managed-networks/) -----------
+
+def test_control_plane_get_router_config_gets_with_bearer(monkeypatch, tmp_path):
+    from remote import control_plane
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    seen = {}
+
+    def handler(request):
+        seen["method"], seen["path"] = request.method, request.url.path
+        seen["auth"] = request.headers.get("authorization")
+        return httpx.Response(200, json={"enabled": False, "rankers": []})
+
+    _mock_control_plane(monkeypatch, handler)
+    assert control_plane.get_router_config("sess-tok", "n1") == {"enabled": False, "rankers": []}
+    assert (seen["method"], seen["path"]) == ("GET", "/v1/grid/networks/n1/router")
+    assert seen["auth"] == "Bearer sess-tok"
+
+
+def test_control_plane_enable_router_posts(monkeypatch, tmp_path):
+    from remote import control_plane
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    seen = {}
+
+    def handler(request):
+        seen["method"], seen["path"] = request.method, request.url.path
+        seen["auth"] = request.headers.get("authorization")
+        return httpx.Response(200, json={"enabled": True, "rankers": [], "synced": True})
+
+    _mock_control_plane(monkeypatch, handler)
+    control_plane.enable_router("sess-tok", "n1")
+    assert (seen["method"], seen["path"]) == ("POST", "/v1/grid/networks/n1/router/enable")
+    assert seen["auth"] == "Bearer sess-tok"
+
+
+def test_control_plane_disable_router_posts(monkeypatch, tmp_path):
+    from remote import control_plane
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    seen = {}
+
+    def handler(request):
+        seen["method"], seen["path"] = request.method, request.url.path
+        return httpx.Response(200, json={"enabled": False, "rankers": [], "synced": True})
+
+    _mock_control_plane(monkeypatch, handler)
+    control_plane.disable_router("sess-tok", "n1")
+    assert (seen["method"], seen["path"]) == ("POST", "/v1/grid/networks/n1/router/disable")
+
+
+def test_control_plane_set_ranker_puts_with_body_and_bearer(monkeypatch, tmp_path):
+    from remote import control_plane
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    seen = {}
+
+    def handler(request):
+        seen["method"], seen["path"] = request.method, request.url.path
+        seen["auth"] = request.headers.get("authorization")
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"enabled": False, "rankers": [], "synced": True})
+
+    _mock_control_plane(monkeypatch, handler)
+    control_plane.set_ranker("sess-tok", "n1", 2, "https://api.openai.com/v1", "gpt-4o-mini", "sk-key")
+    assert (seen["method"], seen["path"]) == ("PUT", "/v1/grid/networks/n1/router/rankers/2")
+    assert seen["auth"] == "Bearer sess-tok"
+    assert seen["body"] == {
+        "base_url": "https://api.openai.com/v1", "model": "gpt-4o-mini", "api_key": "sk-key"}
+
+
+def test_control_plane_remove_ranker_deletes(monkeypatch, tmp_path):
+    from remote import control_plane
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    seen = {}
+
+    def handler(request):
+        seen["method"], seen["path"] = request.method, request.url.path
+        return httpx.Response(204)  # a successful DELETE may answer 204
+
+    _mock_control_plane(monkeypatch, handler)
+    assert control_plane.remove_ranker("sess-tok", "n1", 2) == {}  # no JSON-decode crash on empty body
+    assert (seen["method"], seen["path"]) == ("DELETE", "/v1/grid/networks/n1/router/rankers/2")
+
+
 def _build_gguf(kvs: list[tuple[str, int, object]]) -> bytes:
     """Minimal GGUF v3 blob carrying the given (key, value_type, value) metadata."""
     import struct

--- a/uv.lock
+++ b/uv.lock
@@ -81,7 +81,7 @@ wheels = [
 
 [[package]]
 name = "grid"
-version = "0.1.14"
+version = "0.1.15"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Auto-routing (`model: "auto"`) — Advisor ranking, probe fix, release v0.1.15

Ships the `auto` reserved-model router end-to-end and the ranking-quality work validated live on the dev grid.

### What's included
- **`grid router` command group** — `set-advisors`, `enable`/`disable`, `status`, `models` (advisors v2: platform catalog + per-grid proxy key; no owner-held keys). ADR 0013.
- **Advisor ranking on candidate metadata** — the Advisor receives each candidate's context window + capability names (not just the model name), with a **classification-first rubric** (SIMPLE → smallest/cheapest adequate; DEMANDING → most capable, never sub-billion; owner pays for compute). Converged via live A/B against the real advisor proxy.
- **Excerpt carries the last 3 user turns** (not just the final message) so a terse "continue" still gives the Advisor the task context.
- **Probe context-window fix** — `capability_entry` omits `context_window`/`limits.max_context_tokens` when the real window is unknown instead of baking `128000`, so the router never trusts a fabricated window.
- **`GRID_CONTROL_PLANE_TIMEOUT`** — configurable control-plane HTTP timeout.
- Default catalog advisor = `gpt-4.1-mini` (non-reasoning, stronger difficulty judge).

### Transparency
Only a bounded excerpt (system head + last 3 user-turn tails + derived features) plus grid-side candidate metadata (name, capabilities, context window — capped at 50, feature names bounded to a known vocabulary) leaves the grid; assistant/tool turns, older user turns, pricing/capacity/throughput never do. ADR 0013 + `docs/cli.md` transparency table.

### Verified
Full test suite green (555 passed), ruff clean. Live E2E on the dev grid: probe fix (context_window null, not 128000), router ranking (say-hi → 135M model, hard proof/code → the capable API model, all `X-Grid-Router: ranked`), and an OpenAI api-engine routed via `auto`.

### Release
Bumps `pyproject.toml` → `0.1.15`; the `v0.1.15` tag triggers the release workflow (wheel + Linux binaries + SHA256SUMS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
