### PR TITLE
feat(local): bound child-process logs with rotation + capping

### DIFF
--- a/cli/_main.py
+++ b/cli/_main.py
@@ -2,10 +2,13 @@
 from __future__ import annotations
 
 import argparse
+import os
 import sys
+from datetime import datetime
 
 from local import config
 from local import runtime
+from shared import logging_setup, paths
 from .dispatch import dispatch, resolve_override
 from .parser import build_parser
 
@@ -19,8 +22,47 @@ def cmd_internal_server(grid_id: str) -> int:
     from local.server import create_app
 
     app = create_app(grid_id=cfg["grid_id"], grid_name=cfg["name"])
-    uvicorn.run(app, host=cfg.get("host") or runtime.DEFAULT_HOST, port=int(cfg["port"]))
+    host = cfg.get("host") or runtime.DEFAULT_HOST
+    port = int(cfg["port"])
+    level = os.getenv("UVICORN_LOG_LEVEL", "info").upper()
+    if level not in {"CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "NOTSET"}:
+        level = "INFO"  # a typo'd level would otherwise crash dictConfig at boot
+
+    # The signaling server logs one line per HTTP request (heartbeats, health checks) — the fastest
+    # unbounded grower on a long-running grid. Give uvicorn an in-process rotating handler so it owns
+    # server.log; the raw stdout/stderr redirect in local.runtime is now crash-only (server.err).
+    log_path = paths.grid_dir(grid_id) / "server.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    max_bytes, backup_count = logging_setup.server_log_limits()
+    old_size = logging_setup.truncate_if_oversized(log_path, max_bytes)
+    if old_size is not None:
+        _note_server_log_truncation(log_path, old_size, max_bytes)
+    # Pass ONLY log_config (no log_level=/use_colors=) so our dictConfig is the single source of truth.
+    uvicorn.run(
+        app,
+        host=host,
+        port=port,
+        log_config=logging_setup.build_uvicorn_log_config(
+            log_path, max_bytes=max_bytes, backup_count=backup_count, level=level
+        ),
+    )
     return 0
+
+
+def _note_server_log_truncation(log_path, old_size: int, max_bytes: int) -> None:
+    """Write the boot-time truncation warning as the first line of the fresh server.log (the file the
+    user tails), since it must happen before uvicorn configures its own logging."""
+    # Local time (no tz) to match uvicorn's %(asctime)s, which uses time.localtime.
+    ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    try:
+        with open(log_path, "a", encoding="utf-8") as fh:
+            fh.write(
+                f"{ts} WARNING server.log was {old_size} bytes (> {max_bytes}); "
+                f"truncated on startup, tail preserved (best-effort) in "
+                f"{os.path.basename(os.fspath(log_path))}.oversized\n"
+            )
+    except OSError as exc:
+        sys.stderr.write(f"grid: could not write truncation notice to {os.fspath(log_path)}: {exc!r}\n")
 
 
 def cmd_internal_media_server(port: int, comfyui_url: str) -> int:

--- a/cli/provider.py
+++ b/cli/provider.py
@@ -22,7 +22,7 @@ from typing import Any
 import httpx
 
 from local import config
-from shared import paths, run_records
+from shared import logging_setup, paths, run_records
 from local import runtime
 
 
@@ -188,7 +188,7 @@ def _spawn_engine(
     _write_record(grid_id, engine_id, record)
 
     log_path = paths.engines_dir(grid_id) / f"{engine_id}.log"
-    log = log_path.open("ab")
+    log = logging_setup.cap_and_open_append(log_path, logging_setup.engine_log_max_bytes())
     proc = subprocess.Popen(
         runtime.cli_command() + ["__engine", grid_id, engine_id],
         stdout=log,

--- a/cli/remote_provider.py
+++ b/cli/remote_provider.py
@@ -23,7 +23,7 @@ import sys
 import time
 import uuid
 
-from shared import paths, run_records
+from shared import logging_setup, paths, run_records
 from shared.filelock import file_lock
 from shared.models import api_catalog
 
@@ -664,7 +664,7 @@ def _spawn_remote_engine(network_id: str, engine_id: str) -> subprocess.Popen:
 
     log_path = paths.engines_dir(network_id) / f"{engine_id}.log"
     log_path.parent.mkdir(parents=True, exist_ok=True)
-    log = log_path.open("ab")
+    log = logging_setup.cap_and_open_append(log_path, logging_setup.engine_log_max_bytes())
     return subprocess.Popen(
         runtime.cli_command() + ["__remote-engine", network_id, engine_id],
         stdout=log,

--- a/docs/RUNBOOK-LOCAL-E2E.md
+++ b/docs/RUNBOOK-LOCAL-E2E.md
@@ -1,0 +1,192 @@
+# Runbook — Local mode E2E (1 server + 2 provider `--at` engine ngoài)
+
+Test tay end-to-end **local mode** (không control-plane, không login): build `grid` từ code, dựng 1
+grid local với **1 signaling server** + **2 provider** cùng trỏ tới một gateway OpenAI-compatible bên
+ngoài, rồi gọi thử qua endpoint của grid.
+
+- **Server** = `grid up` (uvicorn signaling, cổng `:8090`) — sổ đăng ký engine + proxy `/v1/*`.
+- **Provider** = `grid join --at <url>` — mỗi cái là 1 tiến trình `__engine` heartbeat, **không** chạy
+  model tại chỗ mà forward tới gateway ngoài. 2 provider ⇒ server load-balance giữa 2 node.
+- **Upstream** = `https://vibe-agent-gateway.eternalai.org/v2`, model `deepreinforce-ai/ornith-1.0-397b`.
+
+> Vì engine ở ngoài (`--at`), **không cần** `grid engine install` hay `grid pull` — bỏ qua tải model.
+
+```
+   grid chat / OpenAI SDK
+            │  POST /v1/chat/completions
+            ▼
+   ┌──────────────────┐   _choose_engine (load-balance)
+   │  __server :8090  │──────────────┬───────────────┐
+   └──────────────────┘              │               │
+                                     ▼               ▼
+                              __engine p1      __engine p2
+                                     │               │
+                                     └──────┬────────┘
+                                            ▼  forward /chat/completions
+                          https://vibe-agent-gateway.eternalai.org/v2
+                                 model: deepreinforce-ai/ornith-1.0-397b
+```
+
+---
+
+## 0. Chuẩn bị: build `grid` từ code
+
+```bash
+cd /Users/dudu/Bitcoin_builder/Grid/autonomous-grid
+uv tool install . --reinstall --no-cache      # cài global `grid` từ source hiện tại
+grid version                                  # xác nhận bản vừa build
+```
+
+> Không có `uv`? Dùng editable: `pip install -e .` rồi gọi `grid`, hoặc chạy thẳng `python -m cli …`
+> trong repo (thay `grid` bằng `python -m cli` ở mọi lệnh dưới).
+
+Trước khi dựng grid, **kiểm tra gateway gọi được không cần key** (xem cảnh báo auth ở mục Ghi chú):
+
+```bash
+curl -sS https://vibe-agent-gateway.eternalai.org/v2/chat/completions \
+  -H 'content-type: application/json' \
+  -d '{"model":"deepreinforce-ai/ornith-1.0-397b","messages":[{"role":"user","content":"hi"}],"max_tokens":16}'
+```
+
+Trả về JSON completion ⇒ OK. Trả về `401/403` ⇒ gateway cần API key, local proxy **không** forward
+key nên phải xử lý trước (xem Ghi chú) rồi mới chạy tiếp.
+
+---
+
+## 1. Terminal 1 — Server (`grid up`)
+
+Dùng `GRID_HOME` riêng ở `/tmp` để cô lập hẳn với `~/.grid` thật và dễ dọn. Cả server lẫn 2 provider
+trong runbook này **chung một `GRID_HOME`** (cùng một máy, cùng một grid) — nên chạy trong cùng shell,
+hoặc `export GRID_HOME=/tmp/grid-local` ở mỗi terminal.
+
+```bash
+export GRID_HOME=/tmp/grid-local
+rm -rf "$GRID_HOME"                 # sạch trạng thái cũ
+
+grid mode local                    # ghi state.json ← local (nhớ cho các lệnh sau)
+grid up                            # tạo grid "home" + bật __server trên :8090
+# → in ra:  grid=home
+#           grid_url=http://<lan-ip>:8090
+```
+
+Kiểm tra server sống:
+
+```bash
+grid ls                            # thấy home ... local ... http://<ip>:8090
+curl -s http://127.0.0.1:8090/grid/info | python3 -m json.tool
+```
+
+---
+
+## 2. Terminal 2 — Provider 1 (`--at`)
+
+```bash
+export GRID_HOME=/tmp/grid-local
+
+grid join \
+  --at https://vibe-agent-gateway.eternalai.org/v2 \
+  -m deepreinforce-ai/ornith-1.0-397b \
+  --advertise-as deepreinforce-ai/ornith-1.0-397b \
+  --ctx-size 200000 \
+  --name p1
+# → Engine node-… advertised on http://<ip>:8090
+#   models=deepreinforce-ai/ornith-1.0-397b
+```
+
+`--name p1` là engine id (bắt buộc phân biệt với provider 2). `--advertise-as` = tên model mà grid
+quảng bá; khi request tới, proxy rewrite alias→tên thật trước khi forward (ở đây trùng nhau nên không
+đổi gì).
+
+---
+
+## 3. Terminal 3 — Provider 2 (`--at`)
+
+Y hệt provider 1, chỉ **đổi `--name`**:
+
+```bash
+export GRID_HOME=/tmp/grid-local
+
+grid join \
+  --at https://vibe-agent-gateway.eternalai.org/v2 \
+  -m deepreinforce-ai/ornith-1.0-397b \
+  --advertise-as deepreinforce-ai/ornith-1.0-397b \
+  --ctx-size 200000 \
+  --name p2
+```
+
+> 2 engine cùng model, cùng upstream ⇒ `_choose_engine` chọn theo `load` rồi `last_heartbeat` (ưu
+> tiên node rảnh / heartbeat cũ nhất), tạo hiệu ứng luân phiên giữa p1 và p2.
+
+---
+
+## 4. Kiểm tra & E2E
+
+```bash
+export GRID_HOME=/tmp/grid-local
+
+grid engines                       # phải thấy 2 engine: p1, p2 (đều live)
+grid models --verbose              # model ornith-1.0-397b, cột engine hiện p1 & p2
+grid info                          # engines=2, models=deepreinforce-ai/ornith-1.0-397b
+```
+
+Gọi qua CLI:
+
+```bash
+grid chat -m deepreinforce-ai/ornith-1.0-397b "viết 1 câu chào ngắn"
+```
+
+Gọi thẳng endpoint OpenAI của grid (đúng cách app thật dùng):
+
+```bash
+source <(grid info --env)          # export OPENAI_BASE_URL=http://<ip>:8090/v1 , OPENAI_API_KEY=local-grid
+curl -sS "$OPENAI_BASE_URL/chat/completions" \
+  -H 'content-type: application/json' \
+  -d '{"model":"deepreinforce-ai/ornith-1.0-397b","messages":[{"role":"user","content":"hi"}],"max_tokens":32}' \
+  | python3 -m json.tool
+```
+
+Chạy lệnh trên vài lần rồi soi access log để thấy request được nhận (và, gián tiếp, phân phối cho 2
+engine):
+
+```bash
+tail -f "$GRID_HOME/grids/"*/server.log          # mỗi request 1 dòng POST /v1/chat/completions 200
+tail -f "$GRID_HOME/run/engines/"*/p1.log         # log của provider 1
+```
+
+---
+
+## 5. Dọn
+
+```bash
+export GRID_HOME=/tmp/grid-local
+grid leave --all                   # gỡ + unregister cả p1, p2
+grid down                          # tắt server
+pkill -f "__engine" ; pkill -f "__server"   # chắc ăn, dọn tiến trình còn sót
+rm -rf "$GRID_HOME"                # xoá sạch (config + log)
+```
+
+---
+
+## Ghi chú & troubleshooting
+
+- **⚠️ Auth upstream KHÔNG được forward.** Proxy local (`local/server.py::_proxy_openai`) chỉ đặt
+  header `content-type` khi forward — **không** gắn/không chuyển tiếp `Authorization`. Nên gateway
+  `--at` phải chấp nhận gọi **keyless**. Nếu nó cần Bearer key thì runbook này chưa chạy được as-is:
+  hoặc dùng gateway không cần key, hoặc sửa `_proxy_openai` để tiêm key (ví dụ đọc từ env) trước khi
+  forward. Luôn chạy bước curl trực tiếp ở Mục 0 để loại trừ nguyên nhân này trước.
+- **`--ctx-size 200000` là no-op với `--at`.** Cờ này (cùng `--n-predict`, `--parallel`, `--flash-attn`,
+  `--temp`, `--reasoning-budget`) chỉ cấu hình engine **built-in** (`--serve` → llama-server). Với
+  `--at` engine đã chạy sẵn ở ngoài nên chúng được lưu vào record nhưng không có tác dụng. Giữ lại
+  cũng không sao; muốn ngữ cảnh 200k thì phải cấu hình ở chính gateway.
+- **URL forward.** `endpoint_url` được nối `"/chat/completions"` ⇒ `--at …/v2` sẽ gọi
+  `…/v2/chat/completions`. Muốn đích khác thì chỉnh phần base của `--at` cho khớp (đừng thêm/thừa
+  `/v1` hay `/chat/completions`).
+- **Engine "sống" theo heartbeat TTL 60s.** Cứ để tiến trình provider chạy; đừng Ctrl-C. Đóng provider
+  ⇒ node rơi khỏi `grid engines`/`grid models` sau TTL.
+- **Trùng `--name`** ⇒ `Engine 'p1' is already joined`. Mỗi provider một tên khác nhau.
+- **Nhiều máy thật (thay vì 2 provider trên 1 máy):** để server ở máy A, provider chạy máy B/C và
+  join bằng **grid_url** thay vì tên: `grid join http://<ip-máy-A>:8090 --at <url> -m <model> …`.
+- **Log ở đâu / vì sao phình:** xem [local-flow-and-logging.md](local-flow-and-logging.md). Tóm tắt:
+  `server.log` (rotating, mỗi HTTP request 1 dòng — heartbeat 15s/engine là nguồn tăng đều),
+  `run/engines/<grid>/p{1,2}.log` (capped 50MB). Muốn giảm access log: đặt `UVICORN_LOG_LEVEL=warning`
+  **trước** `grid up`.

--- a/docs/local-flow-and-logging.md
+++ b/docs/local-flow-and-logging.md
@@ -1,0 +1,304 @@
+# Luồng Local Mode & Điểm ghi log
+
+Tài liệu này mô tả *ai chạy cái gì* trong local mode và *log được ghi vào đâu, khi nào* — để dễ
+hình dung khi debug hoặc khi lo về chuyện "log nhiều".
+
+> Tóm tắt một dòng: local mode có **1 server** (uvicorn, chạy nền) + **N engine** (mỗi engine là 1
+> tiến trình nền, tự spawn llama-server/ComfyUI). Mọi tiến trình nền đều ghi log ra file dưới
+> `~/.grid/`. Server ghi **mỗi HTTP request** một dòng → đây là nguồn phình nhanh nhất.
+
+---
+
+## 1. Các tiến trình trong local mode
+
+| Tiến trình | Vòng đời | Sinh ra bởi | Vai trò |
+|---|---|---|---|
+| `grid …` (CLI) | ngắn (chạy xong thoát) | bạn gõ lệnh | Đọc/ghi config, gọi HTTP tới server, spawn tiến trình nền |
+| `grid __server <grid_id>` | **dài** (nền, detached) | `grid up` | uvicorn signaling server — sổ đăng ký engine + proxy `/v1/*` |
+| `grid __engine <grid_id> <engine_id>` | **dài** (nền, detached) | `grid join` | Vòng lặp heartbeat; tự spawn llama-server / ComfyUI / media server |
+| `llama-server` | dài | `__engine` | Backend LLM thật (OpenAI-compatible trên `:endpoint_port`) |
+| `ComfyUI` | dài | `__engine` (nếu `--media`) | Backend sinh ảnh/video |
+| `grid __media-server` | dài | `__engine` (nếu `--media`) | uvicorn nhỏ, cầu nối HTTP → ComfyUI |
+
+`detached` = `start_new_session=True`: tiến trình nền **sống tiếp sau khi CLI thoát**. Vì thế chúng
+phải ghi log ra **file** (không có terminal để in ra).
+
+---
+
+## 2. Set-up một grid local từ số 0
+
+Đây là hành trình bạn thực sự gõ, từ máy trắng đến lúc gọi được model. Local mode = **mọi thứ chạy
+trên máy bạn**, không cần đăng nhập, API key chỉ là placeholder `local-grid`.
+
+### 2.1 Các bước (lệnh → làm gì → sinh ra tiến trình/log nào)
+
+| # | Lệnh | Làm gì | Tiến trình nền | Log tạo ra |
+|---|---|---|---|---|
+| 1 | `grid mode local` | Ghi mode vào `~/.grid/state.json` (nhớ luôn) | — | — |
+| 2 | `grid engine install llama.cpp` | Cài binary llama-server vào `~/.grid/engines` | — | — |
+| 3 | `grid pull qwen36-35b-a3b-mtp` | Tải file model `.gguf` vào `~/.grid/models` (xem `grid catalog`) | — | — |
+| 4 | `grid up` | Tạo grid `home` + **khởi động server** | `__server` | **`server.log`**, `server.err` |
+| 5 | `grid join --serve <model>` | **Khởi động llama-server + engine** rồi đăng ký vào grid | `__engine` → `llama-server` | `engines/<id>.log`, `llama_llm_8081.log` |
+| 6 | `grid chat -m <model> "…"` | Gửi thử 1 câu qua endpoint | — | +1 dòng `server.log` + log llama |
+| 7 | `grid info --env` | In `OPENAI_*` để trỏ app OpenAI SDK vào grid | — | — |
+
+> Bước 1–3 là **chuẩn bị một lần**. Bước 4–5 là cái tạo ra các tiến trình nền & file log. Từ bước 5,
+> engine bắt đầu vòng lặp heartbeat 15s → `server.log` bắt đầu tăng đều (xem mục 4).
+
+Lệnh xem trạng thái bất kỳ lúc nào:
+
+```bash
+grid ls                  # các grid đang có
+grid engines             # engine nào đang join, còn sống không
+grid models --verbose    # model nào chạy được, trên engine nào
+grid info                # endpoint + số engine + models
+```
+
+Tắt: `grid leave` (gỡ engine) rồi `grid down` (tắt server). Config & log **vẫn được giữ**.
+
+### 2.2 Sequence diagram: toàn bộ set-up
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as Bạn
+    participant CLI as grid CLI
+    participant FS as ~/.grid (config + models)
+    participant SRV as __server (nền)
+    participant ENG as __engine (nền)
+    participant LLA as llama-server
+
+    rect rgb(240,245,255)
+    Note over U,FS: ① Chuẩn bị (một lần, chưa sinh tiến trình/log)
+    U->>CLI: grid mode local
+    CLI->>FS: state.json ← mode=local
+    U->>CLI: grid engine install llama.cpp
+    CLI->>FS: cài llama-server → ~/.grid/engines
+    U->>CLI: grid pull qwen36-35b-a3b-mtp
+    CLI->>FS: tải .gguf → ~/.grid/models
+    end
+
+    rect rgb(240,255,240)
+    Note over U,SRV: ② grid up → tạo server.log + server.err
+    U->>CLI: grid up
+    CLI->>FS: tạo grids/<id>/config
+    CLI->>SRV: Popen(__server) — stdout/stderr → server.err
+    SRV->>SRV: uvicorn ghi server.log (rotating)
+    loop tới 30s (wait_for_health)
+        CLI->>SRV: GET /grid/info
+        SRV-->>CLI: 200 OK
+    end
+    CLI-->>U: grid_url=http://<ip>:8090
+    end
+
+    rect rgb(255,250,235)
+    Note over U,LLA: ③ grid join --serve → engines/<id>.log + llama log
+    U->>CLI: grid join --serve qwen36-35b-a3b-mtp
+    CLI->>ENG: Popen(__engine) — stdout/stderr → engines/<id>.log
+    ENG->>LLA: Popen(llama-server) — stdout/stderr → llama_llm_8081.log
+    ENG->>LLA: đợi /v1/models sẵn sàng (nạp model)
+    ENG->>SRV: PUT /nodes/<id> (đăng ký models)
+    CLI-->>U: engine joined
+    loop mãi mãi, mỗi 15s
+        ENG->>SRV: POST /nodes/heartbeat
+    end
+    end
+
+    rect rgb(250,240,255)
+    Note over U,LLA: ④ Dùng thử
+    U->>CLI: grid chat -m qwen36-35b-a3b-mtp "hi"
+    CLI->>SRV: POST /v1/chat/completions
+    SRV->>LLA: forward request
+    LLA-->>SRV: stream tokens
+    SRV-->>CLI: stream tokens
+    CLI-->>U: câu trả lời
+    end
+```
+
+> **Biến thể `--at` (engine có sẵn):** nếu bạn đã chạy sẵn một engine OpenAI-compatible (vLLM,
+> Ollama, MLX…) thì thay bước 5 bằng `grid join --at http://localhost:8000/v1 -m <model>`. Khi đó
+> `__engine` **không** spawn llama-server (không có `llama_llm_*.log`) — nó chỉ đăng ký URL đó và
+> heartbeat. Grid proxy sẽ forward thẳng tới engine của bạn.
+
+---
+
+## 3. Sequence diagram chi tiết từng lệnh
+
+### 3.1 `grid up` — đưa grid online (khởi động server)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as Bạn (terminal)
+    participant CLI as grid CLI
+    participant CFG as config (~/.grid/grids/<id>/config.*)
+    participant SRV as __server (uvicorn, nền)
+    participant LOG as server.log / server.err
+
+    U->>CLI: grid up [name]
+    CLI->>CFG: init_grid_config() nếu chưa có
+    CLI->>LOG: mở server.err (append, cap 4MB)  %% redirect stdout/stderr thô
+    CLI->>SRV: subprocess.Popen(__server, stdout/stderr → server.err)
+    Note over SRV,LOG: __server chạy uvicorn với log_config →<br/>uvicorn tự sở hữu server.log (rotating, in-process)
+    SRV->>LOG: [server.log] "Uvicorn running on :8090"
+    loop tối đa 30s (wait_for_health)
+        CLI->>SRV: GET /grid/info
+        SRV->>LOG: [server.log] access line: GET /grid/info 200
+        SRV-->>CLI: 200 OK
+    end
+    CLI-->>U: grid=<name> / grid_url=http://<ip>:<port>
+```
+
+Điểm mấu chốt: `server.err` chỉ nhận **output thô lúc bootstrap/crash** (traceback trước khi uvicorn
+kịp cấu hình logging). Còn `server.log` do **chính uvicorn** ghi qua rotating handler bên trong tiến
+trình → đây là file chứa access log.
+
+### 3.2 `grid join` — gắn engine vào grid (khởi động engine + llama)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as Bạn (terminal)
+    participant CLI as grid CLI
+    participant ENG as __engine (nền)
+    participant ELOG as engines/<id>.log
+    participant LLA as llama-server
+    participant LLOG as llama_llm_<port>.log
+    participant SRV as __server
+
+    U->>CLI: grid join --model <m>
+    CLI->>ELOG: mở engines/<engine_id>.log (append, cap 50MB)
+    CLI->>ENG: Popen(__engine, stdout/stderr → engines/<id>.log)
+    CLI->>SRV: poll /nodes/discover đến khi engine "registered"
+
+    ENG->>LLOG: mở llama_llm_<port>.log (append, cap 50MB)
+    ENG->>LLA: Popen(llama-server, stdout/stderr → llama_llm_<port>.log)
+    ENG->>ELOG: [engines log] "Spawned llama-server pid=…"
+    loop wait_for_models (tới 120s)
+        ENG->>LLA: GET /v1/models
+        LLA->>LLOG: [llama log] tiến trình nạp model
+    end
+    ENG->>ELOG: [engines log] "llama-server is ready"
+    ENG->>SRV: PUT /nodes/<node_id> (đăng ký models)
+    SRV->>SRV: [server.log] access: PUT /nodes/… 200
+    ENG->>ELOG: [engines log] "Engine … advertised"
+    CLI-->>U: engine joined
+
+    Note over ENG,SRV: Sau đó ENG vào VÒNG LẶP HEARTBEAT vĩnh viễn
+    loop mỗi heartbeat_interval (mặc định 15s)
+        ENG->>SRV: POST /nodes/heartbeat
+        SRV->>SRV: [server.log] access: POST /nodes/heartbeat 200
+    end
+```
+
+> ⚠️ **Nguồn "log nhiều" ở trạng thái ổn định:** vòng lặp heartbeat. Mỗi engine gửi 1 request/15s →
+> **~5.760 dòng access/ngày/engine** vào `server.log`, ngay cả khi không ai dùng grid. Cộng thêm
+> health-check của desktop app. Đây chính là lý do `server.log` cần rotation.
+
+### 3.3 Một request suy luận (client OpenAI → server → engine)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor APP as App/Client (OpenAI SDK)
+    participant SRV as __server (proxy)
+    participant SLOG as server.log
+    participant LLA as llama-server
+    participant LLOG as llama_llm_<port>.log
+
+    APP->>SRV: POST /v1/chat/completions
+    SRV->>SLOG: [server.log] access: POST /v1/chat/completions 200
+    SRV->>SRV: _choose_engine() theo model + load
+    SRV->>LLA: forward POST /v1/chat/completions
+    LLA->>LLOG: [llama log] prompt eval / generation
+    LLA-->>SRV: stream tokens
+    SRV-->>APP: stream tokens
+```
+
+Mỗi lần gọi suy luận: **1 dòng** vào `server.log` (access) + log chi tiết của llama vào
+`llama_llm_<port>.log`.
+
+### 3.4 `grid down` / `grid leave` — tắt
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as Bạn
+    participant CLI as grid CLI
+    participant ENG as __engine
+    participant SRV as __server
+
+    U->>CLI: grid leave
+    CLI->>ENG: SIGTERM (killpg)
+    ENG->>SRV: DELETE /nodes/<node_id> (unregister)
+    ENG->>ENG: dừng llama-server / ComfyUI con
+    U->>CLI: grid down
+    CLI->>SRV: SIGTERM (killpg) → server dừng
+    Note over SRV: File log KHÔNG bị xoá — config & log vẫn còn
+```
+
+---
+
+## 4. Bảng: log ghi vào đâu, khi nào, bị chặn thế nào
+
+Tất cả nằm dưới `~/.grid/` (override bằng biến môi trường `GRID_HOME`).
+
+| File | Tiến trình ghi | Ghi **khi nào** | Cách chặn phình |
+|---|---|---|---|
+| `grids/<grid_id>/server.log` | `__server` (uvicorn) | **mỗi HTTP request**: health `/grid/info`, `/nodes` (register), `/nodes/heartbeat` (~15s/engine), `/nodes/discover`, proxy `/v1/chat`, `/v1/media/*` | **Rotating in-process** 100MB × 5 file, gzip. Guard cắt file cũ quá cỡ lúc khởi động |
+| `grids/<grid_id>/server.err` | `__server` (redirect thô) | chỉ traceback bootstrap/crash trước khi uvicorn logging lên | Truncate lúc (re)start, cap 4MB |
+| `run/engines/<grid_id>/<engine_id>.log` | `__engine` | các dòng `print()`: "Spawned llama-server", "advertised", lỗi heartbeat, unregister | Truncate lúc (re)start, cap 50MB |
+| `logs/llama_llm_<port>.log` | `llama-server` | nạp model + mỗi request suy luận | Truncate lúc (re)start, cap 50MB |
+| `logs/comfyui_<port>.log` | `ComfyUI` | khởi động + mỗi workflow sinh ảnh/video | Truncate lúc (re)start, cap 50MB |
+| `logs/media_provider_<port>.log` | `__media-server` (uvicorn) | mỗi request media | Truncate lúc (re)start, cap 50MB |
+| `logs/app.log`, `logs/app_cli.log` | **App desktop macOS (Swift)** — *không thuộc repo Python này* | vòng đời app, mỗi lần gọi CLI, kiểm tra update | Do app macOS quản lý |
+
+### Hai kiểu chặn phình khác nhau
+
+1. **Rotation thật trong tiến trình** — *chỉ* `server.log`. uvicorn là app do ta khởi động nên gắn
+   được `GzipRotatingFileHandler`: khi file chạm 100MB → đổi tên + gzip thành `server.log.1.gz`,
+   giữ 5 bản, xoá bản cũ nhất. Chặn tuyệt đối, kể cả tiến trình chạy hàng tháng.
+
+2. **Truncate lúc (re)start** — các log engine/llama/ComfyUI/media. Đây là tiến trình *ngoài*, không
+   gắn handler Python vào stdout của chúng được. Nên chỉ cắt file khi vượt cap **mỗi lần khởi động
+   lại** (giữ ~2MB đuôi vào `<file>.oversized`). Chặn được qua các lần restart; nhưng **một tiến
+   trình chạy liên tục rất lâu vẫn có thể phình file đang mở trong 1 phiên** — muốn chặn tuyệt đối
+   phải thêm reader-thread bơm vào rotating handler (hiện chưa làm).
+
+### Các nút chỉnh qua biến môi trường
+
+| Biến | Mặc định | Tác dụng |
+|---|---|---|
+| `GRID_SERVER_LOG_MAX_BYTES` | 100 MB | Ngưỡng rotate của `server.log` |
+| `GRID_SERVER_LOG_BACKUP_COUNT` | 5 | Số bản `.gz` giữ lại |
+| `GRID_ENGINE_LOG_MAX_BYTES` | 50 MB | Cap cho engine/llama/ComfyUI/media log |
+| `UVICORN_LOG_LEVEL` | `info` | Đổi thành `warning` để **bỏ hẳn** access log (giảm log mạnh nhất) |
+
+> 💡 Muốn giảm log nhiều nhất mà không đụng code: đặt `UVICORN_LOG_LEVEL=warning`. Khi đó
+> `server.log` không còn ghi mỗi heartbeat/health-check nữa, chỉ còn cảnh báo/lỗi.
+
+---
+
+## 5. Sơ đồ thư mục log
+
+```
+~/.grid/
+├── grids/
+│   └── <grid_id>/
+│       ├── config.*              # cấu hình grid
+│       ├── server.log            # ← uvicorn access log (ROTATING + gzip)
+│       ├── server.log.1.gz …     # ← các segment đã xoay & nén
+│       └── server.err            # ← crash bootstrap (cap 4MB)
+├── run/
+│   └── engines/
+│       └── <grid_id>/
+│           └── <engine_id>.log   # ← print() của __engine (cap 50MB)
+└── logs/
+    ├── llama_llm_<port>.log      # ← llama-server (cap 50MB)
+    ├── comfyui_<port>.log        # ← ComfyUI (cap 50MB)
+    ├── media_provider_<port>.log # ← media server (cap 50MB)
+    ├── app.log                   # ← app macOS (ngoài repo)
+    └── app_cli.log               # ← app macOS (ngoài repo)
+```
+
+Xem thêm chi tiết cơ chế rotation ở [shared/logging_setup.py](../shared/logging_setup.py).

--- a/local/media_runtime.py
+++ b/local/media_runtime.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import httpx
 
-from shared import paths
+from shared import logging_setup, paths
 
 
 def start_media_server(*, port: int, comfyui_url: str) -> subprocess.Popen:
@@ -18,7 +18,7 @@ def start_media_server(*, port: int, comfyui_url: str) -> subprocess.Popen:
         raise SystemExit(f"Port {port} is already in use; cannot start provider media server.")
     paths.ensure_all()
     log_path = paths.logs_dir() / f"media_provider_{port}.log"
-    log = log_path.open("ab")
+    log = logging_setup.cap_and_open_append(log_path, logging_setup.engine_log_max_bytes())
     proc = subprocess.Popen(
         _cli_subprocess_command() + [
             "__media-server",

--- a/local/runtime.py
+++ b/local/runtime.py
@@ -14,7 +14,7 @@ from typing import Any
 import httpx
 
 from local import config
-from shared import paths
+from shared import logging_setup, paths
 
 
 GRID_TYPE = "lan-permissionless"
@@ -95,9 +95,11 @@ def start_grid(cfg: dict[str, Any]) -> int:
     if _tcp_port_in_use("127.0.0.1", port):
         raise SystemExit(f"Port {port} is already in use. Choose a different --port.")
 
-    log_path = paths.grid_dir(cfg["grid_id"]) / "server.log"
+    # The rotating handler inside the __server child owns server.log; this raw redirect captures
+    # only bootstrap/crash output (stays tiny — the server has no print()), capped on each start.
+    log_path = paths.grid_dir(cfg["grid_id"]) / "server.err"
     log_path.parent.mkdir(parents=True, exist_ok=True)
-    log = log_path.open("ab")
+    log = logging_setup.cap_and_open_append(log_path, logging_setup.ERR_LOG_MAX_BYTES)
     proc = subprocess.Popen(
         _cli_subprocess_command() + ["__server", cfg["grid_id"]],
         stdout=log,
@@ -138,8 +140,11 @@ def wait_for_health(cfg: dict[str, Any], timeout: int = 30) -> None:
         except Exception:
             pass
         time.sleep(0.25)
-    log = paths.grid_dir(cfg["grid_id"]) / "server.log"
-    raise SystemExit(f"local signaling server did not become healthy. See {log}")
+    grid_dir = paths.grid_dir(cfg["grid_id"])
+    raise SystemExit(
+        "local signaling server did not become healthy. "
+        f"See {grid_dir / 'server.log'} (and {grid_dir / 'server.err'} for bootstrap/crash output)"
+    )
 
 
 def grid_url(cfg: dict[str, Any]) -> str:

--- a/shared/engine/comfyui.py
+++ b/shared/engine/comfyui.py
@@ -27,7 +27,7 @@ from typing import Iterator, Optional
 
 import httpx
 
-from shared import paths
+from shared import logging_setup, paths
 from shared.system import gpu as gpu_probe
 
 
@@ -398,7 +398,9 @@ def start(port: int = COMFYUI_PORT_DEFAULT) -> ComfyProcess:
     paths.ensure_all()
     output_dir().mkdir(parents=True, exist_ok=True)
     log = paths.logs_dir() / f"comfyui_{port}.log"
-    log_fh = log.open("a", buffering=1)
+    log_fh = logging_setup.cap_and_open_append(
+        log, logging_setup.engine_log_max_bytes(), text=True, buffering=1
+    )
     log_fh.write(f"\n=== {time.strftime('%Y-%m-%d %H:%M:%S')} grid starting comfyui on :{port} ===\n")
     cmd = [
         str(comfyui_python()),

--- a/shared/engine/launcher.py
+++ b/shared/engine/launcher.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 import httpx
 
-from shared import paths
+from shared import logging_setup, paths
 
 
 MIN_LLAMA_SERVER_BUILD = 9240
@@ -122,7 +122,9 @@ def start_llm(
 
     log = paths.llama_log(port)
     log.parent.mkdir(parents=True, exist_ok=True)
-    log_fh = log.open("a", buffering=1)
+    log_fh = logging_setup.cap_and_open_append(
+        log, logging_setup.engine_log_max_bytes(), text=True, buffering=1
+    )
     log_fh.write(f"\n=== {time.strftime('%Y-%m-%d %H:%M:%S')} grid starting llm on :{port} ===\n")
 
     cmd = [llama_server_path(), "-m", str(model_path)]

--- a/shared/logging_setup.py
+++ b/shared/logging_setup.py
@@ -1,0 +1,286 @@
+"""In-process log rotation + capping for Grid's local-mode child processes.
+
+Ported from the master CLI's ADR 0004 (commit e84704d). The problem is identical here: every
+managed subprocess redirects its stdout/stderr into an append-mode ``.log`` that nothing ever
+bounds, so a long-running local grid grows ``server.log`` (one line per HTTP request — heartbeats,
+health checks) and the engine/media logs without limit until they fill the disk.
+
+Two mechanisms, applied per the process we own:
+
+* The **signaling server** is a uvicorn app we launch ourselves, so it owns ``server.log`` through
+  an in-process size-based ``GzipRotatingFileHandler`` (:func:`build_uvicorn_log_config`). True
+  rotation, gzipped segments, no external logrotate/cron — ships everywhere the CLI runs.
+* **External engines** (llama-server, ComfyUI, the media/remote-engine subprocesses) log on their
+  own stdout, which we can't reconfigure. There we bound the raw file with :func:`truncate_if_oversized`
+  on every (re)start — it caps growth across restarts, preserving a ~2MB tail to ``<path>.oversized``.
+  A single process that runs for weeks can still grow its active file; only in-process handlers can
+  rotate live, and these processes aren't ours to instrument.
+"""
+
+from __future__ import annotations
+
+import gzip
+import logging
+import os
+import shutil
+import sys
+from logging.handlers import RotatingFileHandler
+
+from uvicorn.logging import AccessFormatter, DefaultFormatter
+
+# Rotated segments are gzipped at level 1 on purpose: compression runs synchronously on the
+# emitting thread (uvicorn's event loop). Level 1 (~0.8s/100MB) stays well under the health-check
+# window; level 9 (~4.5s) would risk stalling a rollover past wait_for_health.
+_GZIP_COMPRESSLEVEL = 1
+
+# Logs hold request lines / client IPs; create them owner-only.
+_LOG_FILE_MODE = 0o600
+
+
+def _chmod_log(path) -> None:
+    try:
+        os.chmod(path, _LOG_FILE_MODE)
+    except OSError:
+        pass
+
+
+def _gzip_namer(name: str) -> str:
+    return name + ".gz"
+
+
+def _gzip_rotator(source: str, dest: str) -> None:
+    """Compress ``source`` into ``dest`` (already carrying ``.gz``).
+
+    Must never raise out of a logging call: on any failure, signal to stderr (never re-enter
+    ``logging`` — the handler lock is held) and fall back to a plain rename so the active file is
+    still rotated out.
+    """
+    if not os.path.exists(source):
+        return
+    tmp = dest + ".tmp"
+    try:
+        with open(source, "rb") as f_in, gzip.GzipFile(
+            filename=tmp, mode="wb", compresslevel=_GZIP_COMPRESSLEVEL
+        ) as f_out:
+            shutil.copyfileobj(f_in, f_out, length=1024 * 1024)
+        _chmod_log(tmp)
+        os.replace(tmp, dest)
+    except Exception as exc:
+        sys.stderr.write(
+            f"grid: log compression failed for {source} -> {dest}: {exc!r}; kept plain rename\n"
+        )
+        try:
+            os.remove(tmp)
+        except OSError:
+            pass
+        try:
+            os.replace(source, dest)
+        except OSError:
+            pass
+        return
+    # Removing the compressed-away source is best-effort and deliberately OUTSIDE the try above:
+    # a racing os.remove failure must not fall into the fallback and clobber the good .gz.
+    try:
+        os.remove(source)
+    except OSError:
+        pass
+
+
+class GzipRotatingFileHandler(RotatingFileHandler):
+    """A size-based rotating handler whose rotated segments are gzip-compressed.
+
+    Subclassing is required because ``logging.config.dictConfig`` builds a handler from its class
+    plus constructor kwargs and has no way to set the ``rotator``/``namer`` attributes.
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.namer = _gzip_namer
+        self.rotator = _gzip_rotator
+
+    def _open(self):
+        stream = super()._open()
+        _chmod_log(self.baseFilename)
+        return stream
+
+
+_DEFAULT_PRESERVE_TAIL_BYTES = 2 * 1024 * 1024
+
+
+def _snapshot_tail_best_effort(path: str, size: int, tail_bytes: int) -> None:
+    """Copy the last ``tail_bytes`` of ``path`` to ``<path>.oversized``. Best-effort: the
+    disk-freeing truncation is what matters, so a failed snapshot must not block it."""
+    if tail_bytes <= 0:
+        return
+    dest = os.fspath(path) + ".oversized"
+    try:
+        with open(path, "rb") as f_in:
+            if size > tail_bytes:
+                f_in.seek(size - tail_bytes)
+            with open(dest, "wb") as f_out:
+                shutil.copyfileobj(f_in, f_out, length=1024 * 1024)
+        _chmod_log(dest)
+    except OSError:
+        pass
+
+
+def truncate_if_oversized(
+    path: str | os.PathLike[str],
+    max_bytes: int,
+    *,
+    preserve_tail_bytes: int = _DEFAULT_PRESERVE_TAIL_BYTES,
+) -> int | None:
+    """Truncate ``path`` to 0 if it already exceeds ``max_bytes``; return the old size (so the
+    caller can WARN) or ``None`` if nothing was done.
+
+    Snapshots the last ``preserve_tail_bytes`` to ``<path>.oversized`` first — the tail that
+    explains the runaway. For the rotating server handler this MUST be called BEFORE the handler
+    opens the file: an empty active file makes ``shouldRollover`` return False, so a multi-GB
+    legacy file never triggers a synchronous gzip that would stall boot past ``wait_for_health``.
+    """
+    try:
+        size = os.path.getsize(path)
+    except OSError:
+        return None
+    if size <= max_bytes:
+        return None
+    _snapshot_tail_best_effort(os.fspath(path), size, preserve_tail_bytes)
+    try:
+        with open(path, "w"):
+            pass  # truncate in place, keep the inode/path
+        _chmod_log(path)
+    except OSError as exc:
+        # Oversized but un-truncatable (read-only mount, perms) is exactly the disk-fill risk this
+        # guard exists to prevent — do NOT stay silent.
+        sys.stderr.write(
+            f"grid: could not truncate oversized log {os.fspath(path)} ({size} bytes): {exc!r}\n"
+        )
+        return None
+    return size
+
+
+# --- scoped size limits (env-overridable) ------------------------------------
+
+_SERVER_DEFAULT_MAX_BYTES = 100 * 1024 * 1024
+_SERVER_DEFAULT_BACKUP_COUNT = 5
+# Engine/media/comfyui logs are truncate-capped (not rotated), so one knob — the cap — is enough.
+_ENGINE_DEFAULT_MAX_BYTES = 50 * 1024 * 1024
+# Bounds on env overrides. A tiny maxBytes would rotate+gzip on nearly every write (a
+# synchronous-rotation storm); an absurd backupCount storms the filesystem. Out-of-range → fallback.
+_MIN_LOG_MAX_BYTES = 64 * 1024
+_MAX_LOG_BACKUP_COUNT = 100
+
+# Bootstrap/crash channel (server.err): normally near-empty, but a crash-restart loop — or an
+# uncaught traceback that writes past `logging` — can grow it. It's a raw FD redirect (not a
+# rotating handler), so bound it with the truncate guard on each (re)start.
+ERR_LOG_MAX_BYTES = 4 * 1024 * 1024
+
+
+def _env_int(
+    name: str, default: int, *, minimum: int = 1, maximum: int | None = None
+) -> int:
+    """Read an int env override, falling back to ``default`` on missing/blank/non-int or when
+    outside ``[minimum, maximum]``. The clamp matters: a value that would disable rotation
+    (``maxBytes`` near 0) or storm the FS (huge ``backupCount``) falls back rather than take effect."""
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        value = int(raw.strip())
+    except ValueError:
+        return default
+    if value < minimum:
+        return default
+    if maximum is not None and value > maximum:
+        return default
+    return value
+
+
+def server_log_limits() -> tuple[int, int]:
+    return (
+        _env_int("GRID_SERVER_LOG_MAX_BYTES", _SERVER_DEFAULT_MAX_BYTES, minimum=_MIN_LOG_MAX_BYTES),
+        _env_int(
+            "GRID_SERVER_LOG_BACKUP_COUNT", _SERVER_DEFAULT_BACKUP_COUNT,
+            minimum=1, maximum=_MAX_LOG_BACKUP_COUNT,
+        ),
+    )
+
+
+def engine_log_max_bytes() -> int:
+    return _env_int("GRID_ENGINE_LOG_MAX_BYTES", _ENGINE_DEFAULT_MAX_BYTES, minimum=_MIN_LOG_MAX_BYTES)
+
+
+def cap_and_open_append(path, max_bytes: int, *, text: bool = False, buffering: int = -1):
+    """Bound an external-process log to ``max_bytes`` (truncate the oversized carry-over, keeping a
+    tail in ``<path>.oversized``), then open it in append mode with owner-only perms — the drop-in
+    for ``path.open("ab")`` at every subprocess launch site. Returns the open file handle.
+    """
+    truncate_if_oversized(path, max_bytes)
+    fh = open(path, "a" if text else "ab", buffering=buffering)
+    _chmod_log(path)
+    return fh
+
+
+# --- uvicorn log formatting/config -------------------------------------------
+
+
+class UvicornFileFormatter(logging.Formatter):
+    """One formatter for the single shared file handler: renders ``uvicorn.access`` records through
+    uvicorn's ``AccessFormatter`` and everything else through ``DefaultFormatter``.
+
+    A handler has exactly one formatter, so dispatching here keeps uvicorn's access rendering while
+    still writing every logger to one file (single writer = safe rotation). ``%(asctime)s`` is
+    prepended (uvicorn's own format carries none) and colours are forced off so no ANSI lands on disk.
+    """
+
+    def __init__(self, use_colors: bool = False) -> None:
+        super().__init__()
+        self._default = DefaultFormatter(
+            fmt="%(asctime)s %(levelprefix)s %(message)s", use_colors=use_colors
+        )
+        self._access = AccessFormatter(
+            fmt='%(asctime)s %(levelprefix)s %(client_addr)s - "%(request_line)s" %(status_code)s',
+            use_colors=use_colors,
+        )
+
+    def format(self, record: logging.LogRecord) -> str:
+        try:
+            if record.name == "uvicorn.access":
+                return self._access.format(record)
+        except Exception:
+            pass  # non-standard access record -> fall through to the default renderer
+        return self._default.format(record)
+
+
+def build_uvicorn_log_config(
+    path: str | os.PathLike[str], *, max_bytes: int, backup_count: int, level: str = "INFO"
+) -> dict:
+    """dictConfig for ``uvicorn.run(log_config=...)`` — one shared rotating file handler.
+
+    A single ``grid_file`` handler instance is shared across ``uvicorn``/``uvicorn.access``/``root``
+    (single writer ⇒ safe rotation); ``propagate: False`` on the uvicorn loggers and a handler-less
+    ``uvicorn.error`` (bubbles to ``uvicorn``) mean every record is emitted exactly once. Do NOT also
+    pass ``log_level=``/``use_colors=`` to ``uvicorn.run`` — either overrides this config
+    (``use_colors`` also KeyErrors on the non-``default`` formatter name).
+    """
+    return {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {"default": {"()": "shared.logging_setup.UvicornFileFormatter"}},
+        "handlers": {
+            "grid_file": {
+                "class": "shared.logging_setup.GzipRotatingFileHandler",
+                "filename": str(path),
+                "maxBytes": int(max_bytes),
+                "backupCount": int(backup_count),
+                "encoding": "utf-8",
+                "formatter": "default",
+            }
+        },
+        "loggers": {
+            "uvicorn": {"handlers": ["grid_file"], "level": level, "propagate": False},
+            "uvicorn.error": {"level": level, "propagate": True},
+            "uvicorn.access": {"handlers": ["grid_file"], "level": level, "propagate": False},
+        },
+        "root": {"handlers": ["grid_file"], "level": level},
+    }


### PR DESCRIPTION
Local mode redirected every subprocess's stdout/stderr into an append-mode .log that nothing bounded, so a long-running grid grew server.log (one line per HTTP request — heartbeats, health checks) and the engine/media logs without limit until they filled the disk. Ports the master CLI's ADR 0004 (commit e84704d) idea to local mode:

- shared/logging_setup.py: GzipRotatingFileHandler (size-based rotation, gzip'd segments), truncate_if_oversized guard (preserves a ~2MB tail to .oversized), env-override clamps, 0600 perms.
- The uvicorn signaling server now owns server.log via an in-process rotating handler (build_uvicorn_log_config); the raw Popen redirect moves to a small, capped server.err (bootstrap/crash only).
- External engines (llama-server, ComfyUI, media/remote-engine) can't be handed a Python handler, so cap_and_open_append truncate-bounds their logs on each (re)start instead.

Docs: local-flow-and-logging.md (process/log flow + sequence diagrams), RUNBOOK-LOCAL-E2E.md (1 server + 2 --at providers end-to-end).