### PR TITLE
feat: dynamic codex catalog — live-probe serving + seat-aware catalog (issue 10a/10b)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ remote/CONTEXT.md
 local/CONTEXT.md
 .worktreeinclude
 guides/
+CLAUDE.md

--- a/cli/models.py
+++ b/cli/models.py
@@ -4,9 +4,13 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # runtime imports stay lazy inside the handlers
+    from remote.codex_oauth import CodexBundle
+    from remote.codex_probe import CodexModel
     from shared.models import api_catalog
 
 
@@ -113,65 +117,237 @@ def _catalog_api(args: argparse.Namespace) -> int:
     return 0
 
 
-def _catalog_codex(kind: str, whitelist: api_catalog.ApiWhitelist, as_json: bool) -> int:
-    """The codex catalog: the per-tier table, offline (ADR 0012 D-a — no credential, no network).
+@dataclass(frozen=True)
+class _CodexPlanBlock:
+    """The signed-in seat's current-plan slice for `grid catalog --api codex` (issue 10b), with the
+    provenance needed to render + mark it. Invariant, guaranteed by construction in
+    ``_codex_current_plan``: a fresh probe → ``live=True, fetched_at=None, warning=None``; a cache
+    fallback → ``live=False`` with ``fetched_at`` and ``warning`` set; no data at all (offline+no
+    cache, rejected+no cache, or no seat) → ``models=None`` + ``warning``. ``models=()`` (NOT ``None``)
+    is a real, empty seat. Folding these five into one type keeps the two renderers at three params and
+    makes the invariant type-checkable rather than doc-only."""
 
-    Only verified tiers are printed; every other tier — unknown, unrecognized, or simply not yet
-    verified — advertises the minimal set at join time (ADR 0015 D-f), and the fallback rule is
-    stated rather than left for the operator to discover at join.
+    plan_type: str | None
+    models: tuple[CodexModel, ...] | None
+    live: bool
+    fetched_at: float | None
+    warning: str | None
+
+
+def _catalog_codex(kind: str, whitelist: api_catalog.ApiWhitelist, as_json: bool) -> int:
+    """The seat-aware codex catalog (issue 10b): the current plan's REAL entitlement from a free
+    `GET /models` when signed in + online (cached for offline), plus the illustrative cross-plan
+    reference of what every plan can serve. No `--live` flag — one automatic path. It NEVER dies on a
+    probe failure: offline / a rejected seat / no seat all fall back to the cache then the static
+    reference, always with a warning (issue 10b Q2). This is the documented departure from ADR 0012
+    D-a's "no network" posture for the codex kind — one free GET, spending nothing.
     """
+    from remote import api_keys
+
+    bundle = api_keys.load_codex_bundle()
+    block = _codex_current_plan(bundle, whitelist)
+    if as_json:
+        return _catalog_codex_json(kind, whitelist, block)
+    return _catalog_codex_human(kind, whitelist, block)
+
+
+def _codex_current_plan(
+    bundle: CodexBundle | None, whitelist: api_catalog.ApiWhitelist
+) -> _CodexPlanBlock:
+    """Resolve the current-plan block, NEVER raising (issue 10b Q2). A fresh probe also (re)writes the
+    cache, scoped to this seat's account fingerprint; on any probe failure it falls back to that
+    seat's cache (if present) then to the static reference, each with a warning.
+    """
+    from remote import codex_models_cache, codex_probe
     from shared.models import api_catalog
 
-    if as_json:
-        # Explicit keys — the stable machine-readable contract (ADR 0012). Per-tier kinds speak
-        # `tiers`, not the flat `models`; no chat-dialect keys (a Responses passthrough cannot
-        # honestly claim them either way); `supports_parallel_tool_calls` comes from the same
-        # `codex_features` derivation the capability envelope uses, so the two cannot disagree.
-        print(json.dumps({
-            "kind": kind,
-            "last_verified": whitelist.last_verified,
-            "endpoints": list(whitelist.endpoints),
-            "minimal_tier": api_catalog.CODEX_MINIMAL_TIER,
-            "tiers": {
-                tier: [
-                    {
-                        "advertised": api_catalog.advertised_name(kind, entry),
-                        "vendor_name": entry.vendor_name,
-                        "context_window": entry.context_window,
-                        "supports_tools": entry.supports_tools,
-                        "supports_vision": entry.supports_vision,
-                        "supports_parallel_tool_calls": api_catalog.codex_features(entry)["parallel_tool_calls"],
-                        "notes": entry.notes,
-                    }
-                    for entry in entries
-                ]
-                for tier, entries in api_catalog.CODEX_TIER_MODELS.items()
-            },
-        }, indent=2))
-        return 0
+    plan_type = bundle.plan_type if bundle is not None else None
+    if bundle is None:
+        return _CodexPlanBlock(
+            plan_type=None, models=None, live=False, fetched_at=None,
+            warning=(
+                "Not signed in to a codex seat — showing illustrative data. Run "
+                "`grid join --api codex` to sign in and confirm your real entitlement."
+            ),
+        )
+
+    client_version = api_catalog.CODEX_CLIENT_VERSION
+    try:
+        live = codex_probe.probe_seat(
+            bundle, base_url=whitelist.base_url, client_version=client_version,
+        )
+    except codex_probe.SeatRejected as rejected:
+        warning = (
+            f"Your codex seat was rejected (HTTP {rejected.status_code}) — re-run "
+            "`grid join --api codex` to sign in again. Showing your last cached set + the "
+            "illustrative reference."
+        )
+    except SystemExit:
+        # `probe_seat` raises SystemExit for offline / 429 / 5xx / contract-drift — its documented
+        # terminal-error TAXONOMY (every `raise SystemExit` in remote/codex_probe.py is one of those
+        # classes). The catalog is read-only and MUST render something (Q2), so we catch that taxonomy,
+        # DISCARD the join-oriented message, and fall back with a generic warning — ALWAYS a visible
+        # warning, never a silent swallow. NOTE: this catch is by-TYPE; if a future change adds a
+        # `raise SystemExit` to probe_seat's call graph for an UNRELATED reason (e.g. a bug-guard), it
+        # would be mislabeled "couldn't reach your seat" — re-check this catch against that taxonomy.
+        warning = (
+            "Couldn't reach your codex seat — showing cached/illustrative data; sign in online to "
+            "confirm your entitlement."
+        )
+    else:
+        codex_models_cache.write_cache(
+            live, client_version=client_version, account_id=bundle.account_id,
+        )
+        return _CodexPlanBlock(plan_type=plan_type, models=live, live=True, fetched_at=None, warning=None)
+
+    cached = codex_models_cache.read_cache(
+        client_version=client_version, account_id=bundle.account_id,
+    )
+    if cached is not None:
+        return _CodexPlanBlock(
+            plan_type=plan_type, models=cached.models, live=False,
+            fetched_at=cached.fetched_at, warning=warning,
+        )
+    return _CodexPlanBlock(
+        plan_type=plan_type, models=None, live=False, fetched_at=None, warning=warning,
+    )
+
+
+def _entry_from_codex_model(model: CodexModel) -> api_catalog.ApiModelEntry:
+    """Adapt a probe/cache ``CodexModel`` to an ``ApiModelEntry`` so live/cached rows reuse
+    ``format_api_entry``. Lives here, not in shared/, which must not import remote/'s ``CodexModel``.
+    Codex is a Responses passthrough, so json/structured are always False (the envelope omits them
+    elsewhere); an unknown ``context_window`` (0) renders `—`."""
+    from shared.models import api_catalog
+
+    return api_catalog.ApiModelEntry(
+        vendor_name=model.slug,
+        context_window=model.context_window,
+        supports_tools=model.supports_tools,
+        supports_vision=model.supports_vision,
+        supports_json_mode=False,
+        supports_structured_outputs=False,
+    )
+
+
+def _codex_plan_heading(plan_type: str | None, suffix: str) -> str:
+    label = f" ({plan_type})" if plan_type else ""
+    return f"Your current plan{label} — {suffix}:"
+
+
+def _catalog_codex_human(
+    kind: str, whitelist: api_catalog.ApiWhitelist, block: _CodexPlanBlock
+) -> int:
+    import time
+
+    from shared.models import api_catalog
+
+    if block.warning:
+        # Warnings go to STDERR so `grid catalog --api codex 2>/dev/null` yields a clean listing (every
+        # sibling warning in this feature — write_cache's note, the probe recovery notice — is already
+        # stderr). `--json` carries the warning as a field, so it is unaffected by this split.
+        print(f"⚠ {block.warning}\n", file=sys.stderr)
+
+    if block.models is not None:
+        if block.live:
+            print(_codex_plan_heading(block.plan_type, "live, from your seat"))
+        else:
+            when = (
+                time.strftime("%Y-%m-%d %H:%M", time.localtime(block.fetched_at))
+                if block.fetched_at else ""
+            )
+            print(_codex_plan_heading(block.plan_type, f"cached {when}".rstrip()))
+        if block.models:
+            for model in block.models:
+                print(api_catalog.format_api_entry(
+                    kind, _entry_from_codex_model(model), whitelist.endpoints,
+                ))
+        else:
+            print("  (your seat currently serves no models)")
+        print()
 
     print(
-        f"Models a `grid join --api {kind}` would serve, by subscription tier "
-        f"(verified {whitelist.last_verified}):"
+        f"All codex plans (illustrative — pricing docs {api_catalog.CODEX_REFERENCE_LAST_VERIFIED}, "
+        f"{api_catalog.CODEX_PRICING_DOCS_URL} — verify against a paid seat):"
     )
-    for tier, entries in api_catalog.CODEX_TIER_MODELS.items():
-        print()
-        print(f"{tier}:")
-        for entry in entries:
-            print(api_catalog.format_api_entry(kind, entry, whitelist.endpoints))
+    _print_codex_reference(kind, whitelist)
     print()
     print(
-        "Tiers not listed are unverified in this release — a seat on one advertises the "
-        f"`{api_catalog.CODEX_MINIMAL_TIER}` set, as does a seat whose tier its token doesn't say."
+        f"{kind} models serve the vendor's `responses` endpoint — point an external Codex app at "
+        "your grid; `grid chat` cannot call them."
     )
     print(
-        f"No sign-in needed to view. {kind} models serve the vendor's `responses` endpoint — "
-        "point an external Codex app at your grid; `grid chat` cannot call them."
+        f"Requests to {kind}:* models leave the grid for the vendor and spend the seat's own monthly "
+        "allowance."
     )
-    print(
-        f"Requests to {kind}:* models leave the grid for the vendor and spend the seat's own "
-        "monthly allowance."
-    )
+    return 0
+
+
+def _print_codex_reference(kind: str, whitelist: api_catalog.ApiWhitelist) -> None:
+    """The cross-plan reference in delta style: the free set under `free / go`, then each higher plan's
+    ADDITIONS over the previous one, then the note that Business/Enterprise/Edu match Plus."""
+    from shared.models import api_catalog
+
+    shown: set[str] = set()
+    for plan, entries in api_catalog.CODEX_TIER_MODELS.items():
+        additions = [entry for entry in entries if entry.vendor_name not in shown]
+        suffix = "" if not shown else " (added over the previous plan)"
+        print(f"\n{plan}:{suffix}")
+        for entry in additions:
+            print(api_catalog.format_api_entry(kind, entry, whitelist.endpoints))
+        shown.update(entry.vendor_name for entry in entries)
+    print("\nBusiness / Enterprise / Edu serve the same set as Plus.")
+
+
+def _codex_json_row(kind: str, entry: api_catalog.ApiModelEntry, live: bool) -> dict[str, object]:
+    """One `--json` row. `context_window` is null when unknown (the `0` sentinel) — uniformly, for
+    both the live `current_plan` rows and the illustrative `tiers` rows — never a fabricated 0.
+
+    Deliberately leaner than the pre-10b codex row: `supports_parallel_tool_calls` is dropped (it was
+    fully derived — always == supports_tools for codex, remote/probe.codex_features) and so is `notes`
+    (illustrative-caveat prose now carried by the row's `live` flag + the envelope's source_url /
+    last_verified). Don't reintroduce them: the caps ENVELOPE hand-duplicated with grid-src is a
+    separate surface and stays unchanged."""
+    from shared.models import api_catalog
+
+    return {
+        "advertised": api_catalog.advertised_name(kind, entry),
+        "vendor_name": entry.vendor_name,
+        "context_window": entry.context_window if entry.context_window > 0 else None,
+        "supports_tools": entry.supports_tools,
+        "supports_vision": entry.supports_vision,
+        "live": live,
+    }
+
+
+def _catalog_codex_json(
+    kind: str, whitelist: api_catalog.ApiWhitelist, block: _CodexPlanBlock
+) -> int:
+    from shared.models import api_catalog
+
+    current_plan = None
+    if block.models is not None:
+        current_plan = {
+            "plan_type": block.plan_type,
+            "live": block.live,
+            "fetched_at": block.fetched_at,
+            "models": [
+                _codex_json_row(kind, _entry_from_codex_model(m), block.live) for m in block.models
+            ],
+        }
+    tiers = {
+        plan: [_codex_json_row(kind, entry, False) for entry in entries]
+        for plan, entries in api_catalog.CODEX_TIER_MODELS.items()
+    }
+    print(json.dumps({
+        "kind": kind,
+        "source_url": api_catalog.CODEX_PRICING_DOCS_URL,
+        "last_verified": api_catalog.CODEX_REFERENCE_LAST_VERIFIED,
+        "endpoints": list(whitelist.endpoints),
+        "warning": block.warning,
+        "current_plan": current_plan,
+        "tiers": tiers,
+    }, indent=2))
     return 0
 
 

--- a/cli/remote_provider.py
+++ b/cli/remote_provider.py
@@ -30,7 +30,7 @@ from shared.models import api_catalog
 
 if TYPE_CHECKING:  # runtime imports of remote.* stay lazy (see the module docstring)
     from remote.codex_oauth import CodexBundle
-    from remote.codex_probe import SeatRejected
+    from remote.codex_probe import CodexModel, SeatRejected
 
 # Remote has exactly ONE identity per grid: the relay node_id is pinned to the per-grid access token
 # (remote/serve._node_id_from_token), so two `grid join`s on a grid would register the same node and
@@ -263,9 +263,10 @@ def _resolve_api_targets(
     from remote import api_keys  # lazy: only stdlib + shared.* at module top (see module docstring)
 
     if kind == api_keys.CODEX_KIND:
-        # `requested`, not `chosen`: codex's no--m default is the seat's TIER row ∩ its live set
-        # (D-f), which the resolver computes itself — the union default here would name paid-tier
-        # models a lesser seat can never serve.
+        # `requested`, not `chosen`: codex's no--m default is the seat's LIVE PROBE set (issue 10a —
+        # the resolver probes and computes it itself, no static intersection), so the `chosen =
+        # list(valid)` union default is wrong here — it would name static-table models the live seat
+        # may not actually serve.
         return _resolve_codex_targets(args, whitelist, requested, network_id)
     return _resolve_key_api_targets(args, kind, whitelist, valid, chosen)
 
@@ -284,7 +285,7 @@ def _resolve_codex_targets(
     ``GET {base}/models`` probe — egress reachability + seat liveness + the seat's real entitled
     set in one round-trip — not the key path's ``GET /v1/models``.
     """
-    from remote import api_keys
+    from remote import api_keys, codex_models_cache
 
     from . import codex_signin
 
@@ -314,29 +315,44 @@ def _resolve_codex_targets(
             "`grid join --api codex`. Nothing was changed."
         )
     if (
-        live_codex is not None and not fresh
+        live_codex is not None and not fresh and live_codex.get("model_caps")
         and (not requested or set(requested) <= set(live_codex.get("models") or []))
     ):
-        # Same credential, no model beyond the live union — nothing a probe could inform. (A -m
-        # SUBSET is unchanged too: narrowing is leave-then-rejoin by design, a join only ever
-        # adds.) The mandated tier warn still fires: a degraded tier must resurface on EVERY
-        # join, not once at the first one (silent-failure review #4). The spec's models list is
-        # copied so the returned spec can never alias the live record's own list.
-        _warn_codex_tier(bundle.plan_type)
-        return [{**live_codex, "models": list(live_codex.get("models") or [])}], False
+        # Same credential, no model beyond the live union, AND the live spec already carries
+        # probe-derived caps — nothing a probe could inform. (A -m SUBSET is unchanged too:
+        # narrowing is leave-then-rejoin by design, a join only ever adds.) The `model_caps` guard
+        # forces a re-probe when the live record predates issue 10a (no caps recorded): skipping it
+        # there would leave the serving side advertising every model fail-closed. The spec's models
+        # list AND model_caps are copied so the returned spec can never alias the live record's own
+        # mutable fields (the immutability rule its sibling `models` already follows).
+        return [{
+            **live_codex,
+            "models": list(live_codex.get("models") or []),
+            "model_caps": dict(live_codex.get("model_caps") or {}),
+        }], False
 
     live, bundle, fresh = _probe_codex_seat_with_recovery(args, whitelist, bundle, fresh)
-    served = _select_codex_models(bundle.plan_type, requested, live)
+    # Cache the fresh probe (issue 10b), scoped to this seat's account fingerprint: an offline
+    # `grid catalog --api codex` then shows the seat's real last-known set instead of only the static
+    # reference. Best-effort inside the writer — a cache-write failure never fails the join. Written
+    # HERE, after a real probe — the probe-skip early-return above never reaches this line, so an
+    # unchanged re-join keeps the last real cache.
+    codex_models_cache.write_cache(
+        live, client_version=api_catalog.CODEX_CLIENT_VERSION, account_id=bundle.account_id,
+    )
+    served, model_caps = _select_codex_models(requested, live)
     return [{
         "endpoint_url": whitelist.base_url,
         "models": served,
         "engine_label": api_keys.CODEX_KIND,
         "api_kind": api_keys.CODEX_KIND,
-        # The seat's tier, so serve can recompute each model's vendor_rank from the SAME tier row
-        # the advertised set was picked from (issue 03). A short plan-label string (the seat's raw
-        # tier claim), never a secret; `None` (vendor said nothing) rides through and degrades to
-        # the minimal row at serve time.
+        # The seat's tier — a display/message label only now (issue 10a: serving no longer gates on
+        # it). A short plan string (the seat's raw claim), never a secret; `None` rides through.
         "plan_type": bundle.plan_type,
+        # The probe-derived per-model caps the serving side reads to build the capability envelope,
+        # now that no static table exists to look them up from (issue 10a). Non-secret routing data
+        # — model names + context_window/vision/tools/vendor_rank, never a token or the account id.
+        "model_caps": model_caps,
     }], fresh
 
 
@@ -345,14 +361,14 @@ def _probe_codex_seat_with_recovery(
     whitelist: api_catalog.ApiWhitelist,
     bundle: CodexBundle,
     fresh: bool,
-) -> tuple[tuple[str, ...], CodexBundle, bool]:
+) -> tuple[tuple[CodexModel, ...], CodexBundle, bool]:
     """D-f's probe, with the ONE recovery issue 05 allows: a STORED seat the vendor rejects gets
     a single fresh sign-in and one re-probe, interactive runs only (the PRD's sign-in inline
     "when the stored one is dead" — without it, a dead stored bundle makes every re-join load the
     same corpse and fail forever, since no other re-sign-in verb exists). A fresh seat failing, a
     second failure, or a non-interactive run gets the terminal auth-class message. Returns
-    ``(live_slugs, bundle, fresh)`` — the bundle and freshness the join must proceed with, since
-    a recovery re-mints both.
+    ``(live_records, bundle, fresh)`` — the probe's rich per-model records, plus the bundle and
+    freshness the join must proceed with, since a recovery re-mints both.
     """
     from remote import codex_probe
 
@@ -391,88 +407,49 @@ def _codex_seat_rejected(rejected: SeatRejected) -> str:
     )
 
 
-def _warn_codex_tier(plan_type: str | None) -> None:
-    """The issue's mandated tier warn (ADR 0015 D-f amendments): it fires HERE, at the moment the
-    tier picks the advertised row — not at sign-in, where the tier has no consumer yet. Three
-    degrade cases, three wordings — the operator's diagnosis differs, the advertised row doesn't:
-
-    * ``None`` — the vendor said NOTHING. Loud, because a vendor rename of the tier claim decays
-      to exactly this (``decode_seat`` degrades a renamed field to None by design), and without
-      this line every seat would quietly advertise the minimal set forever.
-    * unrecognized — the vendor said something outside its own known vocabulary (drift).
-    * known-but-unverified — our table simply has no verified row yet; informational, not a warn.
-
-    A populated known tier prints nothing. Only the LAST case may echo the tier: it is a member
-    of the closed ``CODEX_PLAN_TYPES`` vocabulary, so the echo cannot carry arbitrary token text.
-    """
-    minimal = api_catalog.CODEX_MINIMAL_TIER
-    if plan_type is None:
-        print(
-            "Warning: this codex seat is signed in but reports no subscription tier — the vendor "
-            f"may have changed its token format. Advertising the minimal ('{minimal}') model set; "
-            "if your plan should serve more, check for a newer grid release.",
-            file=sys.stderr,
-        )
-    elif plan_type not in api_catalog.CODEX_PLAN_TYPES:
-        print(
-            "Warning: this codex seat reports a subscription tier this grid release doesn't "
-            f"recognize — advertising the minimal ('{minimal}') model set.",
-            file=sys.stderr,
-        )
-    elif plan_type not in api_catalog.CODEX_TIER_MODELS:
-        print(
-            f"The '{plan_type}' tier's model list isn't verified in this grid release yet — "
-            f"advertising the verified '{minimal}' set.",
-            file=sys.stderr,
-        )
-
-
 def _select_codex_models(
-    plan_type: str | None, requested: list[str], live: tuple[str, ...]
-) -> list[str]:
-    """The advertised set: the seat's tier row ∩ its live entitled set ∩ any explicit ``-m``
-    request (ADR 0015 D-f). The tier row bounds advertising no matter what the seat can reach —
-    an unverified model must never be advertised on a guess."""
+    requested: list[str], live: tuple[CodexModel, ...]
+) -> tuple[list[str], dict[str, dict[str, object]]]:
+    """The advertised set + its persisted caps, straight from the seat's live probe (issue 10a — no
+    static tier intersection; the probe IS the source of truth for both the set and its caps).
+
+    Membership is the probe set. An explicit ``-m`` for a model the seat can't serve is REFUSED,
+    never silently narrowed (the deliberate divergence from openai's skip), naming what the probe
+    set CAN serve. Returns ``(served advertised names, model_caps)`` where ``model_caps[advertised]``
+    is the caps the serving side reads from the run record — ``context_window``/``vision``/``tools``
+    derived from the probe, and ``vendor_rank`` = the model's 1-based position in the probe's visible
+    order (vendor/priority order, the curated ordering today's ranking reproduces).
+    """
     kind = api_catalog.CODEX_KIND
-    tier = api_catalog.codex_effective_tier(plan_type)
-    _warn_codex_tier(plan_type)
-    valid = {
-        api_catalog.advertised_name(kind, entry): entry
-        for entry in api_catalog.CODEX_TIER_MODELS[tier]
+    # Caps for the WHOLE probe set (not just the -m subset): an additive re-join unions this engine's
+    # models, so the persisted caps must cover every entitled model or a later `-m` append would union
+    # a model whose caps this write dropped. `vendor_rank` = 1-based probe order (vendor/priority).
+    model_caps: dict[str, dict[str, object]] = {
+        f"{kind}:{model.slug}": {
+            "context_window": model.context_window,
+            "vision": model.supports_vision,
+            "tools": model.supports_tools,
+            "vendor_rank": index + 1,
+        }
+        for index, model in enumerate(live)
     }
-    # An explicit ask is refused, never silently narrowed (issue 05 — deliberate divergence from
-    # openai's skip: a personal seat asked for a model it lacks deserves a refusal, and a silent
-    # subset would advertise less than the operator believes they joined).
-    outside_tier = [model for model in requested if model not in valid]
-    if outside_tier:
-        # The tier bound (D-f): only a verified row may be advertised, whatever the seat can
-        # reach — so this is refused even when the live set contains the model.
+    outside = [model for model in requested if model not in model_caps]
+    if outside:
+        # A personal seat asked for a model it can't serve deserves a refusal, not a silent subset.
+        # Name what the seat CAN serve (the probe set) so the operator isn't left guessing.
         raise SystemExit(
-            f"Not in the '{tier}' tier's verified list: {', '.join(outside_tier)}. "
-            f"This seat's tier can serve: {', '.join(valid)}. Nothing was joined."
+            f"Not available on this codex seat: {', '.join(outside)}. "
+            f"This seat can serve: {', '.join(model_caps) or '(none)'}. Nothing was joined."
         )
-    target = requested or list(valid)
-    served = [model for model in target if valid[model].vendor_name in live]
-    missing = [model for model in target if model not in served]
-    if requested and missing:
-        available = [model for model in valid if valid[model].vendor_name in live]
-        # Never "serves none" here — the seat may well serve OTHER verified models, and the
-        # actionable fact is which ones.
+    served = requested or list(model_caps)
+    if not served:
+        # The no--m default found nothing: the seat's live listing is empty (every model hidden or
+        # API-unsupported). Nothing was "requested", so no name is blamed.
         raise SystemExit(
-            f"Not available on this codex seat: {', '.join(missing)}. "
-            f"This seat can serve: {', '.join(available) or '(none of the verified models)'}. "
+            "This codex seat currently serves no models — its live listing is empty. "
             "Nothing was joined."
         )
-    if not served:
-        # The no--m default found nothing: name the verified row so the operator sees what a
-        # serving seat WOULD have offered (nothing was "requested", so no name is blamed).
-        raise SystemExit(
-            f"This codex seat currently serves none of the verified '{tier}'-tier models: "
-            f"{', '.join(valid)}. Nothing was joined."
-        )
-    if missing:
-        print(f"Skipping (not on this seat): {', '.join(missing)}", file=sys.stderr)
-    return served
+    return served, model_caps
 
 
 def _resolve_key_api_targets(
@@ -706,6 +683,8 @@ def _merge_engines(
         if existing is None:
             copy = dict(spec)
             copy["models"] = list(copy.get("models") or [])
+            if "model_caps" in copy:  # a fresh dict, like models above — never alias the incoming spec
+                copy["model_caps"] = dict(copy["model_caps"])
             merged.append(copy)
             index[_spec_key(copy)] = copy
             changed = True
@@ -714,13 +693,20 @@ def _merge_engines(
         if added:
             existing["models"] = list(existing.get("models") or []) + added
             changed = True
-        # A re-join re-resolves the seat's scalar facts too: refresh plan_type (the codex tier —
-        # issue 03) from the incoming spec, or the engine ranks against the tier it FIRST joined at
-        # forever (serve reads vendor_rank off this stored field). A same-key engine is the same
-        # seat, so the freshly-resolved value is authoritative. Key-guarded so a non-codex spec,
-        # which never carries plan_type, stays byte-identical.
+        # A re-join re-resolves the seat's scalar facts too: refresh plan_type (the seat's tier
+        # label) and model_caps (the probe-derived per-model caps serve reads from the record —
+        # issue 10a) from the incoming spec, or the engine would keep the caps/rank it FIRST joined
+        # with forever. A same-key engine is the same seat, so the freshly-probed values are
+        # authoritative. Key-guarded so a non-codex spec, which carries neither, stays byte-identical.
         if "plan_type" in spec:
             existing["plan_type"] = spec["plan_type"]
+        if "model_caps" in spec:
+            # UNION, not replace: `existing["models"]` only ever GROWS (above), so a model still in
+            # the union but dropped by a shrunk fresh re-probe must keep its last-known caps rather
+            # than silently degrade to the fail-closed serve entry. Incoming caps win for a re-probed
+            # model; a model absent from the fresh probe keeps its prior entry. A fresh dict (never a
+            # mutate of either side) so the write can't alias the live record or the incoming spec.
+            existing["model_caps"] = {**(existing.get("model_caps") or {}), **spec["model_caps"]}
     return merged, changed
 
 

--- a/docs/adr/0012-api-engines.md
+++ b/docs/adr/0012-api-engines.md
@@ -33,6 +33,20 @@ the only place the CLI itself calls OpenAI. Rejected: a control-plane catalog AP
 (needless moving part for a small curated table; keeping it current is a data edit
 verified against vendor docs, not a live probing subsystem).
 
+> **Amended 2026-07-24 (issue 10b — dynamic codex catalog;
+> `.scratch/codex-subs/PRD-issue-10-dynamic-catalog.md`).** The "no key, no network call" posture
+> holds for the openai kind but is **relaxed for codex**: `grid catalog --api codex` is now
+> **seat-aware**. When a codex seat is signed in it makes ONE free `GET /models` probe (spending
+> nothing) to show the current plan's REAL entitlement, marked live, then writes a grid-side cache
+> (`~/.grid/codex_models_cache.json`, `0o600`, scoped to the seat). Offline or a rejected seat fall
+> back to that cache, then to a static, **illustrative** cross-plan reference encoded from the pricing
+> docs; with **no seat signed in** it shows the illustrative reference directly (the cache is a
+> signed-in seat's entitlement) — always with a warning. There is **no `--live` flag**; the behaviour
+> is automatic. The static table stopped
+> being a serving gate in issue 10a (the live probe is the source of truth for the served set); it
+> survives ONLY as the illustrative reference. The catalog never dies on a probe failure — a read-only
+> surface always renders the cache or the reference.
+
 Curation rule: the current flagship family plus mini/nano variants and the reasoning
 series (which, as of the GPT-5.x lineup, is folded into the flagship family rather than
 a separate o-series); excludes audio/realtime, embeddings, image, moderation, and

--- a/docs/adr/0015-codex-subscription-engine.md
+++ b/docs/adr/0015-codex-subscription-engine.md
@@ -474,6 +474,43 @@ poll-worker default of 8 does **not** apply to codex — a codex-containing unio
 >   ALL api kinds — the codex URL-mismatch refusal above sidesteps it for codex; openai keeps
 >   the historic behavior.
 
+> **Amended 2026-07-24 (issue 10a — the live probe is the source of truth; `.scratch/codex-subs/
+> PRD-issue-10-dynamic-catalog.md`).** D-f's safety rule **flips**: the guarantee is now "an
+> unverified **capability** fails closed", NOT "an unverified **model** is refused". The static
+> tier table stops being a serving gate.
+>
+> - **Served set = the seat's live `GET /models` probe, with NO static intersection.** Membership is
+>   the probe rows where `visibility != "hide"` **and** `supported_in_api is not False` — an
+>   explicit vendor `false` excludes (a model that would 400 if called), but an ABSENT field serves
+>   (never fail closed on a *model*; real bodies always send `true`). A model the seat is entitled to
+>   is served the day the vendor ships it — no CLI edit, no PR — and a paid seat serves its real
+>   entitlement instead of degrading to the free four.
+> - **Caps are DERIVED from the probe and PERSISTED in the run record at join** (`model_caps`:
+>   advertised name → `context_window`/`vision`/`tools`/`vendor_rank`), because the serving side no
+>   longer has a static table to look them up from. `_static_api_caps` reads them from the record;
+>   `vendor_rank` = the model's 1-based position in the probe's visible order (reproduces the curated
+>   order). A model absent from `model_caps` degrades to the responses-only fail-closed entry + a
+>   warn (the stale-catalog posture). An unknown `context_window` (the `0` sentinel) is **omitted**
+>   from the envelope, never fabricated — `codex_capability_entry` now uses the `capability_entry`
+>   conditional-key idiom. `endpoints: ["responses"]` stays byte-for-byte (grid-src lockstep).
+> - **An explicit `-m` miss is still refused, never silently narrowed** — but the "can serve" list
+>   now names the **probe** set, not a tier row.
+> - **The tier machinery is removed** (`codex_effective_tier` / `codex_tier_entries` /
+>   `codex_vendor_rank`, and the whole `_warn_codex_tier` "tier not verified" warning set): with
+>   membership driven by the probe, its degrade concept is meaningless. `plan_type` survives only as
+>   a display/message label (never gates serving). This **supersedes** the issue-05 "Tier selection"
+>   and "tier warns" bullets above and the review-pass "the verified tier row is what actually bounds
+>   advertising" point — the hide + `supported_in_api` filters are now the sole structural guards, so
+>   a `visibility` rename fails **open on the model** (served, fails visibly per-job), no longer
+>   backstopped by an intersection. **Unverified assumption (security review):** "fails visibly
+>   per-job" leans on the vendor's API rejecting a call to a hidden model — but `codex-auto-review`
+>   being hidden from the vendor's own picker does not *prove* the backend 4xxs a direct call. If it
+>   silently serves, a `visibility` rename would route jobs to a vendor-internal/review model unseen.
+>   Left as a documented risk (settling it needs a live probe), not a code gate — the precondition is
+>   a vendor field rename or an in-trust-store MITM.
+> - The static per-tier table survives ONLY as an illustrative cross-plan reference for
+>   `grid catalog` (issue 10b), display-only; it never gates serving again.
+
 > **Amended 2026-07-16 (issue 06 — as built, provider half).** The provider submits whole event
 > blocks via `remote/serve._iter_event_blocks`, regrouping the vendor's arbitrary socket chunking
 > so each HTTP chunk to the relay is one complete `event:`+`data:` block, blank line included —
@@ -513,6 +550,15 @@ poll-worker default of 8 does **not** apply to codex — a codex-containing unio
   in v1 for either kind.
 - Two grids on one box share one seat: refresh is serialized cross-process; quota and rate
   limits are shared and unmanaged in v1.
+- **Grid-side model cache (issue 10b).** Every successful `GET /models` probe — the join probe AND
+  `grid catalog --api codex`'s own seat-aware probe — is cached to `~/.grid/codex_models_cache.json`
+  (`0o600`; slugs + derived caps only, never a token and never the raw account id), so an offline
+  catalog shows the seat's real last-known set instead of only the illustrative reference. It is
+  scoped to the seat by a one-way SHA-256 FINGERPRINT of the account id (the raw id never touches
+  disk), so a cache written by a DIFFERENT seat on the same box is never shown; it is also invalidated
+  on a `client_version` mismatch (a grid upgrade bumps the pin). Both the write (best-effort) and the
+  read (defensive — corrupt / absent / stale / all-rows-unreadable → `None`, and an out-of-range
+  number degrades rather than raising) fail soft: the catalog never dies on its own cache.
 - A residual brick risk remains by design: a crash after the token exchange returns but
   before the write can still lose the rotation; the journal makes it *detectable* (next
   refresh fails cleanly → "re-run `grid join --api codex` to sign in again"), not

--- a/remote/api_keys.py
+++ b/remote/api_keys.py
@@ -125,13 +125,20 @@ def load_codex_bundle() -> codex_oauth.CodexBundle | None:
     if not str(account_id).strip() or not str(account_id).isprintable():
         return None
     plan_type = entry.get("plan_type")
+    # plan_type is a display/message label that rides onto the operator's terminal (`grid catalog`'s
+    # "Your current plan (…)" heading, issue 10b). Bounded + printable-checked HERE at the LOAD
+    # boundary, exactly as `account_id` is above — a forged/hostile token that stored an ANSI-laden or
+    # oversized tier string can't inject terminal escapes or flood output (CWE-150). Unusable → None
+    # ("unknown tier"), identical to absence. (Real labels are short: `enterprise_cbp_usage_based`.)
+    if not (isinstance(plan_type, str) and plan_type.isprintable() and len(plan_type) <= 64):
+        plan_type = None
     return codex_oauth.CodexBundle(
         access_token=str(access_token),
         refresh_token=str(refresh_token),
         account_id=str(account_id),
         # Absent means "the token never said" — ADR 0015 D-f's minimal whitelist. TOML has no null,
         # so absence is the ONLY way None survives a round-trip (see `store_codex_bundle`).
-        plan_type=plan_type if isinstance(plan_type, str) else None,
+        plan_type=plan_type,
         # `isinstance(True, int)` is True in Python, so an unguarded read would turn `last_refresh =
         # true` into 1 — epoch 1970 — and refresh eagerly forever (the guard `codex_auth` uses on `exp`).
         last_refresh=last_refresh if isinstance(last_refresh, int) and not isinstance(last_refresh, bool) else 0,

--- a/remote/codex_models_cache.py
+++ b/remote/codex_models_cache.py
@@ -1,0 +1,136 @@
+"""The grid-side codex model cache (issue 10b) — ``~/.grid/codex_models_cache.json``.
+
+``grid catalog --api codex`` writes the seat's live ``GET /models`` probe result here after every
+successful probe (the join probe too — ``cli/remote_provider``), and reads it back when the seat is
+offline / the probe fails, so the catalog can still show the seat's LAST-KNOWN real set rather than
+only the illustrative static reference. It mirrors the real codex CLI's ``~/.codex/models_cache.json``
+mechanism — a per-seat cache keyed on the pinned ``client_version`` — MINUS the ``etag`` (the grid
+probes rarely, so it needs no conditional GET), and stores only the DERIVED caps ``probe_seat`` already
+returns (``CodexModel``), not the raw vendor rows (DESIGN §7 as refined by 10b's grill).
+
+Safety, both directions fail SOFT — the catalog must NEVER die on its own cache (issue 10b Q2):
+a write failure never fails the join or the catalog (best-effort), and a corrupt / absent / stale
+file reads back as ``None`` (the catalog then falls to the static reference). The file is the seat's
+entitlement — mildly sensitive but NEVER a token: it carries no access token and no RAW account id
+(only slugs + caps + a one-way account FINGERPRINT that scopes it to the seat), and is written
+``0o600`` through the same hardened atomic writer as the credential store. A grid upgrade bumps
+``client_version``, so a cache from an older grid is treated as stale.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+import time
+from dataclasses import dataclass
+
+from shared import jsonio, paths
+
+# The probe's fail-closed coercions are the canonical ones; the cache read applies exactly the same
+# discipline (a hand-edited/corrupted file is untrusted input like a vendor body) so a cached row and
+# a freshly-probed row can never be interpreted differently.
+from .codex_probe import (
+    CodexModel,
+    _flag,
+    _is_finite_number,
+    _positive_int,
+    _readable_slug,
+)
+
+
+@dataclass(frozen=True)
+class CachedModels:
+    """A past successful probe, read back for an offline ``grid catalog --api codex``."""
+
+    fetched_at: float  # POSIX seconds the probe was written; shown to the operator as "cached <when>"
+    models: tuple[CodexModel, ...]
+
+
+def _account_fingerprint(account_id: str) -> str:
+    """A one-way SHA-256 fingerprint of the seat's account id — NEVER the id itself. It scopes the
+    cache to the seat that wrote it, so an offline `grid catalog --api codex` after switching seats on
+    one box shows the illustrative reference rather than the OTHER seat's models under this seat's plan
+    label (issue 10b). A hash, not the raw id, keeps the file free of any recoverable account identifier
+    (the stated privacy goal); on the seat's own `0o600` file it is a scoping key, not a secret."""
+    return hashlib.sha256(account_id.encode("utf-8")).hexdigest()
+
+
+def write_cache(models: tuple[CodexModel, ...], *, client_version: str, account_id: str) -> None:
+    """Persist a successful probe (``0o600``), best-effort, scoped to the signed-in seat.
+
+    Called after every successful probe (join + catalog-online). A write failure — a read-only home, a
+    full disk — must NEVER fail the caller (the join already succeeded; the catalog already has its
+    answer), so an ``OSError`` is swallowed with one operator breadcrumb. Stores only slugs + derived
+    caps + a one-way account FINGERPRINT — never a token and never the raw account id.
+    """
+    payload = {
+        "fetched_at": time.time(),
+        "client_version": client_version,
+        "account": _account_fingerprint(account_id),
+        "models": [
+            {
+                "slug": m.slug,
+                "context_window": m.context_window,
+                "vision": m.supports_vision,
+                "tools": m.supports_tools,
+            }
+            for m in models
+        ],
+    }
+    try:
+        jsonio.atomic_write_json(paths.codex_models_cache_file(), payload)
+    except OSError as exc:
+        print(
+            f"Note: could not write the codex model cache ({exc}); an offline "
+            "`grid catalog --api codex` will fall back to the illustrative reference.",
+            file=sys.stderr,
+        )
+
+
+def read_cache(*, client_version: str, account_id: str) -> CachedModels | None:
+    """The last cached probe for THIS ``client_version`` AND this seat, or ``None``.
+
+    Deliberately does its OWN defensive read rather than ``jsonio.load_json``: that helper raises
+    ``SystemExit`` on a malformed/unreadable file and returns ``{}`` for an absent one, either of which
+    would crash ``grid catalog --api codex`` — but the catalog must never die on its cache (issue 10b
+    Q2). Every failure mode — absent, unreadable, non-dict, wrong ``client_version``, a fingerprint from
+    a DIFFERENT seat, or a non-empty listing whose rows are ALL unreadable (corruption, mirroring the
+    live probe's contract-drift guard) — collapses to ``None``, and the caller falls back to the static
+    reference. Individual bad rows in an otherwise-readable listing are dropped, not fatal (bad slug →
+    dropped; bad caps field → the conservative claim), exactly as the probe does.
+    """
+    path = paths.codex_models_cache_file()
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            doc = json.load(fh)
+    except (OSError, ValueError):
+        return None  # absent, unreadable, or not valid JSON
+    if not isinstance(doc, dict):
+        return None
+    if doc.get("client_version") != client_version:
+        return None  # a cache from a different (older) grid — stale, never trusted
+    if doc.get("account") != _account_fingerprint(account_id):
+        return None  # written by a DIFFERENT seat on this box — never show one seat's set for another
+    rows = doc.get("models")
+    if not isinstance(rows, list):
+        return None
+    readable = [row for row in rows if _readable_slug(row)]
+    if rows and not readable:
+        # A non-empty listing where NO row is readable = corruption, NOT a legitimately-empty seat —
+        # mirrors codex_probe._visible_models' drift guard, so cached-garbage and live-garbage are
+        # interpreted identically (fall back to the illustrative reference, not "0 models").
+        return None
+    models = tuple(
+        CodexModel(
+            slug=row["slug"],
+            context_window=_positive_int(row.get("context_window")),
+            supports_vision=_flag(row.get("vision")),
+            supports_tools=_flag(row.get("tools")),
+        )
+        for row in readable
+    )
+    fetched_at = doc.get("fetched_at")
+    return CachedModels(
+        fetched_at=float(fetched_at) if _is_finite_number(fetched_at) else 0.0,
+        models=models,
+    )

--- a/remote/codex_probe.py
+++ b/remote/codex_probe.py
@@ -32,6 +32,9 @@ exists to prevent. Classification rules paid for in spike evidence:
 
 from __future__ import annotations
 
+import math
+import sys
+from dataclasses import dataclass
 from typing import Any
 
 import httpx
@@ -41,6 +44,31 @@ from . import codex_oauth
 # One request on a human-watched path: a hung socket must surface as an error, not hang the join.
 # Matches `_VENDOR_LIST_TIMEOUT` (the openai join call) and `_EXCHANGE_TIMEOUT` (the sign-in).
 _PROBE_TIMEOUT = 15.0
+
+# A model slug rides into the advertised name and onto the operator's terminal (the join print,
+# the `-m` refusal). Vendor text at best, so it is printable-checked and length-bounded at the ONE
+# point of origin — the same `_safe`/`_bounded_detail` posture — so an unbounded/ANSI-laden slug from
+# a hostile or MITM'd backend can never forge lines or inject escapes downstream (CWE-150). Real
+# slugs are short (`gpt-5.6-terra`); 128 is generous headroom.
+_MAX_SLUG_LEN = 128
+
+
+@dataclass(frozen=True)
+class CodexModel:
+    """One entitled model from the seat's live ``GET /models`` — slug plus the caps the codex
+    capability envelope needs (issue 10a). The probe is the SOLE source of truth for the served set
+    and its caps now that the static tier table no longer gates serving; the CLI persists these into
+    the run record at join so the serving side can build the envelope with no static lookup.
+
+    ``context_window`` uses ``0`` as the "unknown" sentinel (the existing media/doggi convention), so
+    an absent/malformed probe value is OMITTED from the envelope downstream, never a fabricated
+    number. Caps fail closed per field (absent → the conservative claim); the model itself is still
+    served (DESIGN §8 — never fail closed on a model)."""
+
+    slug: str
+    context_window: int  # 0 = unknown (omitted from the envelope), never fabricated
+    supports_vision: bool
+    supports_tools: bool
 
 
 class SeatRejected(Exception):
@@ -59,13 +87,17 @@ class SeatRejected(Exception):
 
 def probe_seat(
     bundle: codex_oauth.CodexBundle, *, base_url: str, client_version: str
-) -> tuple[str, ...]:
-    """The seat's visible model slugs, or why this machine cannot serve it.
+) -> tuple[CodexModel, ...]:
+    """The seat's servable models (slug + derived caps), or why this machine cannot serve it.
 
     One GET, no retry. Raises ``SeatRejected`` for the auth class and ``SystemExit`` (a terminal
-    operator message ending "Nothing was joined.") for every other failure. The slugs come back
-    deduped in vendor order; ``visibility: "hide"`` rows are dropped — a model the vendor hides
-    from its own client must never be advertised to a grid (facts.md #5, ``codex-auto-review``).
+    operator message ending "Nothing was joined.") for every other failure. The records come back
+    deduped in vendor order; membership is ``visibility != "hide"`` AND ``supported_in_api`` is not
+    explicitly ``False`` (issue 10a / DESIGN §6): a model the vendor hides from its own client
+    (``codex-auto-review``) or explicitly marks API-unsupported is never advertised, but an ABSENT
+    ``supported_in_api`` is served (Option A — never fail closed on a model). Caps derive from the
+    probe (``context_window``; vision from ``input_modalities``; tools from the tool-call flags),
+    fail-closed per field.
     """
     url = f"{base_url}/models"
     headers = {
@@ -87,7 +119,7 @@ def probe_seat(
 
     if resp.status_code != 200:
         _raise_probe_failure(resp)
-    return _visible_slugs(resp)
+    return _visible_models(resp)
 
 
 def _raise_probe_failure(resp: httpx.Response) -> None:
@@ -154,12 +186,26 @@ def _bounded_detail(resp: httpx.Response) -> str:
     return ""
 
 
-def _visible_slugs(resp: httpx.Response) -> tuple[str, ...]:
-    """The visible model slugs of a 200 listing, defensively.
+def _readable_slug(model: object) -> bool:
+    """Whether a row carries a usable model slug: a non-empty, PRINTABLE, length-bounded string. A
+    row that fails this is treated exactly like one with no slug — dropped, and (if NO row anywhere
+    is readable) surfaced as contract drift. Bounding + printable-checking at the ONE origin means a
+    hostile/ANSI slug from a compromised or MITM'd backend can never ride the advertised name onto
+    the operator's terminal (the join print / `-m` refusal) and forge lines or inject escapes
+    (CWE-150) — the same posture `_bounded_detail` already takes for vendor `detail` text."""
+    if not isinstance(model, dict):
+        return False
+    slug = model.get("slug")
+    return isinstance(slug, str) and bool(slug) and slug.isprintable() and len(slug) <= _MAX_SLUG_LEN
 
-    The body is vendor JSON with ~42 fields per model; only ``slug`` and ``visibility`` are read,
-    and nothing is indexed without a shape check — a vendor reshape must surface as the
-    "unreadable listing" contract-drift error, never as a KeyError escaping the taxonomy.
+
+def _visible_models(resp: httpx.Response) -> tuple[CodexModel, ...]:
+    """The servable models of a 200 listing (slug + derived caps), defensively.
+
+    The body is vendor JSON with ~42 fields per model; only the caps-critical fields are read, and
+    nothing is indexed without a shape check — a vendor reshape must surface as the "unreadable
+    listing" contract-drift error or a conservative caps claim, never as an exception escaping the
+    failure taxonomy.
     """
     try:
         doc: Any = resp.json()
@@ -169,26 +215,115 @@ def _visible_slugs(resp: httpx.Response) -> tuple[str, ...]:
     if not isinstance(models, list):
         raise _unreadable_listing()
 
-    # Drift vs empty is decided by READABILITY, not by what survives the hide-filter: an
-    # all-hidden listing parsed perfectly and is a legitimate (if unusual) seat state — sending
-    # its operator to "check for a newer grid release" would be a lie. Only a non-empty listing
-    # in which NO row anywhere carries a readable slug is shape drift (silent-failure review #1).
-    readable = [
-        model for model in models
-        if isinstance(model, dict) and isinstance(model.get("slug"), str) and model["slug"]
-    ]
+    # Drift vs empty is decided by READABILITY, not by what survives the membership filters: an
+    # all-hidden (or all-unsupported) listing parsed perfectly and is a legitimate (if unusual) seat
+    # state — sending its operator to "check for a newer grid release" would be a lie. Only a
+    # non-empty listing in which NO row anywhere carries a readable slug is shape drift.
+    readable = [model for model in models if _readable_slug(model)]
     if models and not readable:
         raise _unreadable_listing()
 
-    slugs: dict[str, None] = {}  # insertion-ordered dedupe, vendor order preserved
+    picked: dict[str, CodexModel] = {}  # insertion-ordered dedupe, vendor order, first occurrence wins
+    drifted: set[str] = set()
     for model in readable:
-        # The hide-filter is defence in depth, NOT the wall: if the vendor renames `visibility`
-        # this check fails open, and what actually stops a hidden model being advertised is the
-        # verified tier row the join intersects with (pinned by test). A hidden model that IS in
-        # the tier row would then be advertised and fail per-job — visible damage, not silent.
-        if model.get("visibility") != "hide":
-            slugs.setdefault(model["slug"])
-    return tuple(slugs)
+        # Membership (issue 10a / DESIGN §6): the hide-filter drops a model the vendor hides from its
+        # own picker (codex-auto-review); the supported_in_api filter drops one the vendor EXPLICITLY
+        # marks API-unsupported (US5). These two filters are now the SOLE structural guards — the
+        # static tier intersection that used to backstop them is gone. If the vendor renames
+        # `visibility` the hide-filter fails OPEN and the hidden model is served: visible damage (it
+        # 400s per job), never silent, and never a model failed closed (DESIGN §8). An ABSENT
+        # supported_in_api is served (Option A); only an explicit `False` excludes.
+        if model.get("visibility") == "hide":
+            continue
+        if model.get("supported_in_api") is False:
+            continue
+        slug = model["slug"]
+        if slug not in picked:  # first occurrence wins; a later dup is never re-parsed (nor re-checked)
+            picked[slug] = _model_caps(model)
+            drifted.update(_malformed_caps_fields(model))
+    _warn_caps_drift(drifted)
+    return tuple(picked.values())
+
+
+def _warn_caps_drift(fields: set[str]) -> None:
+    """One operator breadcrumb when a caps-critical field arrived PRESENT-but-unreadable across the
+    listing (a vendor reshape). Per-field fail-closed is otherwise SILENT — a whole-listing field
+    rename would strip vision/tools/context from every model with a "success" join and no signal
+    (the membership set at least surfaces in the join's `models=` print; caps never do). Fires ONLY
+    on genuine shape drift, never on real data or a legitimately absent (sparse) field."""
+    if fields:
+        print(
+            "Note: the codex model listing carried capability field(s) "
+            f"{', '.join(sorted(fields))} in a shape this grid can't read; those capabilities were "
+            "treated conservatively for the affected models. A vendor API change may be "
+            "under-reporting your models — check for a newer grid release.",
+            file=sys.stderr,
+        )
+
+
+def _is_finite_number(value: Any) -> bool:
+    """A real, finite number — the shape a numeric probe field must have before coercion. Excludes
+    ``bool`` (``True``/``False`` are ``int`` in Python) and non-finite floats (Python's ``json``
+    accepts ``Infinity``/``NaN``, and ``int(inf)`` raises ``OverflowError`` — which would escape the
+    probe's failure taxonomy as a raw traceback). A huge arbitrary-precision ``int`` (e.g. a 309-digit
+    JSON literal in a hostile vendor body or a corrupted `codex_models_cache.json`) ALSO overflows the
+    float conversion inside ``math.isfinite`` — caught here so it reads as "not a usable number" (→ the
+    ``0`` unknown sentinel), never a raw traceback that would break the probe's / the cache's contract."""
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return False
+    try:
+        return math.isfinite(value)
+    except OverflowError:
+        return False
+
+
+def _positive_int(value: Any) -> int:
+    """A probe field coerced to a positive int, or the ``0`` unknown sentinel (→ omitted from the
+    envelope downstream, never fabricated) when absent, non-numeric, non-finite, or non-positive."""
+    return int(value) if _is_finite_number(value) and value > 0 else 0
+
+
+def _flag(value: Any) -> bool:
+    """A probe boolean, fail-closed: ``True`` ONLY for the JSON literal ``true``. Any other shape —
+    a vendor reshaping the field to a truthy string (``bool("false")`` is ``True``!), a number, or
+    absence — is the conservative ``False``, the same fail-closed direction as the numeric guard."""
+    return value is True
+
+
+def _malformed_caps_fields(model: dict[str, Any]) -> tuple[str, ...]:
+    """Caps-critical fields PRESENT in a row but in an unreadable SHAPE — the vendor-reshape signal
+    for ``_warn_caps_drift``. Distinct from a legitimately ABSENT field (sparse — no signal, no
+    warn): a key that isn't there is normal; a key that IS there but the wrong type is drift."""
+    bad: list[str] = []
+    ctx = model.get("context_window")
+    if ctx is not None and not _is_finite_number(ctx):
+        bad.append("context_window")
+    modalities = model.get("input_modalities")
+    if modalities is not None and not isinstance(modalities, list):
+        bad.append("input_modalities")
+    for field in ("supports_parallel_tool_calls", "supports_search_tool"):
+        value = model.get(field)
+        if value is not None and not isinstance(value, bool):
+            bad.append(field)
+    return tuple(bad)
+
+
+def _model_caps(model: dict[str, Any]) -> CodexModel:
+    """Derive one model's caps from its probe row, fail-closed per field (never raises).
+
+    ``context_window`` → a positive int, else ``0`` (unknown sentinel); vision → ``"image" in
+    input_modalities``; tools → ``supports_parallel_tool_calls or supports_search_tool``, each
+    accepted ONLY as a real JSON ``true`` (`_flag`). A field the vendor stops sending — or reshapes —
+    yields the conservative claim; the model is still served (DESIGN §8). A present-but-unreadable
+    caps field is additionally surfaced by `_malformed_caps_fields` → `_warn_caps_drift`."""
+    modalities = model.get("input_modalities")
+    return CodexModel(
+        slug=model["slug"],
+        context_window=_positive_int(model.get("context_window")),
+        supports_vision=isinstance(modalities, list) and "image" in modalities,
+        supports_tools=_flag(model.get("supports_parallel_tool_calls"))
+        or _flag(model.get("supports_search_tool")),
+    )
 
 
 def _unreadable_listing() -> SystemExit:

--- a/remote/probe.py
+++ b/remote/probe.py
@@ -554,7 +554,10 @@ def codex_capability_entry(
         "endpoints": codex_endpoints,
         "input_modalities": ["text", "image"] if features["vision"] else ["text"],
         "output_modalities": ["text"],
-        "context_window": int(entry.context_window),
+        # Probe-derived now (issue 10a): an unknown window (the `0` sentinel a caps-absent probe row
+        # carries) is OMITTED, never a fabricated number — the `capability_entry` conditional-key
+        # idiom, so the master/Advisor treats absence as "unknown" rather than trusting a guess.
+        **({"context_window": int(entry.context_window)} if entry.context_window else {}),
         **({"vendor_rank": vendor_rank} if vendor_rank is not None else {}),
         # A routing trait folded in beside the honest capabilities — NOT added to `codex_features`,
         # which also feeds `grid catalog --api codex --json` and must stay capability-only.

--- a/remote/serve.py
+++ b/remote/serve.py
@@ -326,7 +326,7 @@ def _bring_up_engines(
             # caps for all of them — shared with the hot-reload path (`_reload_once`) so the two can't drift.
             caps = _probe_spec_caps(
                 llm_url, advertised, upstream, record.get("ctx_size"), api_kind=spec.get("api_kind"),
-                plan_type=spec.get("plan_type"),
+                model_caps=spec.get("model_caps"),
             )
             results.append((llm_url, advertised, upstream, caps))
     except BaseException:  # a later spec failed — don't orphan a server an earlier spec already launched
@@ -572,19 +572,62 @@ def _adapt_output_token_param(body: dict[str, Any], api_kind: str | None, endpoi
     return adapted
 
 
-def _static_api_caps(api_kind: str, advertised: list[str], plan_type: str | None = None) -> dict[str, Any]:
-    """An API engine's caps envelope from the static whitelist — API engines are never live-probed
-    or benchmarked (ADR 0012); the vendor sees no traffic until a real job forwards. A model missing
-    from the whitelist (catalog edited between join and respawn) degrades like a failed probe: an
-    all-False entry, never a crash.
+def _codex_entry_from_caps(advertised_model: str, caps: dict[str, Any]) -> api_catalog.ApiModelEntry:
+    """Rebuild the ``ApiModelEntry`` ``codex_capability_entry`` consumes from the caps the join
+    persisted in the run record (issue 10a). ``vendor_name`` is the real slug (unread on the codex
+    envelope path, but faithful rather than a placeholder); json/structured are always False — a
+    Responses passthrough can't claim chat-dialect features. ``context_window`` falls back to the
+    ``0`` unknown sentinel (→ omitted from the envelope) when absent/non-numeric, never fabricated."""
+    ctx = caps.get("context_window")
+    return api_catalog.ApiModelEntry(
+        vendor_name=advertised_model.partition(":")[2] or advertised_model,
+        context_window=ctx if isinstance(ctx, int) and not isinstance(ctx, bool) else 0,
+        supports_tools=bool(caps.get("tools")),
+        supports_vision=bool(caps.get("vision")),
+        supports_json_mode=False,
+        supports_structured_outputs=False,
+    )
 
-    ``plan_type`` (codex only) is the seat's stored subscription tier — the row ``vendor_rank`` is
-    read from (issue 03). ``None`` degrades to the minimal row via ``codex_vendor_rank``; it is
-    ignored for every other kind."""
+
+def _codex_caps_entry(advertised_model: str, caps: dict[str, Any] | None) -> dict[str, Any]:
+    """One codex model's capability envelope, from the caps the join PERSISTED in the run record
+    (issue 10a). ``caps`` absent — a record written before the live-probe catalog, or a caps map that
+    dropped this model — degrades to the responses-only fail-closed entry (no capability claims), with
+    a warn: the same posture as a model gone from a static whitelist, so an absent entry is never a
+    silent no-caps advertisement. ``vendor_rank`` rides only when it is a real int."""
+    if not caps:
+        _warn(
+            f"{advertised_model!r} has no probe-derived caps in the run record "
+            "(it predates the live-probe catalog, or its caps were dropped) — advertising it "
+            "responses-only with no capability claims; re-run `grid join --api codex` to refresh"
+        )
+        return probe.codex_capability_entry(None)
+    rank = caps.get("vendor_rank")
+    return probe.codex_capability_entry(
+        _codex_entry_from_caps(advertised_model, caps),
+        vendor_rank=rank if isinstance(rank, int) and not isinstance(rank, bool) else None,
+    )
+
+
+def _static_api_caps(
+    api_kind: str, advertised: list[str], model_caps: dict[str, dict[str, Any]] | None = None
+) -> dict[str, Any]:
+    """An API engine's caps envelope. Most kinds take it from the static whitelist — API engines are
+    never live-probed or benchmarked (ADR 0012); the vendor sees no traffic until a real job forwards
+    — and a model missing from the whitelist (catalog edited between join and respawn) degrades like a
+    failed probe: an all-False entry, never a crash.
+
+    The codex kind is the exception (issue 10a): its served set + per-model caps come from the seat's
+    live probe, PERSISTED at join in ``model_caps`` (advertised name → context_window/vision/tools/
+    vendor_rank), because no static table exists to look them up from. A codex model advertised but
+    absent from ``model_caps`` — a record written before those caps existed, or a caps map that lost a
+    model — degrades to the responses-only fail-closed entry, with a warn. ``model_caps`` is ignored
+    for every other kind."""
     no_features = dict.fromkeys(
         ("vision", "tools", "parallel_tool_calls", "json_object", "json_schema"), False
     )
     caps_models: dict[str, Any] = {}
+    caps_by_model = model_caps or {}  # codex only: the per-model caps the join persisted in the record
     # Which relay endpoint(s) this kind serves comes from its catalog row (issue 03) — NOT a hardcoded
     # chat-only list. This is the wire contract grid-src's per-model `provider_supports` filter reads,
     # so a kind that serves `responses` (openai) must advertise it here or nothing routes. A kind gone
@@ -598,6 +641,16 @@ def _static_api_caps(api_kind: str, advertised: list[str], plan_type: str | None
     # False for free. Gated per-MODEL on `entry is not None` at the call below (a stale model fails closed).
     kind_can_cap = api_catalog.kind_honours_output_cap(api_kind)
     for advertised_model in advertised:
+        if api_kind == api_catalog.CODEX_KIND:
+            # Issue 10a: the codex served set + caps come from the seat's live probe, PERSISTED per
+            # model in the run record (`model_caps`) — there is no static table to look them up from,
+            # so this reads the record, not `find_advertised`. The honest responses-only envelope
+            # (endpoints ["responses"], no chat-dialect flags, no output cap) is built from those caps;
+            # a model absent from them fail-closes with a warn (the stale-catalog posture).
+            caps_models[advertised_model] = _codex_caps_entry(
+                advertised_model, caps_by_model.get(advertised_model)
+            )
+            continue
         entry = api_catalog.find_advertised(api_kind, advertised_model)
         if entry is None:
             # A local data-integrity condition, not a transient probe failure — leave a trace, or
@@ -606,23 +659,6 @@ def _static_api_caps(api_kind: str, advertised: list[str], plan_type: str | None
                 f"{advertised_model!r} is no longer in the {api_kind} whitelist "
                 "(catalog changed since join) — advertising it with no capabilities"
             )
-        if api_kind == api_catalog.CODEX_KIND:
-            # The honest responses-only entry (issue 05): endpoints ["responses"], no chat-dialect
-            # flags, no output cap — a codex envelope must never look like a chat model's. plus the
-            # join-time vendor_rank (issue 03): the model's position in the seat's tier row, or None
-            # when it isn't in that row (guard so the entry=None degrade never dereferences it).
-            rank = api_catalog.codex_vendor_rank(plan_type, entry.vendor_name) if entry else None
-            if entry is not None and rank is None:
-                # Resolves in the flat whitelist union but has no slot in THIS seat's tier row: the
-                # tier table was edited between join and respawn (drift), the same class as the
-                # entry-is-None warn above. Advertise it, just without a rank — but leave a trail, or
-                # an absent rank looks identical to "this seat simply doesn't rank this model".
-                _warn(
-                    f"{advertised_model!r} has no rank in this codex seat's tier row "
-                    "(catalog changed since join) — advertising it without a capability rank"
-                )
-            caps_models[advertised_model] = probe.codex_capability_entry(entry, vendor_rank=rank)
-            continue
         probed = api_catalog.probed_features(entry) if entry else no_features
         ctx = entry.context_window if entry else None
         # Media API engines (e.g. Doggi) advertise media endpoints — their jobs run through
@@ -648,7 +684,7 @@ def _static_api_caps(api_kind: str, advertised: list[str], plan_type: str | None
 
 def _probe_spec_caps(
     llm_url: str, advertised: list[str], upstream: list[str], ctx_size: Any,
-    api_kind: str | None = None, plan_type: str | None = None,
+    api_kind: str | None = None, model_caps: dict[str, dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Probe EVERY model a spec serves into one caps envelope — keyed by the advertised name, probed by
     the upstream name (Ollama/vLLM only know that). Shared by startup (`_bring_up_engines`) and the
@@ -657,10 +693,11 @@ def _probe_spec_caps(
     sequential probes at join/reload (one-time; N is small). A failed probe returns an all-False entry for
     that one model (`probe.capabilities` never raises), so one bad model can't sink the node; ``{}`` only
     when the spec serves no models. An API spec (``api_kind``) takes its caps from the static whitelist
-    instead — no probe ever targets the vendor — via the same seam so startup and reload can't drift.
+    instead — no probe ever targets the vendor — via the same seam so startup and reload can't drift;
+    the codex kind additionally passes ``model_caps`` (its live-probe caps persisted in the record).
     """
     if api_kind:
-        return _static_api_caps(api_kind, advertised, plan_type=plan_type)
+        return _static_api_caps(api_kind, advertised, model_caps=model_caps)
     if not advertised:
         return {}  # no models → nothing to advertise; skip the route probe's network round-trip (loop was a no-op)
     # Discover the Responses dialect ONCE per engine (issue 08 / ADR 0018): the route is a property of
@@ -1402,7 +1439,7 @@ def _reload_once(state: _ServeState, engine_id: str) -> None:
             # (`_probe_spec_caps` is the shared site, so startup and reload can't drift — ADR 0009 C2).
             caps = (
                 _probe_spec_caps(url, advertised, upstream, record.get("ctx_size"), api_kind=api_kind,
-                                 plan_type=spec.get("plan_type"))
+                                 model_caps=spec.get("model_caps"))
                 if models else {}
             )
             reassembled.append((url, advertised, upstream, caps))

--- a/shared/models/api_catalog.py
+++ b/shared/models/api_catalog.py
@@ -140,22 +140,10 @@ CODEX_KIND = "codex"
 # with the whitelist itself.
 CODEX_CLIENT_VERSION = "0.144.2"
 
-# The vendor's own `PlanType` vocabulary, read from the client binary (facts.md #5). Distinguishes
-# "unrecognized tier" (vendor drift — outside this set) from "known but unverified" (inside it, no
-# populated row in CODEX_TIER_MODELS). Neither advertises beyond the minimal row; only the warn
-# wording turns on the difference, and that wording lives with the CLI (issue 05).
-CODEX_PLAN_TYPES = frozenset({
-    "free", "go", "plus", "pro", "prolite", "team", "self_serve_business_usage_based",
-    "business", "enterprise_cbp_usage_based", "enterprise", "hc", "edu", "education",
-})
-
-# Per-tier rows: ONLY a tier verified against a live seat may be populated — paid tiers are
-# UNRESOLVED-NOACCESS and must not be filled from guesswork (facts.md #5); an absent row means
-# "unverified", never "empty tier". Vendor priority order preserved. `codex-auto-review`
-# (visibility: "hide") is deliberately excluded. The json-mode/structured-outputs booleans are
-# False because they are chat-dialect notions a Responses passthrough cannot honestly claim — and
-# the capability envelope OMITS those keys outright rather than advertising False
-# (remote/probe.codex_capability_entry, issue 05).
+# The free set is live-verified (2026-07-15, facts.md #5) against a real seat; `codex-auto-review`
+# (visibility: "hide") is deliberately excluded. The json-mode/structured-outputs booleans are False
+# because they are chat-dialect notions a Responses passthrough cannot honestly claim — the capability
+# envelope OMITS those keys outright rather than advertising False (remote/probe.codex_capability_entry).
 _CODEX_FREE_MODELS: tuple[ApiModelEntry, ...] = (
     ApiModelEntry(
         vendor_name="gpt-5.6-terra",
@@ -195,11 +183,59 @@ _CODEX_FREE_MODELS: tuple[ApiModelEntry, ...] = (
     ),
 )
 
-CODEX_TIER_MODELS: dict[str, tuple[ApiModelEntry, ...]] = {"free": _CODEX_FREE_MODELS}
+# The paid-only rows (issue 10b): ILLUSTRATIVE, encoded from the public pricing docs
+# (`CODEX_PRICING_DOCS_URL`), which give a display name + plan only — no caps. So the context window is
+# the `0` unknown sentinel (rendered `—`, never a fabricated number) and tools/vision follow the
+# profile every codex model has had to date. The slugs are INFERRED from display names — verify against
+# a real paid-seat probe. DISPLAY-ONLY: `grid catalog` shows them; serving is the live probe's job.
+_CODEX_PAID_MODELS: tuple[ApiModelEntry, ...] = (
+    ApiModelEntry(
+        vendor_name="gpt-5.6-sol",
+        context_window=0,
+        supports_tools=True,
+        supports_vision=True,
+        supports_json_mode=False,
+        supports_structured_outputs=False,
+        notes="Illustrative (pricing docs) — Plus and up; verify against a paid seat.",
+    ),
+    ApiModelEntry(
+        vendor_name="gpt-5.4",
+        context_window=0,
+        supports_tools=True,
+        supports_vision=True,
+        supports_json_mode=False,
+        supports_structured_outputs=False,
+        notes="Illustrative (pricing docs) — Plus and up; verify against a paid seat.",
+    ),
+)
 
-# What a missing, unrecognized, or unverified tier advertises (ADR 0015 D-f: never the full
-# table). Free is the least-entitled tier, so degrading to it can only under-advertise.
-CODEX_MINIMAL_TIER = "free"
+_CODEX_PRO_ONLY: tuple[ApiModelEntry, ...] = (
+    ApiModelEntry(
+        vendor_name="gpt-5.3-codex-spark",
+        context_window=0,
+        supports_tools=True,
+        supports_vision=True,
+        supports_json_mode=False,
+        supports_structured_outputs=False,
+        notes="Illustrative (pricing docs) — Pro only, research preview; verify against a paid seat.",
+    ),
+)
+
+# The illustrative cross-plan reference (issue 10b — relabeled from the old serving-gate tier table).
+# DISPLAY-ONLY: `grid catalog --api codex` renders it as a menu of what each plan can serve; it NEVER
+# gates a join (the live probe is the source of truth for the served set). Keyed by PLAN LABELS (not
+# the vendor's `PlanType` vocabulary) — the three distinct membership sets across all plans. Business /
+# Enterprise / Edu share the Plus set, so they are surfaced as a note rather than a duplicate row.
+CODEX_TIER_MODELS: dict[str, tuple[ApiModelEntry, ...]] = {
+    "free / go": _CODEX_FREE_MODELS,
+    "plus": _CODEX_FREE_MODELS + _CODEX_PAID_MODELS,
+    "pro": _CODEX_FREE_MODELS + _CODEX_PAID_MODELS + _CODEX_PRO_ONLY,
+}
+
+# Provenance for the illustrative reference (issue 10b). The pricing-docs read date is distinct from
+# `CODEX_LAST_VERIFIED` (the free-seat probe date) — different data, different verification.
+CODEX_PRICING_DOCS_URL = "https://learn.chatgpt.com/docs/pricing"
+CODEX_REFERENCE_LAST_VERIFIED = "2026-07-24"
 
 
 def _codex_tier_union() -> tuple[ApiModelEntry, ...]:
@@ -234,7 +270,9 @@ WHITELISTS: dict[str, ApiWhitelist] = {
     "codex": ApiWhitelist(
         last_verified=CODEX_LAST_VERIFIED,
         base_url="https://chatgpt.com/backend-api/codex",
-        # The union of the tier rows (issue 05); per-tier selection is `codex_tier_entries`.
+        # The union of the tier rows — the pre-probe `-m` validation reference (issue 05). Serving no
+        # longer intersects it: the live probe is the source of truth for the served set + caps (issue
+        # 10a). 10b relabels this table as the illustrative cross-plan reference and adds the paid rows.
         entries=_codex_tier_union(),
         env_var=None,  # ADR 0015 D-c: an OAuth seat has no env-var input path
         max_output_param=None,  # facts.md #1: this backend has no output-cap parameter, under any name
@@ -278,43 +316,6 @@ def find_advertised(kind: str, advertised: str) -> ApiModelEntry | None:
     for entry in whitelist.entries:
         if advertised_name(kind, entry) == advertised:
             return entry
-    return None
-
-
-def codex_effective_tier(plan_type: str | None) -> str:
-    """The tier whose row a seat claiming ``plan_type`` advertises: its own when populated, else
-    the minimal tier. Split from ``codex_tier_entries`` because operator messages need the NAME
-    of the row they ended up on, not just its contents."""
-    if plan_type is not None and plan_type in CODEX_TIER_MODELS:
-        return plan_type
-    return CODEX_MINIMAL_TIER
-
-
-def codex_tier_entries(plan_type: str | None) -> tuple[ApiModelEntry, ...]:
-    """The tier row a seat claiming ``plan_type`` may advertise (ADR 0015 D-f).
-
-    Missing (``None``), unrecognized (outside ``CODEX_PLAN_TYPES``), and known-but-unverified (no
-    populated row) tiers all degrade to the minimal row — the join must never widen on a guess.
-    Pure lookup: the operator-facing warns for the three degrade cases are the CLI's (issue 05),
-    because they differ only in wording, not in what is advertised.
-    """
-    return CODEX_TIER_MODELS[codex_effective_tier(plan_type)]
-
-
-def codex_vendor_rank(plan_type: str | None, vendor_name: str) -> int | None:
-    """The 1-based capability rank of ``vendor_name`` within the seat's effective tier row
-    (``codex_tier_entries``): 1 = the row's most-capable head, the curated order we own (ADR 0016).
-    ``None`` when the model is absent from that row — a drifted model omits the fact rather than
-    fabricating a position, so the master renders nothing for it and ordering degrades gracefully.
-
-    The tier ROW, not the flat ``entries`` union, is the authority: two tiers may order the same
-    model differently, and a seat advertises exactly one tier's row (``codex_tier_entries`` applies
-    the same D-f degrade the join used to pick that row). Positions are contiguous ``1..N`` because
-    each row is duplicate-free (pinned by ``test_codex_tier_whitelist_integrity``). Sourced from
-    the whitelist order, never the vendor's unverified ``priority`` field (ADR 0016)."""
-    for index, entry in enumerate(codex_tier_entries(plan_type)):
-        if entry.vendor_name == vendor_name:
-            return index + 1
     return None
 
 
@@ -436,7 +437,13 @@ def format_api_entry(kind: str, entry: ApiModelEntry, endpoints: tuple[str, ...]
         )
         if supported
     )
-    return (
-        f"  {advertised_name(kind, entry):<24} {entry.context_window:>9,} ctx   "
-        f"{caps or 'text only'}"
-    )
+    # An unknown context window (the `0` sentinel — a media row, or an illustrative paid codex row
+    # whose caps the pricing docs don't give, issue 10b) renders `—`, never `0 ctx` or a fabricated
+    # number (DESIGN §8.1). No "ctx" unit for the unknown case; width-matched so the caps column stays
+    # aligned. The known (>0) path is byte-identical to before (so the `" ctx   "` split in
+    # test_format_api_entry_shows_responses_dialect is undisturbed).
+    if entry.context_window > 0:
+        ctx = f"{entry.context_window:>9,} ctx   "
+    else:
+        ctx = f"{'—':>9}       "
+    return f"  {advertised_name(kind, entry):<24} {ctx}{caps or 'text only'}"

--- a/shared/paths.py
+++ b/shared/paths.py
@@ -28,6 +28,13 @@ def api_keys_file() -> Path:
     return grid_home() / "api_keys.toml"
 
 
+def codex_models_cache_file() -> Path:
+    """Grid-side cache of the codex seat's last `GET /models` probe (JSON, 0o600). Written after every
+    successful probe (join + `grid catalog --api codex`), read back when offline. The seat's own
+    entitlement — carries no token/account id — and survives logout, like api_keys.toml (issue 10b)."""
+    return grid_home() / "codex_models_cache.json"
+
+
 def grids_dir() -> Path:
     return grid_home() / "grids"
 

--- a/tests/fixtures/codex_models.json
+++ b/tests/fixtures/codex_models.json
@@ -1,0 +1,59 @@
+{
+  "models": [
+    {
+      "slug": "gpt-5.6-terra",
+      "display_name": "GPT-5.6 Terra",
+      "visibility": "list",
+      "supported_in_api": true,
+      "context_window": 272000,
+      "input_modalities": ["text", "image"],
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": true,
+      "priority": 2
+    },
+    {
+      "slug": "gpt-5.6-luna",
+      "display_name": "GPT-5.6 Luna",
+      "visibility": "list",
+      "supported_in_api": true,
+      "context_window": 272000,
+      "input_modalities": ["text", "image"],
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": true,
+      "priority": 3
+    },
+    {
+      "slug": "gpt-5.5",
+      "display_name": "GPT-5.5",
+      "visibility": "list",
+      "supported_in_api": true,
+      "context_window": 272000,
+      "input_modalities": ["text", "image"],
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": true,
+      "priority": 7
+    },
+    {
+      "slug": "gpt-5.4-mini",
+      "display_name": "GPT-5.4 mini",
+      "visibility": "list",
+      "supported_in_api": true,
+      "context_window": 272000,
+      "input_modalities": ["text", "image"],
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": true,
+      "priority": 23
+    },
+    {
+      "slug": "codex-auto-review",
+      "display_name": "codex-auto-review",
+      "visibility": "hide",
+      "supported_in_api": true,
+      "context_window": 272000,
+      "input_modalities": ["text", "image"],
+      "supports_parallel_tool_calls": true,
+      "supports_search_tool": true,
+      "priority": 43
+    }
+  ]
+}

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -858,9 +858,13 @@ def test_api_whitelist_integrity():
         assert all(names), f"{kind} has an entry with an empty vendor name"
         assert len(set(names)) == len(names), f"{kind} has duplicate vendor names"
         for entry in whitelist.entries:
-            # Media APIs (e.g. Doggi) have context_window=0; text APIs must have > 0.
-            if whitelist.supports_model_listing:
+            # Media APIs (e.g. Doggi) have context_window=0. A text API normally declares a real
+            # window, EXCEPT codex, whose illustrative cross-plan reference carries paid rows with the
+            # `0` unknown-ctx sentinel (issue 10b) — their exact values are pinned by
+            # test_codex_tier_whitelist_integrity, so here we only forbid a negative/garbage window.
+            if whitelist.supports_model_listing and kind != api_catalog.CODEX_KIND:
                 assert entry.context_window > 0
+            assert entry.context_window >= 0
             assert api_catalog.advertised_name(kind, entry) == f"{kind}:{entry.vendor_name}"
         date.fromisoformat(whitelist.last_verified)  # dated, ISO format
         # APIs with base_url=None require --at (e.g. Doggi); others must have a valid HTTPS URL.
@@ -874,60 +878,51 @@ def test_api_whitelist_integrity():
         assert whitelist.endpoints, f"{kind} must serve at least one endpoint"
 
 
-def test_catalog_api_codex_prints_per_tier_whitelist(monkeypatch, capsys):
-    """`grid catalog --api codex` prints the static per-tier table — offline, with no credential
-    (ADR 0012 D-a posture; the sign-in and the live probe belong to `grid join`). Each populated
-    tier prints its rows; the fallback rule for every other tier is stated naming the minimal
-    tier; and the consumer-facing facts are disclosed: these models serve the `responses`
-    endpoint (an external Codex app, not `grid chat`), requests leave the grid, and jobs spend
-    the seat's own monthly allowance."""
+def test_catalog_api_codex_no_seat_shows_illustrative_reference(monkeypatch, tmp_path, capsys):
+    """`grid catalog --api codex` with no seat signed in (issue 10b): NO probe, no network — it shows
+    the illustrative cross-plan reference (free through pro, incl. the paid rows) with a "not signed
+    in" note, and the consumer-facing disclosures (responses endpoint, `grid chat` can't call it,
+    requests leave the grid, the seat's own allowance)."""
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))  # a clean home: no stored codex bundle
+
     def _no_network(*args, **kwargs):
-        raise AssertionError("`grid catalog --api` must not touch the network")
+        raise AssertionError("`grid catalog --api codex` must not touch the network with no seat")
 
     monkeypatch.setattr(httpx, "Client", _no_network)
-    monkeypatch.setattr(httpx, "request", _no_network)
-    monkeypatch.setattr(httpx, "stream", _no_network)
 
     rc = cli.cmd_catalog(argparse.Namespace(api="codex", json=False))
 
-    out = capsys.readouterr().out
+    captured = capsys.readouterr()
+    out, err = captured.out, captured.err
     assert rc == 0
     assert "Unknown" not in out
-    assert api_catalog.CODEX_LAST_VERIFIED in out
-    for tier, entries in api_catalog.CODEX_TIER_MODELS.items():
-        assert f"\n{tier}:\n" in out  # a per-tier section header
-        for entry in entries:
-            assert api_catalog.advertised_name("codex", entry) in out
-            assert f"{entry.context_window:,}" in out
+    assert "Not signed in" in err  # the no-seat warning goes to stderr (clean listing on stdout)
+    assert api_catalog.CODEX_REFERENCE_LAST_VERIFIED in out  # the reference's own (pricing-docs) date
+    # every plan renders (delta style: free rows under `free / go`, paid rows under plus/pro)
+    assert "free / go:" in out and "plus:" in out and "pro:" in out
+    for slug in ("gpt-5.6-terra", "gpt-5.6-sol", "gpt-5.3-codex-spark"):
+        assert f"codex:{slug}" in out
+    assert "Business / Enterprise / Edu serve the same set as Plus." in out
     # Chat-dialect capability words never appear on codex rows (honest passthrough claims only).
     assert "json" not in out and "structured" not in out
-    assert api_catalog.CODEX_MINIMAL_TIER in out  # the fallback rule names the minimal tier
-    assert "responses" in out  # the endpoint disclosure...
-    assert "grid chat" in out  # ...and what NOT to point at it
-    assert "leave the grid" in out  # provenance disclosure (openai parity)
-    assert "allowance" in out  # flat-rate seat: jobs spend the provider's own allowance
+    # consumer-facing disclosures (openai parity)
+    assert "responses" in out and "grid chat" in out
+    assert "leave the grid" in out and "allowance" in out
 
 
-def test_catalog_api_codex_shows_responses_per_entry(monkeypatch, capsys):
-    """AC2 (issue 06): the subscription-seat listing shows the dialect too — every codex model
-    serves `responses` (its row is `endpoints=("responses",)`), so the same data-driven cap tag
-    appears on each per-tier entry line, beside the tools/vision it already showed. Asserted on the
-    model's OWN line: distinct from the trailing prose that also says "responses", this witnesses the
-    per-model capability tag. The per-tier GROUPING is unchanged — that is pinned separately by
-    test_catalog_api_codex_prints_per_tier_whitelist's `\nfree:\n` assertion."""
-    def _no_network(*args, **kwargs):
-        raise AssertionError("`grid catalog --api` must not touch the network")
-
-    monkeypatch.setattr(httpx, "Client", _no_network)
-    monkeypatch.setattr(httpx, "request", _no_network)
-    monkeypatch.setattr(httpx, "stream", _no_network)
+def test_catalog_api_codex_reference_shows_responses_per_entry(monkeypatch, tmp_path, capsys):
+    """AC2 (issue 06), now on the illustrative reference (issue 10b): every codex model serves
+    `responses` (its row is `endpoints=("responses",)`), so the same data-driven cap tag appears on
+    each reference line, beside the tools/vision it already showed. Asserted on the model's OWN line,
+    distinct from the trailing prose that also says "responses"."""
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))  # no seat: the reference renders, no probe
 
     rc = cli.cmd_catalog(argparse.Namespace(api="codex", json=False))
 
     out = capsys.readouterr().out
     assert rc == 0
     lines = [ln for ln in out.splitlines() if "codex:gpt-5.6-terra" in ln]
-    assert lines, "the gpt-5.6-terra model line must be printed"
+    assert lines, "the gpt-5.6-terra reference line must be printed"
     assert "responses" in lines[0]  # the per-model dialect tag, not merely the trailing prose
     assert "tools" in lines[0] and "vision" in lines[0]  # alongside the caps it already showed
 
@@ -944,34 +939,141 @@ def test_catalog_api_still_rejects_a_kind_that_really_is_unknown(capsys):
     assert "codex" in msg and "openai" in msg  # the supported list
 
 
-def test_catalog_api_codex_json_emits_per_tier_contract(capsys):
-    """`--json` for codex speaks `tiers`, not the flat `models` (the reshape is safe: v0.2.1
-    predates every codex commit, so the interim flat-empty shape never shipped in a release).
-    Entries carry NO chat-dialect keys — json-mode/structured-outputs are chat notions a
-    Responses passthrough cannot honestly claim — and `supports_parallel_tool_calls` is the one
-    shared derivation the capability envelope also uses, so the two surfaces cannot disagree."""
+def test_catalog_api_codex_json_no_seat_contract(monkeypatch, tmp_path, capsys):
+    """`--json` for codex (issue 10b): keeps the `tiers` shape (every row `live:false`) and ADDS a
+    `current_plan` key (null with no seat), a `source_url`, a `warning`, and per-row `live` flags. An
+    unknown context window is `null`, never a fabricated 0; chat-dialect keys stay absent."""
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))  # no seat → current_plan is null, no probe
+
     rc = cli.cmd_catalog(argparse.Namespace(api="codex", json=True))
 
     payload = json.loads(capsys.readouterr().out)
     assert rc == 0
     assert payload["kind"] == "codex"
-    assert payload["last_verified"] == api_catalog.CODEX_LAST_VERIFIED
     assert payload["endpoints"] == ["responses"]
-    assert payload["minimal_tier"] == api_catalog.CODEX_MINIMAL_TIER
-    assert "models" not in payload  # per-tier kinds speak `tiers`
+    assert payload["last_verified"] == api_catalog.CODEX_REFERENCE_LAST_VERIFIED  # the reference date
+    assert payload["source_url"] == api_catalog.CODEX_PRICING_DOCS_URL
+    assert payload["current_plan"] is None  # not signed in
+    assert payload["warning"] and "Not signed in" in payload["warning"]
+    assert "models" not in payload  # the flat shape never returns; the reference speaks `tiers`
     assert set(payload["tiers"]) == set(api_catalog.CODEX_TIER_MODELS)
-    free = payload["tiers"]["free"]
-    assert len(free) == len(api_catalog.CODEX_TIER_MODELS["free"])
-    first, first_entry = free[0], api_catalog.CODEX_TIER_MODELS["free"][0]
+
+    free = payload["tiers"]["free / go"]
+    assert len(free) == len(api_catalog.CODEX_TIER_MODELS["free / go"])
+    first, first_entry = free[0], api_catalog.CODEX_TIER_MODELS["free / go"][0]
     assert first["advertised"] == api_catalog.advertised_name("codex", first_entry)
     assert first["vendor_name"] == first_entry.vendor_name
-    assert first["context_window"] == first_entry.context_window
-    assert first["supports_tools"] is True
-    assert first["supports_vision"] is True
-    assert first["supports_parallel_tool_calls"] is True
-    assert first["notes"] == first_entry.notes
-    assert "supports_json_mode" not in first
-    assert "supports_structured_outputs" not in first
+    assert first["context_window"] == first_entry.context_window  # a known (>0) free row
+    assert first["supports_tools"] is True and first["supports_vision"] is True
+    assert first["live"] is False  # every reference row is illustrative
+    assert "supports_json_mode" not in first and "supports_structured_outputs" not in first
+
+    # an illustrative paid row carries a NULL context window (unknown), never a fabricated 0
+    sol = next(r for r in payload["tiers"]["plus"] if r["vendor_name"] == "gpt-5.6-sol")
+    assert sol["context_window"] is None and sol["live"] is False
+
+
+def test_catalog_api_codex_online_shows_live_current_plan_and_writes_cache(monkeypatch, tmp_path, capsys):
+    """Signed in + online (issue 10b): the catalog probes the seat's REAL set (marked live), writes
+    the cache, and shows it above the illustrative reference. A brand-new entitled slug in NO static
+    table still appears — the feature's point. `--json` marks the current_plan rows live."""
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    from remote import api_keys, codex_models_cache
+
+    api_keys.store_codex_bundle(_codex_bundle(plan_type="plus"))
+    body = _codex_models_body()
+    body["models"].append({  # a newly-shipped slug in no static table
+        "slug": "gpt-5.7-nova", "visibility": "list", "supported_in_api": True,
+        "context_window": 400000, "input_modalities": ["text", "image"],
+        "supports_parallel_tool_calls": True, "supports_search_tool": True,
+    })
+    _mock_probe(monkeypatch, lambda request: httpx.Response(200, json=body))
+
+    rc = cli.cmd_catalog(argparse.Namespace(api="codex", json=False))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Your current plan (plus) — live" in out
+    assert "codex:gpt-5.7-nova" in out  # served with no code change — the win the feature exists for
+    cached = codex_models_cache.read_cache(
+        client_version=api_catalog.CODEX_CLIENT_VERSION, account_id="acct-1",
+    )
+    assert cached is not None and any(m.slug == "gpt-5.7-nova" for m in cached.models)
+
+    rc = cli.cmd_catalog(argparse.Namespace(api="codex", json=True))
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["current_plan"]["plan_type"] == "plus" and payload["current_plan"]["live"] is True
+    assert all(r["live"] is True for r in payload["current_plan"]["models"])
+    nova = next(r for r in payload["current_plan"]["models"] if r["vendor_name"] == "gpt-5.7-nova")
+    assert nova["context_window"] == 400000
+    assert all(r["live"] is False for rows in payload["tiers"].values() for r in rows)
+
+
+def test_catalog_api_codex_offline_falls_back_to_cache_with_warning(monkeypatch, tmp_path, capsys):
+    """Signed in but the probe fails at the socket (issue 10b Q2): the catalog does NOT die — it warns
+    "couldn't reach your seat" and shows the LAST cached set (marked cached, not live)."""
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    from remote import api_keys, codex_models_cache
+    from remote.codex_probe import CodexModel
+
+    api_keys.store_codex_bundle(_codex_bundle(plan_type="pro"))
+    codex_models_cache.write_cache(  # a prior successful probe for THIS seat
+        (CodexModel(slug="gpt-5.6-terra", context_window=272_000, supports_vision=True, supports_tools=True),),
+        client_version=api_catalog.CODEX_CLIENT_VERSION, account_id="acct-1",
+    )
+
+    def _transport_fail(request):
+        raise httpx.ConnectError("connection refused")
+
+    _mock_probe(monkeypatch, _transport_fail)
+
+    rc = cli.cmd_catalog(argparse.Namespace(api="codex", json=False))
+    captured = capsys.readouterr()
+    out, err = captured.out, captured.err
+    assert rc == 0
+    assert "Couldn't reach your codex seat" in err  # the warning is on stderr
+    assert "cached" in out.lower()  # the current-plan heading (stdout)
+    assert "codex:gpt-5.6-terra" in out  # the cached set still shows, marked cached
+
+
+def test_catalog_api_codex_seat_rejected_warns_distinctly(monkeypatch, tmp_path, capsys):
+    """Signed in but the seat is rejected (401) while ONLINE (issue 10b Q2): a DISTINCT actionable
+    warning naming `grid join --api codex`, NOT the generic offline line; still falls back to the
+    illustrative reference (no cache here)."""
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    from remote import api_keys
+
+    api_keys.store_codex_bundle(_codex_bundle(plan_type="plus"))
+    _mock_probe(monkeypatch, lambda request: httpx.Response(401, json={"detail": "bad token"}))
+
+    rc = cli.cmd_catalog(argparse.Namespace(api="codex", json=False))
+    captured = capsys.readouterr()
+    out, err = captured.out, captured.err
+    assert rc == 0
+    assert "seat was rejected" in err and "grid join --api codex" in err  # the warning is on stderr
+    assert "Couldn't reach" not in err  # distinct from the generic offline warning
+    assert "gpt-5.3-codex-spark" in out  # the illustrative reference still renders on stdout
+
+
+def test_catalog_api_codex_no_seat_ignores_a_leftover_cache(monkeypatch, tmp_path, capsys):
+    """With no seat signed in, `grid catalog --api codex` shows the illustrative reference + the "not
+    signed in" note — it does NOT surface a leftover cache from a prior sign-in as a "current plan"
+    (the cache is a signed-in seat's entitlement; a signed-out box has no current seat). Pins the
+    deliberate no-seat → reference choice (issue 10b Q2)."""
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    from remote import codex_models_cache
+
+    codex_models_cache.write_cache(  # a cache from a prior sign-in remains on disk
+        _cache_models(), client_version=api_catalog.CODEX_CLIENT_VERSION, account_id="acct-1",
+    )
+
+    rc = cli.cmd_catalog(argparse.Namespace(api="codex", json=False))
+    captured = capsys.readouterr()
+    out, err = captured.out, captured.err
+    assert rc == 0
+    assert "Not signed in" in err
+    assert "Your current plan" not in out  # the leftover cache is NOT shown as a current plan
+    assert "free / go:" in out  # only the illustrative reference
 
 
 def test_api_whitelist_key_kinds_name_their_env_var():
@@ -1045,100 +1147,57 @@ def test_kind_is_stream_only_reads_the_stream_only_field():
 
 
 def test_codex_tier_whitelist_integrity():
-    """The per-tier codex table (issue 05). Guards the D-f data rules: every populated tier is
-    real vendor `PlanType` vocabulary; rows are non-empty, duplicate-free, and inside the flat
-    union (`entries` IS the union, so `find_advertised` resolves every codex model); the minimal
-    tier's row exists (the fallback every unknown/unverified tier degrades to); the hidden
-    `codex-auto-review` slug is excluded everywhere (facts.md #5, visibility: "hide"); and the
-    table is dated + carries the probe's pinned client version."""
+    """The illustrative cross-plan reference (issue 10b — relabeled from the old serving-gate tier
+    table; it is display-only now and NEVER gates serving, the live probe does). Guards its internal
+    consistency: plan-LABEL keys (no longer vendor `PlanType` vocabulary); rows non-empty and
+    duplicate-free; a slug shared across plans is the SAME entry (the flat union keeps the first, so
+    a colliding spec would silently lose in every `find_advertised`); `entries` IS exactly the union
+    (so the pre-probe `-m` reference resolves every codex model, the paid slugs included); the hidden
+    `codex-auto-review` slug is excluded; the free set keeps its live-verified 272k caps while the
+    paid rows are illustrative (unknown ctx → the `0` sentinel), inferred from the pricing docs."""
     from datetime import date
 
     tiers = api_catalog.CODEX_TIER_MODELS
-    assert tiers, "at least one tier must be populated"
-    assert set(tiers) <= api_catalog.CODEX_PLAN_TYPES, "tier keys are vendor vocabulary, not ours"
-    assert api_catalog.CODEX_MINIMAL_TIER in tiers, "the minimal fallback row must be populated"
+    assert set(tiers) == {"free / go", "plus", "pro"}  # display labels, not vendor vocabulary
 
     union = {entry.vendor_name for entry in api_catalog.WHITELISTS["codex"].entries}
     seen: set[str] = set()
     by_name: dict = {}
     for tier, entries in tiers.items():
         names = [entry.vendor_name for entry in entries]
-        assert names, f"tier {tier!r} must not be an empty row (absent means unverified)"
-        assert all(names) and len(set(names)) == len(names), f"tier {tier!r} rows must be unique"
-        assert set(names) <= union, f"tier {tier!r} names something the flat union lacks"
-        # issue 03: each row is a valid, gap-free vendor_rank source — positions are exactly 1..N
-        # (no gaps, no duplicate slots), so codex_vendor_rank is a total order over the row.
-        ranks = [api_catalog.codex_vendor_rank(tier, name) for name in names]
-        assert ranks == list(range(1, len(names) + 1)), f"tier {tier!r} is not a gap-free 1..N ranking"
+        assert names, f"plan {tier!r} must not be an empty row"
+        assert all(names) and len(set(names)) == len(names), f"plan {tier!r} rows must be unique"
+        assert set(names) <= union, f"plan {tier!r} names something the flat union lacks"
         for entry in entries:
-            # A vendor_name shared across tiers must be the SAME entry: the flat union keeps the
-            # first occurrence (`_codex_tier_union` setdefault), so a colliding second-tier entry
-            # with different specs would silently lose to it in every serve-time lookup
-            # (silent-failure review, latent trap — inert while one tier exists).
+            # A vendor_name shared across plans must be the SAME entry: the flat union keeps the
+            # first occurrence (`_codex_tier_union` setdefault), so a colliding second entry with
+            # different specs would silently lose to it in every lookup (silent-failure review).
             assert by_name.setdefault(entry.vendor_name, entry) == entry, (
-                f"{entry.vendor_name!r} appears in two tiers with different specs"
+                f"{entry.vendor_name!r} appears in two plans with different specs"
             )
         seen |= set(names)
-    assert seen == union, "WHITELISTS['codex'].entries must be exactly the union of the tier rows"
+    assert seen == union, "WHITELISTS['codex'].entries must be exactly the union of the plan rows"
     assert "codex-auto-review" not in union  # visibility: "hide" — never advertised
 
-    # The free row is the live-verified 2026-07-15 set, in the vendor's priority order.
-    free = [entry.vendor_name for entry in tiers["free"]]
-    assert free == ["gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5", "gpt-5.4-mini"]
+    # The free/go row is the live-verified 2026-07-15 set in vendor priority order; the paid rows
+    # (Plus↑ sol/5.4, Pro-only spark) are illustrative — inferred from the pricing docs, unknown ctx.
+    assert [e.vendor_name for e in tiers["free / go"]] == [
+        "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5", "gpt-5.4-mini",
+    ]
+    paid = {"gpt-5.6-sol", "gpt-5.4", "gpt-5.3-codex-spark"}
+    assert paid <= union
     for entry in api_catalog.WHITELISTS["codex"].entries:
-        assert entry.context_window == 272_000
-        assert entry.supports_tools and entry.supports_vision
+        # Free rows keep the verified 272k; the paid rows carry the `0` unknown-ctx sentinel (→ `—`).
+        assert entry.context_window == (0 if entry.vendor_name in paid else 272_000)
+        assert entry.supports_tools and entry.supports_vision  # true of every codex model to date
         # Chat-dialect notions — a passthrough kind cannot honestly claim them (issue 05).
         assert not entry.supports_json_mode and not entry.supports_structured_outputs
 
     date.fromisoformat(api_catalog.CODEX_LAST_VERIFIED)
+    date.fromisoformat(api_catalog.CODEX_REFERENCE_LAST_VERIFIED)
+    assert api_catalog.CODEX_REFERENCE_LAST_VERIFIED == "2026-07-24"
+    assert api_catalog.CODEX_PRICING_DOCS_URL.startswith("https://")
     assert api_catalog.CODEX_CLIENT_VERSION  # the `GET /models?client_version=…` pin
-
-
-def test_codex_tier_entries_selects_row_or_minimal():
-    """D-f's selection rule as one pure lookup: a populated tier gets its row; a missing (None),
-    unrecognized ("banana"), or known-but-unverified ("plus") tier degrades to the minimal row —
-    the join never widens on a guess. The warn wording for the three degrade cases is the CLI's
-    (they differ only in what the operator is told, not in what is advertised)."""
-    free_row = api_catalog.CODEX_TIER_MODELS["free"]
-    minimal = api_catalog.CODEX_TIER_MODELS[api_catalog.CODEX_MINIMAL_TIER]
-
-    assert api_catalog.codex_tier_entries("free") == free_row
-    assert api_catalog.codex_tier_entries(None) == minimal      # vendor said nothing
-    assert api_catalog.codex_tier_entries("banana") == minimal  # outside the vendor vocabulary
-    assert api_catalog.codex_tier_entries("plus") == minimal    # known tier, row unverified
-    assert "plus" in api_catalog.CODEX_PLAN_TYPES  # pin: "plus" IS known — its degrade differs from banana's only in wording
-
-
-def test_codex_vendor_rank_from_tier_row(monkeypatch):
-    """The join-time capability rank (issue 03 / ADR 0016): a codex model's 1-based position within
-    the seat's EFFECTIVE tier row — 1 = the row's most-capable head, the curated order we own. A
-    model absent from that row has no rank (None): drift omits the fact, never fabricates a
-    position. The source is the tier ROW, not the flat union — proven by a synthetic second tier
-    whose order differs from the free row's."""
-    # The live free row, in curated order: terra, luna, gpt-5.5, gpt-5.4-mini.
-    assert api_catalog.codex_vendor_rank("free", "gpt-5.6-terra") == 1
-    assert api_catalog.codex_vendor_rank("free", "gpt-5.6-luna") == 2
-    assert api_catalog.codex_vendor_rank("free", "gpt-5.5") == 3
-    assert api_catalog.codex_vendor_rank("free", "gpt-5.4-mini") == 4
-    # Absent from the row → no rank (a drifted/unknown model omits the fact, never invents one).
-    assert api_catalog.codex_vendor_rank("free", "gpt-5.6-nonesuch") is None
-    # The tier degrade is codex_tier_entries': None (vendor silent), unrecognized ("banana"), and
-    # known-but-unverified ("plus") all fall to the minimal (free) row, so the rank is computed
-    # against the row the seat actually advertises.
-    assert api_catalog.codex_vendor_rank(None, "gpt-5.6-terra") == 1
-    assert api_catalog.codex_vendor_rank("banana", "gpt-5.6-terra") == 1
-    assert api_catalog.codex_vendor_rank("plus", "gpt-5.6-terra") == 1  # known, unverified → free
-
-    # Rank follows the SEAT'S TIER ROW, not the flat union. Synthetic second tier (the real table
-    # has only `free`): a `plus` row that REVERSES the capability order must rank by ITS OWN order.
-    # Built from REAL entries so the frozen union/whitelist still resolves the names.
-    free = api_catalog.CODEX_TIER_MODELS["free"]
-    terra, luna, big, mini = free  # by curated order
-    monkeypatch.setattr(api_catalog, "CODEX_TIER_MODELS", {"free": free, "plus": (mini, big, luna, terra)})
-    assert api_catalog.codex_vendor_rank("plus", mini.vendor_name) == 1   # head of the plus row
-    assert api_catalog.codex_vendor_rank("plus", terra.vendor_name) == 4  # tail of the plus row
-    assert api_catalog.codex_vendor_rank("free", terra.vendor_name) == 1  # free row unchanged
 
 
 def test_api_whitelist_endpoints_per_kind():
@@ -1242,6 +1301,22 @@ def test_format_api_entry_shows_responses_dialect():
     line = api_catalog.format_api_entry("openai", toolful, serves_responses)
     assert line.startswith("  openai:m")
     assert " ctx   " in line
+
+
+def test_format_api_entry_unknown_context_window_renders_dash():
+    """issue 10b / DESIGN §8.1: an unknown context window (the `0` sentinel — an illustrative paid
+    codex row, or a media model) renders `—`, never `0 ctx` or a fabricated number, and the caps
+    still render after it. The known (>0) rendering path is byte-identical (asserted by
+    test_format_api_entry_shows_responses_dialect, which uses ctx=1000)."""
+    unknown = api_catalog.ApiModelEntry(
+        vendor_name="m", context_window=0,
+        supports_tools=True, supports_vision=True,
+        supports_json_mode=False, supports_structured_outputs=False,
+    )
+    line = api_catalog.format_api_entry("codex", unknown, ("responses",))
+    assert "—" in line
+    assert "0" not in line          # no `0 ctx`, no fabricated number in the ctx column
+    assert "tools" in line and "vision" in line and "responses" in line
 
 
 def test_catalog_api_json_roundtrips(capsys):
@@ -1635,6 +1710,15 @@ def _codex_bundle(plan_type="free"):
     )
 
 
+def _codex_models_body():
+    """The captured real free-seat ``GET /models`` body (issue 10a fixture): terra/luna/5.5/5.4-mini
+    `list` + codex-auto-review `hide`, each `supported_in_api: true`, caps per facts.md #5. Returns a
+    fresh dict each call so a test can append edge rows without mutating the shared fixture."""
+    import json
+
+    return json.loads((Path(__file__).parent / "fixtures" / "codex_models.json").read_text())
+
+
 def _mock_probe(monkeypatch, handler, _real=httpx.Client):
     """The `_mock_vendor` pattern for the codex probe: a REAL httpx.Client with MockTransport
     injected, capturing the whole request for the URL/header asserts."""
@@ -1656,37 +1740,217 @@ def _mock_probe(monkeypatch, handler, _real=httpx.Client):
 
 
 def _probe(monkeypatch, handler):
-    """Run probe_seat against a mocked vendor; returns (result_or_exc, seen)."""
+    """Run probe_seat against a mocked vendor; returns (records_or_exc, seen)."""
     from remote import codex_probe
 
     seen = _mock_probe(monkeypatch, handler)
-    slugs = codex_probe.probe_seat(
+    records = codex_probe.probe_seat(
         _codex_bundle(),
         base_url=api_catalog.WHITELISTS["codex"].base_url,
         client_version=api_catalog.CODEX_CLIENT_VERSION,
     )
-    return slugs, seen
+    return records, seen
 
 
-def test_codex_probe_sends_the_verified_request_and_returns_visible_slugs(monkeypatch):
+def _cache_models():
+    from remote.codex_probe import CodexModel
+
+    return (
+        CodexModel(slug="gpt-5.6-terra", context_window=272_000, supports_vision=True, supports_tools=True),
+        CodexModel(slug="gpt-5.4-mini", context_window=0, supports_vision=False, supports_tools=False),
+    )
+
+
+def test_codex_models_cache_roundtrips(monkeypatch, tmp_path):
+    """issue 10b: write_cache then read_cache returns the same models, keyed on the client_version the
+    join/catalog probe pins. The `0` unknown-ctx sentinel survives the round-trip unchanged."""
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    from remote import codex_models_cache
+
+    models = _cache_models()
+    codex_models_cache.write_cache(models, client_version="0.144.2", account_id="acct-1")
+    cached = codex_models_cache.read_cache(client_version="0.144.2", account_id="acct-1")
+
+    assert cached is not None
+    assert cached.models == models
+    assert cached.fetched_at > 0
+
+
+def test_codex_models_cache_stale_client_version_reads_none(monkeypatch, tmp_path):
+    """A grid upgrade bumps the pinned `client_version`, so a cache written by an older grid is
+    treated as stale (`None`) — never trusted against a mismatched version (issue 10b)."""
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    from remote import codex_models_cache
+
+    codex_models_cache.write_cache(_cache_models(), client_version="0.144.2", account_id="acct-1")
+    assert codex_models_cache.read_cache(client_version="0.144.2", account_id="acct-1") is not None
+    assert codex_models_cache.read_cache(client_version="0.999.0", account_id="acct-1") is None
+
+
+def test_codex_models_cache_absent_or_malformed_reads_none_never_raises(monkeypatch, tmp_path):
+    """Q2 — the catalog must NEVER die on its own cache. An absent, corrupt, non-dict, or
+    models-less file reads back as `None` (fall to the static reference), never a raise; a body with
+    a mix of readable/unreadable rows drops the bad rows rather than the whole cache."""
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    from remote import codex_models_cache
+    from shared import paths
+
+    assert codex_models_cache.read_cache(client_version="0.144.2", account_id="acct-1") is None  # absent
+    path = paths.codex_models_cache_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    for junk in ("not json at all", "[1, 2, 3]", '{"client_version": "0.144.2"}'):
+        path.write_text(junk)
+        assert codex_models_cache.read_cache(client_version="0.144.2", account_id="acct-1") is None
+
+    # a valid body (correct seat + version) with a MIX of readable/unreadable rows → the bad rows
+    # drop, the cache is NOT lost. Built by writing a real body then injecting junk, so the account
+    # fingerprint stays correct.
+    codex_models_cache.write_cache(_cache_models(), client_version="0.144.2", account_id="acct-1")
+    doc = json.loads(path.read_text())
+    doc["models"].extend([{"no": "slug"}, "junk", {"slug": 123}])
+    path.write_text(json.dumps(doc))
+    cached = codex_models_cache.read_cache(client_version="0.144.2", account_id="acct-1")
+    assert cached is not None
+    assert [m.slug for m in cached.models] == ["gpt-5.6-terra", "gpt-5.4-mini"]
+
+
+def test_codex_models_cache_is_hardened_and_secret_free(monkeypatch, tmp_path):
+    """The cache is the seat's entitlement, not a credential: `0o600`, and it carries only slugs +
+    caps — never a token or the account id (issue 10b)."""
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    from remote import codex_models_cache
+    from shared import paths
+
+    codex_models_cache.write_cache(_cache_models(), client_version="0.144.2", account_id="acct-1")
+    path = paths.codex_models_cache_file()
+    assert (path.stat().st_mode & 0o777) == 0o600
+    text = path.read_text()
+    # only slugs + caps + a one-way account FINGERPRINT — never a token, and never the RAW account id
+    for secret in ("access_token", "refresh_token", "tok-", "acct-1"):
+        assert secret not in text
+
+
+def test_codex_models_cache_all_unreadable_rows_reads_none(monkeypatch, tmp_path):
+    """A non-empty listing whose rows are ALL unreadable is corruption, not an empty seat — it reads
+    back as `None` (fall to the illustrative reference), mirroring the live probe's contract-drift
+    guard, so a garbled cache never becomes the false claim "your seat serves no models" (rev-silent).
+    An EMPTY listing, by contrast, is a legitimately-empty cached seat — a valid result, not None."""
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    from remote import codex_models_cache
+    from shared import paths
+
+    codex_models_cache.write_cache(_cache_models(), client_version="0.144.2", account_id="acct-1")
+    path = paths.codex_models_cache_file()
+    doc = json.loads(path.read_text())
+    doc["models"] = [{"no": "slug"}, "junk", {"slug": ""}, {"slug": 123}]  # every row unreadable
+    path.write_text(json.dumps(doc))
+    assert codex_models_cache.read_cache(client_version="0.144.2", account_id="acct-1") is None
+
+    doc["models"] = []  # a legitimately-empty seat
+    path.write_text(json.dumps(doc))
+    empty = codex_models_cache.read_cache(client_version="0.144.2", account_id="acct-1")
+    assert empty is not None and empty.models == ()
+
+
+def test_codex_models_cache_out_of_range_number_reads_without_crash(monkeypatch, tmp_path):
+    """A huge arbitrary-precision int in a numeric field (corruption / hostile edit) must NOT raise
+    OverflowError (which `math.isfinite`/`float` do on the int→float conversion) — it degrades to the
+    `0` unknown-ctx sentinel / epoch-0, never a traceback that breaks Q2's never-dies contract (rev-py)."""
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    from remote import codex_models_cache
+    from shared import paths
+
+    codex_models_cache.write_cache(_cache_models(), client_version="0.144.2", account_id="acct-1")
+    path = paths.codex_models_cache_file()
+    doc = json.loads(path.read_text())
+    doc["fetched_at"] = 10 ** 400
+    doc["models"] = [{"slug": "gpt-5.5", "context_window": 10 ** 400, "vision": True, "tools": True}]
+    path.write_text(json.dumps(doc))
+
+    cached = codex_models_cache.read_cache(client_version="0.144.2", account_id="acct-1")
+    assert cached is not None
+    assert cached.fetched_at == 0.0  # out-of-range → epoch-0, not a crash
+    assert cached.models[0].context_window == 0  # out-of-range → unknown sentinel, not a crash
+
+
+def test_codex_models_cache_write_error_is_swallowed(monkeypatch, tmp_path, capsys):
+    """`write_cache` is best-effort: an OSError from the writer never propagates (the join/catalog must
+    not fail because a cache couldn't be written), and it leaves an operator breadcrumb (rev-silent)."""
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    from remote import codex_models_cache
+
+    def _boom(*a, **k):
+        raise OSError("read-only file system")
+
+    monkeypatch.setattr(codex_models_cache.jsonio, "atomic_write_json", _boom)
+    codex_models_cache.write_cache(_cache_models(), client_version="0.144.2", account_id="acct-1")  # no raise
+
+    assert "could not write the codex model cache" in capsys.readouterr().err
+
+
+def test_codex_models_cache_ignores_a_different_seats_cache(monkeypatch, tmp_path):
+    """The cache is scoped to the seat that wrote it by a one-way account fingerprint: a read for a
+    DIFFERENT account returns `None`, so an offline catalog never shows one seat's models under
+    another seat's plan label (rev-code)."""
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    from remote import codex_models_cache
+
+    codex_models_cache.write_cache(_cache_models(), client_version="0.144.2", account_id="seat-A")
+    assert codex_models_cache.read_cache(client_version="0.144.2", account_id="seat-A") is not None
+    assert codex_models_cache.read_cache(client_version="0.144.2", account_id="seat-B") is None
+
+
+def test_load_codex_bundle_sanitizes_hostile_plan_type(monkeypatch, tmp_path):
+    """plan_type rides onto the terminal (`grid catalog`'s "Your current plan (…)" heading), so the
+    LOAD boundary bounds + printable-checks it exactly as account_id — a forged token that stored an
+    ANSI-laden or oversized tier string reads back as None ("unknown tier"), never terminal-injectable
+    (CWE-150, rev-code). A normal short label passes through unchanged."""
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    from remote import api_keys, credentials
+    from shared import paths
+
+    def _stored(plan_type):
+        credentials.atomic_write_toml(paths.api_keys_file(), {"codex": {
+            "access_token": "a", "refresh_token": "r", "account_id": "acct-1",
+            "last_refresh": 0, "plan_type": plan_type,
+        }})
+        return api_keys.load_codex_bundle().plan_type
+
+    assert _stored("plus") == "plus"  # a real label survives
+    assert _stored("bad\x1b[31mescape") is None  # ANSI escapes → dropped ("unknown tier")
+    assert _stored("x" * 200) is None  # oversized → dropped
+
+
+def test_codex_probe_sends_the_verified_request_and_returns_rich_records(monkeypatch):
     """The probe is the ONE vendor call a changed join makes, and it is free (facts.md B1). It
     sends the verified URL + `client_version` pin and exactly the five headers the real client
-    sends (spike probe.py `headers_for`). It returns the seat's visible slugs — a
-    `visibility: "hide"` row (codex-auto-review) is never advertised — deduped, vendor order
-    preserved; the ~42 unknown fields per model ride along ignored. A CF-RAY header on the 200
-    is NOT a Cloudflare block: CF-RAY rides every response, including successes (facts.md B4)."""
+    sends (spike probe.py `headers_for`). It returns rich per-model records — slug PLUS the caps
+    the envelope needs (issue 10a) — in vendor order, deduped (first occurrence wins); a
+    `visibility: "hide"` row (codex-auto-review) is never advertised; the ~42 unknown fields per
+    model ride along ignored. Caps derive from the probe: `context_window` direct, vision from
+    `"image" in input_modalities`, tools from `supports_parallel_tool_calls or supports_search_tool`.
+    A CF-RAY header on the 200 is NOT a Cloudflare block (facts.md B4)."""
     body = {"models": [
-        {"slug": "gpt-5.6-terra", "visibility": "list", "context_window": 272000, "unknown_field": 1},
-        {"slug": "gpt-5.5", "visibility": "list"},
-        {"slug": "gpt-5.5", "visibility": "list"},            # vendor dupe → deduped
+        {"slug": "gpt-5.6-terra", "visibility": "list", "supported_in_api": True,
+         "context_window": 272000, "input_modalities": ["text", "image"],
+         "supports_parallel_tool_calls": True, "supports_search_tool": True, "unknown_field": 1},
+        {"slug": "gpt-5.5", "visibility": "list", "supported_in_api": True,
+         "context_window": 272000, "input_modalities": ["text"],  # text-only → no vision
+         "supports_parallel_tool_calls": False, "supports_search_tool": True},  # search_tool → tools
+        {"slug": "gpt-5.5", "visibility": "list"},            # vendor dupe → deduped (first wins)
         {"slug": "codex-auto-review", "visibility": "hide"},  # hidden → excluded
     ]}
 
-    slugs, seen = _probe(monkeypatch, lambda request: httpx.Response(
+    records, seen = _probe(monkeypatch, lambda request: httpx.Response(
         200, json=body, headers={"CF-RAY": "a1b94a2e9cacfd7c-SIN"},
     ))
 
-    assert slugs == ("gpt-5.6-terra", "gpt-5.5")
+    assert [m.slug for m in records] == ["gpt-5.6-terra", "gpt-5.5"]
+    terra, big = records
+    assert terra.context_window == 272000 and terra.supports_vision and terra.supports_tools
+    assert big.context_window == 272000
+    assert big.supports_vision is False  # input_modalities text-only
+    assert big.supports_tools is True    # supports_search_tool alone is enough
     assert seen["calls"] == 1  # one request, no retry
     assert seen["method"] == "GET"
     assert seen["url"] == (
@@ -1698,6 +1962,108 @@ def test_codex_probe_sends_the_verified_request_and_returns_visible_slugs(monkey
     assert seen["headers"]["originator"] == "codex_cli_rs"
     assert seen["headers"]["user-agent"] == "codex_cli_rs"
     assert seen["headers"]["accept"] == "application/json"
+
+
+def test_codex_probe_membership_drops_only_explicit_supported_in_api_false(monkeypatch):
+    """Membership = visible ∧ not-explicitly-unsupported. `supported_in_api: false` is dropped
+    (US5 — a model that would 400 if called is never advertised); an ABSENT field is SERVED
+    (Option A / DESIGN §8 — never fail closed on a MODEL, only an explicit vendor `false`
+    excludes). Real bodies always send `true`, so the absent case only bites a reshaped body."""
+    records, _ = _probe(monkeypatch, lambda request: httpx.Response(200, json={"models": [
+        {"slug": "served-true", "visibility": "list", "supported_in_api": True},
+        {"slug": "served-absent", "visibility": "list"},                            # absent → served
+        {"slug": "dropped-false", "visibility": "list", "supported_in_api": False},  # explicit → dropped
+    ]}))
+    assert [m.slug for m in records] == ["served-true", "served-absent"]
+
+
+def test_codex_probe_derives_caps_fail_closed_on_missing_fields(monkeypatch, capsys):
+    """Caps fail CLOSED per field — never raising, never dropping the model: a row missing
+    input_modalities/tool flags claims neither vision nor tools; a missing (or non-numeric)
+    context_window becomes the `0` unknown sentinel (the envelope omits it downstream, never a
+    fabricated number). The model is still served. A legitimately ABSENT field is sparse-normal —
+    NO drift breadcrumb (that fires only for a present-but-unreadable field)."""
+    records, _ = _probe(monkeypatch, lambda request: httpx.Response(200, json={"models": [
+        {"slug": "bare", "visibility": "list"},  # no caps fields at all
+    ]}))
+    (bare,) = records
+    assert bare.slug == "bare"
+    assert bare.supports_vision is False
+    assert bare.supports_tools is False
+    assert bare.context_window == 0
+    assert capsys.readouterr().err == ""  # absent (sparse) fields draw no warn
+
+
+def test_codex_probe_context_window_infinity_is_unknown_not_a_crash(monkeypatch):
+    """A vendor `context_window` of `Infinity`/`1e400` (Python's json accepts both) must degrade to
+    the `0` unknown sentinel, NEVER crash the join with an uncaught `OverflowError` from `int(inf)`
+    (issue 10a review, HIGH). The model is still served."""
+    records, _ = _probe(monkeypatch, lambda request: httpx.Response(
+        200, content='{"models": [{"slug": "big", "visibility": "list", "context_window": 1e400}]}',
+        headers={"Content-Type": "application/json"},
+    ))
+    (big,) = records
+    assert big.slug == "big"
+    assert big.context_window == 0  # inf → unknown, not a crash, not a fabricated number
+
+
+def test_codex_probe_tool_flags_fail_closed_on_a_non_bool(monkeypatch):
+    """The tool flags are accepted ONLY as a real JSON `true` (issue 10a review): a vendor reshape to
+    a truthy STRING must NOT over-claim tools — `bool("false")` is `True` in Python, so a naive
+    coercion would flip the capability OPEN, the wrong direction. Degrades to the conservative False,
+    matching every sibling caps field."""
+    records, _ = _probe(monkeypatch, lambda request: httpx.Response(200, json={"models": [
+        {"slug": "m", "visibility": "list", "supported_in_api": True,
+         "supports_parallel_tool_calls": "false", "supports_search_tool": "false"},
+    ]}))
+    (m,) = records
+    assert m.supports_tools is False  # a truthy string never over-claims
+
+
+def test_codex_probe_drops_a_slug_with_terminal_control_sequences(monkeypatch):
+    """A hostile/MITM'd backend returning a slug with ANSI/OSC escape sequences (or an absurd length)
+    must never let that string ride the advertised name onto the operator's terminal (issue 10a
+    review, CWE-150). Such a row is treated like one with no readable slug — dropped — so clean
+    models still serve; only an all-unreadable listing is contract drift."""
+    records, _ = _probe(monkeypatch, lambda request: httpx.Response(200, json={"models": [
+        {"slug": "gpt-5.5", "visibility": "list", "supported_in_api": True},
+        {"slug": "evil\x1b[2J\x1b[H", "visibility": "list", "supported_in_api": True},  # ANSI clear-screen
+        {"slug": "x" * 300, "visibility": "list", "supported_in_api": True},            # over-long
+    ]}))
+    assert [m.slug for m in records] == ["gpt-5.5"]  # both hostile rows dropped, the clean one served
+
+
+def test_codex_probe_warns_once_on_a_present_but_malformed_caps_field(monkeypatch, capsys):
+    """A caps-critical field PRESENT but in an unreadable shape (a vendor reshape) is treated
+    conservatively AND surfaces ONE operator breadcrumb (issue 10a review) — a whole-listing field
+    rename would otherwise strip caps from every model silently, with a "success" join and no signal.
+    The model is still served."""
+    records, _ = _probe(monkeypatch, lambda request: httpx.Response(200, json={"models": [
+        {"slug": "m", "visibility": "list", "supported_in_api": True,
+         "input_modalities": "text,image", "context_window": 272000},  # modalities a STRING, not a list
+    ]}))
+    (m,) = records
+    assert m.supports_vision is False  # unreadable modalities → conservative claim
+    err = capsys.readouterr().err
+    assert "input_modalities" in err and "conservatively" in err  # the one breadcrumb
+
+
+def test_codex_capability_entry_omits_unknown_context_window():
+    """Issue 10a / DESIGN §8.1: a codex model whose probe carried no context_window (the `0` unknown
+    sentinel) OMITS the key from the envelope — never a fabricated number — while a known window is
+    emitted. Ports the `capability_entry` conditional-key idiom into the codex path."""
+    from remote import probe
+
+    known = api_catalog.ApiModelEntry(
+        vendor_name="gpt-x", context_window=272000, supports_tools=True, supports_vision=True,
+        supports_json_mode=False, supports_structured_outputs=False,
+    )
+    unknown = api_catalog.ApiModelEntry(
+        vendor_name="gpt-y", context_window=0, supports_tools=False, supports_vision=False,
+        supports_json_mode=False, supports_structured_outputs=False,
+    )
+    assert probe.codex_capability_entry(known, vendor_rank=1)["context_window"] == 272000
+    assert "context_window" not in probe.codex_capability_entry(unknown, vendor_rank=2)
 
 
 def test_codex_probe_auth_failures_raise_the_typed_seat_rejection(monkeypatch):
@@ -4810,25 +5176,21 @@ def test_remote_join_api_codex_reuses_a_stored_seat_with_no_sign_in(monkeypatch,
     assert "at-1" not in out_err.out + out_err.err and "rt-1" not in out_err.out + out_err.err
 
 
-def test_remote_join_api_codex_stored_seat_probes_and_serves_the_tier_set(monkeypatch, tmp_path, capsys):
-    """The tracer join (issue 05): a stored free seat, no -m. ONE free probe (`GET {base}/models`
-    with the seat's bearer + account-id header) proves reachability and the entitled set; the
-    advertised set is the tier row ∩ the seat's live set, namespaced `codex:*`; the record's spec
-    is kind-generic (endpoint_url/models/engine_label/api_kind — never a token, never the account
-    id); the serve process spawns. A populated, verified tier draws NO tier warning."""
+def test_remote_join_api_codex_serves_the_probe_set_with_persisted_caps(monkeypatch, tmp_path, capsys):
+    """The tracer join (issue 10a): a stored free seat, no -m. ONE free probe (`GET {base}/models`
+    with the seat's bearer + account-id header) is the SOLE source of truth — the served set is
+    exactly the probe's visible ∧ API-supported models (codex-auto-review, visibility:hide, dropped),
+    namespaced `codex:*`, with NO static tier intersection. Per-model caps DERIVED from the probe are
+    PERSISTED in the run record's spec (`model_caps`) so the serving side needs no static lookup; the
+    spec stays kind-generic and secret-free (never a token or the account id). The free-seat
+    observable set is UNCHANGED (AC8): exactly the four free models, caps per facts.md #5."""
     from remote import api_keys
     from shared import run_records
 
     _seed_running_remote_grid(monkeypatch, tmp_path)
     spawned = _mock_remote_spawn(monkeypatch)
     api_keys.store_codex_bundle(_codex_bundle())
-    seen = _mock_probe(monkeypatch, lambda request: httpx.Response(200, json={"models": [
-        {"slug": "gpt-5.6-terra", "visibility": "list"},
-        {"slug": "gpt-5.6-luna", "visibility": "list"},
-        {"slug": "gpt-5.5", "visibility": "list"},
-        {"slug": "gpt-5.4-mini", "visibility": "list"},
-        {"slug": "codex-auto-review", "visibility": "hide"},
-    ]}))
+    seen = _mock_probe(monkeypatch, lambda request: httpx.Response(200, json=_codex_models_body()))
 
     assert cli.main(["join", "--api", "codex"]) == 0
 
@@ -4837,14 +5199,22 @@ def test_remote_join_api_codex_stored_seat_probes_and_serves_the_tier_set(monkey
     assert seen["headers"]["authorization"] == "Bearer tok-access"
     assert seen["headers"]["chatgpt-account-id"] == "acct-1"
     record = cli.provider._read_records("n1")["remote"]
-    assert record["engines"] == [{
-        "endpoint_url": "https://chatgpt.com/backend-api/codex",
-        "models": ["codex:gpt-5.6-terra", "codex:gpt-5.6-luna", "codex:gpt-5.5", "codex:gpt-5.4-mini"],
-        "engine_label": "codex",
-        "api_kind": "codex",
-        "plan_type": "free",  # issue 03: the seat's tier — the row serve reads vendor_rank from
-    }]
-    assert record["models"] == record["engines"][0]["models"]
+    spec = record["engines"][0]
+    assert spec["endpoint_url"] == "https://chatgpt.com/backend-api/codex"
+    # Exactly the four free models; codex-auto-review (visibility:hide) dropped. No static ∩.
+    assert spec["models"] == [
+        "codex:gpt-5.6-terra", "codex:gpt-5.6-luna", "codex:gpt-5.5", "codex:gpt-5.4-mini",
+    ]
+    assert spec["engine_label"] == "codex" and spec["api_kind"] == "codex"
+    assert spec["plan_type"] == "free"  # a display/message label only now — never gates serving
+    # Caps derived from the probe and persisted per model (facts.md #5: 272k ctx, vision, tools);
+    # vendor_rank = the 1-based probe order (terra 1, luna 2, gpt-5.5 3, gpt-5.4-mini 4).
+    assert spec["model_caps"]["codex:gpt-5.6-terra"] == {
+        "context_window": 272000, "vision": True, "tools": True, "vendor_rank": 1,
+    }
+    assert spec["model_caps"]["codex:gpt-5.5"]["vendor_rank"] == 3
+    assert set(spec["model_caps"]) == set(spec["models"])  # caps cover exactly the served set here
+    assert record["models"] == spec["models"]
     assert spawned["cmd"][-3:] == ["__remote-engine", "n1", "remote"]
     # Secret hygiene: the bearer and the account id reach no record and no terminal output.
     record_text = run_records.record_path("n1", "remote").read_text()
@@ -4852,91 +5222,81 @@ def test_remote_join_api_codex_stored_seat_probes_and_serves_the_tier_set(monkey
     out_err = capsys.readouterr()
     assert "tok-access" not in out_err.out + out_err.err
     assert "acct-1" not in out_err.out + out_err.err
-    assert "Warning" not in out_err.err  # a verified populated tier draws no tier warning
 
 
-def test_remote_join_api_codex_tier_selects_the_row_and_warns_per_degrade_case(monkeypatch, tmp_path, capsys):
-    """D-f row selection + the issue's mandated warn-log, with a synthetic second tier (the real
-    table has only `free`, so a bigger `plus` row is the only way to SEE selection — review L3).
-    Four seats, four outcomes:
-
-      * plus (populated row)   → the plus row, NO tier line at all
-      * None (vendor silent)   → minimal row + "Warning:" — the alarm the issue amendment demands:
-                                 a vendor claim-rename must not silently downgrade seats forever
-      * banana (unrecognized)  → minimal row + "Warning:" (vendor vocabulary drift)
-      * go (known, unverified) → minimal row + an info line that is NOT a warning
-    """
+def test_remote_join_api_codex_serves_a_model_absent_from_the_static_table(monkeypatch, tmp_path):
+    """The wall is gone (issue 10a AC2): a model the seat's probe lists but that no static table ever
+    named — a newly-shipped slug — is served the day the vendor ships it, no CLI edit, no PR. Proven
+    with a probe body carrying a hypothetical `gpt-5.7-nova`, absent from the static reference's whole
+    `entries` union (10b added the paid slugs, so `gpt-5.6-sol` no longer witnesses this); its caps
+    come from the probe and its vendor_rank is its position in the live listing."""
     from remote import api_keys
 
-    free_row = api_catalog.CODEX_TIER_MODELS["free"][:2]
-    plus_row = api_catalog.CODEX_TIER_MODELS["free"]
-    monkeypatch.setattr(api_catalog, "CODEX_TIER_MODELS", {"free": free_row, "plus": plus_row})
-    listing = {"models": [{"slug": e.vendor_name, "visibility": "list"} for e in plus_row]}
+    assert not any(  # guard the premise: nova really is absent from the static reference
+        e.vendor_name == "gpt-5.7-nova" for e in api_catalog.WHITELISTS["codex"].entries
+    )
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_remote_spawn(monkeypatch)
+    api_keys.store_codex_bundle(_codex_bundle())
+    body = _codex_models_body()
+    body["models"].append({
+        "slug": "gpt-5.7-nova", "visibility": "list", "supported_in_api": True,
+        "context_window": 400000, "input_modalities": ["text", "image"],
+        "supports_parallel_tool_calls": True, "supports_search_tool": True,
+    })
+    _mock_probe(monkeypatch, lambda request: httpx.Response(200, json=body))
 
-    cases = [
-        ("plus", 4), (None, 2), ("banana", 2), ("go", 2),
-    ]
-    errs = {}
-    for plan, expected_count in cases:
-        home = tmp_path / f"case-{plan}"
-        _seed_running_remote_grid(monkeypatch, home)
-        _mock_remote_spawn(monkeypatch)
-        api_keys.store_codex_bundle(_codex_bundle(plan_type=plan))
-        _mock_probe(monkeypatch, lambda request: httpx.Response(200, json=listing))
+    assert cli.main(["join", "--api", "codex"]) == 0
 
-        assert cli.main(["join", "--api", "codex"]) == 0
-
-        record = cli.provider._read_records("n1")["remote"]
-        assert len(record["models"]) == expected_count, f"plan={plan!r}"
-        # The seat's tier rides the spec verbatim (issue 03) — even None (vendor silent): serve
-        # reads each model's vendor_rank from the row this plan_type selects.
-        assert record["engines"][0].get("plan_type") == plan, f"plan={plan!r}"
-        errs[plan] = capsys.readouterr().err
-
-    assert "Warning" not in errs["plus"] and "isn't verified" not in errs["plus"]
-    assert "Warning:" in errs[None] and "no subscription tier" in errs[None]
-    assert "newer grid release" in errs[None]  # the recovery hint — this case may be OUR staleness
-    assert "Warning:" in errs["banana"]
-    assert "recognize" in errs["banana"]
-    assert "Warning:" not in errs["go"]  # known tier, merely unverified — informational only
-    assert "isn't verified" in errs["go"] and "'go'" in errs["go"]
+    spec = cli.provider._read_records("n1")["remote"]["engines"][0]
+    assert "codex:gpt-5.7-nova" in spec["models"]  # served with no static-reference entry
+    assert spec["model_caps"]["codex:gpt-5.7-nova"] == {
+        "context_window": 400000, "vision": True, "tools": True, "vendor_rank": 5,
+    }
 
 
-def test_remote_join_api_codex_explicit_model_errors_name_what_is_available(monkeypatch, tmp_path):
-    """D5's explicit--m semantics: an explicit ask is REFUSED, never silently narrowed (the
-    deliberate divergence from openai's skip — a personal seat asked for a model it lacks
-    deserves a refusal). Outside the tier row → the tier's verified list is named (D-f bounds
-    advertising to the verified row whatever the seat has); in the row but not on the seat →
-    what the seat CAN serve is named, and the message never claims the seat "serves none" when
-    it demonstrably serves others. Nothing spawns on either."""
+def test_remote_join_api_codex_writes_the_models_cache(monkeypatch, tmp_path):
+    """issue 10b: the join probe writes `~/.grid/codex_models_cache.json`, so a later offline
+    `grid catalog --api codex` shows the seat's real last-known set instead of only the static
+    reference. Best-effort in the writer, but on a normal join it lands with the served set."""
+    from remote import api_keys, codex_models_cache
+
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_remote_spawn(monkeypatch)
+    api_keys.store_codex_bundle(_codex_bundle())
+    _mock_probe(monkeypatch, lambda request: httpx.Response(200, json=_codex_models_body()))
+
+    assert cli.main(["join", "--api", "codex"]) == 0
+
+    cached = codex_models_cache.read_cache(
+        client_version=api_catalog.CODEX_CLIENT_VERSION, account_id="acct-1",
+    )
+    assert cached is not None
+    # the free-seat set with codex-auto-review (visibility "hide") excluded — the served membership
+    assert [m.slug for m in cached.models] == ["gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5", "gpt-5.4-mini"]
+
+
+def test_remote_join_api_codex_explicit_unentitled_model_is_refused_naming_the_probe_set(monkeypatch, tmp_path):
+    """`-m` semantics (issue 10a AC5): an explicit model the seat's probe doesn't list is REFUSED,
+    never silently narrowed, and the message names what the probe set CAN serve. The probe — not a
+    static tier — is the authority, so the "can serve" list reflects the live seat, and the message
+    never claims the seat "serves none" while it demonstrably serves others. Nothing spawns."""
     from remote import api_keys
-
-    # Synthetic split (review L3): the union whitelist keeps all 4 entries, the tier row shrinks
-    # to 2 — the only way a union-valid, tier-invalid name can exist while only `free` is real.
-    free_row = api_catalog.CODEX_TIER_MODELS["free"][:2]  # terra, luna
-    monkeypatch.setattr(api_catalog, "CODEX_TIER_MODELS", {"free": free_row})
 
     _seed_running_remote_grid(monkeypatch, tmp_path)
     spawned = _mock_remote_spawn(monkeypatch)
     api_keys.store_codex_bundle(_codex_bundle())
+    # The probe serves only terra; gpt-5.5 is a valid whitelist name but not on THIS seat's listing.
     _mock_probe(monkeypatch, lambda request: httpx.Response(200, json={"models": [
-        {"slug": "gpt-5.6-terra", "visibility": "list"},
+        {"slug": "gpt-5.6-terra", "visibility": "list", "supported_in_api": True},
     ]}))
 
-    # -m outside the tier row (but inside the union whitelist): the tier bound refuses it.
     with pytest.raises(SystemExit) as exc:
         cli.main(["join", "--api", "codex", "-m", "codex:gpt-5.5"])
     msg = str(exc.value)
-    assert "codex:gpt-5.5" in msg and "'free'" in msg
-    assert "codex:gpt-5.6-terra" in msg and "codex:gpt-5.6-luna" in msg  # the tier's verified list
-
-    # -m inside the tier row but absent from the live seat: name what IS available, truthfully.
-    with pytest.raises(SystemExit) as exc:
-        cli.main(["join", "--api", "codex", "-m", "codex:gpt-5.6-luna"])
-    msg = str(exc.value)
-    assert "codex:gpt-5.6-luna" in msg
-    assert "codex:gpt-5.6-terra" in msg   # the seat CAN serve this...
-    assert "serves none" not in msg       # ...so "serves none" would be a lie
+    assert "codex:gpt-5.5" in msg             # the refused request, named
+    assert "codex:gpt-5.6-terra" in msg       # ...against what the seat's probe CAN serve
+    assert "serves none" not in msg           # the seat serves terra, so "none" would be a lie
 
     assert cli.provider._read_records("n1") == {} and "cmd" not in spawned
 
@@ -5025,6 +5385,38 @@ def test_merge_engines_refreshes_codex_plan_type_on_rejoin():
     hw_incoming = [{"endpoint_url": "http://h:11434/v1", "models": ["llama3", "qwen"], "engine_label": None}]
     hw_merged, _ = cli.remote_provider._merge_engines(hw_base, hw_incoming)
     assert "plan_type" not in hw_merged[0]
+
+
+def test_merge_engines_unions_codex_model_caps_keeping_a_dropped_models_caps():
+    """A re-join UNIONS model_caps, never replaces it (issue 10a review). `models` only ever grows,
+    so a model still in the union but dropped by a shrunk fresh probe must keep its last-known caps
+    instead of silently degrading to the fail-closed serve entry. Incoming caps win for a re-probed
+    model; a model absent from the fresh probe keeps its prior entry."""
+    codex = "https://chatgpt.com/backend-api/codex"
+
+    def caps(rank):
+        return {"context_window": 272000, "vision": True, "tools": True, "vendor_rank": rank}
+
+    base = [{"endpoint_url": codex, "models": ["codex:a", "codex:b", "codex:c"],
+             "engine_label": "codex", "api_kind": "codex", "plan_type": "free",
+             "model_caps": {"codex:a": caps(1), "codex:b": caps(2), "codex:c": caps(3)}}]
+    # A fresh re-probe DROPPED c (vendor entitlement shrank) and added d; `-m codex:d` forced it.
+    incoming = [{"endpoint_url": codex, "models": ["codex:a", "codex:b", "codex:d"],
+                 "engine_label": "codex", "api_kind": "codex", "plan_type": "free",
+                 "model_caps": {"codex:a": caps(1), "codex:b": caps(2), "codex:d": caps(9)}}]
+
+    merged, changed = cli.remote_provider._merge_engines(base, incoming)
+
+    assert changed  # codex:d is genuinely new
+    (spec,) = merged
+    assert spec["models"] == ["codex:a", "codex:b", "codex:c", "codex:d"]  # models only grow
+    # c is still served (in models) → its last-known caps are RETAINED, not dropped to fail-closed.
+    assert set(spec["model_caps"]) == {"codex:a", "codex:b", "codex:c", "codex:d"}
+    assert spec["model_caps"]["codex:c"]["vendor_rank"] == 3  # base's entry kept (absent from re-probe)
+    assert spec["model_caps"]["codex:d"]["vendor_rank"] == 9  # incoming's entry added
+    # The write is a fresh dict — it never aliases the base or incoming spec's own map.
+    assert spec["model_caps"] is not base[0]["model_caps"]
+    assert spec["model_caps"] is not incoming[0]["model_caps"]
 
 
 def test_remote_join_api_codex_fresh_signin_onto_live_seat_respawns(monkeypatch, tmp_path, capsys):
@@ -5209,59 +5601,33 @@ def test_codex_probe_all_hidden_listing_is_empty_not_drift(monkeypatch):
     back and the join's selection layer then says truthfully that the seat serves nothing. The
     old discriminator sent all-hidden operators chasing a grid upgrade that doesn't exist. Only
     a non-empty listing with NO readable slug anywhere is drift."""
-    slugs, _ = _probe(monkeypatch, lambda request: httpx.Response(200, json={"models": [
+    records, _ = _probe(monkeypatch, lambda request: httpx.Response(200, json={"models": [
         {"slug": "codex-auto-review", "visibility": "hide"},
         {"slug": "under-review-model", "visibility": "hide"},
     ]}))
-    assert slugs == ()
+    assert records == ()
 
 
-def test_remote_join_api_codex_hidden_models_never_advertised_even_if_the_flag_renames(monkeypatch, tmp_path):
-    """(silent-failure review #1, containment pin) If the vendor renames `visibility` the hide
-    filter no-ops — fails OPEN. What actually bounds advertising is the verified tier row: a
-    model absent from it (codex-auto-review) can never be advertised whatever the live listing
-    says. This test pins that containment so the filter stays defence-in-depth, not the wall."""
+def test_remote_join_api_codex_hide_filter_is_the_sole_guard_for_hidden_models(monkeypatch, tmp_path):
+    """(issue 10a) With the static tier intersection gone, the `visibility:"hide"` filter is the
+    SOLE structural guard against advertising a model the vendor hides from its own picker: under
+    the real field name it drops codex-auto-review, so the free-seat observable set is unchanged.
+    If the vendor RENAMES `visibility` the filter fails OPEN and the hidden model is served — visible
+    damage (it 400s per job), never a MODEL failed closed (DESIGN §8). The old "even if renamed"
+    tier-row backstop is intentionally gone; this pins the guarantee that still holds."""
     from remote import api_keys
 
     _seed_running_remote_grid(monkeypatch, tmp_path)
     _mock_remote_spawn(monkeypatch)
     api_keys.store_codex_bundle(_codex_bundle())
     _mock_probe(monkeypatch, lambda request: httpx.Response(200, json={"models": [
-        {"slug": "codex-auto-review", "visible": "hidden"},  # renamed flag → filter can't see it
-        {"slug": "gpt-5.5", "visible": "listed"},
+        {"slug": "codex-auto-review", "visibility": "hide", "supported_in_api": True},
+        {"slug": "gpt-5.5", "visibility": "list", "supported_in_api": True},
     ]}))
 
     assert cli.main(["join", "--api", "codex"]) == 0
 
     assert cli.provider._read_records("n1")["remote"]["models"] == ["codex:gpt-5.5"]
-
-
-def test_remote_join_api_codex_rejoin_warns_again_while_tier_is_degraded(monkeypatch, tmp_path, capsys):
-    """(silent-failure review #4) The mandated tier warn fires on EVERY join — including the
-    zero-vendor-call no-op re-join — while the degraded condition persists. A seat stuck at
-    plan_type=None must not warn once at the first join and then never again for the life of
-    the seat: habitual re-joins (reboots, timers) would otherwise never resurface it, which is
-    exactly the silent decay the issue's amendment exists to prevent."""
-    from remote import api_keys
-
-    _seed_running_remote_grid(monkeypatch, tmp_path)
-    _mock_remote_spawn(monkeypatch)
-    api_keys.store_codex_bundle(_codex_bundle(plan_type=None))
-    _mock_probe(monkeypatch, lambda request: httpx.Response(200, json={"models": [
-        {"slug": "gpt-5.5", "visibility": "list"},
-    ]}))
-
-    assert cli.main(["join", "--api", "codex"]) == 0
-    assert "no subscription tier" in capsys.readouterr().err  # join #1 warns
-
-    monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
-    monkeypatch.setattr(httpx, "Client", lambda *a, **k: pytest.fail(
-        "a no-op re-join still performs zero vendor calls"
-    ))
-    for _ in range(2):
-        assert cli.main(["join", "--api", "codex"]) == 0
-        err = capsys.readouterr().err
-        assert "Warning:" in err and "no subscription tier" in err  # ...and still warns
 
 
 def test_remote_join_api_codex_noop_requires_the_current_backend_url(monkeypatch, tmp_path):
@@ -8797,11 +9163,12 @@ def test_remote_join_codex_onto_api_only_respawns_for_concurrency_flip(monkeypat
     assert (4242, _sig.SIGHUP) not in spawned["signals"]  # ...instead of hot-reloading it
 
 
-def _codex_serve_skeleton(monkeypatch, tmp_path, models, *, plan_type=None):
+def _codex_serve_skeleton(monkeypatch, tmp_path, models, *, plan_type=None, model_caps=None):
     """The register-capture skeleton (:api_only_defaults_to_eight_workers pattern) for a
-    codex-only record serving ``models``. ``plan_type`` (when given) rides the engine spec exactly
-    as the CLI writes it — the tier row serve reads vendor_rank from. Returns the kwargs
-    register_node saw."""
+    codex-only record serving ``models``. ``model_caps`` (advertised name → probe-derived caps) and
+    ``plan_type`` (the seat's tier label) ride the engine spec exactly as the CLI writes them at
+    join — serve reads each model's caps + vendor_rank from ``model_caps`` (issue 10a). Returns the
+    kwargs register_node saw."""
     from remote import api_keys, relay, serve
 
     monkeypatch.setenv("GRID_HOME", str(tmp_path))
@@ -8810,6 +9177,8 @@ def _codex_serve_skeleton(monkeypatch, tmp_path, models, *, plan_type=None):
             "models": list(models), "engine_label": "codex", "api_kind": "codex"}
     if plan_type is not None:
         spec["plan_type"] = plan_type
+    if model_caps is not None:
+        spec["model_caps"] = model_caps
     record = {"grid_id": "n1", "signaling_url": "https://relay.example", "media": False,
               "engines": [spec]}
     monkeypatch.setattr(serve.run_records, "read_record", lambda g, e: record)
@@ -8826,30 +9195,31 @@ def _codex_serve_skeleton(monkeypatch, tmp_path, models, *, plan_type=None):
 
 
 def test_remote_engine_codex_record_registers_honest_responses_caps(monkeypatch, tmp_path):
-    """The codex capability envelope carries ONLY what passthrough can honestly claim (issue 05):
-    `endpoints: ["responses"]` (the wire literal grid-src's per-model filter reads — absent means
-    chat-only there, so old CLIs fail closed), the verified context window, features
-    {vision, tools, parallel_tool_calls, stream_only} (the last a NEGATIVE routing trait, issue 06c —
-    the SSE-only seat, sourced from `kind_is_stream_only`), and the join-time `vendor_rank` (issue 03 / ADR 0016 —
-    a top-level int sibling of context_window, the seat's tier-row position, 1 = most capable). It
-    OMITS — not False — the chat-dialect flags (json_object/json_schema), `max_output_tokens` and
-    the `limits` block (facts #1: the backend has no output cap under any name; a fabricated 64000
-    would be a provider-written limit the relay might act on), and audio/logprobs."""
-    seen = _codex_serve_skeleton(monkeypatch, tmp_path, ["codex:gpt-5.5"])
+    """The codex capability envelope carries ONLY what passthrough can honestly claim, built from the
+    caps the join PERSISTED in the record (issue 10a): `endpoints: ["responses"]` (the wire literal
+    grid-src's per-model filter reads — absent means chat-only there, so old CLIs fail closed), the
+    probe's context window, features {vision, tools, parallel_tool_calls, stream_only} (the last a
+    NEGATIVE routing trait, issue 06c — the SSE-only seat, sourced from `kind_is_stream_only`), and
+    the join-time `vendor_rank` (a top-level int sibling of context_window). It OMITS — not False —
+    the chat-dialect flags (json_object/json_schema), `max_output_tokens` and the `limits` block
+    (facts #1: the backend has no output cap under any name; a fabricated 64000 would be a
+    provider-written limit the relay might act on), and audio/logprobs."""
+    caps = {"codex:gpt-5.5": {"context_window": 272000, "vision": True, "tools": True, "vendor_rank": 3}}
+    seen = _codex_serve_skeleton(monkeypatch, tmp_path, ["codex:gpt-5.5"], model_caps=caps)
 
-    caps = seen["capabilities"]
-    assert caps["schema_version"] == 1
-    entry = caps["models"]["codex:gpt-5.5"]
+    envelope = seen["capabilities"]
+    assert envelope["schema_version"] == 1
+    entry = envelope["models"]["codex:gpt-5.5"]
     assert entry["endpoints"] == ["responses"]
     assert entry["input_modalities"] == ["text", "image"]
     assert entry["output_modalities"] == ["text"]
     assert entry["context_window"] == 272_000
-    # vendor_rank rides top-level (NOT inside features — the grid-src reader takes it there). gpt-5.5
-    # is index 2 in the free tier row [terra, luna, gpt-5.5, gpt-5.4-mini] → rank 3.
+    # vendor_rank rides top-level (NOT inside features — the grid-src reader takes it there), read
+    # straight from the record's model_caps (the probe's visible order at join), never recomputed.
     assert entry["vendor_rank"] == 3
     # issue 06c: the seat also advertises the NEGATIVE `stream_only` routing trait — its backend is
-    # SSE-only — sourced from `kind_is_stream_only`, so a non-streaming `auto` request forbids it and is
-    # never routed here. A routing trait, not a model capability (kept out of `codex_features`).
+    # SSE-only — sourced from `kind_is_stream_only`, so a non-streaming `auto` request is never routed
+    # here. A routing trait, not a model capability (kept out of `codex_features`).
     assert entry["features"] == {
         "vision": True, "tools": True, "parallel_tool_calls": True, "stream_only": True,
     }
@@ -8858,50 +9228,46 @@ def test_remote_engine_codex_record_registers_honest_responses_caps(monkeypatch,
     assert "json_object" not in entry["features"] and "json_schema" not in entry["features"]
 
 
-def test_remote_engine_codex_model_gone_from_whitelist_degrades_honestly(monkeypatch, tmp_path, capsys):
-    """The stale-catalog degrade (catalog edited between join and respawn) stays honest for
-    codex: a warn plus an entry that still says `responses`-only with NO capability claims — never
-    the chat-dialect all-False shape, and never a fabricated output cap. A model gone from the
-    whitelist has no tier-row position either, so `vendor_rank` is omitted (issue 03).
+def test_remote_engine_codex_model_absent_from_caps_degrades_honestly(monkeypatch, tmp_path, capsys):
+    """The fail-closed degrade (issue 10a): a codex model advertised but absent from the record's
+    `model_caps` — a record written before the live-probe catalog, or a caps map that dropped it —
+    stays `responses`-only with NO capability claims (never the chat-dialect all-False shape, never a
+    fabricated output cap or context window) AND warns (an absent no-caps entry must not be silent).
 
-    issue 06c: the degrade still advertises the `stream_only` routing trait — a stale seat's backend
-    is still SSE-only, so a non-streaming `auto` request must still be routed away from it (fail-closed,
-    the opposite polarity to a capability, which degrades OFF)."""
-    seen = _codex_serve_skeleton(monkeypatch, tmp_path, ["codex:ghost"])
+    issue 06c: the degrade still advertises the `stream_only` routing trait — a seat's backend is
+    SSE-only whether or not its caps were recorded, so a non-streaming `auto` request must still be
+    routed away from it (fail-closed, the opposite polarity to a capability, which degrades OFF)."""
+    seen = _codex_serve_skeleton(monkeypatch, tmp_path, ["codex:ghost"], model_caps={})
 
     entry = seen["capabilities"]["models"]["codex:ghost"]
     assert entry["endpoints"] == ["responses"]
     assert entry["features"] == {"stream_only": True}
     assert "max_output_tokens" not in entry and "limits" not in entry
     assert "context_window" not in entry  # unknown is omitted, never invented
-    assert "vendor_rank" not in entry  # absent from the row → omit the fact, never rank 0/None
-    assert "no longer in the codex whitelist" in capsys.readouterr().err
+    assert "vendor_rank" not in entry  # no caps recorded → no rank fabricated
+    assert "no probe-derived caps" in capsys.readouterr().err
 
 
-def test_remote_engine_codex_vendor_rank_follows_the_seats_tier_row(monkeypatch, tmp_path, capsys):
-    """vendor_rank is sourced from the SEAT'S tier row, not the flat union (issue 03 / ADR 0016).
-    A synthetic `plus` tier (the real table has only `free`) REVERSES the free order and drops one
-    model; a seat whose stored plan_type is `plus` must advertise ranks in the plus order. A model
-    advertised but OUTSIDE the seat's row carries no rank — the frozen union resolves its entry, but
-    the row has no position for it, so the fact is omitted (graceful drift) AND an operator warn
-    fires (silent-failure review: a silent no-rank is indistinguishable from tier-table drift).
-    Rows are built from REAL entries so `find_advertised` (frozen union) still resolves every name."""
-    free = api_catalog.CODEX_TIER_MODELS["free"]
-    terra, luna, big, mini = free  # curated free order: terra 1, luna 2, gpt-5.5 3, gpt-5.4-mini 4
-    # plus row: reversed + gpt-5.5 dropped → mini 1, luna 2, terra 3; gpt-5.5 is off-row.
-    monkeypatch.setattr(api_catalog, "CODEX_TIER_MODELS", {"free": free, "plus": (mini, luna, terra)})
+def test_remote_engine_codex_vendor_rank_comes_from_the_recorded_caps(monkeypatch, tmp_path, capsys):
+    """vendor_rank is read from the record's `model_caps` (issue 10a — the join persisted the probe's
+    visible order), NOT recomputed at serve time from a tier row. A model present in `model_caps`
+    advertises its recorded rank; a model advertised but absent from `model_caps` carries NO rank (the
+    fact is omitted, never rank 0/None) and a warn fires (an absent no-caps entry is never silent)."""
+    caps = {
+        "codex:a": {"context_window": 272000, "vision": True, "tools": True, "vendor_rank": 1},
+        "codex:b": {"context_window": 272000, "vision": True, "tools": True, "vendor_rank": 2},
+    }
+    models = _codex_serve_skeleton(
+        monkeypatch, tmp_path, ["codex:a", "codex:b", "codex:c"], model_caps=caps,
+    )["capabilities"]["models"]
 
-    advertised = [f"codex:{e.vendor_name}" for e in (mini, luna, terra, big)]
-    models = _codex_serve_skeleton(monkeypatch, tmp_path, advertised, plan_type="plus")["capabilities"]["models"]
-
-    assert models[f"codex:{mini.vendor_name}"]["vendor_rank"] == 1
-    assert models[f"codex:{luna.vendor_name}"]["vendor_rank"] == 2
-    assert models[f"codex:{terra.vendor_name}"]["vendor_rank"] == 3
-    # gpt-5.5 resolves in the frozen union but has no position in the plus row → no rank, and a warn.
-    assert "vendor_rank" not in models[f"codex:{big.vendor_name}"]
+    assert models["codex:a"]["vendor_rank"] == 1
+    assert models["codex:b"]["vendor_rank"] == 2
+    # codex:c isn't in model_caps → no rank fabricated, and an operator warn fires (not silent).
+    assert "vendor_rank" not in models["codex:c"]
     err = capsys.readouterr().err
-    assert f"codex:{big.vendor_name}" in err and "rank" in err  # off-row model flagged (not silent)
-    assert f"codex:{mini.vendor_name}" not in err               # a ranked model is not flagged
+    assert "codex:c" in err and "no probe-derived caps" in err  # off-caps model flagged
+    assert "codex:a" not in err                                 # a recorded model is not flagged
 
 
 def test_remote_engine_api_only_defaults_to_eight_workers(monkeypatch, tmp_path):
@@ -9956,7 +10322,9 @@ def test_static_api_caps_codex_omits_output_cap_feature():
     so codex omitting the param means codex omitting the feature."""
     from remote import serve
 
-    caps = serve._static_api_caps("codex", ["codex:gpt-5.5"], plan_type="free")
+    caps = serve._static_api_caps("codex", ["codex:gpt-5.5"], model_caps={
+        "codex:gpt-5.5": {"context_window": 272000, "vision": True, "tools": True, "vendor_rank": 1},
+    })
     entry = caps["models"]["codex:gpt-5.5"]
     assert "output_cap" not in entry["features"]
 
@@ -10053,7 +10421,9 @@ def test_api_and_codex_specs_never_run_the_responses_probe(monkeypatch):
 
     serve._probe_spec_caps("https://api.openai.com/v1", ["openai:gpt-5.5"], ["gpt-5.5"], None, api_kind="openai")
     serve._probe_spec_caps("https://chatgpt.com", ["codex:gpt-5.5"], ["gpt-5.5"], None,
-                           api_kind="codex", plan_type="free")
+                           api_kind="codex", model_caps={
+                               "codex:gpt-5.5": {"context_window": 272000, "vision": True,
+                                                 "tools": True, "vendor_rank": 1}})
 
 
 def test_serve_codex_seat_holder_primes_from_the_store_and_self_heals(monkeypatch, tmp_path):


### PR DESCRIPTION
## What & why

Issue 10 — **kill the static free-tier ceiling** for the codex API engine. A paid seat previously
degraded silently to the free set at join (ADR 0015 D-f). The served set and the catalog are now
driven by the seat's own live probe instead of a hardcoded tier table.

### 10a — serve = live probe set
- `grid join --api codex` membership = the probe's visible rows (`visibility != "hide"` **and**
  `supported_in_api`), **no static intersection**. A model the seat is entitled to is served the day
  the vendor ships it — no CLI edit.
- Per-model caps (`context_window`, vision, tools) are **derived from the probe and persisted in the
  run record**; the serving side builds the capability envelope from the record. Unknown
  `context_window` is **omitted** (never fabricated). `endpoints` stays exactly `["responses"]`.
- `-m <unentitled>` is **refused, not silently narrowed**, naming the servable set.
- The dead tier machinery (`codex_effective_tier` / `codex_tier_entries` / `_warn_codex_tier` /
  `codex_vendor_rank`) is removed; `plan_type` is a display label only.

### 10b — `grid catalog --api codex`: seat-aware + offline cache
- Signed in + online → live probe of the current plan (**"Your current plan (…) — live"** block) +
  a full **illustrative cross-plan reference** (free/go → plus → pro), each row marked live vs
  illustrative. Offline / no seat → cache → static reference, with a warning. **No `--live` flag.**
- Grid-side cache `~/.grid/codex_models_cache.json` (`0600`), scoped by a one-way SHA-256 fingerprint
  of the account (raw id never on disk), invalidated on `client_version` mismatch.

ADRs amended: 0012 D-a (catalog now seat-aware), 0015 D-f ("unverified capabilities fail closed").

## Cross-repo
The relay-side companion **10c** (0-target `/responses` miss names the served set) is a separate,
independent change already merged to **grid-src** `main` (`6ad6558`). No new wire-contract lockstep —
`endpoints` and caps keys are byte-for-byte unchanged.

## Test plan
- [x] **849** unit tests green (`uv run pytest tests/`) on `public/main` + issue 10.
- [x] Live E2E on dev grid `codex-e2e-2` (free seat), integrated build:
  - join advertises the 4 free models **from the live probe**, `context_length` from probe caps,
    **no tier warning**; `-m codex:gpt-5.6-sol` refused naming the servable set.
  - `grid catalog --api codex` shows the live current-plan block + illustrative reference; cache
    written `0600`.
  - relay streaming round-trip masks the model, no `data: [DONE]`, real usage; settlement row records
    real tokens.
  - 10c: a `sol` miss returns 503 naming the served set (kind-agnostic — includes a chat engine that
    also advertises `responses`).
- [ ] Paid-seat entitlement (dynamic > static) — fixture-tested only; needs a paid seat to prove live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
