### PR TITLE
feat(local): bound child-process logs with rotation + capping

### DIFF
--- a/cli/_main.py
+++ b/cli/_main.py
@@ -2,10 +2,13 @@
 from __future__ import annotations
 
 import argparse
+import os
 import sys
+from datetime import datetime
 
 from local import config
 from local import runtime
+from shared import logging_setup, paths
 from .dispatch import dispatch, resolve_override
 from .parser import build_parser
 
@@ -19,8 +22,47 @@ def cmd_internal_server(grid_id: str) -> int:
     from local.server import create_app
 
     app = create_app(grid_id=cfg["grid_id"], grid_name=cfg["name"])
-    uvicorn.run(app, host=cfg.get("host") or runtime.DEFAULT_HOST, port=int(cfg["port"]))
+    host = cfg.get("host") or runtime.DEFAULT_HOST
+    port = int(cfg["port"])
+    level = os.getenv("UVICORN_LOG_LEVEL", "info").upper()
+    if level not in {"CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "NOTSET"}:
+        level = "INFO"  # a typo'd level would otherwise crash dictConfig at boot
+
+    # The signaling server logs one line per HTTP request (heartbeats, health checks) — the fastest
+    # unbounded grower on a long-running grid. Give uvicorn an in-process rotating handler so it owns
+    # server.log; the raw stdout/stderr redirect in local.runtime is now crash-only (server.err).
+    log_path = paths.grid_dir(grid_id) / "server.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    max_bytes, backup_count = logging_setup.server_log_limits()
+    old_size = logging_setup.truncate_if_oversized(log_path, max_bytes)
+    if old_size is not None:
+        _note_server_log_truncation(log_path, old_size, max_bytes)
+    # Pass ONLY log_config (no log_level=/use_colors=) so our dictConfig is the single source of truth.
+    uvicorn.run(
+        app,
+        host=host,
+        port=port,
+        log_config=logging_setup.build_uvicorn_log_config(
+            log_path, max_bytes=max_bytes, backup_count=backup_count, level=level
+        ),
+    )
     return 0
+
+
+def _note_server_log_truncation(log_path, old_size: int, max_bytes: int) -> None:
+    """Write the boot-time truncation warning as the first line of the fresh server.log (the file the
+    user tails), since it must happen before uvicorn configures its own logging."""
+    # Local time (no tz) to match uvicorn's %(asctime)s, which uses time.localtime.
+    ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    try:
+        with open(log_path, "a", encoding="utf-8") as fh:
+            fh.write(
+                f"{ts} WARNING server.log was {old_size} bytes (> {max_bytes}); "
+                f"truncated on startup, tail preserved (best-effort) in "
+                f"{os.path.basename(os.fspath(log_path))}.oversized\n"
+            )
+    except OSError as exc:
+        sys.stderr.write(f"grid: could not write truncation notice to {os.fspath(log_path)}: {exc!r}\n")
 
 
 def cmd_internal_media_server(port: int, comfyui_url: str) -> int:

--- a/cli/provider.py
+++ b/cli/provider.py
@@ -22,7 +22,7 @@ from typing import Any
 import httpx
 
 from local import config
-from shared import paths, run_records
+from shared import logging_setup, paths, run_records
 from local import runtime
 
 
@@ -188,7 +188,7 @@ def _spawn_engine(
     _write_record(grid_id, engine_id, record)
 
     log_path = paths.engines_dir(grid_id) / f"{engine_id}.log"
-    log = log_path.open("ab")
+    log = logging_setup.cap_and_open_append(log_path, logging_setup.engine_log_max_bytes())
     proc = subprocess.Popen(
         runtime.cli_command() + ["__engine", grid_id, engine_id],
         stdout=log,

--- a/cli/remote_provider.py
+++ b/cli/remote_provider.py
@@ -23,7 +23,7 @@ import sys
 import time
 import uuid
 
-from shared import paths, run_records
+from shared import logging_setup, paths, run_records
 from shared.filelock import file_lock
 from shared.models import api_catalog
 
@@ -664,7 +664,7 @@ def _spawn_remote_engine(network_id: str, engine_id: str) -> subprocess.Popen:
 
     log_path = paths.engines_dir(network_id) / f"{engine_id}.log"
     log_path.parent.mkdir(parents=True, exist_ok=True)
-    log = log_path.open("ab")
+    log = logging_setup.cap_and_open_append(log_path, logging_setup.engine_log_max_bytes())
     return subprocess.Popen(
         runtime.cli_command() + ["__remote-engine", network_id, engine_id],
         stdout=log,

--- a/local/media_runtime.py
+++ b/local/media_runtime.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import httpx
 
-from shared import paths
+from shared import logging_setup, paths
 
 
 def start_media_server(*, port: int, comfyui_url: str) -> subprocess.Popen:
@@ -18,7 +18,7 @@ def start_media_server(*, port: int, comfyui_url: str) -> subprocess.Popen:
         raise SystemExit(f"Port {port} is already in use; cannot start provider media server.")
     paths.ensure_all()
     log_path = paths.logs_dir() / f"media_provider_{port}.log"
-    log = log_path.open("ab")
+    log = logging_setup.cap_and_open_append(log_path, logging_setup.engine_log_max_bytes())
     proc = subprocess.Popen(
         _cli_subprocess_command() + [
             "__media-server",

--- a/local/runtime.py
+++ b/local/runtime.py
@@ -14,7 +14,7 @@ from typing import Any
 import httpx
 
 from local import config
-from shared import paths
+from shared import logging_setup, paths
 
 
 GRID_TYPE = "lan-permissionless"
@@ -95,9 +95,11 @@ def start_grid(cfg: dict[str, Any]) -> int:
     if _tcp_port_in_use("127.0.0.1", port):
         raise SystemExit(f"Port {port} is already in use. Choose a different --port.")
 
-    log_path = paths.grid_dir(cfg["grid_id"]) / "server.log"
+    # The rotating handler inside the __server child owns server.log; this raw redirect captures
+    # only bootstrap/crash output (stays tiny — the server has no print()), capped on each start.
+    log_path = paths.grid_dir(cfg["grid_id"]) / "server.err"
     log_path.parent.mkdir(parents=True, exist_ok=True)
-    log = log_path.open("ab")
+    log = logging_setup.cap_and_open_append(log_path, logging_setup.ERR_LOG_MAX_BYTES)
     proc = subprocess.Popen(
         _cli_subprocess_command() + ["__server", cfg["grid_id"]],
         stdout=log,
@@ -138,8 +140,11 @@ def wait_for_health(cfg: dict[str, Any], timeout: int = 30) -> None:
         except Exception:
             pass
         time.sleep(0.25)
-    log = paths.grid_dir(cfg["grid_id"]) / "server.log"
-    raise SystemExit(f"local signaling server did not become healthy. See {log}")
+    grid_dir = paths.grid_dir(cfg["grid_id"])
+    raise SystemExit(
+        "local signaling server did not become healthy. "
+        f"See {grid_dir / 'server.log'} (and {grid_dir / 'server.err'} for bootstrap/crash output)"
+    )
 
 
 def grid_url(cfg: dict[str, Any]) -> str:

--- a/shared/engine/comfyui.py
+++ b/shared/engine/comfyui.py
@@ -27,7 +27,7 @@ from typing import Iterator, Optional
 
 import httpx
 
-from shared import paths
+from shared import logging_setup, paths
 from shared.system import gpu as gpu_probe
 
 
@@ -398,7 +398,9 @@ def start(port: int = COMFYUI_PORT_DEFAULT) -> ComfyProcess:
     paths.ensure_all()
     output_dir().mkdir(parents=True, exist_ok=True)
     log = paths.logs_dir() / f"comfyui_{port}.log"
-    log_fh = log.open("a", buffering=1)
+    log_fh = logging_setup.cap_and_open_append(
+        log, logging_setup.engine_log_max_bytes(), text=True, buffering=1
+    )
     log_fh.write(f"\n=== {time.strftime('%Y-%m-%d %H:%M:%S')} grid starting comfyui on :{port} ===\n")
     cmd = [
         str(comfyui_python()),

--- a/shared/engine/launcher.py
+++ b/shared/engine/launcher.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 import httpx
 
-from shared import paths
+from shared import logging_setup, paths
 
 
 MIN_LLAMA_SERVER_BUILD = 9240
@@ -122,7 +122,9 @@ def start_llm(
 
     log = paths.llama_log(port)
     log.parent.mkdir(parents=True, exist_ok=True)
-    log_fh = log.open("a", buffering=1)
+    log_fh = logging_setup.cap_and_open_append(
+        log, logging_setup.engine_log_max_bytes(), text=True, buffering=1
+    )
     log_fh.write(f"\n=== {time.strftime('%Y-%m-%d %H:%M:%S')} grid starting llm on :{port} ===\n")
 
     cmd = [llama_server_path(), "-m", str(model_path)]

--- a/shared/logging_setup.py
+++ b/shared/logging_setup.py
@@ -1,0 +1,286 @@
+"""In-process log rotation + capping for Grid's local-mode child processes.
+
+Ported from the master CLI's ADR 0004 (commit e84704d). The problem is identical here: every
+managed subprocess redirects its stdout/stderr into an append-mode ``.log`` that nothing ever
+bounds, so a long-running local grid grows ``server.log`` (one line per HTTP request — heartbeats,
+health checks) and the engine/media logs without limit until they fill the disk.
+
+Two mechanisms, applied per the process we own:
+
+* The **signaling server** is a uvicorn app we launch ourselves, so it owns ``server.log`` through
+  an in-process size-based ``GzipRotatingFileHandler`` (:func:`build_uvicorn_log_config`). True
+  rotation, gzipped segments, no external logrotate/cron — ships everywhere the CLI runs.
+* **External engines** (llama-server, ComfyUI, the media/remote-engine subprocesses) log on their
+  own stdout, which we can't reconfigure. There we bound the raw file with :func:`truncate_if_oversized`
+  on every (re)start — it caps growth across restarts, preserving a ~2MB tail to ``<path>.oversized``.
+  A single process that runs for weeks can still grow its active file; only in-process handlers can
+  rotate live, and these processes aren't ours to instrument.
+"""
+
+from __future__ import annotations
+
+import gzip
+import logging
+import os
+import shutil
+import sys
+from logging.handlers import RotatingFileHandler
+
+from uvicorn.logging import AccessFormatter, DefaultFormatter
+
+# Rotated segments are gzipped at level 1 on purpose: compression runs synchronously on the
+# emitting thread (uvicorn's event loop). Level 1 (~0.8s/100MB) stays well under the health-check
+# window; level 9 (~4.5s) would risk stalling a rollover past wait_for_health.
+_GZIP_COMPRESSLEVEL = 1
+
+# Logs hold request lines / client IPs; create them owner-only.
+_LOG_FILE_MODE = 0o600
+
+
+def _chmod_log(path) -> None:
+    try:
+        os.chmod(path, _LOG_FILE_MODE)
+    except OSError:
+        pass
+
+
+def _gzip_namer(name: str) -> str:
+    return name + ".gz"
+
+
+def _gzip_rotator(source: str, dest: str) -> None:
+    """Compress ``source`` into ``dest`` (already carrying ``.gz``).
+
+    Must never raise out of a logging call: on any failure, signal to stderr (never re-enter
+    ``logging`` — the handler lock is held) and fall back to a plain rename so the active file is
+    still rotated out.
+    """
+    if not os.path.exists(source):
+        return
+    tmp = dest + ".tmp"
+    try:
+        with open(source, "rb") as f_in, gzip.GzipFile(
+            filename=tmp, mode="wb", compresslevel=_GZIP_COMPRESSLEVEL
+        ) as f_out:
+            shutil.copyfileobj(f_in, f_out, length=1024 * 1024)
+        _chmod_log(tmp)
+        os.replace(tmp, dest)
+    except Exception as exc:
+        sys.stderr.write(
+            f"grid: log compression failed for {source} -> {dest}: {exc!r}; kept plain rename\n"
+        )
+        try:
+            os.remove(tmp)
+        except OSError:
+            pass
+        try:
+            os.replace(source, dest)
+        except OSError:
+            pass
+        return
+    # Removing the compressed-away source is best-effort and deliberately OUTSIDE the try above:
+    # a racing os.remove failure must not fall into the fallback and clobber the good .gz.
+    try:
+        os.remove(source)
+    except OSError:
+        pass
+
+
+class GzipRotatingFileHandler(RotatingFileHandler):
+    """A size-based rotating handler whose rotated segments are gzip-compressed.
+
+    Subclassing is required because ``logging.config.dictConfig`` builds a handler from its class
+    plus constructor kwargs and has no way to set the ``rotator``/``namer`` attributes.
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.namer = _gzip_namer
+        self.rotator = _gzip_rotator
+
+    def _open(self):
+        stream = super()._open()
+        _chmod_log(self.baseFilename)
+        return stream
+
+
+_DEFAULT_PRESERVE_TAIL_BYTES = 2 * 1024 * 1024
+
+
+def _snapshot_tail_best_effort(path: str, size: int, tail_bytes: int) -> None:
+    """Copy the last ``tail_bytes`` of ``path`` to ``<path>.oversized``. Best-effort: the
+    disk-freeing truncation is what matters, so a failed snapshot must not block it."""
+    if tail_bytes <= 0:
+        return
+    dest = os.fspath(path) + ".oversized"
+    try:
+        with open(path, "rb") as f_in:
+            if size > tail_bytes:
+                f_in.seek(size - tail_bytes)
+            with open(dest, "wb") as f_out:
+                shutil.copyfileobj(f_in, f_out, length=1024 * 1024)
+        _chmod_log(dest)
+    except OSError:
+        pass
+
+
+def truncate_if_oversized(
+    path: str | os.PathLike[str],
+    max_bytes: int,
+    *,
+    preserve_tail_bytes: int = _DEFAULT_PRESERVE_TAIL_BYTES,
+) -> int | None:
+    """Truncate ``path`` to 0 if it already exceeds ``max_bytes``; return the old size (so the
+    caller can WARN) or ``None`` if nothing was done.
+
+    Snapshots the last ``preserve_tail_bytes`` to ``<path>.oversized`` first — the tail that
+    explains the runaway. For the rotating server handler this MUST be called BEFORE the handler
+    opens the file: an empty active file makes ``shouldRollover`` return False, so a multi-GB
+    legacy file never triggers a synchronous gzip that would stall boot past ``wait_for_health``.
+    """
+    try:
+        size = os.path.getsize(path)
+    except OSError:
+        return None
+    if size <= max_bytes:
+        return None
+    _snapshot_tail_best_effort(os.fspath(path), size, preserve_tail_bytes)
+    try:
+        with open(path, "w"):
+            pass  # truncate in place, keep the inode/path
+        _chmod_log(path)
+    except OSError as exc:
+        # Oversized but un-truncatable (read-only mount, perms) is exactly the disk-fill risk this
+        # guard exists to prevent — do NOT stay silent.
+        sys.stderr.write(
+            f"grid: could not truncate oversized log {os.fspath(path)} ({size} bytes): {exc!r}\n"
+        )
+        return None
+    return size
+
+
+# --- scoped size limits (env-overridable) ------------------------------------
+
+_SERVER_DEFAULT_MAX_BYTES = 100 * 1024 * 1024
+_SERVER_DEFAULT_BACKUP_COUNT = 5
+# Engine/media/comfyui logs are truncate-capped (not rotated), so one knob — the cap — is enough.
+_ENGINE_DEFAULT_MAX_BYTES = 50 * 1024 * 1024
+# Bounds on env overrides. A tiny maxBytes would rotate+gzip on nearly every write (a
+# synchronous-rotation storm); an absurd backupCount storms the filesystem. Out-of-range → fallback.
+_MIN_LOG_MAX_BYTES = 64 * 1024
+_MAX_LOG_BACKUP_COUNT = 100
+
+# Bootstrap/crash channel (server.err): normally near-empty, but a crash-restart loop — or an
+# uncaught traceback that writes past `logging` — can grow it. It's a raw FD redirect (not a
+# rotating handler), so bound it with the truncate guard on each (re)start.
+ERR_LOG_MAX_BYTES = 4 * 1024 * 1024
+
+
+def _env_int(
+    name: str, default: int, *, minimum: int = 1, maximum: int | None = None
+) -> int:
+    """Read an int env override, falling back to ``default`` on missing/blank/non-int or when
+    outside ``[minimum, maximum]``. The clamp matters: a value that would disable rotation
+    (``maxBytes`` near 0) or storm the FS (huge ``backupCount``) falls back rather than take effect."""
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        value = int(raw.strip())
+    except ValueError:
+        return default
+    if value < minimum:
+        return default
+    if maximum is not None and value > maximum:
+        return default
+    return value
+
+
+def server_log_limits() -> tuple[int, int]:
+    return (
+        _env_int("GRID_SERVER_LOG_MAX_BYTES", _SERVER_DEFAULT_MAX_BYTES, minimum=_MIN_LOG_MAX_BYTES),
+        _env_int(
+            "GRID_SERVER_LOG_BACKUP_COUNT", _SERVER_DEFAULT_BACKUP_COUNT,
+            minimum=1, maximum=_MAX_LOG_BACKUP_COUNT,
+        ),
+    )
+
+
+def engine_log_max_bytes() -> int:
+    return _env_int("GRID_ENGINE_LOG_MAX_BYTES", _ENGINE_DEFAULT_MAX_BYTES, minimum=_MIN_LOG_MAX_BYTES)
+
+
+def cap_and_open_append(path, max_bytes: int, *, text: bool = False, buffering: int = -1):
+    """Bound an external-process log to ``max_bytes`` (truncate the oversized carry-over, keeping a
+    tail in ``<path>.oversized``), then open it in append mode with owner-only perms — the drop-in
+    for ``path.open("ab")`` at every subprocess launch site. Returns the open file handle.
+    """
+    truncate_if_oversized(path, max_bytes)
+    fh = open(path, "a" if text else "ab", buffering=buffering)
+    _chmod_log(path)
+    return fh
+
+
+# --- uvicorn log formatting/config -------------------------------------------
+
+
+class UvicornFileFormatter(logging.Formatter):
+    """One formatter for the single shared file handler: renders ``uvicorn.access`` records through
+    uvicorn's ``AccessFormatter`` and everything else through ``DefaultFormatter``.
+
+    A handler has exactly one formatter, so dispatching here keeps uvicorn's access rendering while
+    still writing every logger to one file (single writer = safe rotation). ``%(asctime)s`` is
+    prepended (uvicorn's own format carries none) and colours are forced off so no ANSI lands on disk.
+    """
+
+    def __init__(self, use_colors: bool = False) -> None:
+        super().__init__()
+        self._default = DefaultFormatter(
+            fmt="%(asctime)s %(levelprefix)s %(message)s", use_colors=use_colors
+        )
+        self._access = AccessFormatter(
+            fmt='%(asctime)s %(levelprefix)s %(client_addr)s - "%(request_line)s" %(status_code)s',
+            use_colors=use_colors,
+        )
+
+    def format(self, record: logging.LogRecord) -> str:
+        try:
+            if record.name == "uvicorn.access":
+                return self._access.format(record)
+        except Exception:
+            pass  # non-standard access record -> fall through to the default renderer
+        return self._default.format(record)
+
+
+def build_uvicorn_log_config(
+    path: str | os.PathLike[str], *, max_bytes: int, backup_count: int, level: str = "INFO"
+) -> dict:
+    """dictConfig for ``uvicorn.run(log_config=...)`` — one shared rotating file handler.
+
+    A single ``grid_file`` handler instance is shared across ``uvicorn``/``uvicorn.access``/``root``
+    (single writer ⇒ safe rotation); ``propagate: False`` on the uvicorn loggers and a handler-less
+    ``uvicorn.error`` (bubbles to ``uvicorn``) mean every record is emitted exactly once. Do NOT also
+    pass ``log_level=``/``use_colors=`` to ``uvicorn.run`` — either overrides this config
+    (``use_colors`` also KeyErrors on the non-``default`` formatter name).
+    """
+    return {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {"default": {"()": "shared.logging_setup.UvicornFileFormatter"}},
+        "handlers": {
+            "grid_file": {
+                "class": "shared.logging_setup.GzipRotatingFileHandler",
+                "filename": str(path),
+                "maxBytes": int(max_bytes),
+                "backupCount": int(backup_count),
+                "encoding": "utf-8",
+                "formatter": "default",
+            }
+        },
+        "loggers": {
+            "uvicorn": {"handlers": ["grid_file"], "level": level, "propagate": False},
+            "uvicorn.error": {"level": level, "propagate": True},
+            "uvicorn.access": {"handlers": ["grid_file"], "level": level, "propagate": False},
+        },
+        "root": {"handlers": ["grid_file"], "level": level},
+    }


### PR DESCRIPTION
Local mode redirected every subprocess's stdout/stderr into an append-mode .log that nothing bounded, so a long-running grid grew server.log (one line per HTTP request — heartbeats, health checks) and the engine/media logs without limit until they filled the disk. Ports the master CLI's ADR 0004 (commit e84704d) idea to local mode:

- shared/logging_setup.py: GzipRotatingFileHandler (size-based rotation, gzip'd segments), truncate_if_oversized guard (preserves a ~2MB tail to .oversized), env-override clamps, 0600 perms.
- The uvicorn signaling server now owns server.log via an in-process rotating handler (build_uvicorn_log_config); the raw Popen redirect moves to a small, capped server.err (bootstrap/crash only).
- External engines (llama-server, ComfyUI, media/remote-engine) can't be handed a Python handler, so cap_and_open_append truncate-bounds their logs on each (re)start instead.

Docs: local-flow-and-logging.md (process/log flow + sequence diagrams), RUNBOOK-LOCAL-E2E.md (1 server + 2 --at providers end-to-end).