### PR TITLE
feat(cli): grid models lists auto when routing enabled

### DIFF
--- a/cli/remote_overview.py
+++ b/cli/remote_overview.py
@@ -64,13 +64,18 @@ def _fetch_overview(args: argparse.Namespace) -> dict[str, Any]:
     return data
 
 
-def _nodes(args: argparse.Namespace) -> list[dict[str, Any]]:
-    """The grid's live engine nodes — only well-formed object entries, so a malformed ``nodes``
-    field (non-list, or a list with scalar junk) renders as empty instead of crashing a handler."""
-    nodes = _fetch_overview(args).get("nodes")
+def _nodes_from(overview: dict[str, Any]) -> list[dict[str, Any]]:
+    """The live engine nodes in an already-fetched overview — only well-formed object entries, so a
+    malformed ``nodes`` field (non-list, or a list with scalar junk) renders as empty, never crashes."""
+    nodes = overview.get("nodes")
     if not isinstance(nodes, list):
         return []
     return [node for node in nodes if isinstance(node, dict)]
+
+
+def _nodes(args: argparse.Namespace) -> list[dict[str, Any]]:
+    """The active remote grid's live engine nodes (fetches the overview)."""
+    return _nodes_from(_fetch_overview(args))
 
 
 def _node_models(node: dict[str, Any]) -> list[str]:
@@ -115,13 +120,20 @@ def cmd_remote_engines(args: argparse.Namespace) -> int:
 
 
 def cmd_remote_models(args: argparse.Namespace) -> int:
-    """`grid models` (remote): the models served across the active grid's live engines."""
-    nodes = _nodes(args)
+    """`grid models` (remote): the models served across the active grid's live engines, plus the
+    reserved ``auto`` model when the grid has auto-routing enabled (mirrors ``GET /relay/v1/models``)."""
+    overview = _fetch_overview(args)
+    nodes = _nodes_from(overview)
     rows = [
         (model, str(node.get("engine") or ""), str(node.get("name") or ""))
         for node in nodes
         for model in _node_models(node)
     ]
+    # When auto routing is enabled, advertise the reserved `auto` model FIRST — same as the relay's
+    # /relay/v1/models endpoint (owner `grid-router`), so it shows even when zero engines are joined.
+    # An older master whose overview lacks the field reports falsy → no auto row (graceful degradation).
+    if overview.get("router_enabled"):
+        rows.insert(0, ("auto", "grid-router", ""))
 
     if getattr(args, "json", False):
         # Derived view (not a raw passthrough like engines): new API fields on a model entry

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -7591,6 +7591,56 @@ def test_remote_models_empty_when_no_nodes(monkeypatch, tmp_path, capsys):
     assert "no live models" in capsys.readouterr().out
 
 
+def test_remote_models_prepends_auto_when_router_enabled(monkeypatch, tmp_path, capsys):
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_overview(monkeypatch, {**_OVERVIEW_2NODES, "router_enabled": True})
+    assert cli.main(["models"]) == 0
+    lines = [ln for ln in capsys.readouterr().out.splitlines() if ln.strip()]
+    assert lines == ["auto", "glm-5.2", "qwen-3"]  # auto first (mirrors /relay/v1/models), then engine models
+
+
+def test_remote_models_omits_auto_when_router_disabled(monkeypatch, tmp_path, capsys):
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_overview(monkeypatch, {**_OVERVIEW_2NODES, "router_enabled": False})
+    assert cli.main(["models"]) == 0
+    lines = [ln for ln in capsys.readouterr().out.splitlines() if ln.strip()]
+    assert lines == ["glm-5.2", "qwen-3"] and "auto" not in lines
+
+
+def test_remote_models_omits_auto_when_field_absent(monkeypatch, tmp_path, capsys):
+    # An older master's overview lacks router_enabled → no auto row (graceful degradation).
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_overview(monkeypatch, _OVERVIEW_2NODES)
+    assert cli.main(["models"]) == 0
+    lines = [ln for ln in capsys.readouterr().out.splitlines() if ln.strip()]
+    assert "auto" not in lines
+
+
+def test_remote_models_verbose_shows_auto_row_when_router_enabled(monkeypatch, tmp_path, capsys):
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_overview(monkeypatch, {**_OVERVIEW_2NODES, "router_enabled": True})
+    assert cli.main(["models", "--verbose"]) == 0
+    out = capsys.readouterr().out
+    assert "auto" in out and "grid-router" in out  # the reserved row, owner grid-router
+
+
+def test_remote_models_json_includes_auto_first_when_router_enabled(monkeypatch, tmp_path, capsys):
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_overview(monkeypatch, {**_OVERVIEW_2NODES, "router_enabled": True})
+    assert cli.main(["models", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload[0] == {"model": "auto", "engine": "grid-router", "node": ""}
+
+
+def test_remote_models_shows_auto_even_with_zero_nodes_when_enabled(monkeypatch, tmp_path, capsys):
+    # Mirrors /relay/v1/models: auto is advertised whenever routing is on, independent of engines.
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_overview(monkeypatch, {"nodes": [], "router_enabled": True})
+    assert cli.main(["models"]) == 0
+    lines = [ln for ln in capsys.readouterr().out.splitlines() if ln.strip()]
+    assert lines == ["auto"]
+
+
 def test_remote_engines_requires_grid_up(monkeypatch, tmp_path):
     _seed_remote(monkeypatch, tmp_path,
                 networks=[{"network_id": "n1", "name": "team", "access_token": "AT", "refresh_token": "RT"}],


### PR DESCRIPTION
## Summary
- `grid models` now lists the reserved `auto` model (owner `grid-router`) whenever the active grid has auto-routing enabled, mirroring what `GET /relay/v1/models` already advertises — the two listings could disagree before this change.
- Gated on a new `router_enabled` field the grid-src overview payload now exposes; an older master without that field simply omits the row (graceful degradation).

## Test plan
- [x] `tests/test_local_cli.py` — 6 new tests: `auto` shown (plain/`--verbose`/`--json`), omitted when disabled or when the field is absent, shown even with zero live nodes when enabled.
- [x] Full suite green: `tests/` 561 passed (555 baseline + 6).
- [x] Live-verified against prod grid `Nightshift`: `grid models` and `/relay/v1/models` now return the same model set including `auto`.