### PR TITLE
feat(remote): report codex seat rate limits to the grid overview

### DIFF
--- a/remote/serve.py
+++ b/remote/serve.py
@@ -210,6 +210,7 @@ def run_remote_engine_from_record(grid_id: str, engine_id: str) -> int:
             signaling_url=signaling_url,
             node_id=node_id,
             network_id=network_id,
+            engine_id=engine_id,
             llm_url=engine_results[0][0] if engine_results else "",
             access_token=access_token,
             refresh_token=refresh_token,
@@ -231,8 +232,13 @@ def run_remote_engine_from_record(grid_id: str, engine_id: str) -> int:
         # with no stored seat dies HERE naming the fix (still inside the try, so the record is
         # reaped like any died-before-registering engine), never as N per-job 401s.
         _prime_codex_seat(state, record)
+        # Restore the last persisted quota so /grid/overview shows it immediately on respawn — and so a
+        # hand-edited remote.json can inject a simulated snapshot for debugging. A response/seed refreshes it.
+        if record.get("codex_rate_limits"):
+            state.set_codex_quota(record["codex_rate_limits"])
         register_once(state)
         registered = True
+        _seed_codex_quota(state, record)  # best-effort: populate quota for /grid/overview before jobs
         print(f"Engine {state.node_id} serving {union_models} via the relay at {signaling_url}")
         print("Send SIGTERM (grid leave) to unregister.")
         # Make the engine reload-ready (install the SIGHUP handler + start the reload daemon) while SIGHUP
@@ -460,6 +466,49 @@ def _prime_codex_seat(state: _ServeState, record: dict[str, Any]) -> None:
     """
     if any(spec.get("api_kind") == api_catalog.CODEX_KIND for spec in record.get("engines") or []):
         state.codex_seat.prime_from_store()
+
+
+def _seed_codex_quota(state: _ServeState, record: dict[str, Any]) -> None:
+    """Seed the seat's quota right after registration, so /grid/overview shows it BEFORE any consumer
+    traffic (the "one minimal request after join" idea). One tiny streamed request whose x-codex-*
+    headers carry the quota; the stream is closed the moment the headers are read, so it spends ~no
+    output. Best-effort: a non-codex record is a no-op, and any failure (offline, CF-403, dead seat)
+    is swallowed — a telemetry seed must never break serve start; the first real job seeds it anyway."""
+    import httpx
+
+    spec = next(
+        (s for s in record.get("engines") or [] if s.get("api_kind") == api_catalog.CODEX_KIND), None
+    )
+    if spec is None:
+        return
+    base_url = (spec.get("endpoint_url") or "").rstrip("/")
+    model = next(
+        (_api_upstream_name(api_catalog.CODEX_KIND, m) for m in spec.get("models") or []), None
+    )
+    if not base_url or not model:
+        return
+    try:
+        bundle = state.codex_seat.bundle()
+    except Exception:  # noqa: BLE001 — unsigned/unreadable seat: nothing to seed, not an error here
+        return
+    body = {
+        "model": model,
+        "instructions": "ping",
+        "input": [{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]}],
+        "stream": True,
+        "store": False,
+    }
+    try:
+        timeout = httpx.Timeout(connect=10, read=15, write=30, pool=10)
+        with httpx.Client(timeout=timeout) as client:
+            with client.stream(
+                "POST", f"{base_url}/responses", json=body, headers=_codex_headers(bundle),
+            ) as resp:
+                # Headers are here as soon as the response starts; harvest and let the `with` close the
+                # stream without draining the body — the seed stays ~free.
+                _capture_codex_quota(state, resp.headers)
+    except Exception as exc:  # noqa: BLE001 — seed is optional telemetry, never fatal to serve start
+        _warn(f"codex quota seed skipped ({exc})")
 
 
 def _api_kinds_by_url(record: dict[str, Any]) -> dict[str, str]:
@@ -1105,6 +1154,7 @@ class _ServeState:
         node_id: str,
         network_id: str,
         llm_url: str,
+        engine_id: str | None = None,
         access_token: str,
         refresh_token: str | None,
         models: list[str],
@@ -1122,6 +1172,9 @@ class _ServeState:
         self.signaling_url = signaling_url
         self.node_id = node_id
         self.network_id = network_id
+        # The run record's engine id (grid_id == network_id keys the record dir). Kept so a quota
+        # update can persist back to remote.json — None in unit fixtures, which skips persistence.
+        self._engine_id = engine_id
         self.llm_url = llm_url.rstrip("/")
         # `bearer_by_url` and `api_kind_by_url` are resolved from the key store / record and live on the
         # reload-swappable snapshot built below (NOT as fixed attributes — see the `bearer_by_url`
@@ -1166,6 +1219,24 @@ class _ServeState:
         # rotation must not rebuild routing. Unconditional; primed only when the record has a
         # codex spec (startup + reload), unprimed otherwise and inert.
         self.codex_seat = _CodexSeatHolder(stop=self.stop)
+        # Latest codex seat rate-limit snapshot (parsed from a served response's x-codex-* headers, or
+        # the start-up seed), guarded by _lock. Rides the heartbeat load so /grid/overview shows it
+        # per-node. None until the first codex response/seed; a non-codex engine leaves it None.
+        self._codex_quota: dict[str, Any] | None = None
+
+    def set_codex_quota(self, quota: dict[str, Any]) -> None:
+        """Record the seat's latest rate-limit snapshot; the next heartbeat carries it to the relay.
+        Short section under _lock (no calls out), then persist OUTSIDE the lock."""
+        with self._lock:
+            self._codex_quota = quota
+        # Persist to the engine's run record (remote.json) so the snapshot survives a respawn and can
+        # be inspected — or hand-edited to simulate a tier/usage — for debugging. Best-effort and off
+        # the lock: a telemetry write must never fail a served job. network_id IS the record's grid_id.
+        if self._engine_id is not None:
+            try:
+                run_records.update_record(self.network_id, self._engine_id, codex_rate_limits=quota)
+            except Exception as exc:  # noqa: BLE001 — persistence is optional, never fatal
+                _warn(f"could not persist codex quota to the run record ({exc})")
 
     @property
     def models(self) -> list[str]:
@@ -1258,6 +1329,7 @@ class _ServeState:
     def load(self) -> dict[str, Any]:
         with self._lock:
             load = {"active_tasks": self._inflight}
+            codex_quota = self._codex_quota
         # VRAM/GPU load for the grid page (per-provider VRAM roll-up). Probed OUTSIDE the lock — it
         # shells out to nvidia-smi / system_profiler (up to a few seconds); absent a GPU it returns {}.
         from shared.system import gpu, host
@@ -1265,6 +1337,10 @@ class _ServeState:
         load.update(gpu.load_snapshot())
         # OS/arch so the grid knows what a node runs: linux / macos-arm64 / macos-x86_64 / windows / other.
         load["platform"] = host.platform_kind()
+        # Codex seat quota (when this engine serves a seat) — surfaced per-node on /grid/overview. The
+        # value only changes on a served response / the join seed; the heartbeat just re-ships the last.
+        if codex_quota:
+            load["codex_rate_limits"] = codex_quota
         return load
 
     def enter_inference(self) -> None:
@@ -1820,6 +1896,90 @@ def _codex_headers(bundle: codex_oauth.CodexBundle) -> dict[str, str]:
     }
 
 
+def _codex_window(group: dict[str, str], face: str) -> dict[str, Any] | None:
+    """One rate-limit face (``primary``/``secondary``) parsed from a flat ``suffix -> value`` map of
+    a codex header group. Returns None when the face carries no numeric field (a free seat's
+    ``secondary`` is all-empty), so the shape never advertises a window the vendor didn't report."""
+    def _num(suffix: str) -> int | None:
+        try:
+            return int(group[f"{face}-{suffix}"])
+        except (KeyError, ValueError, TypeError):
+            return None
+    used = _num("used-percent")
+    win = _num("window-minutes")
+    reset_at = _num("reset-at")
+    reset_after = _num("reset-after-seconds")
+    if used is None and win is None and reset_at is None and reset_after is None:
+        return None
+    return {
+        "used_percent": used,
+        "remaining_percent": (100 - used) if used is not None else None,
+        "window_minutes": win,  # 43200=30d (free), 10080=7d (weekly, paid) — read it, never assume
+        "reset_at": reset_at,
+        "reset_after_seconds": reset_after,
+    }
+
+
+def _parse_codex_quota(headers: Any) -> dict[str, Any] | None:
+    """The seat's rate-limit snapshot, parsed from a vendor response's ``x-codex-*`` headers.
+
+    The subscription backend reports quota ONLY on response headers (never the body); the official
+    Codex client reads this same set. Free seats carry a single ``primary`` window + ``credits``;
+    paid tiers add per-model sub-limits under a dynamic prefix (``x-codex-bengalfox-*`` etc.), so we
+    group every non-main header by its leading name rather than cherry-picking a fixed list. Returns
+    None when no ``x-codex-*`` header is present, so a non-codex or header-less response never clobbers
+    a good snapshot. The raw headers ride along under ``headers`` so nothing is lost to the parse."""
+    raw = {k.lower(): v for k, v in headers.items() if k.lower().startswith("x-codex-")}
+    if not raw:
+        return None
+    fields = {k[len("x-codex-"):]: v for k, v in raw.items()}
+    _MAIN = ("primary-", "secondary-", "plan-type", "active-limit", "credits-")
+    main: dict[str, str] = {}
+    subs: dict[str, dict[str, str]] = {}
+    for key, val in fields.items():
+        if key.startswith(_MAIN):
+            main[key] = val
+        else:  # a named sub-limit, e.g. "bengalfox-primary-used-percent" -> name "bengalfox"
+            name, _, suffix = key.partition("-")
+            subs.setdefault(name, {})[suffix] = val
+
+    def _truthy(val: str | None) -> bool | None:
+        return None if val is None else str(val).strip().lower() in ("true", "1", "yes")
+
+    return {
+        "plan_type": main.get("plan-type"),
+        "active_limit": main.get("active-limit"),
+        "primary": _codex_window(main, "primary"),
+        "secondary": _codex_window(main, "secondary"),
+        "credits": {
+            "balance": main.get("credits-balance") or None,
+            "has_credits": _truthy(main.get("credits-has-credits")),
+            "unlimited": _truthy(main.get("credits-unlimited")),
+        },
+        "sublimits": {
+            name: {
+                "limit_name": grp.get("limit-name"),
+                "primary": _codex_window(grp, "primary"),
+                "secondary": _codex_window(grp, "secondary"),
+            }
+            for name, grp in subs.items()
+        },
+        "headers": raw,
+    }
+
+
+def _capture_codex_quota(state: "_ServeState", headers: Any) -> None:
+    """Stash the seat's quota snapshot from a response's headers onto the serve state, so the next
+    heartbeat carries it to the relay (surfaced per-node on /grid/overview). Best-effort: a telemetry
+    read must never fail a served job, and a header-less response leaves the last snapshot intact."""
+    try:
+        quota = _parse_codex_quota(headers)
+    except Exception:  # noqa: BLE001 — telemetry must not break the forward path
+        return
+    if quota:
+        state.set_codex_quota(quota)
+
+
 def _warn_codex_upstream(status: int, headers: Any) -> None:
     """The operator's serve-time taxonomy for a codex upstream failure (ADR 0015 D-f): the two
     403s demand OPPOSITE actions, so they must not share wording — Cloudflare-challenge means
@@ -1863,6 +2023,7 @@ class _UpstreamFailure:
 def _forward_responses_stream(
     state: _ServeState, txn: str, endpoint: str, body: dict[str, Any], read_timeout: float,
     target_url: str, headers: dict[str, str],
+    on_headers: Callable[[Any], None] | None = None,
 ) -> _UpstreamFailure | None:
     """Forward one responses job and stream the reply back as whole event blocks.
 
@@ -1894,6 +2055,10 @@ def _forward_responses_stream(
         with client.stream(
             "POST", f"{target_url}/{endpoint}", json=body, headers=headers,
         ) as resp:
+            # Quota/rate-limit headers ride EVERY response and arrive before the body — read them here
+            # (engine-agnostic hook; the codex path uses it to harvest x-codex-*), whatever the status.
+            if on_headers is not None:
+                on_headers(resp.headers)
             if resp.status_code == 200:
                 _submit_response(
                     state, txn, stream=True,
@@ -1948,6 +2113,9 @@ def _forward_codex(
         failure = _forward_responses_stream(
             state, txn, endpoint, body, read_timeout, target_url,
             headers=_codex_headers(bundle),
+            # Harvest the seat's quota off this response's x-codex-* headers, so the next heartbeat
+            # carries it to /grid/overview. Best-effort inside — never fails the served job.
+            on_headers=lambda h: _capture_codex_quota(state, h),
         )
         if failure is None:
             return  # submitted — the shared path already gave the job its terminal signal


### PR DESCRIPTION
Harvest the seat's x-codex-* quota headers on each served response (and a best-effort seed right after join), parse them into a rich snapshot, stash it on the serve state, persist to the engine run record (remote.json, for durability + debugging), and ride the heartbeat load so the relay/overview can show per-node codex usage. Non-codex engines are unaffected.