### PR TITLE
feat(release): publish notes from an approved tag message + pin install.sh in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # The release notes are read off the annotated tag object below, so it has to
+          # be here in full. 0 is the setting that guarantees that; the default depth
+          # might well suffice, but a release is a poor place to find out.
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@v5
         with:
           python-version: "3.12"
@@ -66,8 +71,37 @@ jobs:
           chmod +x grid-linux-* 2>/dev/null || true
           sha256sum grid-* > SHA256SUMS
           echo "::group::SHA256SUMS"; cat SHA256SUMS; echo "::endgroup::"
+      # The notes are the tag's own message: drafted with packaging/changelog.py, then
+      # edited and approved by a human, who tags with the result (see the
+      # release-grid-cli skill, step 5). CI generates nothing — what was reviewed at tag
+      # time is exactly what publishes.
+      #
+      # ref_name goes through env, not `${{ }}` inside run: git allows `"`, backticks and
+      # `$()` in ref names, so interpolating it into the shell would let a tag name run
+      # as code.
+      - name: Take the release notes from the tag
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          # A lightweight tag has no message of its own, and %(contents) would quietly
+          # fall through to the commit's — publishing "chore(release): vX.Y.Z" as the notes.
+          if [ "$(git cat-file -t "$REF_NAME")" != tag ]; then
+            echo "::error::$REF_NAME is a lightweight tag, so it carries no release notes."
+            echo "::error::Re-tag with:  git tag -a $REF_NAME --cleanup=verbatim -F /tmp/notes.md"
+            exit 1
+          fi
+          git tag -l --format='%(contents)' "$REF_NAME" > RELEASE_NOTES.md
+          if [ ! -s RELEASE_NOTES.md ]; then
+            echo "::error::$REF_NAME has an empty tag message — no notes to publish."
+            exit 1
+          fi
+          echo "::group::RELEASE_NOTES.md"; cat RELEASE_NOTES.md; echo "::endgroup::"
+
+      # event_name, not just the ref: workflow_dispatch accepts a *tag* for --ref, which
+      # would otherwise satisfy the refs/tags/ test and publish a "dry" run for real.
       - name: Publish GitHub Release
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
           files: |
@@ -75,4 +109,9 @@ jobs:
             artifacts/grid-linux-arm64
             artifacts/grid-*-py3-none-any.whl
             artifacts/SHA256SUMS
-          generate_release_notes: true
+          # The approved tag message, verbatim. generate_release_notes would append a
+          # second, differently-built list under it — one that silently omits whatever
+          # reached main without a PR (every release bump, for one) — and would overrule
+          # the editing that just happened.
+          body_path: RELEASE_NOTES.md
+          generate_release_notes: false

--- a/packaging/changelog.py
+++ b/packaging/changelog.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Draft a release's notes from the commit log.
+
+    packaging/changelog.py <ref> [<base>] > /tmp/notes.md
+
+`<ref>` is the release being drafted (v0.2.1), or a branch to preview one (main).
+`<base>` overrides the previous-tag lookup — needed only when no earlier tag is
+reachable, e.g. a genuine first release (pass the root commit).
+
+This is a **draft for a human to edit**, not the last word. The release-grid-cli skill's
+step 5 pipes it to a file, opens it in an editor, and tags with the result
+(`git tag -a vX.Y.Z -F /tmp/notes.md`); release.yml then publishes that tag message
+verbatim. So nothing here ships unreviewed — cut what you like.
+
+It drafts from `git log` rather than leaning on GitHub's `generate_release_notes`
+because that generator lists only commits it can tie to a *merged PR*, and plenty of
+grid's commits (every release bump, for one) go straight to main with no PR: its list is
+a silent subset, complete-looking and missing half the release. Every release through
+v0.2.1 got the degenerate version of that — an empty list and one bare compare link.
+A git log cannot miss a commit; the compare link is re-added here.
+
+The trade is that PR numbers and @credit are gone — paste them in while editing if a
+release wants them.
+
+This runs only on the release path — the same once-a-release path that shipped v0.1.1
+(wrong version in the wheel) and v0.1.12 (tagged without a bump), both on green runs.
+So it prefers dying loudly over guessing: a changelog that is quietly wrong looks
+exactly like one that is right.
+
+Only `!` marks a breaking change here — a `BREAKING CHANGE:` footer won't, since this
+reads subjects, not bodies. Nothing is dropped silently: an unrecognised subject is
+listed verbatim under "Other changes".
+"""
+
+import os
+import re
+import subprocess
+import sys
+
+# Actions sets both; the fallbacks are for previewing a release from a local checkout.
+# Deliberately not derived from a git remote: `origin` here is a throwaway staging repo,
+# so a link built from it would point somewhere users can't reach.
+DEFAULT_SERVER = "https://github.com"
+DEFAULT_REPO = "autonomous-ai/autonomous-grid"
+
+# feat(scope)!: description
+CONVENTIONAL = re.compile(
+    r"^(?P<type>[a-z]+)(?:\((?P<scope>[^)]*)\))?(?P<breaking>!)?: (?P<desc>.+)$"
+)
+
+# Types that earn their own section, in the order users care about.
+SECTION_BY_TYPE = {
+    "feat": "Features",
+    "fix": "Fixes",
+    "perf": "Performance",
+}
+BREAKING = "Breaking changes"
+OTHER = "Other changes"
+HEADING_ORDER = [BREAKING, *SECTION_BY_TYPE.values(), OTHER]
+
+# Separates the sha from the subject in git's pretty format. A subject may legally
+# contain this byte, so the sha — always plain hex — goes first and we split once.
+SEP = "\x1f"
+
+
+def _git(*args: str) -> str:
+    return subprocess.run(
+        ["git", *args], check=True, capture_output=True, text=True, encoding="utf-8"
+    ).stdout.strip()
+
+
+def require_full_history() -> None:
+    """Refuse to run against a shallow clone.
+
+    A shallow clone can't see the previous tag, so every commit before the fetch horizon
+    vanishes. The result isn't an error — it's a changelog that is silently wrong, and
+    *how* wrong depends on which commit happens to sit at the tip. actions/checkout
+    defaults to depth 1; release.yml passes fetch-depth: 0.
+    """
+    if _git("rev-parse", "--is-shallow-repository") == "true":
+        sys.exit(
+            "changelog: refusing to run in a shallow clone — the previous tag isn't "
+            "reachable, so the notes would be silently incomplete. Give the checkout "
+            "step `fetch-depth: 0`."
+        )
+
+
+def previous_tag(ref: str) -> str:
+    """The nearest tag reachable from `ref`'s first parent.
+
+    Never falls back to "render everything". "No tag is reachable" is indistinguishable
+    from "the tags were never fetched" (a full-depth clone can still carry zero tags —
+    `clone --no-tags`, `fetch-tags: false`), and guessing wrong renders the repo's entire
+    history as one release: real subjects, real shas, perfectly formatted, completely
+    wrong. Pass an explicit `<base>` for the rare case where there truly is no previous
+    tag.
+
+    `--tags` matches lightweight tags too — most of this repo's are. Tags cut on a
+    divergent line (v0.1.13) aren't ancestors, so they're correctly skipped.
+    """
+    try:
+        return _git("describe", "--tags", "--abbrev=0", f"{ref}^")
+    except subprocess.CalledProcessError:
+        pass  # no tag reachable, or no parent — both land on the same remedy below
+    _git("rev-parse", "--verify", f"{ref}^{{commit}}")  # a bad ref dies here, with git's words
+    sys.exit(
+        f"changelog: no tag is reachable from {ref}^ — either the tags weren't fetched "
+        "(actions/checkout needs fetch-depth: 0), or this is a first release. If you "
+        f"meant it, name the base explicitly:  changelog.py {ref} <base>"
+    )
+
+
+def commits(ref: str, base: str) -> list[tuple[str, str]]:
+    """(subject, short_sha) for each non-merge commit shipping in this release."""
+    log = _git("log", "--no-merges", f"--pretty=%h{SEP}%s", f"{base}..{ref}")
+    return [
+        (line.partition(SEP)[2], line.partition(SEP)[0]) for line in log.splitlines()
+    ]
+
+
+def _described(match: re.Match) -> str:
+    """"scope: description" — the type is already the heading; the scope isn't."""
+    return f"{match['scope']}: {match['desc']}" if match["scope"] else match["desc"]
+
+
+def _classify(match: re.Match | None, subject: str) -> tuple[str, str]:
+    """(heading, entry) for one commit. `!` outranks the type: a breaking refactor is
+    still breaking, and burying it under "Other changes" is how a migration gets missed.
+    """
+    if match and match["breaking"]:
+        return BREAKING, _described(match)
+    if match and match["type"] in SECTION_BY_TYPE:
+        return SECTION_BY_TYPE[match["type"]], _described(match)
+    return OTHER, subject  # out here the type *is* the context — keep it verbatim
+
+
+def compare_link(base: str, ref: str) -> str:
+    """The line GitHub contributed back when it generated part of the body."""
+    server = os.environ.get("GITHUB_SERVER_URL") or DEFAULT_SERVER
+    slug = os.environ.get("GITHUB_REPOSITORY") or DEFAULT_REPO
+    return f"**Full Changelog**: {server}/{slug}/compare/{base}...{ref}"
+
+
+def render(ref: str, base: str | None = None) -> str:
+    """The whole Release body: the commits in `ref`, grouped, plus the compare link.
+
+    The `chore(release)` bump for this very release is dropped as noise in its own notes.
+    The compare link is always emitted — a release with nothing else to say should still
+    say where to look.
+    """
+    require_full_history()
+    base = base or previous_tag(ref)
+    buckets: dict[str, list[str]] = {}
+    for subject, sha in commits(ref, base):
+        match = CONVENTIONAL.match(subject)
+        if match and match["type"] == "chore" and match["scope"] == "release":
+            continue
+        heading, entry = _classify(match, subject)
+        buckets.setdefault(heading, []).append(f"- {entry} ({sha})")
+
+    sections = [
+        f"### {heading}\n" + "\n".join(buckets[heading])
+        for heading in HEADING_ORDER
+        if heading in buckets
+    ]
+    return "\n\n".join([*sections, compare_link(base, ref)])
+
+
+def main() -> int:
+    if not 2 <= len(sys.argv) <= 3:
+        print(__doc__, file=sys.stderr)
+        return 2
+    try:
+        print(render(sys.argv[1], sys.argv[2] if len(sys.argv) == 3 else None))
+    except subprocess.CalledProcessError as exc:
+        # capture_output holds git's diagnostic, and CalledProcessError's str() drops it.
+        # Release-day debugging is the worst time to be handed a bare exit code.
+        sys.exit(f"changelog: {' '.join(exc.cmd)} failed:\n{(exc.stderr or '').strip()}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -1,0 +1,381 @@
+"""Tests for packaging/changelog.py — the release-notes renderer.
+
+GitHub's `generate_release_notes` builds its list from *merged PRs*, but grid's release
+commits land on public/main directly, with no PR — so every release through v0.2.1
+shipped notes consisting of one bare "Full Changelog" compare link. This renderer reads
+the commit log instead.
+
+It runs only at release time, which is precisely the code path that shipped the v0.1.1
+(wrong version in the wheel) and v0.1.12 (tagged without a bump) mistakes: both had green
+runs, because nothing exercised the release path until it was the release. Hence tests.
+
+Each test builds a throwaway git repo and runs the real script against it — same approach
+as tests/test_install_sh.py, which drives the real install.sh.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "packaging" / "changelog.py"
+
+
+def _git(repo: Path, *args: str) -> str:
+    res = subprocess.run(
+        ["git", *args], cwd=repo, check=True, capture_output=True, text=True
+    )
+    return res.stdout.strip()
+
+
+def _commit(repo: Path, subject: str) -> None:
+    _git(repo, "commit", "--allow-empty", "-q", "-m", subject)
+
+
+def _render(repo: Path, ref: str, *base: str, env: dict[str, str] | None = None) -> str:
+    """Run the real renderer against `repo`, returning the markdown body."""
+    res = subprocess.run(
+        [sys.executable, str(SCRIPT), ref, *base],
+        cwd=repo, capture_output=True, text=True, env=env,
+    )
+    assert res.returncode == 0, f"changelog.py failed:\n{res.stdout}\n{res.stderr}"
+    return res.stdout
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    r = tmp_path / "repo"
+    r.mkdir()
+    _git(r, "init", "-q", "-b", "main")
+    _git(r, "config", "user.email", "test@example.com")
+    _git(r, "config", "user.name", "Test")
+    _git(r, "config", "commit.gpgsign", "false")
+    _commit(r, "chore: initial commit")
+    return r
+
+
+def test_groups_features_and_fixes_under_their_own_headings(repo):
+    _git(repo, "tag", "v1.0.0")
+    _commit(repo, "feat(router): add auto model selection")
+    _commit(repo, "fix(api-engine): send the vendor's own output-token parameter")
+    _git(repo, "tag", "v1.1.0")
+
+    out = _render(repo, "v1.1.0")
+
+    assert "### Features" in out
+    assert "### Fixes" in out
+    # The type prefix is stripped, the scope is kept — the scope is the useful part.
+    assert "- router: add auto model selection" in out
+    assert "- api-engine: send the vendor's own output-token parameter" in out
+    assert "feat(router)" not in out, "the conventional-commit type should be stripped"
+
+
+def test_skips_the_release_bump_commit(repo):
+    """`chore(release): vX.Y.Z` is the bump itself — noise in its own release notes."""
+    _git(repo, "tag", "v1.0.0")
+    _commit(repo, "feat: something users care about")
+    _commit(repo, "chore(release): v1.1.0")
+    _git(repo, "tag", "v1.1.0")
+
+    out = _render(repo, "v1.1.0")
+
+    assert "something users care about" in out
+    assert "chore(release)" not in out
+    # Not a bare `"v1.1.0" not in out`: the compare link names the ref, legitimately.
+    listed = [line for line in out.splitlines() if line.startswith("- ")]
+    assert not any("v1.1.0" in line for line in listed), (
+        f"the release bump commit must not appear in its own notes; listed: {listed}"
+    )
+
+
+def test_only_includes_commits_since_the_previous_tag(repo):
+    _commit(repo, "feat: shipped in the previous release")
+    _git(repo, "tag", "v1.0.0")
+    _commit(repo, "feat: shipped in this release")
+    _git(repo, "tag", "v1.1.0")
+
+    out = _render(repo, "v1.1.0")
+
+    assert "shipped in this release" in out
+    assert "shipped in the previous release" not in out
+
+
+def test_previous_tag_resolution_works_for_annotated_tags(repo):
+    """This repo's history is split: v0.1.15/v0.2.0 annotated, the rest lightweight."""
+    _commit(repo, "feat: shipped in the previous release")
+    _git(repo, "tag", "-a", "v1.0.0", "-m", "v1.0.0")
+    _commit(repo, "feat: shipped in this release")
+    _git(repo, "tag", "-a", "v1.1.0", "-m", "v1.1.0")
+
+    out = _render(repo, "v1.1.0")
+
+    assert "shipped in this release" in out
+    assert "shipped in the previous release" not in out
+
+
+def _run(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args], cwd=repo, capture_output=True, text=True
+    )
+
+
+def test_refuses_when_no_previous_tag_is_reachable(repo):
+    """"No previous tag" and "the tags were never fetched" look identical from here.
+
+    Guessing the former renders the whole repo history as one release — real subjects,
+    real shas, perfectly formatted, completely wrong. So say so instead, and name both
+    the likely cause and the override.
+    """
+    _commit(repo, "feat: the very first feature")
+    _git(repo, "tag", "v0.1.0")
+
+    res = _run(repo, "v0.1.0")
+
+    assert res.returncode != 0, f"expected a loud failure; instead printed {res.stdout!r}"
+    assert "fetch-depth: 0" in res.stderr, f"error must name the likely cause: {res.stderr!r}"
+    assert "<base>" in res.stderr, f"error must name the override: {res.stderr!r}"
+
+
+def test_a_clone_with_full_depth_but_no_tags_refuses_rather_than_rendering_everything(
+    repo, tmp_path
+):
+    """The gap `require_full_history` alone misses: complete history, absent tags.
+
+    `--is-shallow-repository` reports false here, so the shallow guard waves it through.
+    Without the previous-tag guard this rendered every commit since the repo's creation,
+    exit 0, including releases that shipped long ago.
+    """
+    _commit(repo, "feat: shipped ages ago in v1.0.0")
+    _git(repo, "tag", "v1.0.0")
+    _commit(repo, "fix: the only thing in this release")
+    _git(repo, "tag", "v1.1.0")
+
+    notags = tmp_path / "notags"
+    subprocess.run(
+        ["git", "clone", "-q", "--no-tags", f"file://{repo}", str(notags)],
+        check=True, capture_output=True,
+    )
+    _git(notags, "tag", "v1.1.0")  # only the pushed tag came along
+    assert _git(notags, "rev-parse", "--is-shallow-repository") == "false"
+
+    res = _run(notags, "v1.1.0")
+
+    assert res.returncode != 0, f"expected a loud failure; instead printed {res.stdout!r}"
+    assert "shipped ages ago" not in res.stdout
+
+
+def test_an_explicit_base_overrides_tag_discovery(repo):
+    """The escape hatch the refusal points at — also the first-release path."""
+    root = _git(repo, "rev-list", "--max-parents=0", "HEAD")
+    _commit(repo, "feat: the very first feature")
+    _git(repo, "tag", "v0.1.0")
+
+    out = _render(repo, "v0.1.0", root)
+
+    assert "the very first feature" in out
+
+
+def test_a_bad_ref_fails_loudly_with_gits_own_diagnostic(repo):
+    """CalledProcessError's str() drops stderr; a bare exit code is useless at 2am."""
+    res = _run(repo, "v9.9.9-does-not-exist")
+
+    assert res.returncode != 0
+    assert "Needed a single revision" in res.stderr or "unknown revision" in res.stderr, (
+        f"git's own message must survive; got: {res.stderr!r}"
+    )
+
+
+def test_breaking_change_gets_its_own_section(repo):
+    _git(repo, "tag", "v1.0.0")
+    _commit(repo, "feat(cli)!: rename --node to --engine")
+    _git(repo, "tag", "v2.0.0")
+
+    out = _render(repo, "v2.0.0")
+
+    assert "### Breaking changes" in out
+    assert "- cli: rename --node to --engine" in out
+    # A breaking feat belongs in Breaking changes, not duplicated under Features.
+    assert out.count("rename --node to --engine") == 1
+
+
+def test_breaking_marker_wins_for_any_type_not_just_the_curated_ones(repo):
+    """`!` means breaking whatever the type — a breaking refactor is still breaking.
+
+    Routing it to "Other changes" is how a migration-impacting flag rename gets missed
+    by someone scanning the notes for exactly that.
+    """
+    _git(repo, "tag", "v1.0.0")
+    _commit(repo, "refactor!: drop --node flag, use --engine")
+    _git(repo, "tag", "v2.0.0")
+
+    out = _render(repo, "v2.0.0")
+
+    assert "### Breaking changes" in out
+    assert "- drop --node flag, use --engine" in out
+    assert "### Other changes" not in out
+
+
+def test_a_subject_containing_the_field_separator_survives_intact(repo):
+    """git allows \\x1f in a subject; splitting sha-first and once keeps it whole.
+
+    Splitting subject-first truncated the description and printed a fragment of the
+    subject where the sha belongs — exit 0, nothing amiss to look at.
+    """
+    _git(repo, "tag", "v1.0.0")
+    _commit(repo, "feat: weird\x1fsubject here")
+    _git(repo, "tag", "v1.1.0")
+    sha = _git(repo, "rev-parse", "--short", "HEAD")
+
+    out = _render(repo, "v1.1.0")
+
+    assert "weird\x1fsubject here" in out
+    assert f"({sha})" in out, f"the real sha must be the sha; got:\n{out}"
+
+
+def test_renders_a_branch_ref_for_the_dry_run_preview(repo):
+    """release.yml's render step is not tag-guarded: a dispatch previews from `main`."""
+    _git(repo, "tag", "v1.0.0")
+    _commit(repo, "feat: not yet tagged")
+    _commit(repo, "chore(release): v1.1.0")
+
+    out = _render(repo, "main")
+
+    assert "- not yet tagged" in out
+    assert "v1.1.0" not in out, "the untagged bump commit is still noise"
+
+
+def test_a_tag_on_a_divergent_branch_is_not_used_as_the_base(repo):
+    """v0.1.13 was cut on a line that never merged; describe must skip such tags."""
+    _git(repo, "tag", "v1.0.0")
+    _git(repo, "checkout", "-q", "-b", "sideline")
+    _commit(repo, "feat: never merged to main")
+    _git(repo, "tag", "v1.0.5-divergent")
+    _git(repo, "checkout", "-q", "main")
+    _commit(repo, "feat: actually shipped")
+    _git(repo, "tag", "v1.1.0")
+
+    out = _render(repo, "v1.1.0")
+
+    assert "- actually shipped" in out
+    assert "never merged" not in out, "a tag off the mainline must not become the base"
+
+
+def test_other_types_land_in_other_changes_with_their_prefix_intact(repo):
+    _git(repo, "tag", "v1.0.0")
+    _commit(repo, "docs(router): ADR 0014 — the Advisor sees candidate prices")
+    _git(repo, "tag", "v1.0.1")
+
+    out = _render(repo, "v1.0.1")
+
+    assert "### Other changes" in out
+    # Outside the curated sections the type itself is the context — keep it.
+    assert "- docs(router): ADR 0014 — the Advisor sees candidate prices" in out
+
+
+def test_non_conventional_subjects_are_kept_verbatim(repo):
+    _git(repo, "tag", "v1.0.0")
+    _commit(repo, "Revert an unrelated thing")
+    _git(repo, "tag", "v1.0.1")
+
+    out = _render(repo, "v1.0.1")
+
+    assert "- Revert an unrelated thing" in out
+
+
+def test_each_entry_carries_its_short_sha(repo):
+    _git(repo, "tag", "v1.0.0")
+    _commit(repo, "fix: a real bug")
+    _git(repo, "tag", "v1.0.1")
+    sha = _git(repo, "rev-parse", "--short", "HEAD")
+
+    out = _render(repo, "v1.0.1")
+
+    assert sha in out, f"expected short sha {sha} in:\n{out}"
+
+
+def test_refuses_to_run_in_a_shallow_clone(repo, tmp_path):
+    """A shallow clone can't see the previous tag, so it renders *empty* notes.
+
+    That fails in the worst possible way: silently, on the release path, producing
+    exactly the empty changelog this script exists to fix. actions/checkout defaults
+    to depth 1 — release.yml must pass fetch-depth: 0 — so if that ever regresses,
+    say so loudly instead of shipping a blank release body.
+    """
+    _commit(repo, "feat: shipped in the previous release")
+    _git(repo, "tag", "v1.0.0")
+    _commit(repo, "feat: shipped in this release")
+    _git(repo, "tag", "v1.1.0")
+    shallow = tmp_path / "shallow"
+    subprocess.run(
+        ["git", "clone", "-q", "--depth", "1", "--branch", "v1.1.0",
+         f"file://{repo}", str(shallow)],
+        check=True, capture_output=True,
+    )
+
+    res = subprocess.run(
+        [sys.executable, str(SCRIPT), "v1.1.0"], cwd=shallow, capture_output=True, text=True
+    )
+
+    assert res.returncode != 0, f"expected a loud failure; instead it printed {res.stdout!r}"
+    assert "shallow" in res.stderr.lower(), f"error must name the cause; got: {res.stderr!r}"
+
+
+def test_a_range_with_no_shippable_commits_still_renders_the_compare_link(repo):
+    """`generate_release_notes` is off, so nothing back-fills an empty body any more."""
+    _commit(repo, "feat: shipped already")
+    _git(repo, "tag", "v1.0.0")
+    _commit(repo, "chore(release): v1.0.1")
+    _git(repo, "tag", "v1.0.1")
+
+    out = _render(repo, "v1.0.1")
+
+    assert out.strip() == (
+        "**Full Changelog**: https://github.com/autonomous-ai/autonomous-grid"
+        "/compare/v1.0.0...v1.0.1"
+    )
+
+
+def test_the_body_ends_with_the_compare_link(repo):
+    _git(repo, "tag", "v1.0.0")
+    _commit(repo, "fix: a real bug")
+    _git(repo, "tag", "v1.1.0")
+
+    out = _render(repo, "v1.1.0")
+
+    assert out.strip().endswith("/compare/v1.0.0...v1.1.0")
+    assert "### Fixes" in out
+
+
+def test_the_compare_link_names_the_repository_ci_is_building(repo):
+    """Actions sets GITHUB_REPOSITORY/GITHUB_SERVER_URL; they win over the fallback."""
+    _git(repo, "tag", "v1.0.0")
+    _commit(repo, "fix: a real bug")
+    _git(repo, "tag", "v1.1.0")
+    env = {
+        **os.environ,
+        "GITHUB_SERVER_URL": "https://github.example",
+        "GITHUB_REPOSITORY": "someone/elsewhere",
+    }
+
+    out = _render(repo, "v1.1.0", env=env)
+
+    assert (
+        "**Full Changelog**: https://github.example/someone/elsewhere"
+        "/compare/v1.0.0...v1.1.0" in out
+    )
+
+
+def test_the_compare_link_falls_back_to_the_public_repo_outside_ci(repo):
+    """A local preview must not point at `origin` — that's the throwaway staging repo."""
+    _git(repo, "tag", "v1.0.0")
+    _commit(repo, "fix: a real bug")
+    _git(repo, "tag", "v1.1.0")
+    env = {k: v for k, v in os.environ.items() if not k.startswith("GITHUB_")}
+
+    out = _render(repo, "v1.1.0", env=env)
+
+    assert "https://github.com/autonomous-ai/autonomous-grid/compare/" in out
+    assert "super-grid-tmp" not in out

--- a/tests/test_install_sh.py
+++ b/tests/test_install_sh.py
@@ -1,12 +1,23 @@
-"""Regression tests for install.sh's post-install PATH hint (macOS wheel path).
+"""Regression tests for install.sh.
 
-install_macos_wheel exports ~/.local/bin into the script's own PATH, so the
-post-install "Add <dir> to PATH" check must test the invoking shell's PATH
-(ORIG_PATH), not the augmented one — otherwise the hint is dead code on macOS
-and users get a success banner with `grid` unreachable in their shell.
+install.sh is served from raw `main` by the grid.autonomous.ai worker, so it goes
+live the moment `main` is pushed: no release carries it, no tag rolls it back, and
+nothing stands between the push and the next user's `curl … | bash`. Its invariants
+are therefore pinned here, where CI checks them on every push and PR.
 
-The installer runs against a throwaway HOME with `uv`, `uname`, and `curl`
-stubbed out, so the tests are deterministic and never touch the network.
+Two classes of test live in this file:
+
+1. Behaviour, driven through the real script. install_macos_wheel exports
+   ~/.local/bin into the script's own PATH, so the post-install "Add <dir> to PATH"
+   check must test the invoking shell's PATH (ORIG_PATH), not the augmented one —
+   otherwise the hint is dead code on macOS and users get a success banner with
+   `grid` unreachable in their shell. The installer runs against a throwaway HOME
+   with `uv`, `uname`, and `curl` stubbed out, so it never touches the network.
+
+2. Static invariants (valid bash; never calls api.github.com). These were previously
+   enforced only by a grep inside the release-grid-cli skill — a guard that holds
+   only while a human remembers to run it, on the one path nobody exercises until
+   it is already release day.
 """
 
 import stat
@@ -85,4 +96,38 @@ def test_no_hint_when_local_bin_already_on_users_path(tmp_path):
     assert res.returncode == 0, f"installer failed:\n{res.stdout}\n{res.stderr}"
     assert "to PATH" not in res.stdout, (
         f"no hint expected when ~/.local/bin is already on PATH; output was:\n{res.stdout}"
+    )
+
+
+def _code_lines(text: str) -> list[tuple[int, str]]:
+    """(lineno, code) for each line, with comments stripped.
+
+    Mirrors the `^[^#]*` guard this check replaces. Truncating at a `#` inside a
+    quoted string could only ever *hide* a violation sitting after it, never invent
+    one — and on these lines anything past a `#` is prose.
+    """
+    return [(n, line.split("#", 1)[0]) for n, line in enumerate(text.splitlines(), 1)]
+
+
+def test_installer_is_valid_bash():
+    """A syntax error here reaches users directly, with no release in between."""
+    res = subprocess.run(["bash", "-n", str(INSTALL_SH)], capture_output=True, text=True)
+    assert res.returncode == 0, f"install.sh is not valid bash:\n{res.stderr}"
+
+
+def test_installer_never_calls_the_github_api():
+    """api.github.com's 60 req/hr/IP cap 403s every install behind a shared NAT.
+
+    install.sh must resolve releases through github.com itself — the /releases/latest
+    redirect, falling back to the releases.atom feed — neither of which is rate
+    limited. See the rationale block above latest_release_tag().
+    """
+    offenders = [
+        (n, code.strip())
+        for n, code in _code_lines(INSTALL_SH.read_text())
+        if "api.github.com" in code
+    ]
+    assert not offenders, (
+        "install.sh must never call api.github.com: shared-NAT IPs exhaust its "
+        f"60 req/hr limit and every install behind them 403s. Offending lines: {offenders}"
     )


### PR DESCRIPTION
## Summary

Lands the release-path hardening that the `release-grid-cli` skill has documented but the workflow never actually enforced: **release notes now come from a human-approved tag message**, and **`install.sh`'s invariants are pinned by CI** instead of a grep a human has to remember to run.

## What changes

### `feat(release): publish release notes from an approved tag message`

Every release through v0.2.1 shipped notes that were a single bare "Full Changelog" compare link — `generate_release_notes` lists only commits it can tie to a merged PR, and much of this repo reaches `main` by direct push (every release bump included), so its list is a silent subset.

- The notes are now the tag's own message. CI reads `%(contents)` off the tag and publishes it **verbatim** — what you approve at tag time is exactly what ships.
- `packaging/changelog.py` **drafts** notes from `git log <prev-tag>..<ref>` (which cannot miss a commit) grouped by conventional-commit type. It runs locally only — the same release path that shipped the v0.1.1 and v0.1.12 mistakes on green runs — so it **dies rather than guess**: a shallow clone and an unreachable previous tag both exit loudly and name the fix.
- Two more quiet-wrong-body paths refused in CI: a **lightweight tag** (no message → falls through to the commit subject) and git's default cleanup **stripping every `#` heading** (hence `--cleanup=verbatim`).
- Workflow hardening: `github.ref_name` reaches the shell via `env:` (git permits `` ` ``, `$()` in ref names, and `${{ }}` in `run:` would execute them); publishing now also requires `event_name == 'push'`, since `workflow_dispatch --ref <tag>` would otherwise satisfy the `refs/tags/` test and publish a dry run for real.

### `test(install): pin install.sh invariants in CI`

`install.sh` ships from raw `main` via the `grid.autonomous.ai` worker — it goes live the moment `main` is pushed, with no release to carry it and no tag to roll it back. Its two invariants were enforced only by a grep inside the release skill:

- it must be **valid bash**
- it must **never call `api.github.com`** (whose 60 req/hr/IP limit 403s every install behind a shared NAT)

Both are now pinned by `tests/test_install_sh.py`, so CI enforces them on every push instead of a human on release day.

## Files

- `packaging/changelog.py` (+183, new) — local-only notes drafter
- `tests/test_changelog.py` (+381, new) — its guards (shallow clone, missing prev-tag, grouping)
- `.github/workflows/release.yml` (+43/−11) — publish tag message verbatim; ref-name via env; push-only publish
- `tests/test_install_sh.py` (+63/−…) — valid-bash + no-`api.github.com` invariants

## Test plan

- [x] `uv run --extra dev ruff check .` — clean
- [x] `uv run --extra dev pytest tests/test_changelog.py tests/test_install_sh.py -q` — 25 passed
- [ ] CI green on all three interpreters (3.11/3.12/3.13)

## Note

Branch predates v0.3.0; merges cleanly into current `main` (the four touched files were not modified on `main` since the branch point). First release to actually publish a verbatim tag message will be the next one after this merges — v0.3.0 was cut on the old workflow.
