### PR TITLE
feat(responses): /responses as an engine capability — public CLI (issues 01–10, 06b, 06c)

### DIFF
--- a/cli/models.py
+++ b/cli/models.py
@@ -71,6 +71,10 @@ def _catalog_api(args: argparse.Namespace) -> int:
         print(json.dumps({
             "kind": kind,
             "last_verified": whitelist.last_verified,
+            # The endpoint list every API kind serves — now emitted for the generic path too, not
+            # only the codex seat (issue 06 AC5), so a script reads `"responses" in endpoints` the
+            # same way for any kind. Mirrors the codex JSON's placement in `_catalog_codex`.
+            "endpoints": list(whitelist.endpoints),
             "models": [
                 {
                     "advertised": api_catalog.advertised_name(kind, entry),
@@ -103,7 +107,7 @@ def _catalog_api(args: argparse.Namespace) -> int:
         f"(verified {whitelist.last_verified}):"
     )
     for entry in whitelist.entries:
-        print(api_catalog.format_api_entry(kind, entry))
+        print(api_catalog.format_api_entry(kind, entry, whitelist.endpoints))
     print()
     print(f"No key needed to view. Requests to {kind}:* models leave the grid for the vendor.")
     return 0
@@ -154,7 +158,7 @@ def _catalog_codex(kind: str, whitelist: api_catalog.ApiWhitelist, as_json: bool
         print()
         print(f"{tier}:")
         for entry in entries:
-            print(api_catalog.format_api_entry(kind, entry))
+            print(api_catalog.format_api_entry(kind, entry, whitelist.endpoints))
     print()
     print(
         "Tiers not listed are unverified in this release — a seat on one advertises the "

--- a/cli/remote_overview.py
+++ b/cli/remote_overview.py
@@ -87,6 +87,17 @@ def _node_models(node: dict[str, Any]) -> list[str]:
     return [str(model) for model in models]
 
 
+def _node_responses_models(node: dict[str, Any]) -> set[str]:
+    """The subset of a node's served models that serve the Responses dialect (issue 10), read from
+    the overview's ``responses_models`` and str-coerced to match ``_node_models``' ids. Defends
+    against a non-list field, non-string items, and an older master that omits it entirely — each
+    yields an empty set, so a capability is never falsely shown (graceful degradation, fail-closed)."""
+    models = node.get("responses_models")
+    if not isinstance(models, list):
+        return set()
+    return {str(model) for model in models}
+
+
 def cmd_remote_engines(args: argparse.Namespace) -> int:
     """`grid engines` (remote): the live engines (nodes) joined to the active grid."""
     nodes = _nodes(args)
@@ -121,25 +132,34 @@ def cmd_remote_engines(args: argparse.Namespace) -> int:
 
 def cmd_remote_models(args: argparse.Namespace) -> int:
     """`grid models` (remote): the models served across the active grid's live engines, plus the
-    reserved ``auto`` model when the grid has auto-routing enabled (mirrors ``GET /relay/v1/models``)."""
+    reserved ``auto`` model when the grid has auto-routing enabled (mirrors ``GET /relay/v1/models``).
+
+    Each engine row carries whether it serves the model via the Responses dialect (issue 10), read
+    per-engine from the overview's ``responses_models``; shown in ``-v`` and ``--json`` (an older
+    master omits the field → nothing shown). The plain listing stays bare model ids for scripting."""
     overview = _fetch_overview(args)
     nodes = _nodes_from(overview)
-    rows = [
-        (model, str(node.get("engine") or ""), str(node.get("name") or ""))
-        for node in nodes
-        for model in _node_models(node)
-    ]
+    rows: list[tuple[str, str, str, bool]] = []
+    for node in nodes:
+        engine = str(node.get("engine") or "")
+        name = str(node.get("name") or "")
+        capable = _node_responses_models(node)  # resolved once per node, not per served model
+        for model in _node_models(node):
+            rows.append((model, engine, name, model in capable))
     # When auto routing is enabled, advertise the reserved `auto` model FIRST — same as the relay's
     # /relay/v1/models endpoint (owner `grid-router`), so it shows even when zero engines are joined.
     # An older master whose overview lacks the field reports falsy → no auto row (graceful degradation).
+    # `responses` is False for `auto`: dialect-reachability is a per-request routing outcome, not a
+    # static property of the reserved model (no AC covers it) — a real model's badge is its engine's.
     if overview.get("router_enabled"):
-        rows.insert(0, ("auto", "grid-router", ""))
+        rows.insert(0, ("auto", "grid-router", "", False))
 
     if getattr(args, "json", False):
         # Derived view (not a raw passthrough like engines): new API fields on a model entry
-        # won't surface here.
+        # won't surface here. `responses` is this engine's dialect capability (issue 10).
         print(json.dumps(
-            [{"model": model, "engine": engine, "node": node} for model, engine, node in rows],
+            [{"model": model, "engine": engine, "node": node, "responses": serves}
+             for model, engine, node, serves in rows],
             indent=2,
         ))
         return 0
@@ -149,13 +169,17 @@ def cmd_remote_models(args: argparse.Namespace) -> int:
         return 0
 
     if getattr(args, "verbose", False):
-        mwidth = max(len("MODEL"), *(len(model) for model, _, _ in rows))
-        ewidth = max(len("ENGINE"), *(len(engine) for _, engine, _ in rows))
+        mwidth = max(len("MODEL"), *(len(model) for model, _, _, _ in rows))
+        ewidth = max(len("ENGINE"), *(len(engine) for _, engine, _, _ in rows))
         print(f"{'MODEL':<{mwidth}}  {'ENGINE':<{ewidth}}  NODE")
-        for model, engine, node in rows:
-            print(f"{model:<{mwidth}}  {engine:<{ewidth}}  {node}")
+        for model, engine, node, serves in rows:
+            # `responses` joins the line as a trailing capability field — issue 06's intent (annotate
+            # the line, not add a column); shown only when this engine serves the dialect, else the
+            # row ends at NODE.
+            trailer = "  responses" if serves else ""
+            print(f"{model:<{mwidth}}  {engine:<{ewidth}}  {node}{trailer}")
         return 0
 
-    for model in dict.fromkeys(model for model, _, _ in rows):  # order-preserving dedup
+    for model in dict.fromkeys(model for model, *_ in rows):  # order-preserving dedup
         print(model)
     return 0

--- a/docs/adr/0017-auto-router-resilience.md
+++ b/docs/adr/0017-auto-router-resilience.md
@@ -1,0 +1,244 @@
+---
+status: accepted
+---
+
+# Auto-router resilience: per-(node,model) health, a truthful empty-pool contract, startup servability checks
+
+The 2026-07-16 Nightshift outage traced to one provider advertising a model its engine no longer served:
+the engine's 503s tripped the per-**node** demotion, which emptied the `auto` candidate pool, which
+rendered a **400 "…supports tools"** — a transient outage dressed as a permanent capability error — and
+the whole thing flapped ~every 10 minutes as the demotion self-expired. This ADR records how a single bad
+`(provider, model)` is made unable to take down `auto`. Grill log: `.scratch/auto-router-resilience/`
+(PRD + decisions). Scope: issues 1/3/4 implemented; issue 2 (failover) design-only.
+
+Choices a future reader will otherwise re-litigate:
+
+- **Provider health is keyed per-(node, model) and classified by failure reason — not per-node.** A
+  *model-level* failure (the engine's error body says it cannot serve the model) sets aside just that
+  `(node, model)` pairing (**prune**); a *box-level* failure (timeout, connection refused, no engine
+  status) still steps the whole node down (**demotion**), because a sick box is sick for every model.
+  Rejected **per-node + a "never demote the last live provider" exemption**: it keeps a broken provider in
+  rotation, so the consumer keeps hitting the failing engine (billed $0, but a wall of failures) instead of
+  a clean, truthful 503 — and it leaves the root (advertised ≠ servable) unaddressed. Cheap because the
+  failure-recording point already holds both the node id and the model on the transaction, and the engine
+  status is already parsed. Concession: state stays **in-memory** (reset on respawn) and **reuses** the
+  existing failure threshold/window/penalty, re-keyed — a persisted or escalating variant is a follow-up,
+  not a prerequisite.
+
+- **An empty candidate pool returns one of three answers, by cause — a demotion-emptied pool is now a
+  503, not a 400.** No live model → 503 `no_providers_available`; otherwise-capable providers all
+  transiently unhealthy → **503 `provider_temporarily_unavailable`**; live healthy providers but a genuine
+  capability gap → 400 naming the **real** unsupported capability (aggregated from the capability check's
+  own reason). The surprising part: the same "no candidate" condition can now be a 400 *or* a 503,
+  deliberately — because the old code rebuilt the error from the *request's* requested parameters, which is
+  exactly why a transient demotion read as "your request wants tools." Rejected **everything-503** (a real
+  capability mismatch — vision on a text-only grid — would then say "retry" forever) and **message-only,
+  keep the 400** (leaves the retryability lie intact). The capability check already returned its true
+  reason; it was being discarded.
+
+- **Providers verify their advertised set against the engine at startup, best-effort — runtime
+  re-verification is deliberately NOT built.** When the engine's model list is non-empty and excludes an
+  advertised model, the provider drops it and warns loudly (failing startup if nothing remains); when the
+  list is empty or unreachable, it advertises as before (non-breaking). The existing "exactly one model
+  served, assume that's the one" fallback — which hid the mismatch — is closed. Rejected **hard fail-fast**
+  (breaks providers whose serving stack has a flaky/absent model list) and **periodic runtime reconcile
+  now** (loop complexity + a provider redeploy + the same reliability caveat, when the master-side
+  per-(node,model) prune already catches models that vanish after startup, reactively). Defense at the
+  source *and* master-side, because a provider is untrusted: a buggy or non-upgraded one must not be able
+  to take down `auto`.
+
+- **Cross-provider failover is designed, not built — because the incident was single-provider.** With one
+  live provider there is no rank-2 to fall to, so failover would not have prevented this outage; it is
+  multi-provider hardening on a different axis. The recorded target: on a retryable poll-back failure,
+  *before any chunk is delivered*, re-select the next healthy provider and re-enqueue the same transaction
+  (idempotency key + request hash make it safe) while the consumer stays attached to its mailbox stream —
+  bounded by a retry count and the transaction deadline. The hard constraint that makes it non-trivial: a
+  mid-stream failure cannot be un-sent and must terminate, which matters most on the always-streaming
+  responses/codex path. A cheaper interim (a retryable terminal signal plus the reactive prune) falls out
+  of the three fixes above almost for free; build the transparent version only if that proves insufficient.
+  Its implementable expansion — hook point, gates, transaction-state transitions, bounds, and the explicit
+  "is the interim good enough?" test — is the **§ Failover design (issue 2)** section below.
+
+Master relay (`grid_cli/private_server/`) and provider runtime (`grid_cli/provider_runtime/`) both change;
+both are in grid-src. Basing the work on `ae0cc69` keeps the responses-auto path, so the master-side error
+contract and health keying cover `chat/completions` and `responses` in one place (ADR 0016's shared path).
+
+## Post-review follow-ups (issue 02, deferred — not prerequisites)
+
+Surfaced by the four-reviewer pass on the per-(node, model) implementation; accepted as tracked follow-ups
+rather than expand that slice. Both are bounded and neither reopens the outage this ADR closes.
+
+- **Sick-box evasion via always-model-level error text.** Because classification keys off the provider's own
+  error string, a genuinely sick box can word every failure as "model not found" and be *pruned per model*
+  rather than *demoted as a node* — so it stays in rotation for `threshold × (its model count)` failed jobs
+  instead of a fixed `threshold`. Bounded (consumers still get the truthful retryable 503, and a box that
+  fails structurally — timeout / connection-refused — has no model-level text so it still demotes at once).
+  Fix when warranted: an aggregate per-node failure tally, incremented on model-level failures too, that
+  trips a node demotion once one node accumulates prunes across too many *distinct* models in the window —
+  keeping the surgical single-bad-model benefit while capping the "budget scales with advertised models" gap.
+- **Health-dict eviction is recency-ordered, not cooldown-aware.** The `(node, model)` health dicts are
+  capped (`PROVIDER_MODEL_HEALTH_MAX_ENTRIES`, default 10000) with least-recently-failed eviction — bounded
+  memory and O(1), but under a sustained flood of novel model keys it can evict an unrelated pairing whose
+  prune cooldown is still active, ending that penalty early (self-correcting: the pairing re-prunes on its
+  next failure). Not reachable in normal operation (a real grid has far fewer than 10k pairings). A
+  cooldown-aware eviction (prefer entries past their `until`) was rejected for this pass because it is O(n)
+  per insert *when over the cap* — i.e. O(n²) under the very flood it defends against, trading a bounded-
+  memory attack for a CPU one; revisit only if the flood becomes a real threat.
+
+## Failover design (issue 2 — design-only; not built this pass)
+
+Cross-provider failover is the *transparent* version of what 1+3+4 already do reactively: when a provider's
+engine fails a job, re-send that same job to the next healthy provider so the consumer never sees the blip.
+It is **designed here, not built** — the Nightshift incident was single-provider, where there is no rank-2 to
+fall to, so failover would not have prevented it (scope bullet above). This section records the target so a
+later pass can build it without re-deriving the seams. All references are grid-src @ `7cfed10`
+(`fix/auto-router-resilience`); nothing below changes runtime behaviour, and there is no code or test.
+
+### Where it hooks in
+
+`provider_error` (`relay.py:3966`, `POST /error/{txn}`) is the seam. Today, under a `SELECT … FOR UPDATE` on
+the transaction, it does four things in order: `_record_provider_failure` (classify → prune `(node,model)` or
+demote the node), `UPDATE state="failed"`, `settle_failed_within(…, 0, …)` ($0), then post-commit
+`_live_bus.publish_terminal`. Transparent re-dispatch **intercepts between the classify and the mark-failed**:
+if the failure is *retryable* **and** *no chunk has been delivered* **and** *budget remains*, re-select the
+next healthy provider and re-enqueue instead of terminating. A mid-stream engine break is reported only after
+the provider has already POSTed chunks via `POST /response/{txn}`, so it fails the "no chunk delivered" gate
+and terminates unchanged — the gate is what separates the two paths, not a second code site.
+
+### Retryable vs terminal
+
+The distinguishing question is fault attribution: is the failure the *request's* fault (terminal — another
+provider of the same model would fail identically) or the *engine/provider's* fault (retryable — worth another
+seat)? The existing `_terminal_error` (`relay.py:1237`) and `_is_model_level_failure` (`relay.py:844`) already
+draw this line:
+
+- **Retryable (re-dispatch-eligible):** a model-level "unservable" error (→ this pairing is already pruned),
+  an upstream **5xx**, a **timeout**, a **429** (rate-limited — another seat may be free), and upstream
+  **401/403** (the *provider's* vendor credentials, not the consumer's request — provider-specific, so a
+  different provider is worth trying).
+- **Terminal (never re-dispatch):** a genuine upstream **request 4xx** (400/413/422 …) that `_terminal_error`
+  passes through — the request really is invalid for this model, so re-sending it elsewhere only wastes a
+  second provider and delays the truthful error.
+
+Implementation is a small predicate over the already-parsed engine status — no new plumbing (the status is
+extracted by `_ENGINE_ERROR_RE`, `relay.py:1234`; the reason is already in hand at the hook).
+
+### The pre-first-chunk gate
+
+The gate is **"has any byte reached the consumer's mailbox?"**, and the mailbox answers it exactly: the
+`ChunkRow` table (`db.py:155`, PK `(transaction_id, seq)`) is the *only* thing `_stream_from_mailbox`
+(`relay.py:1398`) ever yields to the consumer besides the terminal render and keepalives. So the gate is
+`SELECT 1 FROM relay_chunks WHERE transaction_id = :txn LIMIT 1` — **no row ⇒ nothing delivered ⇒ safe to
+re-dispatch.** Do **not** gate on `state`: `state="streaming"` is set when the provider *claims* the job at
+poll (`provider_poll`, `relay.py:3057`), long before any byte, so it would forbid a perfectly safe retry.
+Evaluate the gate under the same `FOR UPDATE` lock as the state reset so it cannot race a concurrent
+`_insert_chunk` (`relay.py:3648`); a chunk that commits after the gate but before re-enqueue is the residual
+edge, bounded by the fact that a provider reporting an error via `/error` is by construction not also
+streaming success via `/response`.
+
+### Re-enqueue + transaction state changes
+
+When all three gates pass:
+
+1. **Re-select** the next healthy provider for the *same real model* (`txn.model` already holds the routed
+   real name, not `auto`). Reuse `_select_provider(...)`; the just-failed pairing is **already excluded**,
+   because `_record_provider_failure` pruned/demoted it one step earlier — the reactive prune *is* the
+   steering mechanism. If none is found, fall through to terminate (below).
+2. **Retain the request.** The provider-facing body lives only in the in-memory `PendingRequest`
+   (`relay.py:2462`), never on the txn — so re-dispatch needs it kept. Recommended: an **in-memory map keyed
+   by `txn_id`**, dropped on any terminal, holding the body + derived `requirements`. This matches the
+   in-memory health state (both die on respawn, which is fine — a respawn already fails in-flight txns), and
+   it adds **no request bytes at rest** (a persisted `request_body` column would). Master-respawn continuation
+   is explicitly out of scope, exactly as for demotion state.
+3. **Reset the row** under the lock: `state="queued"` (re-arm the poll), `provider_node_id = new_node`,
+   increment a new `retry_count`, **keep `status="pending"`** (do *not* settle), and **do not**
+   `publish_terminal`. Refresh `input_rate`/`output_rate` to the new provider's price (they were fixed to the
+   first provider's rate at creation, `relay.py:2408`) so the winner is paid and the consumer billed at the
+   rate that actually served them.
+4. **Re-enqueue** a fresh `PendingRequest` onto `_get_provider_queue(new_node)`; a `QueueFull` counts as this
+   attempt failing (try the next provider, or terminate).
+
+The consumer's `_stream_from_mailbox` loop never saw a terminal, so it keeps waiting across the whole
+re-dispatch — invisibly; the 15 s keepalives hold the socket open through the gap.
+
+| Phase | `state` | `status` | `provider_node_id` |
+|---|---|---|---|
+| created | `queued` | `pending` | provider #1 |
+| claimed at poll | `streaming` | `pending` | #1 |
+| retryable pre-chunk failure → re-dispatch | `queued` (`retry_count`++) | `pending` (unsettled) | provider #2 |
+| … | `streaming` | `pending` | #2 |
+| win | `completed` | `completed` (settle at #2's rate) | winner |
+| exhausted / no provider / deadline | `failed` / `timed_out` | `failed` / `partial` ($0) | last tried |
+
+On idempotency: `idempotency_key` (client `Idempotency-Key` header) + `request_hash` (`relay.py:2306`, hashed
+*pre*-routing) protect **client-driven** re-sends — the interim-B path, where the app itself retries and
+`_find_idempotent_transaction` de-dupes it onto the existing txn. Transparent A re-enqueues **internally** on
+one txn, so its safety rests on the gate + the still-`pending` (unsettled) row + the retained body, not on
+those keys; the two mechanisms are complementary, not substitutes.
+
+### Bounds — terminate truthfully on whichever fires first
+
+Three independent limits; whichever fires first ends the retry loop and renders the truthful terminal error:
+
+- **Retry count** — a new `retry_count`, capped by `PROVIDER_FAILOVER_MAX_RETRIES` (new env knob mirroring the
+  `PROVIDER_FAILURE_*` family; a small default such as 2). At the cap, terminate.
+- **Deadline** — the existing `deadline_at` = `created_at + inference_timeout_seconds` (600 s, `db.py:99`),
+  enforced by the reaper (`idx_transactions_deadline_active`). Re-dispatch does **not** extend it, so total
+  failover time stays inside the budget the consumer already agreed to; a deadline reached mid-retry fails the
+  txn to `timed_out` (504) regardless of `retry_count`.
+- **Provider pool** — no next healthy provider ⇒ terminate immediately. This is the single-provider incident
+  case: nothing to fail to → the truthful `503 provider_temporarily_unavailable` from issue 01.
+
+### Billing — unchanged, correct by omission
+
+`settle_transaction` / `settle_failed` (`credits.py:112` / `:198`) are idempotent on `status=="pending"`.
+Because a re-dispatched attempt **does not settle**, the txn stays `pending` across every failed attempt and
+exactly **one** settlement ever fires: the winning attempt (`settle_transaction`, at the winner's refreshed
+rate) or the final exhaustion / reaper (`settle_failed`, `$0` — "consumer pays nothing for a failed task").
+"Failed attempts $0, only the winner bills" therefore needs **no billing change** — it is a consequence of not
+settling on re-dispatch, plus the rate refresh in step 3.
+
+### Responses / codex path
+
+Pre-first-chunk failover is dialect-agnostic — the mailbox is the same, and a responses consumer that has seen
+no `response.created` yet cannot tell a retry happened. The **hard constraint** lives entirely on the
+*post*-first-chunk side and is a *correctness* invariant, not an optimisation: responses is always-streaming,
+so once any `response.*` event is in the mailbox, a second provider would emit a fresh `response.created` —
+two in one stream, which a Codex client cannot reconcile. The "no `ChunkRow`" gate is exactly what forbids
+that. On termination the responses failure render is already `_responses_failure_block` (`relay.py:1280`,
+wired at `_stream_from_mailbox` `relay.py:1508`): a single `response.failed` event coded `server_error` (or
+`rate_limit_exceeded` for a 429) — a coherent, backoff-able terminal outcome that needs no change. Failover
+simply runs *before* that render when eligible. (A codex seat is flat-rate and usually pinned to
+`max_concurrency = 1`, so the realistic multi-provider case here is several seats; the same gate and logic
+apply.)
+
+### The interim "B" — already shipped by 1+2, and its "good enough?" test
+
+The cheap interim falls out of the three fixes with no extra work, and is live @ `7cfed10`:
+
+1. **Prune** — the failure sets aside the bad `(node,model)` (`_record_provider_failure`, issue 02).
+2. **Steer the re-send** — a re-sent `auto` request drops the pruned pairing in `_build_auto_candidates`
+   (`relay.py:2006`) and ranks the survivors, so it lands on rank-2; if every capable pairing is pruned it
+   returns the retryable **`503 provider_temporarily_unavailable`** (`_apply_auto_routing:2171`, issue 01)
+   rather than the old capability-400 lie.
+3. **Retryable terminal signal on the failed job itself** — a non-stream job gets a real **502/504** through
+   the bounded status-wait (`relay_nonstream_status_wait_seconds = 50`, `config.py:89`); responses gets the
+   `response.failed` block above; **streaming chat** gets the error envelope *in-band* (200 headers are long
+   sent, so no retryable HTTP status is left — the one place B is structurally weakest).
+
+So **B** = "the client re-sends and the grid steers it to health"; **A** = "the grid re-sends transparently, so
+even the first request succeeds." Build **A** only when **all** of these hold — otherwise B is the answer:
+
+- **Multi-provider is the norm on the grid.** Single-provider (the incident) has no rank-2, so A cannot help
+  there at all; A only earns its complexity where a healthy alternate usually exists.
+- **A client-visible one-request failure actually hurts.** OpenAI SDKs retry 502/503/504 with backoff, so B is
+  already transparent for them; A matters for non-retrying clients and for **streaming-chat** clients, whose
+  in-band error carries no retryable status and so does not auto-retry.
+- **The complexity is paid for.** A costs body/requirements retention, a `retry_count` column, the under-lock
+  chunk-gate + rate refresh, conditional settlement, and the responses double-`response.created` guard — each
+  small, but the gate-vs-concurrent-insert race needs care.
+
+**Recorded decision:** ship 1+3+4 (done), run **B** in production, and revisit **A** only if telemetry shows
+the overlap — multi-provider grids *and* client-visible failures that B's retryable signal does not absorb
+(chiefly streaming-chat clients that do not retry). The streaming-chat gap is the one B structurally cannot
+close (a 200 has already committed the status), and is the strongest single reason A would ever be built.

--- a/docs/adr/0017-auto-router-resilience.md
+++ b/docs/adr/0017-auto-router-resilience.md
@@ -24,6 +24,25 @@ Choices a future reader will otherwise re-litigate:
   status is already parsed. Concession: state stays **in-memory** (reset on respawn) and **reuses** the
   existing failure threshold/window/penalty, re-keyed — a persisted or escalating variant is a follow-up,
   not a prerequisite.
+  **Amendment (2026-07-22, issue 05):** a **third** class sits above both — an engine-reported
+  *client-shape* `4xx` (status 400/422: `invalid_request_error` / `unsupported_parameter`) is the
+  *request's* fault, not provider ill-health, so it is exempt from the **normal** demote/prune — checked
+  *after* the model-level classifier (a model-missing body an engine wraps in a 400/422 rather than a 404
+  still prunes; a media job still takes the box path) and gated `not is_media`. Because the failure
+  `reason` is provider-forgeable (the POST `/error` body), the exemption is **not unconditional**: a
+  per-node tally of exempted client-shape failures still trips a box-level demotion at a **much higher**
+  threshold (`provider_client_shape_failure_threshold`, default 50), cleared by any success — so a healthy
+  low-volume seat is never demoted, while a node claiming a 400/422 on *every* job (forged or badly
+  misconfigured) still is. (The naive "exempt entirely" of the first cut was hardened here after a security
+  review flagged the forge-a-400-forever evasion; the narrower per-model always-model-level spoof stays a
+  documented follow-up below.) Surfaced when a non-streaming `auto` request reached a
+  stream-only codex seat (extend-responses-api) and its `400 "Stream must be set to true"` — having no
+  model-level marker and not being a 404 — took the box-level path and demoted the whole *unioned* node:
+  a grid-wide outage from a healthy provider correctly refusing a malformed request. This is the same
+  fault attribution the § Failover design already applies (a request 4xx is *terminal* — another
+  provider would fail identically), extended from re-dispatch to the health classifier. The broader
+  *union blast-radius on a genuine failure* — one engine's real 5xx still demoting its siblings under a
+  shared `node_id` — is a pre-existing property left as a separate follow-up, not closed here.
 
 - **An empty candidate pool returns one of three answers, by cause — a demotion-emptied pool is now a
   503, not a 400.** No live model → 503 `no_providers_available`; otherwise-capable providers all

--- a/docs/adr/0018-responses-as-an-engine-capability.md
+++ b/docs/adr/0018-responses-as-an-engine-capability.md
@@ -126,6 +126,37 @@ Choices a future reader will otherwise re-litigate:
   actionable, but it leaves `auto` non-deterministic against its own contract, and the config that
   triggers it — both kinds on one grid, `auto`, a cap — is real, not a straw man.
 
+- **The auto-router excludes a stream-only engine from a NON-streaming `/responses` request — the
+  filter's first *forbidden-feature* axis.** (Added after Phase-2 E2E surfaced the interaction live;
+  issue 06c.) Lifting mandatory streaming (§4 / issue 05) made a non-streaming Responses request valid
+  for every engine **except** the subscription seat, whose backend is stream-only and refuses one at
+  its per-kind gate. But that gate runs **after** routing, so `auto` — which picks *for* the app — can
+  still rank a non-streaming request onto the seat and have it refused post-queue: the same
+  succeed-or-fail-on-where-it-lands asymmetry user story 21 forbids, now on the *stream* axis rather
+  than the cap axis. Issue 05 opened the non-streaming path but never added the matching auto-router
+  exclusion, exactly as the cap gap sat open until the axis above. The fix mirrors that axis with one
+  difference that is the reason it is recorded separately. The cap axis is a **positive** capability —
+  an engine advertises it **can** honour a cap and a capped request requires it
+  (`requirements.features <= candidate.features`). Streaming inverts: a non-streaming request is the
+  SDK **default** and the common case, so requiring a positive `nonstream` capability would exclude
+  every engine that does not advertise it — including hardware engines on an **older CLI** that serve
+  non-streaming perfectly well — during the master-before-CLI window, a regression on the common path.
+  So the seat advertises a **negative** trait (`stream_only`) and the filter gains an **exclusion**
+  axis: a non-streaming request *forbids* `stream_only`, and only an engine that advertises it — the
+  seat, nothing else — is dropped. Absence is the safe default (an old CLI advertises nothing → is
+  never excluded), the same fail-closed direction the positive axes rely on, reached by the opposite
+  polarity. The trait is sourced from `kind_is_stream_only`, the sibling of the cap source, read by
+  **both** the engine-side gate and the advertised envelope, so the layer that refuses and the layer
+  that routes can never disagree about which kind is stream-only. Rejected **hardcoding `codex` in the
+  routing path** (drop the kind for a non-streaming `auto`): it reintroduces an engine *name* into
+  candidate selection — the exact coupling this ADR's per-engine model removes — and a future
+  stream-only kind would not be caught for free. Rejected the **positive `nonstream` capability**, for
+  the rollout regression above. This makes the auto-branch filter's axes **three** — endpoint, output
+  cap, stream-only — and its polarities **two**: a request both requires positive capabilities and
+  forbids negative ones. The `stream_only` literal joins the endpoint list and `output_cap` as a
+  hand-duplicated CLI ↔ relay wire value; an old CLI never advertising it fails closed (its engine is
+  simply never excluded), so the master-before-CLI order this ADR already fixes covers it too.
+
 Deliberately unchanged, so the widening is not read as wider than it is: **local mode** stays
 chat-only (it forwards blind by design and has never probed *any* text capability — not vision, not
 tools — so a Responses probe there would be the first of its kind; the exclusion is the absent

--- a/docs/adr/0018-responses-as-an-engine-capability.md
+++ b/docs/adr/0018-responses-as-an-engine-capability.md
@@ -1,0 +1,127 @@
+---
+status: accepted
+---
+
+# `/responses` as an engine capability: per-engine endpoints, discovery by probe, a narrowed allow-list statement
+
+ADR 0015 D-b made the servable relay endpoint a property of an engine's **kind** — codex ⇒
+`responses`, openai ⇒ `chat/completions`, hardware ⇒ the chat pair. That is why the Responses
+dialect today reaches exactly one kind of engine: a codex subscription seat. Everything else a
+grid serves — llama.cpp, Ollama, vLLM, and the `openai` API engine whose vendor defines the
+dialect — is invisible to an app that speaks Responses: real capacity someone is contributing that
+a whole class of apps cannot reach. This ADR records how `responses` becomes a capability **any**
+engine can hold. Grill log: `.scratch/extend-responses-api/` (PRD + `decisions.md`, the verified
+file-and-line map).
+
+Scope: this CLI + grid-src (the relay); grid-apis has **no slice** — checked, not assumed (PRD §9).
+Written **before** any code lands: the decisions below are normative, not descriptive. It ships in
+two phases: **P1** = the shared core plus the `openai` kind; **P2** = hardware engines (the probe,
+per-engine resolution, and the live capability display). Two wire values this feature touches are
+hand-duplicated with grid-src and have no compile-time link between the copies: the endpoint-path
+literal `"responses"`, which must match grid-src's `endpoint_path` byte-for-byte, and the per-model
+`endpoints` capability list, whose absence on grid-src's side means chat-only — which is precisely
+what makes old CLIs fail closed. Changing one repo alone compiles, passes every test, and breaks the
+seam at runtime.
+
+Choices a future reader will otherwise re-litigate:
+
+- **Endpoint capability resolves per ENGINE for hardware, and stays per KIND for API engines —
+  partially superseding ADR 0015 D-b.** What D-b got right and is kept in full: the gate runs
+  **after** routing where the kind is known; a mismatch is refused with a structured error, never
+  translated and never blind-forwarded; each advertised model's capability envelope carries its
+  endpoints so the relay's per-model filter excludes mismatched candidates at selection time; and
+  old CLIs, which never advertise the capability, fail closed. What is superseded is exactly one
+  clause **of the mechanism**: **`hardware ⇒ chat/completions + completions` as a fixed property of
+  being hardware.** A per-kind matrix is only true while every engine of a kind is identical, and
+  hardware engines stop being identical the moment they differ by *software version* — one Ollama
+  box serves the dialect and the box beside it, a few releases behind, does not, and both are the
+  same "kind". Which
+  release grew the endpoint is second-hand for every hardware engine (`decisions.md` §4 rates it
+  medium confidence), and that is itself an argument for asking the engine rather than tabulating
+  versions. API-engine kinds are genuinely uniform (the kind *is* one vendor's service), so they
+  keep static per-kind catalog data; hardware resolves from what was discovered at join.
+  D-b's enumeration nonetheless goes stale in a **second** place, for an unrelated reason: the
+  `openai ⇒ chat/completions only` row's *value* gains the dialect in P1. That is catalog data
+  moving under the mechanism D-b established, not the mechanism being superseded — but a reader
+  diffing D-b against the running system finds two of its three rows no longer describing reality,
+  and only one of them is a design change. Both are recorded here so neither reads as drift.
+  Rejected **keeping the matrix wholly per-kind** — ship P1's `openai` widening and declare hardware
+  chat-only forever. That is a shippable position rather than a straw man, and the cheapest one on
+  offer; it loses because it permanently excludes every hardware engine from the dialect on the
+  strength of a claim about kinds that the world falsifies as soon as two boxes run different
+  versions.
+  Rejected **per-model resolution**: the route either exists on the engine's server or it does not,
+  so per-model would re-ask the same question once per model and invite two models on one server to
+  disagree about their server. The probe is a property of the server, run **once per engine**,
+  stamped onto every model that engine advertises.
+
+- **Capability is DISCOVERED at join, not assumed and not declared.** The engine is asked once
+  whether the route exists — a deliberately invalid request, where a *route-missing* status means
+  no and a *bad-request* status means yes. By design no inference runs and no tokens are spent, so
+  joining stays free. Transport failure, timeout, or an ambiguous answer is treated as **no** — fail
+  closed, because the cost of under-advertising is that an engine keeps serving chat traffic
+  normally, while the cost of over-advertising is a candidate filter that lies.
+  Rejected **assume-and-let-the-forward-fail**:
+  it makes the relay's candidate filter untruthful and reproduces precisely the misleading-error
+  class ADR 0017 exists to prevent — a request routed to an engine that cannot serve it, failing in
+  a way that describes the request rather than the gap. Rejected **an opt-in join flag**: it pushes
+  an engine-version detail onto the person joining, and when they get it wrong it fails in exactly
+  the same way as assuming, with the added insult that they were asked. Because capability is
+  discovered rather than enumerated, an engine this ADR never names — LM Studio, MLX, something
+  that does not exist yet — is handled the day it grows the endpoint, with no release from us.
+  Recorded as **unverified** (`decisions.md` §5, items 3 **and** 4): that a route-existence probe
+  reliably answers *bad-request* rather than 404/405/a catch-all page is not confirmed per engine —
+  and neither is the premise that an empty probe body never triggers work, which is the whole reason
+  the probe is free. P2's live gate confirms both. Until then the fail-closed rule makes the first
+  ambiguity safe; the second has no such backstop, so an engine found to do real work on an empty
+  body would force the probe to change shape rather than merely fail closed.
+
+- **The anti-traversal statement at the engine-side gate is deliberately NARROWED, and this is not a
+  loosening.** The gate today asserts that "`responses` never enters `_ALLOWED_ENDPOINTS`, so the
+  anti-traversal property is unchanged", under the heading that the global allow-list is
+  "deliberately NOT widened". Be precise about what stops holding: `_ALLOWED_ENDPOINTS` is only the
+  hardware branch's return value inside `_served_endpoints`, so an implementation may leave that
+  module constant untouched and have the branch compose a per-engine set instead. What necessarily
+  changes is that the literal enters **the set the gate consults** for a capable hardware engine —
+  the thing the comment was really asserting could never happen. It is the **implication** that goes
+  stale, not inevitably the sentence, and it must be corrected rather than quietly deleted.
+  **The safety was never in which literals are in that set — it is in the endpoint being
+  checked against a closed set of fixed literals before it is used to build a URL.** The allow-list's
+  own comment states the threat model it defends: the endpoint is *relay-supplied* and interpolated
+  into a local engine URL, so the membership check is what stops a buggy or compromised relay
+  probing other local paths via `../`. Only a value that matched the set ever reaches
+  `f"{target_url}/{endpoint}"`, and every member of that set is a literal authored in this repo,
+  never a string from the request or the wire — and for P2 the probe decides **whether** the
+  authored literal `"responses"` is included, not **what** it is, so nothing discovered over the
+  network reaches URL construction. Rejected **a second, parallel allow-list for the Responses
+  path**: the `_MEDIA_ENDPOINTS` frozenset is precedent for exactly that shape, but it is separate
+  for a reason that does not transfer — media routes to this box's *media server*, a different URL,
+  whereas Responses goes to the same LLM engine as chat. A second set for the same URL costs another
+  closed set to keep in lockstep and buys nothing the membership check does not already provide.
+  D-b's actual concern also survives, by a different mechanism: it rejected widening the *global*
+  allow-list because a Responses job could then blind-forward into a
+  hardware engine and die as a 404 instead of a clean refusal — and per-engine resolution keeps
+  exactly that protection, since an engine that failed the probe does not have the literal in its
+  set and still gets the clean structured refusal. What is genuinely lost is only that the old
+  comment claimed a **stronger property than was ever needed**. Recording this is the single
+  strongest reason this ADR exists: a future reader who finds a security statement silently relaxed
+  cannot tell whether it was deliberate, and would be right to assume the worst.
+
+Deliberately unchanged, so the widening is not read as wider than it is: **local mode** stays
+chat-only (it forwards blind by design and has never probed *any* text capability — not vision, not
+tools — so a Responses probe there would be the first of its kind; the exclusion is the absent
+capability pipeline, not effort); **stateful Responses** — prior-response linkage, conversation
+reference, and server-side storage — stays *refused* by the relay's normalizer for every engine,
+because the grid keeps no conversation and pinning one to an engine would break the property that
+any capable engine can serve the request; the **retrieval and cancellation routes** are a different
+mechanism and not refused at all, simply **not proxied** — some engines expose them, the grid does
+not forward them, and they share that stateful reasoning; and **no translation shim is built** for
+engines that lack the dialect, which is the whole point of discovering capability rather than
+assuming it.
+
+Rollout order is fixed per phase: the **master deploys before the CLI is released**. The reverse
+order does not break — it degrades silently, because an older relay still enforces mandatory
+streaming and still refuses the output cap, so someone would see subscription-seat restrictions on
+an ordinary hardware engine with nothing to explain why. The opposite skew is safe by the capability
+list's own fail-closed design: an older CLI advertises nothing new, and the relay's filter excludes
+it.

--- a/docs/adr/0018-responses-as-an-engine-capability.md
+++ b/docs/adr/0018-responses-as-an-engine-capability.md
@@ -107,6 +107,25 @@ Choices a future reader will otherwise re-litigate:
   strongest reason this ADR exists: a future reader who finds a security statement silently relaxed
   cannot tell whether it was deliberate, and would be right to assume the worst.
 
+- **The auto-router filters `/responses` candidates on the output cap, so `auto` never routes a capped
+  request to an engine that cannot honour one.** Moving the cap refusal to the engine-side per-kind
+  gate (this feature's decision above / PRD §3) is right for a *named* model, where the app chose the
+  engine. But `auto` picks *for* the app, and the auto-branch candidate filter keys only on the dialect
+  endpoint, vision, and tools — not the cap. On a grid serving both an `openai` engine and a codex
+  seat, a capped `auto` request could therefore be ranked onto the seat and refused *after* queueing:
+  the same request succeeding or failing on where routing lands, which is precisely what user story 21
+  ("`auto` never picks an engine that will fail") forbids. So "honours an output cap" becomes a hard
+  routing filter — sourced from the **same** catalog fact the engine gate reads
+  (`max_output_tokens ∈ unsupported_params`, so the two layers can never disagree), advertised in the
+  capability envelope, and required by the auto deriver only when the body carries a cap. This makes
+  the request-contract split **three** layers, not two: the relay normalizer refuses the universal
+  facts; the **auto-router excludes cap-incapable engines**; the engine-side gate refuses a *named*
+  seat pick. It extends ADR 0016's auto-branch hard filter by one axis, reusing the existing `features`
+  subset check — not `special_params`, which that deriver deliberately avoids. Rejected **accept the
+  asymmetry and only document it**: cheaper (no wire change) and the post-queue failure is loud and
+  actionable, but it leaves `auto` non-deterministic against its own contract, and the config that
+  triggers it — both kinds on one grid, `auto`, a cap — is real, not a straw man.
+
 Deliberately unchanged, so the widening is not read as wider than it is: **local mode** stays
 chat-only (it forwards blind by design and has never probed *any* text capability — not vision, not
 tools — so a Responses probe there would be the first of its kind; the exclusion is the absent

--- a/remote/probe.py
+++ b/remote/probe.py
@@ -410,8 +410,9 @@ def capability_entry(
     included ONLY when actually known (the engine's ``--ctx-size`` or an API whitelist entry) — an
     unknown window is omitted, never defaulted, so the master (and the auto-router Advisor) treats
     absence as "unknown" rather than trusting a fabricated 128000. ``endpoints`` defaults to the
-    hardware-engine pair; an API engine passes ``["chat/completions"]`` — it never serves legacy
-    completions (ADR 0012)."""
+    hardware-engine pair; an API engine passes its catalog row's endpoints (issue 03) — chat plus
+    ``responses`` for a kind whose vendor serves the dialect (openai) — but never legacy completions
+    (ADR 0012)."""
     input_modalities = ["text", "image"] if probed["vision"] else ["text"]
     ctx = int(context_window) if context_window else None
     return {

--- a/remote/probe.py
+++ b/remote/probe.py
@@ -25,6 +25,7 @@ _PROBE_TIMEOUT = 15.0
 _PROPS_TIMEOUT = 5.0
 _SHOW_TIMEOUT = 5.0
 _BENCHMARK_TIMEOUT = 60.0
+_RESPONSES_PROBE_TIMEOUT = 5.0
 
 # A minimal valid image for the live vision probe — we only test whether the engine ACCEPTS image
 # input, not the answer, so any decodable pixel works. Bump the size if a specific engine rejects
@@ -47,6 +48,8 @@ def capabilities(
     *,
     advertise_as: str | None = None,
     context_window: int | None = None,
+    endpoints: list[str] | None = None,
+    honours_output_cap: bool = False,
 ) -> dict[str, Any]:
     """One-call public API: live-probe ``llm_url`` for ``model`` and return the register envelope.
 
@@ -56,8 +59,45 @@ def capabilities(
     answers to) yet register under the alias (what consumers ask for).
 
     ``context_window`` (the engine's ``--ctx-size``) is advertised so the master can catalog it.
+
+    ``endpoints`` and ``honours_output_cap`` carry the once-per-engine Responses discovery (issue 08):
+    the caller runs ``probe_responses_endpoint`` ONCE for the engine's server and passes the same
+    answer here for every model it advertises — the dialect is a property of the server, not a model.
+    Both default to the pre-Phase-2 hardware posture (chat pair, no cap feature), so a caller that has
+    not probed the route is unchanged.
     """
-    return envelope(advertise_as or model, probe_llama_capabilities(llm_url, model), context_window)
+    return envelope(
+        advertise_as or model, probe_llama_capabilities(llm_url, model), context_window,
+        endpoints=endpoints, honours_output_cap=honours_output_cap,
+    )
+
+
+def probe_responses_endpoint(llm_url: str, *, timeout: float = _RESPONSES_PROBE_TIMEOUT) -> bool:
+    """Discover whether the engine's server serves the Responses dialect at ``/responses`` (ADR 0018).
+
+    A route-existence probe, NOT an inference: POST a deliberately-invalid (empty) body and read the
+    status. A *bad-request* (400/422) means the route exists and rejected the payload → ``True``; a
+    *route-missing* status (404), *method-not-allowed* (405), a catch-all ``200`` page, any other
+    status, and any transport failure / timeout all mean "does not serve it" → ``False``. **Fail
+    closed**: over-advertising makes the relay's candidate filter lie (the ADR 0017 error class),
+    while under-advertising only keeps the engine on the chat traffic it already serves.
+
+    The dialect is a property of the engine's SERVER, not of a model, so callers run this ONCE per
+    engine and stamp the answer onto every model it advertises — never once per model.
+
+    No tokens are spent and no inference runs: an empty body is *expected* to fail request validation
+    before any forward pass. That "the probe is free" premise is unverified per engine (decisions.md
+    §5 item 4) and — unlike the 404-vs-400 ambiguity, which the fail-closed rule above already makes
+    safe — has no fail-closed backstop; if issue 11's live gate finds an engine doing real work on an
+    empty body, this probe must change shape (a structurally-invalid but still-cheap body), not merely
+    keep failing closed.
+    """
+    try:
+        with httpx.Client(timeout=timeout) as client:
+            resp = client.post(f"{llm_url.rstrip('/')}/responses", json={})
+    except httpx.HTTPError:
+        return False
+    return resp.status_code in (400, 422)
 
 
 # --- HTTP (routed through httpx.Client so tests can inject a MockTransport) ---

--- a/remote/probe.py
+++ b/remote/probe.py
@@ -530,12 +530,19 @@ def codex_capability_entry(
     the caller supplies it — never for the ``entry=None`` degrade, which has no row position.
     """
     codex_endpoints = list(api_catalog.WHITELISTS[api_catalog.CODEX_KIND].endpoints)
+    # issue 06c: the seat advertises the NEGATIVE `stream_only` routing trait on BOTH branches (its
+    # backend is SSE-only, stale-catalog or not). Sourced from the predicate the engine-side stream gate
+    # also reads (`kind_is_stream_only`), NOT a literal True, so advertise and gate can't disagree.
+    stream_only = api_catalog.kind_is_stream_only(api_catalog.CODEX_KIND)
     if entry is None:
         return {
             "endpoints": codex_endpoints,
             "input_modalities": ["text"],
             "output_modalities": ["text"],
-            "features": {},
+            # No capability claims for an unresolved model — but the seat's backend is still SSE-only, so
+            # the `stream_only` routing trait stays (issue 06c). Fail-closed: a non-streaming `auto`
+            # request is still routed away from a stale seat, the opposite polarity to a capability.
+            "features": {"stream_only": stream_only},
         }
     features = api_catalog.codex_features(entry)
     # vendor_rank (1 = most capable) is a TOP-LEVEL capability fact, a sibling of context_window —
@@ -549,7 +556,9 @@ def codex_capability_entry(
         "output_modalities": ["text"],
         "context_window": int(entry.context_window),
         **({"vendor_rank": vendor_rank} if vendor_rank is not None else {}),
-        "features": features,
+        # A routing trait folded in beside the honest capabilities — NOT added to `codex_features`,
+        # which also feeds `grid catalog --api codex --json` and must stay capability-only.
+        "features": {**features, "stream_only": stream_only},
     }
 
 

--- a/remote/probe.py
+++ b/remote/probe.py
@@ -404,7 +404,7 @@ def probe_llama_capabilities(llm_url: str, llm_model: str) -> dict[str, bool]:
 
 def capability_entry(
     probed: dict[str, bool], context_window: int | None = None,
-    endpoints: list[str] | None = None,
+    endpoints: list[str] | None = None, honours_output_cap: bool = False,
 ) -> dict[str, Any]:
     """Render one model's capability entry (matches the desktop/relay shape). ``context_window`` is
     included ONLY when actually known (the engine's ``--ctx-size`` or an API whitelist entry) — an
@@ -412,7 +412,17 @@ def capability_entry(
     absence as "unknown" rather than trusting a fabricated 128000. ``endpoints`` defaults to the
     hardware-engine pair; an API engine passes its catalog row's endpoints (issue 03) — chat plus
     ``responses`` for a kind whose vendor serves the dialect (openai) — but never legacy completions
-    (ADR 0012)."""
+    (ADR 0012).
+
+    ``honours_output_cap`` advertises the ``output_cap`` FEATURE — the engine honours a Responses
+    ``max_output_tokens`` cap. It is a hand-duplicated wire literal grid-src's auto-router filters on
+    (issue 06b): a capped ``auto`` request excludes engines that lack it, so it never lands on a seat
+    that would 400 the cap post-queue. Defaults ``False`` so every current caller — every Phase-1
+    hardware probe — is unchanged; the openai kind passes ``True`` via ``_static_api_caps``, and
+    Phase 2's hardware probe (issue 08) flips this default on. Distinct from the numeric
+    ``max_output_tokens`` LIMIT below: that is issue 09's enforcement ceiling, this is the routing
+    boolean. The codex seat uses ``codex_capability_entry`` and never reaches here, so it never
+    advertises the feature — the fail-closed omission this filter relies on."""
     input_modalities = ["text", "image"] if probed["vision"] else ["text"]
     ctx = int(context_window) if context_window else None
     return {
@@ -430,6 +440,8 @@ def capability_entry(
             "audio": False,
             "logprobs": False,
             "top_logprobs": False,
+            # Appended last so the existing feature order is undisturbed. issue 06b wire literal.
+            "output_cap": honours_output_cap,
         },
         "limits": {
             **({"max_context_tokens": ctx} if ctx is not None else {}),
@@ -443,12 +455,14 @@ def capability_entry(
 
 def envelope(
     model_name: str, probed: dict[str, bool], context_window: int | None = None,
-    endpoints: list[str] | None = None,
+    endpoints: list[str] | None = None, honours_output_cap: bool = False,
 ) -> dict[str, Any]:
     """Wrap a probed-features dict in the ``{schema_version, models}`` envelope the relay requires."""
     return {
         "schema_version": 1,
-        "models": {model_name: capability_entry(probed, context_window, endpoints=endpoints)},
+        "models": {model_name: capability_entry(
+            probed, context_window, endpoints=endpoints, honours_output_cap=honours_output_cap,
+        )},
     }
 
 

--- a/remote/serve.py
+++ b/remote/serve.py
@@ -64,6 +64,12 @@ _MAX_RELOAD_REGISTER_RETRIES = 5
 # Text goes to the LLM engine; media goes to this box's media server, each with its own fixed
 # allowlist (the media paths are NOT under `_ALLOWED_ENDPOINTS` — they route to a different URL).
 _ALLOWED_ENDPOINTS = frozenset({"chat/completions", "completions"})
+# The Responses dialect's endpoint literal, authored HERE — never taken from the wire. Kept OUT of the
+# closed `_ALLOWED_ENDPOINTS` frozenset and composed onto a hardware engine's served set only when its
+# join-time probe found the route (issue 08 / ADR 0018 decision 3): the probe decides WHETHER this
+# authored literal is included, never WHAT it is, so nothing discovered over the network reaches URL
+# construction. Must match grid-src's `endpoint_path` byte-for-byte (CLAUDE.md lockstep).
+_RESPONSES_ENDPOINT = "responses"
 _MEDIA_ENDPOINTS = frozenset({"media/image/generate", "media/image/edit", "media/video/i2v"})
 
 # The proactive rotation's due-conditions (ADR 0015 D-d), evaluated on the heartbeat tick so an
@@ -638,10 +644,24 @@ def _probe_spec_caps(
     """
     if api_kind:
         return _static_api_caps(api_kind, advertised, plan_type=plan_type)
+    if not advertised:
+        return {}  # no models → nothing to advertise; skip the route probe's network round-trip (loop was a no-op)
+    # Discover the Responses dialect ONCE per engine (issue 08 / ADR 0018): the route is a property of
+    # the server, not of a model, so probe here — OUTSIDE the per-model loop — and stamp the one answer
+    # onto every model. A capable engine advertises `responses` in its endpoints and (PRD §3 — every
+    # non-seat engine accepts an output cap) the `output_cap` routing FEATURE too, so a capped `auto`
+    # request can land on it; a failed/absent probe leaves the pre-Phase-2 chat pair untouched (fail
+    # closed). The API-kind branch returned above is never probed — seat/openai caps are static data.
+    serves_responses = probe.probe_responses_endpoint(llm_url)
+    # Opt-in breadcrumb (GRID_ENGINE_DEBUG): the one lever an operator has to answer "why didn't my
+    # engine pick up Responses" — the probe verdict is otherwise silent, and a False sticks until re-join.
+    _debug(f"responses probe {llm_url!r}: {'serves' if serves_responses else 'does not serve'} /responses")
+    endpoints = ["chat/completions", "completions"] + (["responses"] if serves_responses else [])
     caps_models: dict[str, Any] = {}
     for advertised_model, upstream_model in zip(advertised, upstream, strict=True):
         env = probe.capabilities(
             llm_url, upstream_model, advertise_as=advertised_model, context_window=ctx_size,
+            endpoints=endpoints, honours_output_cap=serves_responses,
         )
         caps_models.update((env or {}).get("models") or {})
     return {"schema_version": 1, "models": caps_models} if caps_models else {}
@@ -1406,13 +1426,49 @@ def _reload_once(state: _ServeState, engine_id: str) -> None:
             state._reload_register_fails = 0
 
 
-def _served_endpoints(api_kind: str | None) -> tuple[str, ...] | frozenset[str]:
-    """The relay endpoints the routed engine's KIND serves — ADR 0015 D-b's matrix, one row per
-    kind: hardware (``None``) keeps the legacy chat pair, an API kind serves exactly its whitelist
-    row's endpoints (openai ⇒ chat/completions, codex ⇒ responses). A kind no longer in the
-    catalog (edited between join and respawn) degrades to the ``ApiWhitelist`` default — chat-only,
-    never the hardware pair — the same posture as ``_static_api_caps``."""
+def _hardware_serves_responses(snap: _Snapshot, model: str | None, target: str) -> bool:
+    """Whether the hardware engine at ``target`` serves the Responses dialect — read from the per-model
+    ``endpoints`` list the probe wrote into the caps envelope (issue 08), so the engine-side gate and the
+    relay's candidate filter can never disagree about who serves the dialect.
+
+    The capability is a property of the ENGINE, not the model (ADR 0018 — probed once per engine, stamped
+    on every model it advertises). Normally ``model`` matches an advertised name and its entry answers
+    directly. But ``route_and_kind``'s single-engine fallback resolves an unmatched/missing ``model`` onto
+    the sole engine (as chat does), and that model has no caps entry — so on a miss, resolve the answer
+    from ANY model routed to the same ``target`` (all carry the identical per-engine answer). Without this
+    a single-engine grid would refuse a responses job with "unsupported endpoint" even though its one
+    engine serves the dialect — the misleading-error class ADR 0017/0018 exist to prevent.
+
+    Defensive: a non-dict entry or a non-list ``endpoints`` reads as "no" (fail closed), never raises."""
+    models = snap.capabilities.get("models") or {}
+    entry = models.get(model)
+    if not isinstance(entry, dict):
+        # The routed model has no caps entry (single-engine fallback on an unmatched/missing model):
+        # consult the ENGINE via any model routed to the same target — the probe stamped one answer on all.
+        for advertised_model, url in snap.routes.items():
+            if url == target and isinstance(models.get(advertised_model), dict):
+                entry = models[advertised_model]
+                break
+    endpoints = entry.get("endpoints") if isinstance(entry, dict) else None
+    return isinstance(endpoints, list) and _RESPONSES_ENDPOINT in endpoints
+
+
+def _served_endpoints(
+    api_kind: str | None, *, hardware_serves_responses: bool = False,
+) -> tuple[str, ...] | frozenset[str]:
+    """The relay endpoints the routed engine serves. An API kind keeps ADR 0015 D-b's per-KIND matrix:
+    it serves exactly its whitelist row's endpoints (openai ⇒ chat/completions, codex ⇒ responses),
+    degrading to the ``ApiWhitelist`` default — chat-only, never the hardware pair — for a kind edited
+    out of the catalog between join and respawn (the same posture as ``_static_api_caps``).
+
+    Hardware (``api_kind`` is None) is now per-ENGINE, not a fixed property of being hardware (ADR 0018
+    decision 1): the closed ``_ALLOWED_ENDPOINTS`` chat pair, plus the authored ``responses`` literal
+    composed on ONLY when this engine's join-time probe found the route (``hardware_serves_responses``).
+    ``_ALLOWED_ENDPOINTS`` itself is never widened — the served set stays a closed set of fixed literals
+    checked before any URL is built (decision 3)."""
     if not api_kind:
+        if hardware_serves_responses:
+            return _ALLOWED_ENDPOINTS | {_RESPONSES_ENDPOINT}  # frozenset | set → frozenset; the closed set is unchanged
         return _ALLOWED_ENDPOINTS
     whitelist = api_catalog.WHITELISTS.get(api_kind)
     return whitelist.endpoints if whitelist else ("chat/completions",)
@@ -1459,14 +1515,24 @@ def handle_job(state: _ServeState, job: dict[str, Any]) -> None:
     if target is None:
         _try_submit_error(state, txn, f"no engine serves model {model!r}")
         return
-    # Per-kind endpoint matrix (ADR 0015 D-b): which endpoint an engine serves is a property of its
-    # KIND, so the gate runs AFTER routing, where the kind is known — codex ⇒ responses only,
-    # openai ⇒ chat/completions only, hardware ⇒ the chat pair. A mismatch — including a job that
-    # arrived via the single-URL fallback above — is refused with a structured error, never
-    # translated and never blind-forwarded. The global allow-list is deliberately NOT widened:
-    # `responses` never enters `_ALLOWED_ENDPOINTS`, so the anti-traversal property is unchanged —
-    # only a literal that matched this matrix ever reaches `f"{target_url}/{endpoint}"`.
-    served = _served_endpoints(api_kind)
+    # Endpoint gate, AFTER routing where the engine is known. API kinds keep ADR 0015 D-b's per-KIND
+    # matrix (codex ⇒ responses only, openai ⇒ chat/completions); HARDWARE is now per-ENGINE (ADR 0018
+    # decision 1) — the chat pair plus `responses` iff this engine's join-time probe found the route,
+    # read from the caps the probe stamped. A mismatch — including a job that arrived via the single-URL
+    # fallback above — is refused with a structured error, never translated and never blind-forwarded.
+    #
+    # ADR 0018 decision 3 deliberately NARROWS the old anti-traversal statement (which read "`responses`
+    # never enters `_ALLOWED_ENDPOINTS`, so the property is unchanged"): the literal now DOES enter the
+    # set the gate consults for a capable hardware engine. This is not a loosening. The safety was never
+    # that `responses` was absent — it is that the endpoint is checked against a CLOSED set of fixed
+    # literals before it is used to build `f"{target_url}/{endpoint}"`. `_ALLOWED_ENDPOINTS` stays a
+    # frozenset untouched; the `responses` composed onto the hardware set is a literal authored in this
+    # repo, and the probe decides only WHETHER it is included, never WHAT it is — so nothing from the
+    # relay or the engine's wire answer reaches URL construction.
+    served = _served_endpoints(
+        api_kind,
+        hardware_serves_responses=api_kind is None and _hardware_serves_responses(snap, model, target),
+    )
     if endpoint not in served:
         if api_kind:
             _try_submit_error(

--- a/remote/serve.py
+++ b/remote/serve.py
@@ -500,6 +500,24 @@ def _refuse_unsupported_api_params(state: _ServeState, txn: str, api_kind: str, 
     _try_submit_error(state, txn, f"engine error 400: {payload}")
 
 
+def _refuse_stream_only_seat(state: _ServeState, txn: str) -> None:
+    """Refuse a non-stream responses job for the stream-only subscription seat (issue 05, AC7).
+
+    The seat's backend speaks SSE only. The relay lifted its global stream-mandatory rule so that every
+    other engine may serve a non-stream responses request; this per-kind gate — the layer that knows
+    the kind — re-homes the seat's refusal, wearing the same `engine error 400: {…}` string the other
+    per-kind gates use. The relay's `_terminal_error` extracts (400, "Stream must be set to true") and
+    renders this dialect's `{"detail": "Stream must be set to true"}` + 400 — byte-identical to the old
+    pre-queue refusal, so the seat's observable behaviour is unchanged (user story 16)."""
+    payload = json.dumps({"error": {
+        "message": "Stream must be set to true",
+        "type": "invalid_request_error",
+        "param": "stream",
+        "code": "unsupported_parameter",
+    }})
+    _try_submit_error(state, txn, f"engine error 400: {payload}")
+
+
 def _adapt_output_token_param(body: dict[str, Any], api_kind: str | None, endpoint: str) -> dict[str, Any]:
     """Rename the output-token cap to the vendor's CHAT parameter when forwarding a chat job to an
     API engine.
@@ -1461,6 +1479,12 @@ def handle_job(state: _ServeState, job: dict[str, Any]) -> None:
         if unsupported:
             _refuse_unsupported_api_params(state, txn, api_kind, unsupported)
             return
+        # The subscription seat is SSE-only, so a non-stream responses job is refused here (issue 05,
+        # AC7) — the relay lifted its global stream rule precisely so this kind-aware gate answers it.
+        # Every other kind serves a non-stream responses request (the forward block's whole-body arm).
+        if api_kind == api_catalog.CODEX_KIND and endpoint == "responses" and not is_stream:
+            _refuse_stream_only_seat(state, txn)
+            return
 
     # Consumers address the model by its advertised name; an external engine behind ``--advertise-as``
     # only knows its real name, so rewrite the body's model before forwarding (a new dict — never
@@ -1478,14 +1502,12 @@ def handle_job(state: _ServeState, job: dict[str, Any]) -> None:
             # streaming forward, submitting whole event blocks (ADR 0015 D-e); headers come from
             # the live seat holder, never the snapshot (D-d).
             _forward_codex(state, txn, endpoint, forward_body, read_timeout, target)
-        elif endpoint == "responses":
-            # A responses job served by a non-seat engine (openai, Phase 1). The shared block-aligned
-            # forward RETURNS a non-200 rather than reporting it; unlike the seat's D-d refresh an
-            # openai engine does NOT retry (ADR 0012, job-error-only) — so answer a failure here with a
-            # terminal signal, or the consumer hangs (issue 02 handoff: the toolchain enforces nothing,
-            # not even `ruff --select ALL`). Not guarding on `is_stream` mirrors the codex arm and keeps
-            # a responses job out of the chat forwards, which lack block alignment; non-streaming
-            # responses is issue 05, and the relay enforces stream=True for the dialect today.
+        elif endpoint == "responses" and is_stream:
+            # A STREAMING responses job served by a non-seat engine (openai, Phase 1). The shared
+            # block-aligned forward RETURNS a non-200 rather than reporting it; unlike the seat's D-d
+            # refresh an openai engine does NOT retry (ADR 0012, job-error-only) — so answer a failure
+            # here with a terminal signal, or the consumer hangs. Kept off the chat forwards below,
+            # which lack block alignment (the terminal event carrying usage would tear).
             failure = _forward_responses_stream(
                 state, txn, endpoint, forward_body, read_timeout, target,
                 headers=_forward_headers(state, target, snap),
@@ -1493,6 +1515,14 @@ def handle_job(state: _ServeState, job: dict[str, Any]) -> None:
             if failure is not None:
                 _warn_api_auth_failure(api_kind, failure.status)
                 _try_submit_error(state, txn, f"engine error {failure.status}: {failure.text[:200]}")
+        elif endpoint == "responses":
+            # A NON-streaming responses job (issue 05). The vendor returns ONE whole response object,
+            # so the dialect-agnostic whole-body forward serves it — block alignment is a streaming
+            # concern and there is no stream here. `_forward_whole` already answers a non-200 with a
+            # terminal signal, so the same caller obligation is met. The codex seat never reaches this
+            # arm: it is stream-only and refuses a non-stream job at the per-kind gate above.
+            _forward_whole(state, txn, endpoint, forward_body, read_timeout, target,
+                           headers=_forward_headers(state, target, snap), api_kind=api_kind)
         elif is_stream:
             _forward_stream(state, txn, endpoint, forward_body, read_timeout, target,
                             headers=_forward_headers(state, target, snap), api_kind=api_kind)

--- a/remote/serve.py
+++ b/remote/serve.py
@@ -1559,10 +1559,13 @@ def handle_job(state: _ServeState, job: dict[str, Any]) -> None:
         if unsupported:
             _refuse_unsupported_api_params(state, txn, api_kind, unsupported)
             return
-        # The subscription seat is SSE-only, so a non-stream responses job is refused here (issue 05,
-        # AC7) — the relay lifted its global stream rule precisely so this kind-aware gate answers it.
-        # Every other kind serves a non-stream responses request (the forward block's whole-body arm).
-        if api_kind == api_catalog.CODEX_KIND and endpoint == "responses" and not is_stream:
+        # A stream-only seat is SSE-only, so a non-stream responses job is refused here (issue 05 AC7)
+        # — the relay lifted its global stream rule precisely so this kind-aware gate answers it. Gated
+        # on `kind_is_stream_only` (issue 06c), the SAME predicate the advertised `stream_only` trait is
+        # sourced from, so the layer that refuses and the auto-router that routes around it can't
+        # disagree, and a future stream-only kind inherits this refusal for free. Every other kind
+        # serves a non-stream responses request (the forward block's whole-body arm).
+        if api_catalog.kind_is_stream_only(api_kind) and endpoint == "responses" and not is_stream:
             _refuse_stream_only_seat(state, txn)
             return
 

--- a/remote/serve.py
+++ b/remote/serve.py
@@ -534,6 +534,12 @@ def _static_api_caps(api_kind: str, advertised: list[str], plan_type: str | None
         ("vision", "tools", "parallel_tool_calls", "json_object", "json_schema"), False
     )
     caps_models: dict[str, Any] = {}
+    # Which relay endpoint(s) this kind serves comes from its catalog row (issue 03) — NOT a hardcoded
+    # chat-only list. This is the wire contract grid-src's per-model `provider_supports` filter reads,
+    # so a kind that serves `responses` (openai) must advertise it here or nothing routes. A kind gone
+    # from the catalog between join and respawn degrades to chat-only, matching `_served_endpoints`.
+    whitelist = api_catalog.WHITELISTS.get(api_kind)
+    kind_endpoints = list(whitelist.endpoints) if whitelist else ["chat/completions"]
     for advertised_model in advertised:
         entry = api_catalog.find_advertised(api_kind, advertised_model)
         if entry is None:
@@ -562,9 +568,9 @@ def _static_api_caps(api_kind: str, advertised: list[str], plan_type: str | None
             continue
         probed = api_catalog.probed_features(entry) if entry else no_features
         ctx = entry.context_window if entry else None
-        # chat/completions only: the gate in handle_job refuses legacy completions, so the relay
-        # must not be told this model serves it (honest advertisement, ADR 0012).
-        env = probe.envelope(advertised_model, probed, ctx, endpoints=["chat/completions"])
+        # Endpoints come from the kind's row (above), never legacy `completions` — an API engine never
+        # serves it, and the handle_job gate refuses it anyway (honest advertisement, ADR 0012).
+        env = probe.envelope(advertised_model, probed, ctx, endpoints=kind_endpoints)
         caps_models.update((env or {}).get("models") or {})
     return {"schema_version": 1, "models": caps_models} if caps_models else {}
 
@@ -1449,6 +1455,21 @@ def handle_job(state: _ServeState, job: dict[str, Any]) -> None:
             # streaming forward, submitting whole event blocks (ADR 0015 D-e); headers come from
             # the live seat holder, never the snapshot (D-d).
             _forward_codex(state, txn, endpoint, forward_body, read_timeout, target)
+        elif endpoint == "responses":
+            # A responses job served by a non-seat engine (openai, Phase 1). The shared block-aligned
+            # forward RETURNS a non-200 rather than reporting it; unlike the seat's D-d refresh an
+            # openai engine does NOT retry (ADR 0012, job-error-only) — so answer a failure here with a
+            # terminal signal, or the consumer hangs (issue 02 handoff: the toolchain enforces nothing,
+            # not even `ruff --select ALL`). Not guarding on `is_stream` mirrors the codex arm and keeps
+            # a responses job out of the chat forwards, which lack block alignment; non-streaming
+            # responses is issue 05, and the relay enforces stream=True for the dialect today.
+            failure = _forward_responses_stream(
+                state, txn, endpoint, forward_body, read_timeout, target,
+                headers=_forward_headers(state, target, snap),
+            )
+            if failure is not None:
+                _warn_api_auth_failure(api_kind, failure.status)
+                _try_submit_error(state, txn, f"engine error {failure.status}: {failure.text[:200]}")
         elif is_stream:
             _forward_stream(state, txn, endpoint, forward_body, read_timeout, target,
                             headers=_forward_headers(state, target, snap), api_kind=api_kind)

--- a/remote/serve.py
+++ b/remote/serve.py
@@ -21,7 +21,7 @@ import sys
 import threading
 import time
 import traceback
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable, Iterator, Mapping
 from dataclasses import dataclass
 from typing import Any, Callable
 
@@ -1567,23 +1567,85 @@ def _warn_codex_upstream(status: int, headers: Any) -> None:
         _warn_api_auth_failure(api_catalog.CODEX_KIND, status)
 
 
-def _forward_codex(
-    state: _ServeState, txn: str, endpoint: str, body: dict[str, Any], read_timeout: float,
-    target_url: str,
-) -> None:
-    """Forward one responses job to the seat and stream the reply back as whole event blocks.
+@dataclass(frozen=True)
+class _UpstreamFailure:
+    """One engine's non-200 on the responses path, drained and bound so it outlives the response
+    context. `headers` is carried alongside `status` because the operator taxonomy needs it — a
+    Cloudflare-challenge 403 and an auth 403 demand OPPOSITE actions and cannot be told apart from
+    the status int alone (ADR 0015 D-f).
 
-    Always the streaming path, whatever the job's stream flag says — the upstream only speaks SSE
-    (ADR 0015 D-e). The bearer is resolved from the seat holder PER ATTEMPT (D-d: outside the
-    routing snapshot, so a rotation needs no reload), and an upstream 401 refreshes and retries
-    exactly once, codex-scoped — openai keeps ADR 0012's job-error-only. The refresh runs OUTSIDE
-    the response context: the non-200 is drained and (status, headers, text) bound first, so no
-    vendor connection is held through a ≤15s token exchange, and the warning path sees the
-    response headers (CF-403 vs auth-403), not just the status int.
+    `headers` is typed structurally rather than as `httpx.Headers`: a lookup is all any reader does,
+    and this record is meant to stay kind-agnostic, so it does not take a dependency on the client
+    library. It holds a live mapping and so is NOT hashable — never put one in a set or dict key."""
+
+    status: int
+    headers: Mapping[str, str]
+    text: str
+
+
+def _forward_responses_stream(
+    state: _ServeState, txn: str, endpoint: str, body: dict[str, Any], read_timeout: float,
+    target_url: str, headers: dict[str, str],
+) -> _UpstreamFailure | None:
+    """Forward one responses job and stream the reply back as whole event blocks.
+
+    The dialect's streaming submission, with NO engine-kind knowledge — any kind that serves
+    `responses` can call it (PRD §5 / ADR 0018). Block alignment is the point, and it is a property
+    of the dialect rather than of any one backend (ADR 0015 D-e, kept verbatim): one submitted chunk
+    is one whole `event:`+`data:` block, so the terminal event that carries the usage is never torn
+    across two submissions, and an engine dying mid-stream strands only complete events at the relay.
+
+    Credentials are the CALLER's business — whatever `headers` says is what goes on the wire, so a
+    seat resolving a rotating bearer per attempt and an API engine carrying a static key are the
+    same code here. A streamed 401 from the RELAY re-raises out of `_submit_response` and
+    `handle_job`'s guard reports it — the same terminal-signal guarantee `_forward_stream` has.
+
+    Returns None once a 200 has been submitted. A non-200 is drained inside the response context and
+    returned, with BOTH contexts closed first: how to answer it differs by kind (the seat refreshes
+    and retries once, D-d; an API engine does not, ADR 0012), and deciding out here means no vendor
+    connection is held open through a ≤15s token exchange.
+
+    **The caller MUST answer a non-None return with a terminal signal** — `_try_submit_error`, or a
+    retry that reaches one. Nothing has been submitted for the job at that point, and a dropped
+    return is invisible to `handle_job`'s `except Exception` guard, so the consumer would hang until
+    it timed out: exactly the outcome `_submit_response` and `_try_submit_error` exist to prevent.
     """
     import httpx
 
     timeout = httpx.Timeout(connect=10, read=read_timeout, write=None, pool=10)
+    with httpx.Client(timeout=timeout) as client:
+        with client.stream(
+            "POST", f"{target_url}/{endpoint}", json=body, headers=headers,
+        ) as resp:
+            if resp.status_code == 200:
+                _submit_response(
+                    state, txn, stream=True,
+                    content=_traced_stream(txn, _iter_event_blocks(resp.iter_bytes())),
+                )
+                return None
+            resp.read()  # drain inside the context so .text is readable after it closes
+            return _UpstreamFailure(resp.status_code, resp.headers, resp.text)
+
+
+def _forward_codex(
+    state: _ServeState, txn: str, endpoint: str, body: dict[str, Any], read_timeout: float,
+    target_url: str,
+) -> None:
+    """Forward one responses job to the seat — the seat's own credential behaviour, wrapped around
+    the shared responses forward.
+
+    Always the streaming path, whatever the job's stream flag says — the upstream only speaks SSE
+    (ADR 0015 D-e). What is genuinely the SEAT's and stays here: the bearer is resolved from the
+    seat holder PER ATTEMPT (D-d: outside the routing snapshot, so a rotation needs no reload), an
+    upstream 401 refreshes and retries exactly once, codex-scoped — openai keeps ADR 0012's
+    job-error-only — and the CF-403-vs-auth-403 operator taxonomy (D-f). Block alignment is NOT a
+    seat concern and lives in `_forward_responses_stream`, where any kind can reach it.
+
+    The refresh still runs OUTSIDE the response context — now by construction rather than by care:
+    the shared forward returns a failure only after draining it and closing both contexts, so no
+    vendor connection is held through a ≤15s token exchange, and the warning path still sees the
+    response headers (CF-403 vs auth-403), not just the status int.
+    """
     for attempt in (1, 2):
         try:
             bundle = state.codex_seat.bundle()  # bind once per attempt, like a snapshot
@@ -1606,25 +1668,16 @@ def _forward_codex(
                 "to re-create it",
             )
             return
-        with httpx.Client(timeout=timeout) as client:
-            with client.stream(
-                "POST", f"{target_url}/{endpoint}", json=body, headers=_codex_headers(bundle),
-            ) as resp:
-                if resp.status_code == 200:
-                    # Whole event blocks per submitted chunk (D-e); a streamed 401 from the RELAY
-                    # re-raises out of _submit_response and handle_job's guard reports it — same
-                    # terminal-signal guarantees as _forward_stream.
-                    _submit_response(
-                        state, txn, stream=True,
-                        content=_traced_stream(txn, _iter_event_blocks(resp.iter_bytes())),
-                    )
-                    return
-                resp.read()  # drain inside the context so .text is readable after it closes
-                status, resp_headers, text = resp.status_code, resp.headers, resp.text
-        if status == 401 and attempt == 1 and state.codex_seat.refresh(bundle.access_token):
+        failure = _forward_responses_stream(
+            state, txn, endpoint, body, read_timeout, target_url,
+            headers=_codex_headers(bundle),
+        )
+        if failure is None:
+            return  # submitted — the shared path already gave the job its terminal signal
+        if failure.status == 401 and attempt == 1 and state.codex_seat.refresh(bundle.access_token):
             continue  # rotated — retry once with the fresh bearer (reactive D-d)
-        _warn_codex_upstream(status, resp_headers)
-        _try_submit_error(state, txn, f"engine error {status}: {text[:200]}")
+        _warn_codex_upstream(failure.status, failure.headers)
+        _try_submit_error(state, txn, f"engine error {failure.status}: {failure.text[:200]}")
         return
 
 

--- a/remote/serve.py
+++ b/remote/serve.py
@@ -479,9 +479,17 @@ def _api_unsupported_params(api_kind: str, body: dict[str, Any]) -> list[str]:
 
 
 def _refuse_unsupported_api_params(state: _ServeState, txn: str, api_kind: str, params: list[str]) -> None:
-    """Refuse the job wearing the vendor's own error shape — byte-for-byte what forwarding would
-    have earned ("engine error 400: {openai-style json}"), so consumers and the relay's
-    terminal-error mapper see no difference, minus the vendor round-trip."""
+    """Refuse the job with an openai-style `engine error 400: {"error": {...}}`. For the openai/chat
+    case this is byte-for-byte what forwarding would have earned, so consumers and the relay's
+    terminal-error mapper see no difference, minus the vendor round-trip. For a kind whose real 400
+    wears a different shape — the codex seat answers `{"detail": ...}` (facts.md #7) — it is NOT
+    byte-identical, but the relay's `_terminal_error` keys on `["error"]["message"]`, so this shape
+    yields a CLEANER extracted message than the raw seat body would, and the relay re-renders it per
+    dialect (chat json / responses `response.failed`) either way.
+
+    Only the first unsupported param is named, mirroring the relay's own pre-queue denylist (which
+    raises on the first `param in body` match): a multi-violation body is corrected one param per
+    round-trip, consistently across both layers."""
     param = params[0]
     payload = json.dumps({"error": {
         "message": f"Unsupported parameter: '{param}' is not supported with this model.",
@@ -492,19 +500,27 @@ def _refuse_unsupported_api_params(state: _ServeState, txn: str, api_kind: str, 
     _try_submit_error(state, txn, f"engine error 400: {payload}")
 
 
-def _adapt_output_token_param(body: dict[str, Any], api_kind: str | None) -> dict[str, Any]:
-    """Rename the output-token cap to the vendor's parameter when forwarding to an API engine.
+def _adapt_output_token_param(body: dict[str, Any], api_kind: str | None, endpoint: str) -> dict[str, Any]:
+    """Rename the output-token cap to the vendor's CHAT parameter when forwarding a chat job to an
+    API engine.
 
-    The relay's contract layer normalises every request to ``max_tokens`` — the only name hardware
-    engines understand — including rewriting a consumer's ``max_completion_tokens`` into it. A vendor
-    that renamed the parameter (OpenAI's GPT-5.x) then 400s on every job, so translate on the way
-    out. ``max_tokens`` holds the value the relay validated against its cap, so it wins over any
-    ``max_completion_tokens`` left beside it by that rewrite; only one name may go upstream.
+    The relay's chat normaliser rewrites every request to ``max_tokens`` — the only name hardware
+    engines understand — including a consumer's ``max_completion_tokens``. A vendor that renamed the
+    parameter (OpenAI's GPT-5.x) then 400s on every job, so translate on the way out. ``max_tokens``
+    holds the value the relay validated against its cap, so it wins over any ``max_completion_tokens``
+    left beside it by that rewrite; only one name may go upstream.
 
-    Returns ``body`` unchanged for hardware engines, for vendors that still take ``max_tokens``, and
-    for vendors that take no output cap at all.
+    Scoped to ``chat/completions`` (issue 04). The relay's responses contract is a PASSTHROUGH — it
+    does not normalise to ``max_tokens``; it lets the dialect's own cap ``max_output_tokens`` through
+    byte-for-byte, already the name the vendor's responses endpoint wants. So on responses there is
+    nothing to translate, and applying the chat rename would MIS-name a stray ``max_tokens`` as the
+    chat spelling that endpoint rejects. (The relay also refuses ``max_tokens`` on responses, so a real
+    body never carries it there — but this guard does not lean on that cross-repo rule.)
+
+    Returns ``body`` unchanged for the responses dialect, for hardware engines, for vendors that still
+    take ``max_tokens``, and for vendors that take no output cap at all.
     """
-    if not api_kind:
+    if not api_kind or endpoint != "chat/completions":
         return body
     whitelist = api_catalog.WHITELISTS.get(api_kind)
     param = whitelist.max_output_param if whitelist else "max_tokens"
@@ -1428,13 +1444,19 @@ def handle_job(state: _ServeState, job: dict[str, Any]) -> None:
         else:  # don't forward an unknown path to the local engine (the pre-matrix behavior, kept verbatim)
             _try_submit_error(state, txn, f"unsupported endpoint: {endpoint!r}")
         return
-    # Params the vendor is known to reject (e.g. GPT-5.x and `stop`): refuse now, with the vendor's
-    # own error shape, instead of forwarding to learn a static catalog fact. A CHAT-dialect gate —
-    # the fabricated refusal wears the chat `{"error": ...}` envelope — so it runs only on the chat
-    # forward: provably inert for a responses job, whose contract violations are the vendor's to
-    # answer in its own `{"detail": ...}` shape (facts.md #7; the codex whitelist row's
-    # `unsupported_params` is thereby advisory catalog data, not an executable gate).
-    if api_kind and endpoint == "chat/completions":
+    # Params the vendor is known to reject (GPT-5.x rejects `stop`; the codex seat rejects every
+    # output-cap spelling and `temperature` — facts.md #7): refuse now, with the vendor's own error
+    # shape, instead of forwarding to learn a static catalog fact. Runs on EVERY dialect an API kind
+    # serves (issue 04), so the codex row's `unsupported_params` is an executable per-kind gate, not
+    # advisory data — this is the layer that knows the seat's kind, which the relay (normalising
+    # before it selects an engine) cannot. The refusal is the same `engine error 400: {"error": ...}`
+    # string on both dialects; the relay renders it PER-DIALECT — chat's `{"error"/"detail": ...}`, or
+    # a `response.failed` block for responses (`relay._responses_failure_block`, which lifts the
+    # message that names the param) — so an app's error handling never forks on which layer caught it.
+    # The relay still refuses the chat-dialect cap spellings on `responses` pre-queue (they are the
+    # wrong dialect for every engine), so what this gate newly answers there is the seat's
+    # `max_output_tokens` and `temperature`.
+    if api_kind:
         unsupported = _api_unsupported_params(api_kind, body)
         if unsupported:
             _refuse_unsupported_api_params(state, txn, api_kind, unsupported)
@@ -1445,8 +1467,9 @@ def handle_job(state: _ServeState, job: dict[str, Any]) -> None:
     # mutate the job). No mapping / already-equal → forward unchanged (built-in + single-engine paths).
     upstream_model = state.upstream_model(model, snap)
     forward_body = {**body, "model": upstream_model} if upstream_model and upstream_model != model else body
-    # ... and an API vendor may spell the output-token cap differently from the grid's internal name.
-    forward_body = _adapt_output_token_param(forward_body, api_kind)
+    # ... and an API vendor may spell the output-token cap differently from the grid's internal name
+    # on the CHAT dialect (the responses dialect passes its own cap through — see the function).
+    forward_body = _adapt_output_token_param(forward_body, api_kind, endpoint)
 
     state.enter_inference()
     try:

--- a/remote/serve.py
+++ b/remote/serve.py
@@ -574,6 +574,12 @@ def _static_api_caps(api_kind: str, advertised: list[str], plan_type: str | None
     # from the catalog between join and respawn degrades to chat-only, matching `_served_endpoints`.
     whitelist = api_catalog.WHITELISTS.get(api_kind)
     kind_endpoints = list(whitelist.endpoints) if whitelist else ["chat/completions"]
+    # Loop-invariant per-kind fact, hoisted beside kind_endpoints (issue 06b): whether this kind honours
+    # a Responses output cap. Sourced from the SAME catalog fact the engine gate refuses on
+    # (`unsupported_params`) via `kind_honours_output_cap`, so the auto-router filter (layer 2) and the
+    # per-kind engine gate (layer 3, issue 04) can never disagree — openai True, any future can't-cap kind
+    # False for free. Gated per-MODEL on `entry is not None` at the call below (a stale model fails closed).
+    kind_can_cap = api_catalog.kind_honours_output_cap(api_kind)
     for advertised_model in advertised:
         entry = api_catalog.find_advertised(api_kind, advertised_model)
         if entry is None:
@@ -604,7 +610,15 @@ def _static_api_caps(api_kind: str, advertised: list[str], plan_type: str | None
         ctx = entry.context_window if entry else None
         # Endpoints come from the kind's row (above), never legacy `completions` — an API engine never
         # serves it, and the handle_job gate refuses it anyway (honest advertisement, ADR 0012).
-        env = probe.envelope(advertised_model, probed, ctx, endpoints=kind_endpoints)
+        # `honours_output_cap` is gated on `entry is not None`: a model gone from the whitelist degrades
+        # to an all-False FEATURES dict (like a failed probe), so its `output_cap` is False too — a capped
+        # `auto` request then excludes the anomaly rather than routing to a likely-broken model, the
+        # fail-closed posture the whole filter relies on. `endpoints` stays per-KIND (outside features)
+        # because it is what makes the gate refuse a wrong dialect at all.
+        env = probe.envelope(
+            advertised_model, probed, ctx, endpoints=kind_endpoints,
+            honours_output_cap=entry is not None and kind_can_cap,
+        )
         caps_models.update((env or {}).get("models") or {})
     return {"schema_version": 1, "models": caps_models} if caps_models else {}
 

--- a/shared/models/api_catalog.py
+++ b/shared/models/api_catalog.py
@@ -332,6 +332,29 @@ def responses_only_kind(model: str) -> str | None:
     return kind
 
 
+# The Responses-dialect output-token cap parameter. A kind honours a cap IFF this is NOT among its
+# `unsupported_params` — the exact fact remote/serve.py `_api_unsupported_params` refuses on — so the
+# auto-router's cap filter (issue 06b) and the per-kind engine gate (issue 04) read ONE source and can
+# never disagree. This is the dialect's OWN spelling (`max_tokens`/`max_completion_tokens` are the
+# chat-dialect spellings the relay refuses on `responses` outright).
+RESPONSES_OUTPUT_CAP_PARAM = "max_output_tokens"
+
+
+def kind_honours_output_cap(kind: str) -> bool:
+    """True iff an API engine of ``kind`` honours a Responses output-token cap (``max_output_tokens``).
+
+    Read from the SAME catalog fact issue 04's engine-side gate reads (``unsupported_params``), so the
+    auto-router's candidate filter (issue 06b, layer 2) and the engine gate (issue 04, layer 3) can
+    never disagree about a kind: ``openai`` honours it, the ``codex`` seat cannot cap under any name.
+    An unknown kind is not-cap-capable — fail closed, matching how ``_static_api_caps`` and
+    ``_served_endpoints`` degrade an unknown kind to the conservative answer.
+    """
+    whitelist = WHITELISTS.get(kind)
+    if whitelist is None:
+        return False
+    return RESPONSES_OUTPUT_CAP_PARAM not in whitelist.unsupported_params
+
+
 def format_api_entry(kind: str, entry: ApiModelEntry, endpoints: tuple[str, ...]) -> str:
     """The human-readable catalog line for one model: ``kind``/``entry`` name and size it, while
     ``endpoints`` (the whitelist row's — a per-KIND fact, not a per-model boolean) says which relay

--- a/shared/models/api_catalog.py
+++ b/shared/models/api_catalog.py
@@ -200,6 +200,11 @@ WHITELISTS: dict[str, ApiWhitelist] = {
         # All four whitelist models reject `stop` ("Unsupported parameter: 'stop' is not supported
         # with this model.") — verified against the live API on 2026-07-14. `stop: null` is accepted.
         unsupported_params=("stop",),
+        # ADR 0018 (issue 03): the openai vendor serves the Responses dialect natively, so this kind
+        # serves BOTH endpoints. `responses` is hand-duplicated with grid-src's per-model
+        # `provider_supports` filter and must match its `endpoint_path` byte-for-byte (absent there ⇒
+        # chat-only, so old CLIs fail closed) — CLAUDE.local.md lockstep rule. Never `completions`.
+        endpoints=("chat/completions", "responses"),
     ),
     "codex": ApiWhitelist(
         last_verified=CODEX_LAST_VERIFIED,

--- a/shared/models/api_catalog.py
+++ b/shared/models/api_catalog.py
@@ -52,6 +52,17 @@ class ApiWhitelist:
     # rule). Default = the API-engine chat single: an API kind never serves legacy `completions`
     # (ADR 0012); hardware's chat pair is remote/probe.py's own default, not a whitelist row's.
     endpoints: tuple[str, ...] = ("chat/completions",)
+    # This kind's backend speaks SSE only, so it cannot serve a NON-streaming Responses request — the
+    # codex subscription seat (ADR 0018 / issue 06c). Advertised to the relay as the NEGATIVE
+    # `stream_only` capability-feature (remote/probe.codex_capability_entry) and forbidden by a
+    # non-streaming `auto` request, so the auto-router never lands one on a seat that would 400 it
+    # post-queue. Read by BOTH that advertise path and the engine-side stream gate (remote/serve.py) via
+    # `kind_is_stream_only`, so the two can't disagree. Hand-duplicated with grid-src's
+    # KNOWN_FEATURE_KEYS (CLAUDE.md lockstep): only the seat ever sets this True, and an old CLI / master
+    # that doesn't know the literal simply doesn't exclude the seat — the pre-06c behaviour, never a NEW
+    # failure (master-before-CLI rollout, ADR 0018 §11). Default False: every other API kind and every
+    # hardware engine (never in this table) serves non-streaming.
+    stream_only: bool = False
 
 
 # Verified against https://platform.openai.com/docs/models (which 301-redirects to
@@ -220,6 +231,9 @@ WHITELISTS: dict[str, ApiWhitelist] = {
         unsupported_params=("max_tokens", "max_output_tokens", "max_completion_tokens", "temperature"),
         # ADR 0015 D-b: a codex seat serves the `responses` endpoint ONLY.
         endpoints=("responses",),
+        # ADR 0018 / issue 06c: the seat's backend is SSE-only, so it cannot serve a non-streaming
+        # Responses request. The ONLY row that sets this — see `kind_is_stream_only`.
+        stream_only=True,
     ),
 }
 
@@ -353,6 +367,27 @@ def kind_honours_output_cap(kind: str) -> bool:
     if whitelist is None:
         return False
     return RESPONSES_OUTPUT_CAP_PARAM not in whitelist.unsupported_params
+
+
+def kind_is_stream_only(kind: str) -> bool:
+    """True iff an API engine of ``kind`` can serve ONLY streaming Responses requests — the codex
+    subscription seat, whose backend speaks SSE only (ADR 0018 / issue 06c).
+
+    Read from the whitelist row's ``stream_only`` field by BOTH the engine-side stream gate
+    (``remote/serve.py``, which refuses a non-stream job for such a kind) and the advertised envelope
+    (``remote/probe.codex_capability_entry``, which emits the negative ``stream_only`` trait the
+    auto-router forbids on a non-streaming request), so the layer that refuses and the layer that routes
+    around it can never disagree about which kind is stream-only.
+
+    An unknown kind — and every hardware engine, which is never in ``WHITELISTS`` — is NOT stream-only:
+    absence is the safe default (never excluded), the OPPOSITE fail-direction from
+    ``kind_honours_output_cap`` and the reason a non-streaming request stays backward-compatible against
+    an old CLI that advertises nothing.
+    """
+    whitelist = WHITELISTS.get(kind)
+    if whitelist is None:
+        return False
+    return whitelist.stream_only
 
 
 def format_api_entry(kind: str, entry: ApiModelEntry, endpoints: tuple[str, ...]) -> str:

--- a/shared/models/api_catalog.py
+++ b/shared/models/api_catalog.py
@@ -332,7 +332,16 @@ def responses_only_kind(model: str) -> str | None:
     return kind
 
 
-def format_api_entry(kind: str, entry: ApiModelEntry) -> str:
+def format_api_entry(kind: str, entry: ApiModelEntry, endpoints: tuple[str, ...]) -> str:
+    """The human-readable catalog line for one model: ``kind``/``entry`` name and size it, while
+    ``endpoints`` (the whitelist row's — a per-KIND fact, not a per-model boolean) says which relay
+    dialects the kind serves.
+
+    Only the notable dialect — ``responses`` — is surfaced as a capability; ``chat/completions`` is
+    never rendered as one, so a kind that serves only chat shows no endpoint tag at all (issue 06
+    AC3). Reads the same ``endpoints`` tuple the relay filter and ``responses_only_kind`` read, so a
+    new responses-serving kind lights up here for free.
+    """
     caps = ", ".join(
         name
         for name, supported in (
@@ -340,6 +349,11 @@ def format_api_entry(kind: str, entry: ApiModelEntry) -> str:
             ("vision", entry.supports_vision),
             ("json", entry.supports_json_mode),
             ("structured", entry.supports_structured_outputs),
+            # Appended last so the existing caps order and the fixed-width columns are undisturbed;
+            # folding it into the SAME list (not a separate suffix after `caps or 'text only'`) is
+            # what keeps a model whose only capability is the dialect rendering `responses`, never
+            # the contradictory `text only, responses` (issue 06 AC4).
+            ("responses", "responses" in endpoints),
         )
         if supported
     )

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -8718,11 +8718,34 @@ def test_adapt_output_token_param_leaves_a_kind_with_no_cap_parameter_alone():
     for value in (None, 16):  # the null is what slipped through; a real value must not re-key either
         body = {"model": "codex:gpt-5.4-mini", "max_tokens": value, "messages": []}
 
-        adapted = _adapt_output_token_param(body, "codex")
+        adapted = _adapt_output_token_param(body, "codex", "chat/completions")
 
         assert adapted == body
         assert None not in adapted  # `adapted[None] = ...` — not a JSON key
         assert '"null"' not in json.dumps(adapted)
+
+
+def test_adapt_output_token_param_leaves_the_responses_dialect_cap_alone():
+    """Defense-in-depth (issue 04): the adapter is a CHAT-dialect translator. On `chat/completions`
+    the grid-internal `max_tokens` is renamed to the vendor's chat spelling (openai →
+    `max_completion_tokens`); on `responses` the dialect's OWN cap `max_output_tokens` is already the
+    name the vendor wants — the relay passes it through byte-for-byte — so nothing is renamed.
+
+    The relay refuses `max_tokens` on `responses` (its wrong-dialect spelling), so a responses body
+    can never really carry it — but the guard must not DEPEND on that cross-repo invariant: a stray
+    `max_tokens` on a responses job is left alone, NOT mis-renamed to the chat spelling the vendor's
+    responses endpoint would reject."""
+    from remote.serve import _adapt_output_token_param
+
+    # the real path: the responses-dialect cap reaches openai untouched
+    body = {"model": "openai:gpt-5.5", "input": [], "max_output_tokens": 256}
+    assert _adapt_output_token_param(body, "openai", "responses") == body
+
+    # defense-in-depth: a stray chat-spelling on a responses job is left alone, not rewritten
+    stray = {"model": "openai:gpt-5.5", "input": [], "max_tokens": 256}
+    adapted = _adapt_output_token_param(stray, "openai", "responses")
+    assert adapted == stray
+    assert "max_completion_tokens" not in adapted
 
 
 def test_serve_handle_job_hardware_keeps_stop(monkeypatch, tmp_path):
@@ -8970,6 +8993,65 @@ def test_serve_handle_job_openai_responses_streams_through(monkeypatch, tmp_path
         b'event: response.completed\ndata: {"usage":{"total_tokens":3}}\n\n',
     ]  # two whole blocks, realigned from the 7-byte socket chunking
     assert b"".join(captured["chunks"]) == sse
+
+
+def test_serve_handle_job_openai_responses_honours_output_cap(monkeypatch, tmp_path):
+    """AC1 (issue 04): an app sets an output ceiling on a Responses request to an ``openai`` engine
+    and the value REACHES the vendor. The relay's responses contract is a passthrough that lifted its
+    blanket cap refusal, so the dialect's own ``max_output_tokens`` arrives here byte-for-byte; the
+    per-kind gate admits it (not in openai's ``unsupported_params``) and the chat-only cap adapter
+    leaves it untouched — so the vendor sees the ceiling the app asked for, under the dialect's own
+    name, never mis-translated to the chat spelling."""
+    from remote import relay, serve
+
+    state = _api_serve_state(monkeypatch, tmp_path)
+    captured = {}
+    monkeypatch.setattr(relay, "submit_response", lambda url, tok, txn, *, content, stream: list(content))
+    monkeypatch.setattr(relay, "submit_error",
+                        lambda url, tok, txn, *, message, tokens_delivered=0: captured.update(error=message))
+
+    def vendor(request):
+        captured.update(sent=json.loads(request.content))
+        return httpx.Response(200, content=b'event: response.completed\ndata: {"usage":{"total_tokens":3}}\n\n')
+
+    _mock_serve_engine(monkeypatch, vendor)
+
+    serve.handle_job(state, {"transaction_id": "t1", "endpoint_path": "responses",
+                             "body": {"model": "openai:gpt-5.5",
+                                      "input": [{"role": "user", "content": "hi"}],
+                                      "stream": True, "max_output_tokens": 256}, "is_stream": True})
+
+    assert "error" not in captured
+    assert captured["sent"]["max_output_tokens"] == 256      # the ceiling reached the vendor, dialect-named
+    assert "max_completion_tokens" not in captured["sent"]   # not mis-translated to the chat spelling
+    assert captured["sent"]["model"] == "gpt-5.5"            # advertised → vendor rewrite still applies
+
+
+def test_serve_handle_job_openai_responses_refuses_stop_before_the_vendor(monkeypatch, tmp_path):
+    """A consequence of the per-kind gate now running on the responses dialect (issue 04): openai's
+    `unsupported_params` (`stop`, verified against the CHAT API on 2026-07-14) is refused up-front on
+    `/responses` too, before any vendor call. This is a fail-closed EXTRAPOLATION — the responses
+    endpoint does not document `stop`, so the vendor would reject it, and refusing here saves the
+    round-trip (the gate's whole purpose). Pinned so the behavior is deliberate, not accidental: if
+    openai is ever found to accept `stop` on `/responses`, that is a catalog-data fix, not a code
+    change."""
+    from remote import relay, serve
+
+    state = _api_serve_state(monkeypatch, tmp_path)
+    captured = {}
+    monkeypatch.setattr(relay, "submit_error",
+                        lambda url, tok, txn, *, message, tokens_delivered=0: captured.update(error=message))
+    monkeypatch.setattr(relay, "submit_response", lambda *a, **k: pytest.fail("a refused job has no response"))
+    _mock_serve_engine(monkeypatch, lambda request: pytest.fail("a refused job must never reach the vendor"))
+
+    serve.handle_job(state, {"transaction_id": "t1", "endpoint_path": "responses",
+                             "body": {"model": "openai:gpt-5.5",
+                                      "input": [{"role": "user", "content": "hi"}],
+                                      "stream": True, "stop": ["\n"]}, "is_stream": True})
+
+    assert captured["error"].startswith("engine error 400: ")
+    inner = json.loads(captured["error"][len("engine error 400: "):])["error"]
+    assert inner["param"] == "stop"                          # names the param the vendor rejects
 
 
 def test_serve_handle_job_openai_responses_non200_submits_terminal_error(monkeypatch, tmp_path):
@@ -9384,13 +9466,13 @@ def test_forward_responses_stream_flushes_a_final_block_with_no_trailing_blank_l
 
 
 def test_serve_handle_job_codex_forwards_verbatim_with_the_seat_headers(monkeypatch, tmp_path):
-    """AC 1: URL = the kind's base URL + the job's endpoint path; headers are the real client's
-    set, built fresh from the live bundle (bearer + account id + originator/user-agent + SSE
+    """AC 1 (issue 03): URL = the kind's base URL + the job's endpoint path; headers are the real
+    client's set, built fresh from the live bundle (bearer + account id + originator/user-agent + SSE
     accept + json content-type — and NO OpenAI-Beta); the body goes verbatim except the
-    advertised→vendor model rewrite (the one existing alias mechanism). `temperature` — which IS
-    in the codex whitelist's `unsupported_params` — and a null `max_tokens` both pass through
-    untouched: the chat-dialect refusal and the output-param rename are provably inert on the
-    responses path (contract violations are the vendor's to answer, in its own shape)."""
+    advertised→vendor model rewrite (the one existing alias mechanism). A null `max_tokens` passes
+    through untouched: the per-kind gate refuses only a REAL value (issue 04), so a null is neither
+    refused nor renamed. (A real cap spelling or `temperature` IS now refused up-front on this path —
+    see ``test_serve_handle_job_codex_responses_refuses_unsupported_param_before_the_seat``.)"""
     from remote import api_keys, relay, serve
 
     state = _codex_serve_state(monkeypatch, tmp_path)
@@ -9405,7 +9487,7 @@ def test_serve_handle_job_codex_forwards_verbatim_with_the_seat_headers(monkeypa
     monkeypatch.setattr(relay, "submit_error",
                         lambda url, tok, txn, *, message, tokens_delivered=0: captured.update(error=message))
     job_body = {"model": "codex:gpt-5.4-mini", "input": [{"role": "user", "content": "hi"}],
-                "stream": True, "temperature": 0.5, "max_tokens": None}
+                "stream": True, "max_tokens": None}
 
     def vendor(request):
         assert str(request.url) == f"{_CODEX_BASE}/responses"
@@ -9427,6 +9509,41 @@ def test_serve_handle_job_codex_forwards_verbatim_with_the_seat_headers(monkeypa
     assert "error" not in captured
     assert captured["stream"] is True
     assert captured["body"] == b"event: response.created\ndata: {}\n\n"
+
+
+@pytest.mark.parametrize("param,value", [
+    ("max_output_tokens", 256),   # the responses-dialect cap the relay now lets through (issue 04)
+    ("temperature", 0.5),         # a chat-era knob the seat's allowlist backend denies (facts.md #7)
+])
+def test_serve_handle_job_codex_responses_refuses_unsupported_param_before_the_seat(
+        monkeypatch, tmp_path, param, value):
+    """AC2/AC7 (issue 04): the codex row's ``unsupported_params`` is now an EXECUTABLE per-kind gate
+    on the responses dialect, not advisory catalog data. The relay lifted its blanket
+    ``max_output_tokens`` refusal precisely so the kind-aware engine — the only layer that knows the
+    seat cannot set a cap under any name — answers it; and the seat genuinely 400s both of these
+    (facts.md #7). So a responses job carrying one is refused BEFORE any seat call, riding the same
+    ``engine error 400: {…}`` string the chat gate uses. The relay re-renders that into the responses
+    ``response.failed`` envelope, so the app's error handling does not fork on which layer caught it."""
+    from remote import api_keys, relay, serve
+
+    state = _codex_serve_state(monkeypatch, tmp_path)
+    api_keys.store_codex_bundle(_codex_bundle())
+    state.codex_seat.prime_from_store()
+    captured = {}
+    monkeypatch.setattr(relay, "submit_error",
+                        lambda url, tok, txn, *, message, tokens_delivered=0: captured.update(error=message))
+    monkeypatch.setattr(relay, "submit_response", lambda *a, **k: pytest.fail("a refused job has no response"))
+    _mock_serve_engine(monkeypatch, lambda request: pytest.fail("a refused job must never reach the seat"))
+
+    serve.handle_job(state, {"transaction_id": "t1", "endpoint_path": "responses",
+                             "body": {"model": "codex:gpt-5.4-mini",
+                                      "input": [{"role": "user", "content": "hi"}],
+                                      "stream": True, param: value}, "is_stream": True})
+
+    assert captured["error"].startswith("engine error 400: ")
+    inner = json.loads(captured["error"][len("engine error 400: "):])["error"]
+    assert inner["param"] == param                    # names the parameter (AC6)
+    assert inner["code"] == "unsupported_parameter"
 
 
 def test_serve_handle_job_codex_streams_regardless_of_the_job_flag(monkeypatch, tmp_path):

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -888,6 +888,21 @@ def test_kind_honours_output_cap_reads_unsupported_params():
     )
 
 
+def test_kind_is_stream_only_reads_the_stream_only_field():
+    """Issue 06c's single source of truth for the auto-router's forbidden-feature axis: a kind is
+    stream-only IFF its whitelist row says so (`stream_only`). Read by BOTH the engine-side stream
+    gate (`remote/serve.py`) and the advertised envelope (`codex_capability_entry`), so the layer that
+    refuses a non-stream seat request and the layer that routes around it can never disagree. Unknown
+    kind → False: the OPPOSITE fail-direction from `kind_honours_output_cap` — absence means "never
+    excluded", so an old CLI / any hardware engine (never in WHITELISTS) is backward-compatible."""
+    assert api_catalog.kind_is_stream_only("codex") is True
+    assert api_catalog.kind_is_stream_only("openai") is False
+    assert api_catalog.kind_is_stream_only("nonexistent-kind") is False
+    # The predicate tracks the row, never a second declaration: only the seat carries the trait.
+    assert api_catalog.WHITELISTS["codex"].stream_only is True
+    assert api_catalog.WHITELISTS["openai"].stream_only is False
+
+
 def test_codex_tier_whitelist_integrity():
     """The per-tier codex table (issue 05). Guards the D-f data rules: every populated tier is
     real vendor `PlanType` vocabulary; rows are non-empty, duplicate-free, and inside the flat
@@ -8541,7 +8556,8 @@ def test_remote_engine_codex_record_registers_honest_responses_caps(monkeypatch,
     """The codex capability envelope carries ONLY what passthrough can honestly claim (issue 05):
     `endpoints: ["responses"]` (the wire literal grid-src's per-model filter reads — absent means
     chat-only there, so old CLIs fail closed), the verified context window, features
-    {vision, tools, parallel_tool_calls}, and the join-time `vendor_rank` (issue 03 / ADR 0016 —
+    {vision, tools, parallel_tool_calls, stream_only} (the last a NEGATIVE routing trait, issue 06c —
+    the SSE-only seat, sourced from `kind_is_stream_only`), and the join-time `vendor_rank` (issue 03 / ADR 0016 —
     a top-level int sibling of context_window, the seat's tier-row position, 1 = most capable). It
     OMITS — not False — the chat-dialect flags (json_object/json_schema), `max_output_tokens` and
     the `limits` block (facts #1: the backend has no output cap under any name; a fabricated 64000
@@ -8558,7 +8574,12 @@ def test_remote_engine_codex_record_registers_honest_responses_caps(monkeypatch,
     # vendor_rank rides top-level (NOT inside features — the grid-src reader takes it there). gpt-5.5
     # is index 2 in the free tier row [terra, luna, gpt-5.5, gpt-5.4-mini] → rank 3.
     assert entry["vendor_rank"] == 3
-    assert entry["features"] == {"vision": True, "tools": True, "parallel_tool_calls": True}
+    # issue 06c: the seat also advertises the NEGATIVE `stream_only` routing trait — its backend is
+    # SSE-only — sourced from `kind_is_stream_only`, so a non-streaming `auto` request forbids it and is
+    # never routed here. A routing trait, not a model capability (kept out of `codex_features`).
+    assert entry["features"] == {
+        "vision": True, "tools": True, "parallel_tool_calls": True, "stream_only": True,
+    }
     assert "max_output_tokens" not in entry
     assert "limits" not in entry
     assert "json_object" not in entry["features"] and "json_schema" not in entry["features"]
@@ -8566,14 +8587,18 @@ def test_remote_engine_codex_record_registers_honest_responses_caps(monkeypatch,
 
 def test_remote_engine_codex_model_gone_from_whitelist_degrades_honestly(monkeypatch, tmp_path, capsys):
     """The stale-catalog degrade (catalog edited between join and respawn) stays honest for
-    codex: a warn plus an entry that still says `responses`-only with NO feature claims — never
+    codex: a warn plus an entry that still says `responses`-only with NO capability claims — never
     the chat-dialect all-False shape, and never a fabricated output cap. A model gone from the
-    whitelist has no tier-row position either, so `vendor_rank` is omitted (issue 03)."""
+    whitelist has no tier-row position either, so `vendor_rank` is omitted (issue 03).
+
+    issue 06c: the degrade still advertises the `stream_only` routing trait — a stale seat's backend
+    is still SSE-only, so a non-streaming `auto` request must still be routed away from it (fail-closed,
+    the opposite polarity to a capability, which degrades OFF)."""
     seen = _codex_serve_skeleton(monkeypatch, tmp_path, ["codex:ghost"])
 
     entry = seen["capabilities"]["models"]["codex:ghost"]
     assert entry["endpoints"] == ["responses"]
-    assert entry["features"] == {}
+    assert entry["features"] == {"stream_only": True}
     assert "max_output_tokens" not in entry and "limits" not in entry
     assert "context_window" not in entry  # unknown is omitted, never invented
     assert "vendor_rank" not in entry  # absent from the row → omit the fact, never rank 0/None

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -8995,6 +8995,42 @@ def test_serve_handle_job_openai_responses_streams_through(monkeypatch, tmp_path
     assert b"".join(captured["chunks"]) == sse
 
 
+def test_serve_handle_job_openai_responses_non_stream_forwards_whole(monkeypatch, tmp_path):
+    """Issue 05 (AC1): a NON-stream Responses job to an ``openai:*`` engine takes the whole-body
+    forward (``_forward_whole``), not the block-aligned stream. The vendor is called once,
+    non-streaming, and its whole JSON response object is submitted with ``stream=False`` — the same
+    non-stream arm chat has always had, reused because it is dialect-agnostic. Streaming (is_stream=True)
+    still goes through ``_forward_responses_stream`` (test_serve_handle_job_openai_responses_streams_through)."""
+    from remote import relay, serve
+
+    state = _api_serve_state(monkeypatch, tmp_path)
+    captured = {}
+    monkeypatch.setattr(relay, "submit_response",
+                        lambda url, tok, txn, *, content, stream: captured.update(content=content, stream=stream))
+    monkeypatch.setattr(relay, "submit_error",
+                        lambda url, tok, txn, *, message, tokens_delivered=0: captured.update(error=message))
+
+    vendor_obj = (b'{"id":"resp_x","object":"response","status":"completed","model":"gpt-5.5",'
+                  b'"output":[],"usage":{"input_tokens":3,"output_tokens":5}}')
+
+    def vendor(request):
+        assert str(request.url) == "https://api.openai.com/v1/responses"   # {base}/{endpoint}
+        assert request.headers["authorization"] == "Bearer sk-test-123"    # the stored vendor key
+        sent = json.loads(request.content)
+        assert sent["model"] == "gpt-5.5"                                  # advertised → vendor rewrite
+        assert sent.get("stream") in (None, False)                        # NOT forced to stream
+        return httpx.Response(200, content=vendor_obj)
+
+    _mock_serve_engine(monkeypatch, vendor)
+
+    serve.handle_job(state, {"transaction_id": "t5", "endpoint_path": "responses",
+                             "body": {"model": "openai:gpt-5.5"}, "is_stream": False})
+
+    assert "error" not in captured
+    assert captured["stream"] is False        # the whole-body arm, not the block-aligned stream
+    assert captured["content"] == vendor_obj  # submitted verbatim — no block realignment on this path
+
+
 def test_serve_handle_job_openai_responses_honours_output_cap(monkeypatch, tmp_path):
     """AC1 (issue 04): an app sets an output ceiling on a Responses request to an ``openai`` engine
     and the value REACHES the vendor. The relay's responses contract is a passthrough that lifted its
@@ -9546,10 +9582,41 @@ def test_serve_handle_job_codex_responses_refuses_unsupported_param_before_the_s
     assert inner["code"] == "unsupported_parameter"
 
 
+def test_serve_handle_job_codex_refuses_a_non_stream_responses_job(monkeypatch, tmp_path):
+    """AC7 (issue 05): the subscription seat is SSE-only, so a NON-stream responses job is refused by
+    its per-kind ENGINE gate. The relay lifted its global stream-mandatory rule for every other engine,
+    so the kind-aware layer — the only one that knows this backend cannot stream off — is where the
+    seat's refusal now lives. Refused BEFORE any seat call, riding the same ``engine error 400: {…}``
+    string the other per-kind gates use; the relay re-renders it into the responses ``{"detail": …}``
+    envelope, byte-identical to the old pre-queue ``Stream must be set to true`` (user story 16)."""
+    from remote import api_keys, relay, serve
+
+    state = _codex_serve_state(monkeypatch, tmp_path)
+    api_keys.store_codex_bundle(_codex_bundle())
+    state.codex_seat.prime_from_store()
+    captured = {}
+    monkeypatch.setattr(relay, "submit_error",
+                        lambda url, tok, txn, *, message, tokens_delivered=0: captured.update(error=message))
+    monkeypatch.setattr(relay, "submit_response", lambda *a, **k: pytest.fail("a refused job has no response"))
+    _mock_serve_engine(monkeypatch, lambda request: pytest.fail("a refused job must never reach the seat"))
+
+    serve.handle_job(state, {"transaction_id": "t1", "endpoint_path": "responses",
+                             "body": {"model": "codex:gpt-5.4-mini",
+                                      "input": [{"role": "user", "content": "hi"}], "stream": False},
+                             "is_stream": False})
+
+    assert captured["error"].startswith("engine error 400: ")
+    inner = json.loads(captured["error"][len("engine error 400: "):])["error"]
+    assert inner["param"] == "stream"
+    assert inner["code"] == "unsupported_parameter"
+    assert "Stream must be set to true" in inner["message"]
+
+
 def test_serve_handle_job_codex_streams_regardless_of_the_job_flag(monkeypatch, tmp_path):
-    """D-e: the upstream only speaks SSE, so a codex job takes the streaming forward whatever the
-    job's `is_stream` says (the relay always marks responses jobs streaming; this pins our side
-    against relay drift)."""
+    """D-e: the upstream only speaks SSE, so a codex job takes the streaming forward whatever a
+    STREAMING job's transport says. A NON-stream codex responses job is a different case — the seat
+    refuses it at its per-kind gate (test_serve_handle_job_codex_refuses_a_non_stream_responses_job) —
+    so this pins that once a job IS streaming, the forward stays streaming regardless of drift."""
     from remote import api_keys, relay, serve
 
     state = _codex_serve_state(monkeypatch, tmp_path)
@@ -9565,7 +9632,7 @@ def test_serve_handle_job_codex_streams_regardless_of_the_job_flag(monkeypatch, 
         200, content=b"event: response.created\ndata: {}\n\n"))
 
     serve.handle_job(state, {"transaction_id": "t1", "endpoint_path": "responses",
-                             "body": {"model": "codex:gpt-5.4-mini"}, "is_stream": False})
+                             "body": {"model": "codex:gpt-5.4-mini"}, "is_stream": True})
 
     assert captured["stream"] is True  # forced — the flag cannot demote a responses job
 

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -1658,6 +1658,76 @@ def test_codex_probe_unreadable_listing_is_contract_drift_but_empty_is_empty(mon
 
 
 # ---------------------------------------------------------------------------
+# responses-endpoint route probe (issue 08 / ADR 0018) — hardware capability discovery.
+# Reuses `_mock_probe`: a real httpx.Client with MockTransport, so no network call is made.
+# ---------------------------------------------------------------------------
+
+
+def test_probe_responses_endpoint_true_on_bad_request(monkeypatch):
+    """The route-existence probe (ADR 0018): a hardware engine that SERVES `/v1/responses` rejects a
+    deliberately-invalid body with a bad-request status — the route exists, the payload does not. A
+    bad-request is the ONLY answer read as "yes"."""
+    from remote import probe
+
+    seen = _mock_probe(monkeypatch, lambda request: httpx.Response(400, json={"error": "missing model"}))
+
+    assert probe.probe_responses_endpoint("http://engine.example/v1") is True
+    assert seen["method"] == "POST"
+    assert seen["url"] == "http://engine.example/v1/responses"
+
+
+def test_probe_responses_endpoint_true_on_unprocessable(monkeypatch):
+    """422 is the other bad-request the dialect commonly answers an empty body with — the route
+    exists, so it is "yes" too."""
+    from remote import probe
+
+    _mock_probe(monkeypatch, lambda request: httpx.Response(422, json={"detail": "field required"}))
+    assert probe.probe_responses_endpoint("http://engine.example/v1") is True
+
+
+def test_probe_responses_endpoint_fails_closed_on_ambiguous_status(monkeypatch):
+    """Everything that is NOT a bad-request means "does not serve it" — route-missing (404),
+    method-not-allowed (405), a catch-all 200 page, and any other status. Advertising a capability an
+    engine lacks makes the router's candidate filter lie (the ADR 0017 class), so ambiguity is "no"."""
+    from remote import probe
+
+    for status in (404, 405, 200, 301, 500, 503):
+        _mock_probe(monkeypatch, lambda request, s=status: httpx.Response(s, json={"x": 1}))
+        assert probe.probe_responses_endpoint("http://engine.example/v1") is False, status
+
+
+def test_probe_responses_endpoint_fails_closed_on_transport_error(monkeypatch):
+    """A timeout or transport failure is "no" — a slow or unreachable probe must never advertise a
+    capability the engine may not have (fail closed)."""
+    from remote import probe
+
+    def boom(request):
+        raise httpx.ConnectError("unreachable")
+
+    _mock_probe(monkeypatch, boom)
+    assert probe.probe_responses_endpoint("http://engine.example/v1") is False
+
+
+def test_probe_responses_endpoint_sends_empty_body_and_spends_no_inference(monkeypatch):
+    """The probe posts a deliberately-EMPTY body (no messages, no input) exactly once, so it is a
+    route-existence question, not an inference: an empty body is expected to fail request validation
+    before any forward pass. (Whether that stays free per engine is issue 11's to confirm.)"""
+    from remote import probe
+
+    captured = {}
+
+    def handler(request):
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(400)
+
+    seen = _mock_probe(monkeypatch, handler)
+    probe.probe_responses_endpoint("http://engine.example/v1")
+
+    assert captured["body"] == {}          # no prompt, no messages, no input — nothing to infer on
+    assert seen["calls"] == 1              # one request, no retry loop
+
+
+# ---------------------------------------------------------------------------
 # codex OAuth PKCE (ADR 0015 D-c) — the vendor protocol `grid join --api codex` speaks.
 # Every test here mocks the vendor: this suite never makes a network call.
 # ---------------------------------------------------------------------------
@@ -7456,10 +7526,14 @@ def _seed_reload_state(monkeypatch, tmp_path, engines, *, retained, media_models
     is the ``[(url, advertised, upstream, caps), ...]`` the live snapshot was built from; the state's
     ``media_signature`` reflects the STARTUP media config (``startup_bundles``), which the reload
     compares the re-read record against."""
-    from remote import api_keys, serve
+    from remote import api_keys, probe, serve
     from shared import run_records
 
     monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    # A reload that adds a hardware --at engine now runs the once-per-engine Responses route probe
+    # (issue 08). Stub it False here so every reload test stays network-free without each restubbing it;
+    # a test asserting the probe overrides this afterward.
+    monkeypatch.setattr(probe, "probe_responses_endpoint", lambda *a, **k: False)
     routes, upstream, models, caps, _warn = (
         serve._build_routing([tuple(r) for r in retained]) if retained else ({}, {}, [], {}, [])
     )
@@ -9061,23 +9135,192 @@ def test_serve_handle_job_codex_refuses_chat_via_the_single_url_fallback_too(mon
     assert "serves responses only" in captured["error"]
 
 
-def test_serve_handle_job_responses_never_reaches_a_hardware_engine(monkeypatch, tmp_path):
-    """The other half of D-b: the global allow-list is NOT widened, so a responses job that routes
-    to a hardware engine — direct or via the fallback — is refused before any URL interpolation,
-    with the pre-matrix wording."""
+def test_serve_handle_job_responses_refused_by_a_hardware_engine_lacking_the_capability(monkeypatch, tmp_path):
+    """Per-engine gate (ADR 0018 decision 1 — this OVERTURNS the old unconditional 'never reaches a
+    hardware engine' invariant): a hardware engine whose join-time probe did NOT find `/responses`
+    refuses a responses job before any URL interpolation, with the pre-matrix wording, direct or via
+    the fallback. The default-caps engine here advertises no `responses` in its `endpoints`, so it is
+    exactly that engine. This is the fail-closed half of the widening — capability is per-engine, so an
+    engine that lacks it still gets the clean structured refusal, never a blind forward that would 404
+    at the engine. (A responses-CAPABLE engine is served: test_serve_handle_job_hardware_responses_streams_through.)"""
     from remote import relay, serve
 
-    state = _serve_state(monkeypatch, tmp_path)  # one hardware engine serving "m"
+    state = _serve_state(monkeypatch, tmp_path)  # one hardware engine serving "m", no `responses` in its caps
     captured = {}
     monkeypatch.setattr(relay, "submit_error",
                         lambda url, tok, txn, *, message, tokens_delivered=0: captured.update(error=message))
-    _mock_serve_engine(monkeypatch, lambda request: pytest.fail("responses must never reach a hardware engine"))
+    _mock_serve_engine(monkeypatch, lambda request: pytest.fail(
+        "responses must not reach a hardware engine that lacks the capability"))
 
     serve.handle_job(state, {"transaction_id": "t3", "endpoint_path": "responses",
                              "body": {"model": "m"}, "is_stream": True})
 
     assert "unsupported endpoint" in captured["error"].lower()
     assert "'responses'" in captured["error"]
+
+
+def _responses_capable_hardware_caps(model="m"):
+    """A hardware caps envelope whose model advertises the Responses dialect — what the join-time probe
+    stamps (issue 08). The gate reads this same field to decide the engine may serve `responses`."""
+    return {"schema_version": 1,
+            "models": {model: {"endpoints": ["chat/completions", "completions", "responses"]}}}
+
+
+def test_serve_handle_job_hardware_responses_streams_through(monkeypatch, tmp_path):
+    """Issue 08 (AC1): a hardware engine whose probe found `/responses` serves a STREAMING Responses
+    request end-to-end. The forward arms are already dialect- (not kind-) specific, so once the gate
+    admits the job it takes the SAME shared block-aligned path openai/codex use — no bearer (it is a
+    local engine), whole `event:`+`data:` blocks realigned so the usage-bearing terminal event is never
+    torn. The only thing that changed vs the old refusal is the gate now consults the per-engine caps."""
+    from remote import relay, serve
+
+    state = _serve_state(monkeypatch, tmp_path, capabilities=_responses_capable_hardware_caps())
+    captured = {}
+
+    def cap_submit(url, tok, txn, *, content, stream):
+        captured.update(stream=stream, chunks=list(content))
+
+    monkeypatch.setattr(relay, "submit_response", cap_submit)
+    monkeypatch.setattr(relay, "submit_error",
+                        lambda url, tok, txn, *, message, tokens_delivered=0: captured.update(error=message))
+    sse = (b'event: response.created\ndata: {}\n\n'
+           b'event: response.completed\ndata: {"usage":{"total_tokens":3}}\n\n')
+
+    def engine(request):
+        assert str(request.url) == "http://127.0.0.1:8081/v1/responses"  # {target}/{endpoint}
+        assert "authorization" not in request.headers                    # a hardware engine gets no bearer
+        return httpx.Response(200, content=iter([sse[i:i + 7] for i in range(0, len(sse), 7)]))
+
+    _mock_serve_engine(monkeypatch, engine)
+
+    serve.handle_job(state, {"transaction_id": "t8", "endpoint_path": "responses",
+                             "body": {"model": "m"}, "is_stream": True})
+
+    assert "error" not in captured
+    assert captured["stream"] is True
+    assert b"".join(captured["chunks"]) == sse
+
+
+def test_serve_handle_job_hardware_responses_non_stream_forwards_whole(monkeypatch, tmp_path):
+    """Issue 08 + issue 05: a NON-stream Responses job to a responses-capable hardware engine takes the
+    dialect-agnostic whole-body forward (`_forward_whole`) — the engine's single response object is
+    submitted with stream=False. Only the seat refuses a non-stream responses job; every other engine,
+    hardware included, serves it (the relay lifted its global stream mandate for exactly this)."""
+    from remote import relay, serve
+
+    state = _serve_state(monkeypatch, tmp_path, capabilities=_responses_capable_hardware_caps())
+    captured = {}
+    monkeypatch.setattr(relay, "submit_response",
+                        lambda url, tok, txn, *, content, stream: captured.update(content=content, stream=stream))
+    monkeypatch.setattr(relay, "submit_error",
+                        lambda url, tok, txn, *, message, tokens_delivered=0: captured.update(error=message))
+    obj = (b'{"id":"resp_x","object":"response","status":"completed",'
+           b'"output":[],"usage":{"input_tokens":1,"output_tokens":2}}')
+
+    def engine(request):
+        assert str(request.url) == "http://127.0.0.1:8081/v1/responses"
+        assert json.loads(request.content).get("stream") in (None, False)  # not forced to stream
+        return httpx.Response(200, content=obj)
+
+    _mock_serve_engine(monkeypatch, engine)
+    serve.handle_job(state, {"transaction_id": "t9", "endpoint_path": "responses",
+                             "body": {"model": "m"}, "is_stream": False})
+
+    assert "error" not in captured
+    assert captured["stream"] is False
+    assert captured["content"] == obj
+
+
+def test_serve_handle_job_hardware_responses_capable_still_serves_chat(monkeypatch, tmp_path):
+    """AC: chat/completions traffic is entirely unaffected by the widening — an engine that gained
+    `responses` keeps serving chat, because the composed set is the chat pair PLUS responses, not a
+    replacement. (An engine that FAILED the probe keeping chat is the default-caps case above.)"""
+    from remote import relay, serve
+
+    state = _serve_state(monkeypatch, tmp_path, capabilities=_responses_capable_hardware_caps())
+    captured = {}
+    monkeypatch.setattr(relay, "submit_response",
+                        lambda url, tok, txn, *, content, stream: captured.update(content=content))
+    monkeypatch.setattr(relay, "submit_error",
+                        lambda url, tok, txn, *, message, tokens_delivered=0: pytest.fail(f"unexpected error: {message}"))
+    _mock_serve_engine(monkeypatch,
+                       lambda request: httpx.Response(200, json={"choices": [{"message": {"content": "ok"}}]}))
+
+    serve.handle_job(state, {"transaction_id": "t10", "endpoint_path": "chat/completions",
+                             "body": {"model": "m"}, "is_stream": False})
+
+    assert captured["content"]  # forwarded and answered — chat still works on a responses-capable engine
+
+
+def test_serve_handle_job_hardware_responses_capable_keeps_a_closed_endpoint_set(monkeypatch, tmp_path):
+    """AC + ADR 0018 decision 3: the endpoint the gate consults stays a CLOSED set of fixed literals. A
+    responses-capable hardware engine still refuses anything but the exact literals — a stateful
+    retrieval route (`responses/resp_123`) and a traversal attempt (`responses/../secret`) are both
+    refused before any URL is built, proving the widening added ONE fixed literal, not an open prefix."""
+    from remote import relay, serve
+
+    state = _serve_state(monkeypatch, tmp_path, capabilities=_responses_capable_hardware_caps())
+    _mock_serve_engine(monkeypatch, lambda request: pytest.fail("an off-set endpoint must never be forwarded"))
+
+    for endpoint in ("responses/resp_123", "responses/../secret"):
+        captured = {}
+        monkeypatch.setattr(relay, "submit_error",
+                            lambda url, tok, txn, *, message, tokens_delivered=0: captured.update(error=message))
+        serve.handle_job(state, {"transaction_id": "t11", "endpoint_path": endpoint,
+                                 "body": {"model": "m"}, "is_stream": True})
+        assert "unsupported endpoint" in captured["error"].lower(), endpoint
+
+
+def test_serve_handle_job_single_engine_fallback_serves_responses(monkeypatch, tmp_path):
+    """Review finding (rev-code/rev-silent): a grid with ONE responses-capable hardware engine must serve
+    a responses job even when body['model'] does not resolve to the advertised name. `route_and_kind`'s
+    single-engine fallback routes it to the sole engine (as chat does), and the capability is the
+    ENGINE's (ADR 0018), so the gate resolves it per-engine — not by the unmatched model. Refusing here
+    would emit 'unsupported endpoint' for an engine that DOES serve the dialect: the misleading-error
+    class ADR 0017/0018 exist to prevent, and an asymmetry with chat (which forwards blind here)."""
+    from remote import relay, serve
+
+    state = _serve_state(monkeypatch, tmp_path, capabilities=_responses_capable_hardware_caps("m"))
+    captured = {}
+    monkeypatch.setattr(relay, "submit_response",
+                        lambda url, tok, txn, *, content, stream: captured.update(stream=stream, chunks=list(content)))
+    monkeypatch.setattr(relay, "submit_error",
+                        lambda url, tok, txn, *, message, tokens_delivered=0: captured.update(error=message))
+    sse = b'event: response.completed\ndata: {"usage":{"total_tokens":1}}\n\n'
+
+    def engine(request):
+        assert str(request.url) == "http://127.0.0.1:8081/v1/responses"  # the sole engine, via fallback
+        return httpx.Response(200, content=iter([sse]))
+
+    _mock_serve_engine(monkeypatch, engine)
+    # "other-model" is NOT the advertised "m" → single-engine fallback resolves the one engine; the gate
+    # must consult THAT engine's capability, so responses is served rather than falsely refused.
+    serve.handle_job(state, {"transaction_id": "t12", "endpoint_path": "responses",
+                             "body": {"model": "other-model"}, "is_stream": True})
+
+    assert "error" not in captured        # served, not refused as "unsupported endpoint"
+    assert captured["stream"] is True
+
+
+def test_hardware_serves_responses_guards_malformed_caps(monkeypatch, tmp_path):
+    """Review finding (rev-python): the fail-closed guards in `_hardware_serves_responses` are proven
+    directly. A non-dict model entry and a non-LIST `endpoints` both read as "no" without raising — the
+    latter is the interesting trap, since a bare string `endpoints="responses"` would make
+    `"responses" in "responses"` True on a naive membership check; the `isinstance(..., list)` guard
+    defeats it. A proper list carrying the literal reads True."""
+    from remote import serve
+
+    def snap(caps):
+        return serve._Snapshot.build(routes={"m": "http://e/v1"}, upstream={}, models=["m"],
+                                     capabilities=caps, meta={}, pricing={}, max_concurrency=1)
+
+    non_dict = snap({"schema_version": 1, "models": {"m": "not-a-dict"}})
+    string_eps = snap({"schema_version": 1, "models": {"m": {"endpoints": "responses"}}})  # a string, not a list
+    real = snap({"schema_version": 1, "models": {"m": {"endpoints": ["chat/completions", "responses"]}}})
+
+    assert serve._hardware_serves_responses(non_dict, "m", "http://e/v1") is False
+    assert serve._hardware_serves_responses(string_eps, "m", "http://e/v1") is False  # substring trap defeated
+    assert serve._hardware_serves_responses(real, "m", "http://e/v1") is True
 
 
 def test_serve_handle_job_openai_responses_streams_through(monkeypatch, tmp_path):
@@ -9305,6 +9548,84 @@ def test_static_api_caps_stale_openai_model_fails_closed_on_output_cap():
     # ...but a model absent from the whitelist degrades all-False, so its advertised feature is False.
     entry = serve._static_api_caps("openai", ["openai:not-a-real-model"])["models"]["openai:not-a-real-model"]
     assert entry["features"]["output_cap"] is False
+
+
+def _stub_hardware_probe(monkeypatch, *, serves_responses):
+    """Stub only the two HTTP layers of a hardware probe so the REAL `capabilities`/`envelope`/
+    `capability_entry` threading runs — `probe_llama_capabilities` (the live feature probe) returns a
+    fixed all-False dict, and `probe_responses_endpoint` returns the given route answer. Returns a
+    counter of route-probe calls so a test can assert it runs once per engine."""
+    from remote import probe
+
+    calls = {"responses": 0}
+
+    def _responses(url, **kw):
+        calls["responses"] += 1
+        return serves_responses
+
+    monkeypatch.setattr(probe, "probe_responses_endpoint", _responses)
+    monkeypatch.setattr(probe, "probe_llama_capabilities", lambda url, model: {
+        "vision": False, "json_object": False, "json_schema": False,
+        "tools": False, "parallel_tool_calls": False,
+    })
+    return calls
+
+
+def test_hardware_caps_advertise_responses_when_probe_true(monkeypatch):
+    """Issue 08 / ADR 0018: a hardware engine whose server serves ``/responses`` advertises the dialect
+    on EVERY model it serves — the ``endpoints`` list gains ``responses`` — and (PRD §3, since every
+    non-seat engine accepts an output cap) also flips the ``output_cap`` routing FEATURE True. That
+    per-model ``endpoints`` list is exactly what the relay's candidate filter reads to route a Responses
+    request, and ``output_cap`` is what lets a capped ``auto`` land on it."""
+    from remote import serve
+
+    _stub_hardware_probe(monkeypatch, serves_responses=True)
+    caps = serve._probe_spec_caps("http://engine.example/v1", ["m1", "m2"], ["m1", "m2"], None)
+
+    entry = caps["models"]["m1"]
+    assert entry["endpoints"] == ["chat/completions", "completions", "responses"]
+    assert entry["features"]["output_cap"] is True
+    assert "responses" in caps["models"]["m2"]["endpoints"]  # stamped on every model, not just the first
+
+
+def test_hardware_caps_omit_responses_when_probe_false(monkeypatch):
+    """An engine whose server does NOT serve the route (or answered ambiguously) is unchanged from
+    Phase 1: the chat pair only, and `output_cap` stays False so a capped `auto` request excludes it.
+    This is the fail-closed half — a missing capability costs the operator nothing on chat traffic."""
+    from remote import serve
+
+    _stub_hardware_probe(monkeypatch, serves_responses=False)
+    entry = serve._probe_spec_caps("http://engine.example/v1", ["m1"], ["m1"], None)["models"]["m1"]
+
+    assert entry["endpoints"] == ["chat/completions", "completions"]
+    assert entry["features"]["output_cap"] is False
+
+
+def test_hardware_responses_probe_runs_once_per_engine(monkeypatch):
+    """AC: the probe runs ONCE per engine, not once per model — it asks about the server's route, and N
+    models on one server would be N identical questions. A three-model spec probes exactly once, and the
+    single answer covers all three."""
+    from remote import serve
+
+    calls = _stub_hardware_probe(monkeypatch, serves_responses=True)
+    caps = serve._probe_spec_caps("http://engine.example/v1", ["m1", "m2", "m3"], ["m1", "m2", "m3"], None)
+
+    assert calls["responses"] == 1                                       # one probe for the whole engine
+    assert all("responses" in caps["models"][m]["endpoints"] for m in ("m1", "m2", "m3"))
+
+
+def test_api_and_codex_specs_never_run_the_responses_probe(monkeypatch):
+    """AC: API engines and subscription seats are never probed — their caps are static catalog data
+    (`_static_api_caps`), reached by the early return BEFORE the hardware route probe. A vendor must
+    see no traffic at join, and a codex seat must behave exactly as it does today (user story 16)."""
+    from remote import probe, serve
+
+    monkeypatch.setattr(probe, "probe_responses_endpoint",
+                        lambda *a, **k: pytest.fail("API engines / seats are never route-probed"))
+
+    serve._probe_spec_caps("https://api.openai.com/v1", ["openai:gpt-5.5"], ["gpt-5.5"], None, api_kind="openai")
+    serve._probe_spec_caps("https://chatgpt.com", ["codex:gpt-5.5"], ["gpt-5.5"], None,
+                           api_kind="codex", plan_type="free")
 
 
 def test_serve_codex_seat_holder_primes_from_the_store_and_self_heals(monkeypatch, tmp_path):
@@ -10911,8 +11232,11 @@ def test_bring_up_engines_external_multi_probes_each(monkeypatch, tmp_path):
         "advertise_as": [],
     }
     seen = []
+    # A hardware spec now runs the once-per-engine Responses route probe (issue 08); stub it away so this
+    # `_bring_up_engines` test stays network-free and asserts only the per-model capability probing.
+    monkeypatch.setattr(probe, "probe_responses_endpoint", lambda *a, **k: False)
     monkeypatch.setattr(probe, "capabilities",
-                        lambda url, model, *, advertise_as=None, context_window=None: seen.append((url, model))
+                        lambda url, model, *, advertise_as=None, context_window=None, **_: seen.append((url, model))
                         or {"schema_version": 1, "models": {advertise_as or model: {"f": model}}})
 
     results, launched, launcher = serve._bring_up_engines(record)
@@ -10938,8 +11262,9 @@ def test_bring_up_engines_single_spec_multi_model_probes_every_model(monkeypatch
         "advertise_as": [],
     }
     seen = []
+    monkeypatch.setattr(probe, "probe_responses_endpoint", lambda *a, **k: False)  # issue 08: keep this test network-free
     monkeypatch.setattr(probe, "capabilities",
-                        lambda url, model, *, advertise_as=None, context_window=None: seen.append(model)
+                        lambda url, model, *, advertise_as=None, context_window=None, **_: seen.append(model)
                         or {"schema_version": 1, "models": {advertise_as or model: {"f": model}}})
 
     results, launched, _ = serve._bring_up_engines(record)
@@ -11024,8 +11349,9 @@ def test_bring_up_engines_mixed_union_probes_only_hardware(monkeypatch, tmp_path
         "advertise_as": [],
     }
     probed = []
+    monkeypatch.setattr(probe, "probe_responses_endpoint", lambda *a, **k: False)  # issue 08: keep this test network-free
     monkeypatch.setattr(probe, "capabilities",
-                        lambda url, model, *, advertise_as=None, context_window=None: probed.append((url, model))
+                        lambda url, model, *, advertise_as=None, context_window=None, **_: probed.append((url, model))
                         or {"schema_version": 1, "models": {advertise_as or model: {}}})
 
     results, launched, _ = serve._bring_up_engines(record)
@@ -11045,10 +11371,11 @@ def test_bring_up_engines_external_alias_probes_real_name_keys_alias(monkeypatch
     }
     seen = {}
 
-    def fake_caps(url, model, *, advertise_as=None, context_window=None):
+    def fake_caps(url, model, *, advertise_as=None, context_window=None, **_):
         seen.update(url=url, model=model, advertise_as=advertise_as)
         return {"schema_version": 1, "models": {advertise_as or model: {"f": model}}}
 
+    monkeypatch.setattr(probe, "probe_responses_endpoint", lambda *a, **k: False)  # issue 08: keep this test network-free
     monkeypatch.setattr(probe, "capabilities", fake_caps)
 
     results, launched, _ = serve._bring_up_engines(record)
@@ -11065,8 +11392,9 @@ def test_bring_up_engines_falls_back_to_flat_record(monkeypatch, tmp_path):
 
     # A record written before multi-engine has no `engines` list — synthesise one spec from flat fields.
     record = {"endpoint_url": "http://h:11434/v1", "models": ["llama3"], "advertise_as": []}
+    monkeypatch.setattr(probe, "probe_responses_endpoint", lambda *a, **k: False)  # issue 08: keep this test network-free
     monkeypatch.setattr(probe, "capabilities",
-                        lambda url, model, *, advertise_as=None, context_window=None: {"schema_version": 1, "models": {advertise_as or model: {}}})
+                        lambda url, model, *, advertise_as=None, context_window=None, **_: {"schema_version": 1, "models": {advertise_as or model: {}}})
 
     results, launched, _ = serve._bring_up_engines(record)
     assert launched == []  # external engine: nothing launched

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -12560,9 +12560,11 @@ def test_remote_models_json_maps_name_to_node_key(monkeypatch, tmp_path, capsys)
     _mock_overview(monkeypatch, _OVERVIEW_2NODES)
     assert cli.main(["models", "--json"]) == 0
     payload = json.loads(capsys.readouterr().out)
-    assert {"model": "glm-5.2", "engine": "MLX", "node": "mac-studio"} in payload
-    assert {"model": "qwen-3", "engine": "MLX", "node": "mac-studio"} in payload
-    assert {"model": "glm-5.2", "engine": "ollama", "node": "ollama-box"} in payload
+    # `responses` joins every entry (issue 10); this overview omits `responses_models`, so an older
+    # master degrades to False everywhere rather than crashing.
+    assert {"model": "glm-5.2", "engine": "MLX", "node": "mac-studio", "responses": False} in payload
+    assert {"model": "qwen-3", "engine": "MLX", "node": "mac-studio", "responses": False} in payload
+    assert {"model": "glm-5.2", "engine": "ollama", "node": "ollama-box", "responses": False} in payload
 
 
 def test_remote_models_empty_when_no_nodes(monkeypatch, tmp_path, capsys):
@@ -12610,7 +12612,7 @@ def test_remote_models_json_includes_auto_first_when_router_enabled(monkeypatch,
     _mock_overview(monkeypatch, {**_OVERVIEW_2NODES, "router_enabled": True})
     assert cli.main(["models", "--json"]) == 0
     payload = json.loads(capsys.readouterr().out)
-    assert payload[0] == {"model": "auto", "engine": "grid-router", "node": ""}
+    assert payload[0] == {"model": "auto", "engine": "grid-router", "node": "", "responses": False}
 
 
 def test_remote_models_shows_auto_even_with_zero_nodes_when_enabled(monkeypatch, tmp_path, capsys):
@@ -12620,6 +12622,74 @@ def test_remote_models_shows_auto_even_with_zero_nodes_when_enabled(monkeypatch,
     assert cli.main(["models"]) == 0
     lines = [ln for ln in capsys.readouterr().out.splitlines() if ln.strip()]
     assert lines == ["auto"]
+
+
+# ── responses dialect annotation on the live listing (issue 10) ──
+
+# Two engines both serve `glm-5.2`, but only the MLX one serves the Responses dialect; `qwen-3` serves
+# it nowhere. Exercises AC1 (capable shows), AC2 (incapable omits), AC4 (same id, per-engine truth).
+_OVERVIEW_RESPONSES = {
+    "nodes": [
+        {"name": "mac-studio", "engine": "MLX", "models": ["glm-5.2", "qwen-3"],
+         "responses_models": ["glm-5.2"], "online": True},
+        {"name": "ollama-box", "engine": "ollama", "models": ["glm-5.2"],
+         "responses_models": [], "online": True},
+    ],
+}
+
+
+def test_remote_models_verbose_annotates_a_responses_capable_row(monkeypatch, tmp_path, capsys):
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_overview(monkeypatch, _OVERVIEW_RESPONSES)
+    assert cli.main(["models", "--verbose"]) == 0
+    rows = [ln for ln in capsys.readouterr().out.splitlines() if "glm-5.2" in ln and "mac-studio" in ln]
+    assert rows and "responses" in rows[0]  # glm-5.2 on the MLX engine serves the dialect
+
+
+def test_remote_models_verbose_omits_responses_per_engine(monkeypatch, tmp_path, capsys):
+    # Per-engine truth (AC2/AC4): glm-5.2 serves the dialect on MLX but NOT on ollama; qwen-3 nowhere.
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_overview(monkeypatch, _OVERVIEW_RESPONSES)
+    assert cli.main(["models", "--verbose"]) == 0
+    by_row: dict[str, str] = {}
+    for ln in capsys.readouterr().out.splitlines():
+        if "glm-5.2" in ln and "mac-studio" in ln:
+            by_row["mac_glm"] = ln
+        if "glm-5.2" in ln and "ollama-box" in ln:
+            by_row["ollama_glm"] = ln
+        if "qwen-3" in ln:
+            by_row["qwen"] = ln
+    assert "responses" in by_row["mac_glm"]         # capable engine shows it
+    assert "responses" not in by_row["ollama_glm"]  # same id, incapable engine → omitted
+    assert "responses" not in by_row["qwen"]        # not served via the dialect anywhere
+
+
+def test_remote_models_json_carries_per_engine_responses_flag(monkeypatch, tmp_path, capsys):
+    # AC6: the machine-readable form carries the same per-engine fact, true and false alike.
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_overview(monkeypatch, _OVERVIEW_RESPONSES)
+    assert cli.main(["models", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert {"model": "glm-5.2", "engine": "MLX", "node": "mac-studio", "responses": True} in payload
+    assert {"model": "glm-5.2", "engine": "ollama", "node": "ollama-box", "responses": False} in payload
+    assert {"model": "qwen-3", "engine": "MLX", "node": "mac-studio", "responses": False} in payload
+
+
+def test_remote_models_verbose_degrades_when_responses_field_absent(monkeypatch, tmp_path, capsys):
+    # An older master's overview omits responses_models entirely → nothing annotated, no crash.
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_overview(monkeypatch, _OVERVIEW_2NODES)
+    assert cli.main(["models", "--verbose"]) == 0
+    assert "responses" not in capsys.readouterr().out
+
+
+def test_remote_models_plain_listing_stays_bare_names(monkeypatch, tmp_path, capsys):
+    # The default (non-verbose) output is unchanged — bare deduped ids for scripting, no annotation.
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_overview(monkeypatch, _OVERVIEW_RESPONSES)
+    assert cli.main(["models"]) == 0
+    lines = [ln for ln in capsys.readouterr().out.splitlines() if ln.strip()]
+    assert lines == ["glm-5.2", "qwen-3"]  # deduped, first-seen order, no `responses` suffix
 
 
 def test_remote_engines_requires_grid_up(monkeypatch, tmp_path):

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -9194,6 +9194,119 @@ def test_iter_event_blocks_never_flushes_a_partial_block_on_error():
     assert out == [b"event: a\ndata: {}\n\n"]  # exactly the complete block; the torn half never left
 
 
+# A plain bearer header set — what a non-seat kind's `_forward_headers` produces. Deliberately NOT
+# the seat's five (`_codex_headers`): the shared responses forward must not know a seat exists.
+_NON_SEAT_HEADERS = {"Content-Type": "application/json", "Authorization": "Bearer k-plain"}
+
+
+def test_forward_responses_stream_submits_whole_event_blocks_for_any_kind(monkeypatch, tmp_path):
+    """PRD §5 / ADR 0018: block alignment is a property of the DIALECT, not of the subscription
+    seat — so the streaming submission is a path any engine kind can take.
+
+    Exercised here with no seat anywhere in the call: a plain `_serve_state` (whose codex holder is
+    created but never primed) and a plain bearer header set. It still submits one whole
+    `event:`+`data:` block per chunk. `test_serve_handle_job_codex_submits_the_fixture_as_whole_
+    event_blocks` asserts the same invariants THROUGH the seat; that overlap is deliberate, and
+    what is unique here is the seat's ABSENCE — if this path ever reached for `state.codex_seat`,
+    the unprimed holder would raise `CodexNotSignedIn` and this test would fail loudly rather than
+    let the two concerns quietly re-couple."""
+    from remote import relay, serve
+
+    state = _serve_state(monkeypatch, tmp_path)
+    fixture = _codex_fixture_bytes()
+    captured = {}
+
+    def cap_submit(url, tok, txn, *, content, stream):
+        captured.update(stream=stream, chunks=list(content))  # keep the chunk boundaries
+
+    monkeypatch.setattr(relay, "submit_response", cap_submit)
+
+    def engine(request):
+        captured["url"] = str(request.url)
+        captured["headers"] = dict(request.headers)
+        # Awkward 7-byte chunking: block boundaries land mid-line, mid-JSON, everywhere.
+        return httpx.Response(200, content=iter([fixture[i:i + 7] for i in range(0, len(fixture), 7)]))
+
+    _mock_serve_engine(monkeypatch, engine)
+
+    failure = serve._forward_responses_stream(
+        state, "t1", "responses", {"model": "m"}, 600.0, "http://engine.example/v1",
+        headers=dict(_NON_SEAT_HEADERS),
+    )
+
+    assert failure is None  # a submitted 200 reports nothing back to the caller
+    assert captured["url"] == "http://engine.example/v1/responses"  # {target}/{endpoint}
+    assert captured["headers"]["authorization"] == "Bearer k-plain"  # the CALLER's headers, verbatim
+    assert "chatgpt-account-id" not in captured["headers"]  # nothing seat-shaped was added
+    assert captured["stream"] is True
+    assert len(captured["chunks"]) == 47
+    assert all(chunk.endswith(b"\n\n") for chunk in captured["chunks"])
+    assert b"".join(captured["chunks"]) == fixture  # byte-for-byte, whatever the socket chunking
+    assert b"[DONE]" not in b"".join(captured["chunks"])
+
+
+def test_forward_responses_stream_returns_the_drained_failure_without_submitting(monkeypatch, tmp_path):
+    """A non-200 is reported back to the CALLER rather than answered here, because the right answer
+    differs by kind: the seat refreshes a rotated bearer and retries once (ADR 0015 D-d), an API
+    engine does not (ADR 0012 keeps it job-error-only). Two properties make that split safe.
+
+    The body is drained INSIDE the response context and bound before both contexts close — so a
+    caller that then runs a token exchange holds no vendor connection open through it, and the
+    `Cf-Mitigated` header that the CF-403-vs-auth-403 taxonomy keys on (`_warn_codex_upstream`,
+    D-f) is still readable afterwards, not just the status int. And nothing is submitted: the job
+    has had NO terminal signal yet, which is precisely why a non-None return OBLIGES its caller to
+    send one — dropping it would hang the consumer."""
+    from remote import relay, serve
+
+    state = _serve_state(monkeypatch, tmp_path)
+    submissions = []
+    monkeypatch.setattr(relay, "submit_response",
+                        lambda *a, **k: submissions.append("response"))
+    monkeypatch.setattr(relay, "submit_error",
+                        lambda *a, **k: submissions.append("error"))
+    _mock_serve_engine(monkeypatch, lambda request: httpx.Response(
+        403, headers={"Cf-Mitigated": "challenge"}, json={"detail": "blocked"}))
+
+    failure = serve._forward_responses_stream(
+        state, "t1", "responses", {"model": "m"}, 600.0, "http://engine.example/v1",
+        headers=dict(_NON_SEAT_HEADERS),
+    )
+
+    assert submissions == []  # the caller owns the terminal signal — nothing was sent for it
+    assert failure is not None
+    assert failure.status == 403
+    assert failure.headers.get("cf-mitigated") == "challenge"  # readable after the contexts closed
+    assert "blocked" in failure.text
+
+
+def test_forward_responses_stream_flushes_a_final_block_with_no_trailing_blank_line(monkeypatch, tmp_path):
+    """An engine that ends its stream without a trailing blank line must still have its last block
+    submitted — that block is the `response.completed` carrying the usage, so swallowing it would
+    under-bill whoever served the request while looking exactly like a clean stream.
+
+    `_iter_event_blocks` already guarantees this and is tested directly above; what this pins is the
+    WIRING — that the grouper is genuinely in the shared submission path, so a later change that
+    forwarded raw bytes here (as the chat path legitimately does) could not silently drop the tail."""
+    from remote import relay, serve
+
+    state = _serve_state(monkeypatch, tmp_path)
+    tail = b'event: response.completed\ndata: {"usage":{"total_tokens":7}}'  # no trailing blank line
+    stream = b"event: response.created\ndata: {}\n\n" + tail
+    captured = {}
+    monkeypatch.setattr(relay, "submit_response",
+                        lambda url, tok, txn, *, content, stream: captured.update(chunks=list(content)))
+    _mock_serve_engine(monkeypatch, lambda request: httpx.Response(200, content=iter([stream])))
+
+    failure = serve._forward_responses_stream(
+        state, "t1", "responses", {"model": "m"}, 600.0, "http://engine.example/v1",
+        headers=dict(_NON_SEAT_HEADERS),
+    )
+
+    assert failure is None
+    assert captured["chunks"][-1] == tail  # flushed verbatim, terminator or not
+    assert b"".join(captured["chunks"]) == stream
+
+
 def test_serve_handle_job_codex_forwards_verbatim_with_the_seat_headers(monkeypatch, tmp_path):
     """AC 1: URL = the kind's base URL + the job's endpoint path; headers are the real client's
     set, built fresh from the live bundle (bearer + account id + originator/user-agent + SSE

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -663,6 +663,30 @@ def test_catalog_api_openai_prints_whitelist(monkeypatch, capsys):
     assert "leave the grid" in out
 
 
+def test_catalog_api_openai_shows_responses_capability(monkeypatch, capsys):
+    """AC1 (issue 06): the human-readable `grid catalog --api openai` listing shows the Responses
+    dialect among each model's capabilities. The openai kind serves it (its whitelist row carries
+    `responses` in `endpoints` since issue 03), so a person picking a model reads it here instead of
+    learning by trial and error. Asserted on the model's OWN line — the per-model capability tag,
+    not incidental prose elsewhere in the output."""
+    def _no_network(*args, **kwargs):
+        raise AssertionError("`grid catalog --api` must not touch the network")
+
+    monkeypatch.setattr(httpx, "Client", _no_network)
+    monkeypatch.setattr(httpx, "request", _no_network)
+    monkeypatch.setattr(httpx, "stream", _no_network)
+
+    rc = cli.cmd_catalog(argparse.Namespace(api="openai", json=False))
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    lines = [ln for ln in out.splitlines() if "openai:gpt-5.5" in ln]
+    assert lines, "the gpt-5.5 model line must be printed"
+    # The dialect joins the model's capability list, alongside the content caps already shown.
+    assert "responses" in lines[0]
+    assert "tools" in lines[0] and "vision" in lines[0]
+
+
 def test_catalog_api_unknown_kind_errors():
     with pytest.raises(SystemExit) as exc:
         cli.cmd_catalog(argparse.Namespace(api="anthropic", json=False))
@@ -702,6 +726,11 @@ def test_api_whitelist_integrity():
         date.fromisoformat(whitelist.last_verified)  # dated, ISO format
         assert whitelist.base_url.startswith("https://"), f"{kind} needs a vendor base URL"
         assert not whitelist.base_url.endswith("/"), f"{kind} base URL must not end with '/'"
+        # Every kind must serve at least one endpoint. An empty tuple would make both the catalog
+        # display (issue 06) and the relay's `_served_endpoints` gate silently treat the kind as an
+        # ordinary chat-only model while it actually serves nothing. The dataclass default is
+        # non-empty; this pins that no row may override it to `()`.
+        assert whitelist.endpoints, f"{kind} must serve at least one endpoint"
 
 
 def test_catalog_api_codex_prints_per_tier_whitelist(monkeypatch, capsys):
@@ -736,6 +765,30 @@ def test_catalog_api_codex_prints_per_tier_whitelist(monkeypatch, capsys):
     assert "grid chat" in out  # ...and what NOT to point at it
     assert "leave the grid" in out  # provenance disclosure (openai parity)
     assert "allowance" in out  # flat-rate seat: jobs spend the provider's own allowance
+
+
+def test_catalog_api_codex_shows_responses_per_entry(monkeypatch, capsys):
+    """AC2 (issue 06): the subscription-seat listing shows the dialect too — every codex model
+    serves `responses` (its row is `endpoints=("responses",)`), so the same data-driven cap tag
+    appears on each per-tier entry line, beside the tools/vision it already showed. Asserted on the
+    model's OWN line: distinct from the trailing prose that also says "responses", this witnesses the
+    per-model capability tag. The per-tier GROUPING is unchanged — that is pinned separately by
+    test_catalog_api_codex_prints_per_tier_whitelist's `\nfree:\n` assertion."""
+    def _no_network(*args, **kwargs):
+        raise AssertionError("`grid catalog --api` must not touch the network")
+
+    monkeypatch.setattr(httpx, "Client", _no_network)
+    monkeypatch.setattr(httpx, "request", _no_network)
+    monkeypatch.setattr(httpx, "stream", _no_network)
+
+    rc = cli.cmd_catalog(argparse.Namespace(api="codex", json=False))
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    lines = [ln for ln in out.splitlines() if "codex:gpt-5.6-terra" in ln]
+    assert lines, "the gpt-5.6-terra model line must be printed"
+    assert "responses" in lines[0]  # the per-model dialect tag, not merely the trailing prose
+    assert "tools" in lines[0] and "vision" in lines[0]  # alongside the caps it already showed
 
 
 def test_catalog_api_still_rejects_a_kind_that_really_is_unknown(capsys):
@@ -971,6 +1024,49 @@ def test_api_catalog_find_advertised_and_probed_features():
     assert features["json_schema"] is entry.supports_structured_outputs
 
 
+def test_format_api_entry_shows_responses_dialect():
+    """AC3/AC4/AC6 (issue 06), exercised on the formatter directly because no real catalog kind
+    reaches these states: every listed API kind serves `responses` and every listed model has
+    content caps, so the chat-only and zero-caps cases have no witness through the `grid catalog`
+    command. This unit test is therefore the ONLY coverage for AC3 and AC4 — do not trim it.
+
+    The rule is data-driven off the kind's `endpoints` tuple, exactly as `responses_only_kind`
+    reads it: `responses` shows iff the tuple carries it, and `chat/completions` is the assumed
+    baseline that is never shown."""
+    plain = api_catalog.ApiModelEntry(
+        vendor_name="m", context_window=1000,
+        supports_tools=False, supports_vision=False,
+        supports_json_mode=False, supports_structured_outputs=False,
+    )
+    toolful = api_catalog.ApiModelEntry(
+        vendor_name="m", context_window=1000,
+        supports_tools=True, supports_vision=False,
+        supports_json_mode=False, supports_structured_outputs=False,
+    )
+
+    def caps(line: str) -> str:
+        # The capability field is everything after the fixed `... ctx   ` prefix.
+        return line.split(" ctx   ", 1)[1]
+
+    serves_responses = ("chat/completions", "responses")
+    chat_only = ("chat/completions",)
+
+    # Serves responses + content caps → the dialect is appended AFTER the content caps.
+    assert caps(api_catalog.format_api_entry("openai", toolful, serves_responses)) == "tools, responses"
+    # AC4: serves responses + NO content caps → `responses`, never an empty field and never the
+    # contradictory `text only, responses` (the whole reason it joins the SAME list before the fallback).
+    assert caps(api_catalog.format_api_entry("openai", plain, serves_responses)) == "responses"
+    # AC3: a chat/completions-only kind shows no such capability...
+    assert caps(api_catalog.format_api_entry("openai", toolful, chat_only)) == "tools"
+    # ...and a bare chat-only model with no caps still reads as `text only`.
+    assert caps(api_catalog.format_api_entry("openai", plain, chat_only)) == "text only"
+
+    # AC6: the name/ctx columns are undisturbed — the change touches only the trailing caps field.
+    line = api_catalog.format_api_entry("openai", toolful, serves_responses)
+    assert line.startswith("  openai:m")
+    assert " ctx   " in line
+
+
 def test_catalog_api_json_roundtrips(capsys):
     rc = cli.cmd_catalog(argparse.Namespace(api="openai", json=True))
 
@@ -986,6 +1082,19 @@ def test_catalog_api_json_roundtrips(capsys):
     assert first["context_window"] == first_entry.context_window
     assert first["supports_tools"] is first_entry.supports_tools
     assert first["supports_vision"] is first_entry.supports_vision
+
+
+def test_catalog_api_openai_json_emits_endpoints(capsys):
+    """AC5 (issue 06): the machine-readable listing emits the endpoint list for EVERY API kind, not
+    just the codex seat. Before issue 06 the generic `_catalog_api` JSON omitted `endpoints`, so a
+    script could read it for codex (test_catalog_api_codex_json_emits_per_tier_contract) but not for
+    openai — the asymmetry this closes. The value is the whole tuple, so a script checks
+    `"responses" in endpoints` the same way for any kind."""
+    rc = cli.cmd_catalog(argparse.Namespace(api="openai", json=True))
+
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["endpoints"] == ["chat/completions", "responses"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -916,7 +916,7 @@ def test_api_whitelist_endpoints_per_kind():
     values are hand-duplicated with grid-src's `provider_supports` filter (absent ⇒ chat-only,
     old CLIs fail closed); the literal `"responses"` must match its `endpoint_path` byte-for-byte
     (CLAUDE.local.md lockstep rule)."""
-    assert api_catalog.WHITELISTS["openai"].endpoints == ("chat/completions",)
+    assert api_catalog.WHITELISTS["openai"].endpoints == ("chat/completions", "responses")
     assert api_catalog.WHITELISTS["codex"].endpoints == ("responses",)
 
 
@@ -932,14 +932,16 @@ def test_codex_kind_constant_is_defined_in_shared_and_reexported():
     assert api_keys.CODEX_KIND == api_catalog.CODEX_KIND
 
 
-def test_responses_only_kind_flags_codex_models_only():
+def test_responses_only_kind_flags_only_kinds_that_cannot_serve_chat():
     """The `grid chat` pre-flight asks one question — "is this model namespaced under a kind that
-    cannot serve chat/completions?" — and the answer is data-driven from the whitelist's
-    `endpoints`, never a hardcoded kind name. Anything that isn't such a namespace (openai's chat
-    kind, a hardware model whose NAME merely contains a colon, no namespace at all) is None."""
-    assert api_catalog.responses_only_kind("codex:gpt-5.5") == "codex"
+    cannot serve chat/completions?" — data-driven from the whitelist's `endpoints`, never a hardcoded
+    kind name. openai now serves `responses` TOO (issue 03), but is still NOT flagged: it is
+    responses-*capable*, not responses-*only*, because it also serves chat — so `grid chat` still
+    works against it. Only a kind with no chat endpoint at all (codex) is flagged. Anything that isn't
+    an API namespace (a hardware model whose NAME merely contains a colon, no namespace at all) is None."""
+    assert api_catalog.responses_only_kind("codex:gpt-5.5") == "codex"  # responses-only → refuse chat
     assert api_catalog.responses_only_kind("codex:") == "codex"  # still a codex-namespaced request
-    assert api_catalog.responses_only_kind("openai:gpt-5.5") is None  # serves chat/completions
+    assert api_catalog.responses_only_kind("openai:gpt-5.5") is None  # serves responses AND chat → not flagged
     assert api_catalog.responses_only_kind("llama3:8b") is None  # colon, but not an API kind
     assert api_catalog.responses_only_kind("gpt-5.5") is None  # no namespace
     assert api_catalog.responses_only_kind("") is None
@@ -8158,9 +8160,10 @@ def test_remote_engine_api_record_registers_static_caps_and_kind(monkeypatch, tm
     assert seen["node"] == "node-1" and seen["models"] == ["openai:gpt-5.5"]
     entry = seen["capabilities"]["models"]["openai:gpt-5.5"]
     assert entry["context_window"] == 1_050_000 and entry["features"]["tools"] is True
-    # Honest advertisement: an API engine never serves the legacy completions endpoint, so the
-    # relay must not be told it does (the serve-side gate stays as defense in depth).
-    assert entry["endpoints"] == ["chat/completions"]
+    # Honest advertisement: openai serves both dialects now (issue 03) but never the legacy
+    # completions endpoint, so the relay is told exactly that (the serve-side gate stays as defense
+    # in depth). Sourced from the kind's catalog row, not a hardcoded list.
+    assert entry["endpoints"] == ["chat/completions", "responses"]
     assert seen["meta"]["engine"] == "openai"  # the grid page shows the API engine's kind
     assert state_seen["bearer_by_url"] == {"https://api.openai.com/v1": "sk-test-123"}
 
@@ -8924,21 +8927,94 @@ def test_serve_handle_job_responses_never_reaches_a_hardware_engine(monkeypatch,
     assert "'responses'" in captured["error"]
 
 
-def test_serve_handle_job_responses_never_reaches_an_openai_engine(monkeypatch, tmp_path):
-    """openai stays chat-only under the matrix — its refusal message is byte-compatible with the
-    pre-matrix one, so consumers and the relay's terminal-error mapper see no difference."""
+def test_serve_handle_job_openai_responses_streams_through(monkeypatch, tmp_path):
+    """The tracer bullet (issue 03): an app streams a Responses request naming an ``openai:*`` model
+    and gets the vendor's reply back through the grid. ``openai`` now serves the dialect (its catalog
+    row lists ``responses``), so the per-kind gate admits the job and it forwards through the SHARED
+    block-aligned responses path — the same one the seat uses — with the vendor key attached and the
+    advertised name rewritten to the vendor name.
+
+    This is the inverse of the deleted ``responses_never_reaches_an_openai_engine``: that openai is
+    chat-only is exactly the invariant this slice overturns. The 7-byte vendor chunking proves the
+    grouper realigns whole ``event:``+``data:`` blocks (a chat raw-passthrough forward would leak the
+    socket's 7-byte chunks instead), so the usage-bearing terminal event is never torn."""
     from remote import relay, serve
 
     state = _api_serve_state(monkeypatch, tmp_path)
     captured = {}
+
+    def cap_submit(url, tok, txn, *, content, stream):
+        captured.update(stream=stream, chunks=list(content))  # keep the block boundaries
+
+    monkeypatch.setattr(relay, "submit_response", cap_submit)
     monkeypatch.setattr(relay, "submit_error",
                         lambda url, tok, txn, *, message, tokens_delivered=0: captured.update(error=message))
-    _mock_serve_engine(monkeypatch, lambda request: pytest.fail("responses must never reach the openai vendor"))
+    sse = (b'event: response.created\ndata: {}\n\n'
+           b'event: response.completed\ndata: {"usage":{"total_tokens":3}}\n\n')
+
+    def vendor(request):
+        assert str(request.url) == "https://api.openai.com/v1/responses"  # {base}/{endpoint}
+        assert request.headers["authorization"] == "Bearer sk-test-123"   # the stored vendor key
+        assert json.loads(request.content)["model"] == "gpt-5.5"          # advertised → vendor rewrite
+        return httpx.Response(200, content=iter([sse[i:i + 7] for i in range(0, len(sse), 7)]))
+
+    _mock_serve_engine(monkeypatch, vendor)
 
     serve.handle_job(state, {"transaction_id": "t4", "endpoint_path": "responses",
                              "body": {"model": "openai:gpt-5.5"}, "is_stream": True})
 
-    assert "API engine 'openai' serves chat/completions only" in captured["error"]
+    assert "error" not in captured
+    assert captured["stream"] is True
+    assert captured["chunks"] == [
+        b'event: response.created\ndata: {}\n\n',
+        b'event: response.completed\ndata: {"usage":{"total_tokens":3}}\n\n',
+    ]  # two whole blocks, realigned from the 7-byte socket chunking
+    assert b"".join(captured["chunks"]) == sse
+
+
+def test_serve_handle_job_openai_responses_non200_submits_terminal_error(monkeypatch, tmp_path):
+    """The caller obligation issue 02 handed to issue 03: ``_forward_responses_stream`` RETURNS a
+    non-200 (``_UpstreamFailure``) rather than reporting it, so this second caller — unlike the seat's
+    D-d refresh — must answer it with a terminal signal and does NOT retry (ADR 0012 job-error-only).
+    NOTHING in the toolchain catches a dropped return (issue 02's as-built: not even ``ruff --select
+    ALL``), so this test is what pins it: a vendor non-200 reaches the consumer as a ``submit_error``,
+    nothing is streamed, and the vendor is hit exactly once. Modelled on
+    ``test_forward_responses_stream_returns_the_drained_failure_without_submitting``, one layer up."""
+    from remote import relay, serve
+
+    state = _api_serve_state(monkeypatch, tmp_path)
+    submissions = []
+    monkeypatch.setattr(relay, "submit_response", lambda *a, **k: submissions.append("response"))
+    monkeypatch.setattr(relay, "submit_error",
+                        lambda url, tok, txn, *, message, tokens_delivered=0: submissions.append(("error", message)))
+    calls = []
+
+    def vendor(request):
+        calls.append(str(request.url))
+        return httpx.Response(429, json={"error": {"message": "rate limited"}})
+
+    _mock_serve_engine(monkeypatch, vendor)
+
+    serve.handle_job(state, {"transaction_id": "t5", "endpoint_path": "responses",
+                             "body": {"model": "openai:gpt-5.5"}, "is_stream": True})
+
+    assert calls == ["https://api.openai.com/v1/responses"]   # hit once — no retry (unlike the seat)
+    assert "response" not in submissions                      # nothing was streamed back
+    errors = [s for s in submissions if isinstance(s, tuple)]
+    assert len(errors) == 1 and "429" in errors[0][1]         # the terminal signal carries the status
+
+
+def test_static_api_caps_openai_advertises_both_endpoints():
+    """Change #2 in isolation: the advertised caps envelope sources its ``endpoints`` from the kind's
+    catalog row rather than a hardcoded chat-only list. This list is exactly what grid-src's per-model
+    ``provider_supports`` filter reads to decide the openai engine can serve ``responses`` — so if it
+    stayed hardcoded, the row change would never reach the relay and nothing would route. The
+    startup-path cousin ``test_remote_engine_api_record_registers_static_caps_and_kind`` proves the
+    same value through the full registration path; this pins the source at the unit layer."""
+    from remote import serve
+
+    entry = serve._static_api_caps("openai", ["openai:gpt-5.5"])["models"]["openai:gpt-5.5"]
+    assert entry["endpoints"] == ["chat/completions", "responses"]
 
 
 def test_serve_codex_seat_holder_primes_from_the_store_and_self_heals(monkeypatch, tmp_path):

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -867,6 +867,27 @@ def test_codex_whitelist_has_no_env_var_and_no_output_cap():
     assert codex.entries  # issue 05: populated from the tier table
 
 
+def test_kind_honours_output_cap_reads_unsupported_params():
+    """The single source of truth for issue 06b's auto-router cap filter: a kind honours a Responses
+    output-token cap IFF `max_output_tokens` is NOT among its `unsupported_params` — the SAME catalog
+    fact the engine-side gate (`_api_unsupported_params`, issue 04) refuses on, so layer 2 (the auto
+    router) and layer 3 (the engine gate) can never disagree about a kind. An unknown kind fails
+    closed (not-cap-capable), matching how `_static_api_caps`/`_served_endpoints` degrade one."""
+    assert api_catalog.kind_honours_output_cap("openai") is True
+    assert api_catalog.kind_honours_output_cap("codex") is False
+    assert api_catalog.kind_honours_output_cap("nonexistent-kind") is False
+    # Read from the fact, never a second declaration: the helper's answer must track the rows.
+    assert api_catalog.RESPONSES_OUTPUT_CAP_PARAM == "max_output_tokens"
+    assert (
+        api_catalog.RESPONSES_OUTPUT_CAP_PARAM
+        not in api_catalog.WHITELISTS["openai"].unsupported_params
+    )
+    assert (
+        api_catalog.RESPONSES_OUTPUT_CAP_PARAM
+        in api_catalog.WHITELISTS["codex"].unsupported_params
+    )
+
+
 def test_codex_tier_whitelist_integrity():
     """The per-tier codex table (issue 05). Guards the D-f data rules: every populated tier is
     real vendor `PlanType` vocabulary; rows are non-empty, duplicate-free, and inside the flat
@@ -9244,6 +9265,48 @@ def test_static_api_caps_openai_advertises_both_endpoints():
     assert entry["endpoints"] == ["chat/completions", "responses"]
 
 
+def test_static_api_caps_openai_advertises_output_cap_feature():
+    """Issue 06b: the openai caps envelope advertises the `output_cap` routing FEATURE — the engine
+    honours a Responses `max_output_tokens` cap — sourced from the kind's `unsupported_params` via
+    `kind_honours_output_cap`. This is the CLI half of the hand-duplicated wire literal grid-src's
+    auto-router filters on; absent here, a capped `auto` request would wrongly exclude the openai
+    engine that can in fact cap. Distinct from the numeric `max_output_tokens` limit already in the
+    envelope — this is the boolean the responses auto-branch keys on."""
+    from remote import serve
+
+    entry = serve._static_api_caps("openai", ["openai:gpt-5.5"])["models"]["openai:gpt-5.5"]
+    assert entry["features"]["output_cap"] is True
+
+
+def test_static_api_caps_codex_omits_output_cap_feature():
+    """The codex seat cannot honour an output cap under any name (facts.md #1), so its envelope must
+    NOT advertise `output_cap` — a capped `auto` request then excludes it (fail closed). Guards the
+    layer-2/layer-3 agreement: the routing feature and the engine gate read the same catalog fact,
+    so codex omitting the param means codex omitting the feature."""
+    from remote import serve
+
+    caps = serve._static_api_caps("codex", ["codex:gpt-5.5"], plan_type="free")
+    entry = caps["models"]["codex:gpt-5.5"]
+    assert "output_cap" not in entry["features"]
+
+
+def test_static_api_caps_stale_openai_model_fails_closed_on_output_cap():
+    """Fail-closed on degrade (issue 06b): a model gone from the whitelist between join and respawn
+    degrades to an all-False features dict — so even though the `openai` KIND honours the cap, the stale
+    model advertises `output_cap: False` and a capped `auto` request excludes the anomaly rather than
+    routing to a likely-broken model. Pins the `entry is not None and kind_honours_output_cap(...)`
+    short-circuit DIRECTLY at the unit layer: a future 'simplification' that drops the entry guard
+    (advertising True for a model we cannot resolve) fails here, not only through the slower
+    `_bring_up_engines` integration path (test_bring_up_engines_api_model_gone_from_whitelist_...)."""
+    from remote import serve
+
+    # KIND-level: openai honours the cap...
+    assert api_catalog.kind_honours_output_cap("openai") is True
+    # ...but a model absent from the whitelist degrades all-False, so its advertised feature is False.
+    entry = serve._static_api_caps("openai", ["openai:not-a-real-model"])["models"]["openai:not-a-real-model"]
+    assert entry["features"]["output_cap"] is False
+
+
 def test_serve_codex_seat_holder_primes_from_the_store_and_self_heals(monkeypatch, tmp_path):
     """ADR 0015 D-d: the codex credential lives OUTSIDE the routing snapshot, in a per-kind holder
     on the serve state — a rotation must not rebuild routing or race a hot-reload swap. The holder
@@ -10941,6 +11004,10 @@ def test_bring_up_engines_api_model_gone_from_whitelist_warns_and_degrades(monke
     assert upstream == ["gpt-5.5", "gpt-legacy"]  # prefix-strip fallback still rewrites sanely
     legacy = caps["models"]["openai:gpt-legacy"]
     assert all(v is False for v in legacy["features"].values())  # degraded, not crashed
+    # issue 06b: `output_cap` is a per-KIND fact, but a model gone from the whitelist fails CLOSED —
+    # its degraded features are all-False, so a capped `auto` request excludes the anomaly rather than
+    # routing to a likely-broken model. (`endpoints` stays per-kind; the features dict does not.)
+    assert legacy["features"]["output_cap"] is False
     err = capsys.readouterr().err
     assert "openai:gpt-legacy" in err and "whitelist" in err  # ...and the degrade is observable
 


### PR DESCRIPTION
## What

The **public-CLI** half of `extend-responses-api` — `/responses` becomes an engine capability any engine
can hold (hardware: llama.cpp / Ollama / vLLM; and the `openai` API engine), **discovered by a join-time
probe**, instead of a property only the codex seat has. Pairs with the grid-src (master) PR #8 (already
merged to main). Deploy the master **before this CLI is released (tagged)** per ADR 0018 §11 — merging
this to `main` is safe now; the version tag waits for the master deploy.

## Commits (12)

- `886c2df` **issue 01** — ADR 0018: responses as an engine capability · `c95d843` ADR 0017 (auto-router
  resilience) · `650bd7d` ADR 0018 cap-filter addendum
- `f9d98f7` **issue 02** — extract the shared Responses streaming forward out of the codex-seat path
- `4b8ae4f` **issue 03** — serve streaming Responses on the openai API engine
- `d79117a` **issue 04** — honour the Responses output cap per engine kind
- `eeda34c` **issue 05** — serve non-streaming Responses on the engine, refuse it for the seat + string input
- `b0ac25d` **issue 06** — surface the Responses dialect in the API-engine catalog listing
- `7e905d9` **issue 06b** — exclude cap-incapable engines from capped Responses `auto` routing
- `4b1c471` **issue 08** — discover hardware Responses capability by a join-time probe (per-ENGINE capability)
- `7e40d3e` **issue 10** — show which live models serve Responses in `grid models`
- `1a25d7b` **issue 06c** — exclude the stream-only seat from non-streaming Responses `auto` (`stream_only` trait)

## Test plan

- Unit: `test_local_cli.py` **778** passed; full `tests/` green.
- **Live Phase-2 E2E gate PASSED** (2026-07-23, dev VM) — **this CLI drove the run**: join-time probe advertises
  a hardware engine's `/responses`, per-engine surface (stream/non-stream/string/cap), 06c seat exclusion,
  live-display `responses` badge, negative case. The grid-src PR #8 covers the relay side.
- **Phase-1 vendor-API E2E gate** passed earlier (issue 07).

## Rollout

Master (grid-src PR #8) **deployed before** this CLI is **released (version tag)** — an old relay would
silently enforce seat restrictions on a hardware engine (ADR 0018 §11). Old CLIs fail closed by design.

## Merge style

**Merge commit, not squash.**
