### PR TITLE
feat(launch): `grid launch claude` starts Claude Code on a remote grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,21 @@ at your grid with `grid info --env`
 with that same guidance. Jobs spend the seat's own monthly allowance.
 Walkthrough: [docs/codex-quickstart.md](docs/codex-quickstart.md) · [ADR 0015](docs/adr/0015-codex-subscription-engine.md).
 
+### Run Claude Code on your grid
+
+```bash
+grid launch claude                      # …or `-- --continue`, and any other Claude Code flag
+```
+
+`grid launch` starts an app already pointed at your grid: endpoint, credential and model names go
+into that app's own process environment and nowhere else — nothing exported to your shell, nothing
+written to a config file, nothing to undo. Remote only, because Claude Code speaks the Anthropic
+Messages dialect and only the relay translates it. This release fixes the model names
+(`claude:opus`, `claude:haiku`), so check `grid models` before your first launch — the command
+refuses up front, naming what's missing, rather than failing inside the app.
+Walkthrough: [docs/claude-code-quickstart.md](docs/claude-code-quickstart.md) ·
+[contract](docs/cli.md#launch) · [ADR 0028](docs/adr/0028-launch-hands-an-app-the-grid.md).
+
 ### Don't know which model to ask for? Send `auto`
 
 A grid's catalog shifts as engines join and leave. Rather than hardcoding a model name, an app can

--- a/README.md
+++ b/README.md
@@ -256,9 +256,9 @@ grid launch claude                      # …or `-- --continue`, and any other C
 `grid launch` starts an app already pointed at your grid: endpoint, credential and model names go
 into that app's own process environment and nowhere else — nothing exported to your shell, nothing
 written to a config file, nothing to undo. Remote only, because Claude Code speaks the Anthropic
-Messages dialect and only the relay translates it. This release fixes the model names
-(`claude:opus`, `claude:haiku`), so check `grid models` before your first launch — the command
-refuses up front, naming what's missing, rather than failing inside the app.
+Messages dialect and only the relay translates it. It chooses **no model for you** — your own Claude
+Code configuration and `/model` still decide, so check `grid models` and point the app at a name the
+grid serves.
 Walkthrough: [docs/claude-code-quickstart.md](docs/claude-code-quickstart.md) ·
 [contract](docs/cli.md#launch) · [ADR 0028](docs/adr/0028-launch-hands-an-app-the-grid.md).
 

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -49,6 +49,7 @@ from .grid import (
     cmd_version,
 )
 from .device import cmd_device_info
+from .launch import cmd_launch
 from .mode import cmd_mode, cmd_use
 from .models import cmd_catalog, cmd_pull, cmd_rm
 from .parser import build_parser
@@ -94,6 +95,7 @@ __all__ = [
     "cmd_image",
     "cmd_edit",
     "cmd_video",
+    "cmd_launch",
     "cmd_agent_install",
     "cmd_agent_status",
     "cmd_engine_install",

--- a/cli/_main.py
+++ b/cli/_main.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from local import config
 from local import runtime
 from shared import logging_setup, paths
-from .dispatch import dispatch, resolve_override
+from .dispatch import dispatch, resolve_override, split_forwarded
 from .parser import build_parser
 
 
@@ -102,8 +102,16 @@ def main(argv: list[str] | None = None) -> int:
     if internal is not None:
         return internal
     override, cleaned = resolve_override(raw_argv)
+    # After the override strip, and before the parser sees anything: the forwarded vector must never
+    # reach argparse, which would bind the app's own flags to this CLI's positionals.
+    cleaned, forwarded = split_forwarded(cleaned)
     parser = build_parser()
     args = parser.parse_args(cleaned)
+    if forwarded:
+        # Only when there is something to forward, so every other command's namespace is untouched.
+        # The parser declares `forward=()` on `launch`, so its handler always finds the attribute —
+        # `grid launch claude --` with nothing after it is therefore identical to no `--` at all.
+        args.forward = forwarded
     return dispatch(args, override)
 
 

--- a/cli/dispatch.py
+++ b/cli/dispatch.py
@@ -16,6 +16,7 @@ mode; `None` takes the sign-in default.
 from __future__ import annotations
 
 import argparse
+import sys
 from typing import NoReturn
 
 from shared import state
@@ -141,13 +142,31 @@ def resolve_override(argv: list[str]) -> tuple[str | None, list[str]]:
     """
     override: str | None = None
     cleaned: list[str] = []
+    past_separator = False
     for token in argv:
         if token in ("--local", "--remote"):
+            if past_separator:
+                # The one substitution on this surface a user cannot see happening. After `--` they
+                # were addressing another program (`grid launch <target> -- …`), and this took the
+                # token anyway. `--remote` then simply vanishes; `--local` flips the run's mode, so a
+                # remote-only command refuses and reports a *mode* problem — pointing at a fix that
+                # has nothing to do with what they actually did. Said here, where the token is taken,
+                # so it covers both directions and every command rather than one gate's message.
+                print(
+                    f"Warning: `{token}` after `--` is grid's own one-shot mode override, not the "
+                    f"launched app's — it has been removed from the command line and this run uses "
+                    f"{token[2:]} mode.",
+                    file=sys.stderr,
+                    flush=True,
+                )
             flag = token[2:]
             if override is not None and override != flag:
                 raise SystemExit("Pass only one of --local / --remote.")
             override = flag
         else:
+            # Only the first `--` opens the forwarded region, but re-marking on a later one is
+            # harmless: everything from the first onwards is already past it.
+            past_separator = past_separator or token == "--"
             cleaned.append(token)
     return override, cleaned
 

--- a/cli/dispatch.py
+++ b/cli/dispatch.py
@@ -9,7 +9,9 @@ guidance when run in local mode — the mirror image of the remote stub.
 
 `AGNOSTIC`, `REMOTE_HANDLERS`, and `REMOTE_ONLY` must together classify *every* registered
 command — a test asserts this so a future command can never silently run local code in remote
-mode (nor remote code in local mode).
+mode (nor remote code in local mode). `REMOTE_ONLY` maps each of its commands to the *reason*
+its local-mode gate gives, because "sign in" is not why every remote-only command needs remote
+mode; `None` takes the sign-in default.
 """
 from __future__ import annotations
 
@@ -91,15 +93,36 @@ REMOTE_HANDLERS = {
 }
 
 
+# The purpose clause completing "Run `grid mode remote` (or pass --remote) …" for a command that
+# registers no reason of its own — every command below today, all gated because they need a
+# signed-in account.
+_DEFAULT_LOCAL_GATE_REASON = "to sign in."
+
 # Remote-only commands: they run their real handlers in remote mode and are gated with
 # guidance in local mode — the mirror image of ``remote_stub`` for the GATED commands.
-REMOTE_ONLY = frozenset({"login", "logout", "members", "sync", "price", "router"})
+#
+# command -> why switching to remote mode is what this user wants, or ``None`` for the default
+# above. Sign-in is not every command's reason: a command gated for some other reason (a local grid
+# not serving the dialect an app speaks, say) registers its own. A value completes the sentence in
+# ``local_stub``, so it reads as a purpose clause and carries its own final period; the
+# `grid mode remote` signpost stays in the fixed part, where no later command can drop it.
+REMOTE_ONLY: dict[str, str | None] = {
+    "login": None,
+    "logout": None,
+    "members": None,
+    "sync": None,
+    "price": None,
+    "router": None,
+}
 
 
 def local_stub(command: str | None) -> NoReturn:
+    # ``or``, not ``is None``: a registered reason that is empty is a coding error, and today's
+    # sentence is a better thing to print than a sentence that stops mid-air.
+    reason = REMOTE_ONLY.get(command) or _DEFAULT_LOCAL_GATE_REASON
     raise SystemExit(
         f"`grid {command}` is a remote-mode command. Run `grid mode remote` (or pass --remote) "
-        "to sign in."
+        f"{reason}"
     )
 
 

--- a/cli/dispatch.py
+++ b/cli/dispatch.py
@@ -152,6 +152,44 @@ def resolve_override(argv: list[str]) -> tuple[str | None, list[str]]:
     return override, cleaned
 
 
+# The one command whose ``--`` means "everything after this belongs to the app it launches", rather
+# than argparse's own "stop looking for options". Deliberately a single name and not a growing list:
+# a second passthrough command is a decision, not a config value.
+_PASSTHROUGH_COMMAND = "launch"
+
+
+def split_forwarded(argv: list[str]) -> tuple[list[str], tuple[str, ...]]:
+    """Split ``grid launch … -- <the app's own arguments>`` at the first bare ``--``.
+
+    Returns ``(argv for the parser, the forwarded vector)``.
+
+    Done **here, before ``parse_args``**, because argparse cannot do it. ``launch`` has two
+    ``nargs="?"`` positionals (target, grid), so a third ``nargs="*"`` positional binds the first
+    forwarded word to *grid* — ``launch claude -- -p hi`` yields ``grid="-p"`` — and
+    ``nargs=REMAINDER`` swallows the launcher's own ``--print-env`` into the forwarded vector while
+    leaving the flag False. Both verified against argparse, not assumed.
+
+    Scoped to one command on purpose. Every other command keeps argparse's own ``--`` handling, so
+    what ``grid chat -- hello`` has always meant cannot change as a side effect of this feature.
+
+    Runs **after** ``resolve_override``, which has already pulled ``--local``/``--remote`` out of any
+    position — *including* from after this separator. Those two exact tokens therefore cannot be
+    forwarded to a launched app (ADR 0028), which is why `grid launch --help` says so.
+    """
+    try:
+        # The FIRST separator only: a later ``--`` is one of the app's own arguments and is forwarded
+        # verbatim, exactly as it would be if the user had typed it into the app's own command line.
+        separator = argv.index("--")
+    except ValueError:
+        return argv, ()
+    # The command word, found the way argparse finds it: the first token that is not an option. This
+    # tolerates the global flags that may precede a subcommand (`grid --json launch …`).
+    command = next((token for token in argv[:separator] if not token.startswith("-")), None)
+    if command != _PASSTHROUGH_COMMAND:
+        return argv, ()
+    return argv[:separator], tuple(argv[separator + 1:])
+
+
 def dispatch(args: argparse.Namespace, override: str | None) -> int:
     mode = state.resolve_mode(override)
     args.mode = mode

--- a/cli/dispatch.py
+++ b/cli/dispatch.py
@@ -113,6 +113,13 @@ REMOTE_ONLY: dict[str, str | None] = {
     "sync": None,
     "price": None,
     "router": None,
+    # The one command whose reason is not sign-in (ADR 0028): a local grid serves chat/completions,
+    # completions, models and media — never Anthropic Messages, which is the only dialect Claude Code
+    # speaks. Naming the dialect is what stops this being filed as a bug.
+    "launch": (
+        "to launch an app that speaks the Anthropic Messages dialect, which a local grid "
+        "does not serve."
+    ),
 }
 
 

--- a/cli/grid.py
+++ b/cli/grid.py
@@ -11,7 +11,7 @@ import httpx
 
 from local import config
 from local import runtime
-from shared import run_records, state
+from shared import run_records, shell, state
 from shared._version import __version__
 
 
@@ -129,8 +129,11 @@ def cmd_info(args: argparse.Namespace) -> int:
     grid_url = runtime.grid_url(cfg)
 
     if args.env:
-        print(f'export OPENAI_BASE_URL="{grid_url}/v1"')
-        print('export OPENAI_API_KEY="local-grid"')
+        # Quoted the same way as the remote form, though the local token is a constant and the URL
+        # is built from this machine's own config: two commands printing the same block in two
+        # different quoting styles is how one of them stays wrong after the other is fixed.
+        print(f"export OPENAI_BASE_URL={shell.quote(f'{grid_url}/v1')}")
+        print(f"export OPENAI_API_KEY={shell.quote('local-grid')}")
         return 0
 
     engines, reachable = _live_engines(grid_url)

--- a/cli/grid_credential.py
+++ b/cli/grid_credential.py
@@ -1,0 +1,292 @@
+"""Is the credential we are about to hand an app going to be accepted — and can we fix it if not?
+
+ADR 0029. `grid launch` hands its access token to a *different, long-lived process* whose error
+surface this CLI does not own: a rejected token surfaces at the app's first prompt, minutes later,
+dressed as the vendor's own `authentication_error`, with nothing in it naming `grid`. So the token is
+checked here, before hand-over, and repaired in place when it can be.
+
+Two checks, because neither subsumes the other. The offline one reads the JWT's `exp` and is the only
+thing that can refuse a token which is valid *now* and dies mid-session. The relay probe is the only
+thing that can see an epoch bump, a revoked membership, a missing scope — or this machine's clock
+being wrong. Between them sits **one** refresh, shared: whichever check asks for it first spends it.
+
+Deliberately not shared with ``remote/serve._ServeState.refresh``, which does the same exchange for
+the serve loop. That one must never die, is thread-locked against concurrent workers, and adopts a
+token another process stored; this one is a one-shot that raises CLI-shaped ``SystemExit`` and speaks
+to a person. Merging them would make each carry the other's concerns.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import time
+from typing import Any
+
+# How close to `exp` still counts as "refresh it now". Not `remote/serve._CODEX_EXPIRY_MARGIN`'s ten
+# minutes: what is being protected here is a human work session, not a poll iteration, and a token
+# with four minutes left passes every check and then dies at the user's third prompt. A day is 0.27%
+# of a grid token's 365-day life, so it cannot cause a refresh that would not have happened anyway.
+LAUNCH_EXPIRY_MARGIN_SECONDS = 24 * 3600
+
+# The scope `POST /messages` requires. Read off the token only to *explain* a 403 — never to gate,
+# which is the relay's job. The control plane grants the inference scopes as one bundle, so this is
+# also what the probe's own `inference:models` implies.
+_INFERENCE_SCOPE = "inference:create"
+
+
+def ensure_usable(rec: dict[str, Any], label: str, token: str, base: str) -> str:
+    """The access token to hand over — refreshed first if it needed it — or a clean ``SystemExit``.
+
+    ``rec`` is a snapshot of the stored grid record, so the refreshed token is **returned**; a caller
+    that re-reads ``rec`` afterwards would use the stale one.
+    """
+    token, refreshed, expiry_note = _repair_if_stale(rec, label, token)
+    return _prove(rec, label, token, base, refreshed=refreshed, expiry_note=expiry_note)
+
+
+# ---------------------------------------------------------------------------
+# Layer 1 + 2: what the token says about itself, and the repair
+# ---------------------------------------------------------------------------
+
+def _repair_if_stale(rec: dict[str, Any], label: str, token: str) -> tuple[str, bool, str | None]:
+    """``(token, refreshed, expiry_note)`` after the offline check has had its say.
+
+    ``expiry_note`` is what we learned and could not act on — carried forward so that if the probe
+    then refuses, the refusal can say *why* the token was already suspect instead of reporting a bare
+    rejection.
+
+    A token we cannot repair is **not** refused here even when `exp` has passed. The clock is the one
+    input this check cannot verify (a VM resumed from a snapshot, a dead CMOS battery), and the probe
+    is one round-trip away and authoritative — refusing on local evidence alone would take away a
+    launch that works, which is precisely what ADR 0029 forbids.
+    """
+    exp = _token_expiry(token)
+    now = time.time()
+    if exp is None or exp - now > LAUNCH_EXPIRY_MARGIN_SECONDS:
+        return token, False, None
+
+    phrase = _expiry_phrase(exp, now)
+    expired = exp <= now
+    if not str(rec.get("refresh_token") or ""):
+        # Nothing to exchange. Say so once — a token inside the margin with no way to renew it is a
+        # launch that will stop working soon — and let the probe decide whether it works right now.
+        _warn(f"grid {label}'s access token {phrase} and no refresh credential is stored for it; "
+              f"run `grid login` to renew it.")
+        return token, False, phrase
+
+    try:
+        fresh = _refresh(rec, label)
+    except _RefreshFailed as failure:
+        if not expired:
+            # It still works. A control-plane hiccup must not cost a launch that would have succeeded.
+            _warn(f"couldn't renew grid {label}'s access token ({failure.reason}); it {phrase}, "
+                  f"launching anyway.")
+            return token, False, phrase
+        raise SystemExit(failure.refusal(label, phrase)) from None
+    _note(f"Refreshed grid {label}'s access token (it {phrase}).")
+    return fresh, True, None
+
+
+class _RefreshFailed(Exception):
+    """A refresh that did not produce a token, and enough about why to say the right thing.
+
+    ``status`` is the control plane's, or ``None`` when it never answered — the difference decides
+    whether the user is told to sign in again or told to try again later, and telling them the wrong
+    one sends them to a browser for an outage.
+    """
+
+    def __init__(self, reason: str, *, status: int | None) -> None:
+        super().__init__(reason)
+        self.reason = reason
+        self.status = status
+
+    def refusal(self, label: str, phrase: str) -> str:
+        lead = f"Grid {label}'s access token {phrase}, and it couldn't be renewed: {self.reason}"
+        if self.status == 401:
+            return f"{lead}\nRun `grid login` to sign in again."
+        if self.status == 403:
+            # The refresh credential is fine; the *membership* it names is not. `grid login` re-mints
+            # from the same membership, so recommending it would send the user in a circle.
+            return (f"{lead}\nThat is about your membership of this grid, not your sign-in — "
+                    f"`grid login` will not change it.")
+        return (f"{lead}\nNothing is wrong with your sign-in; the control plane could not mint a "
+                f"token. Try again shortly.")
+
+
+def _refresh(rec: dict[str, Any], label: str) -> str:
+    """Exchange the stored refresh token for a fresh access token, persisting **both**.
+
+    Persisting both is not tidiness. The control plane rotates the refresh credential on *every*
+    exchange and the old one stops matching immediately, while ``update_network_tokens`` takes
+    ``refresh_token`` as an **optional** argument — so omitting it destroys this machine's refresh
+    credential permanently and silently, sending every later launch *and* the serve loop back to
+    `grid login`. ``remote/serve._ServeState.refresh`` carries the same line for the same reason.
+    """
+    from remote import control_plane, credentials
+
+    from . import remote_grid
+
+    network_id = remote_grid._network_id(rec)  # the validated id, before it reaches a request path
+    stored_refresh = str(rec.get("refresh_token") or "")
+    try:
+        bundle = control_plane.refresh_network_token(
+            network_id=network_id, refresh_token=stored_refresh
+        )
+    except control_plane.ControlPlaneError as exc:
+        raise _RefreshFailed(_reason(exc), status=exc.status) from None
+    access = str(bundle.get("access_token") or "") if isinstance(bundle, dict) else ""
+    if not access:
+        # A 2xx that carried no token. Treated as a failure rather than trusted, because the
+        # alternative is handing the app an empty bearer and calling it a repair.
+        raise _RefreshFailed("the control plane returned no access token", status=None)
+    credentials.update_network_tokens(
+        network_id,
+        access_token=access,
+        # `or stored_refresh` for a control plane that chose not to rotate: never store an empty one.
+        refresh_token=str(bundle.get("refresh_token") or stored_refresh),
+    )
+    return access
+
+
+# ---------------------------------------------------------------------------
+# Layer 3: what the grid says about the token
+# ---------------------------------------------------------------------------
+
+def _prove(
+    rec: dict[str, Any],
+    label: str,
+    token: str,
+    base: str,
+    *,
+    refreshed: bool,
+    expiry_note: str | None,
+) -> str:
+    """Ask the relay whether it will accept this token, repairing once if the budget is unspent."""
+    from remote import relay
+
+    try:
+        relay.check_credential(base, token)
+        return token
+    except relay.RelayUnauthorized:
+        pass
+    except relay.RelayError as exc:
+        if exc.status == 403:
+            raise SystemExit(_forbidden(label, token, exc)) from None
+        # 429, 5xx, a timeout, no answer at all: nothing was learned about the token, so nothing is
+        # taken away from the user (ADR 0029). Named, not swallowed — if the app then fails the same
+        # way, this line is what makes that make sense.
+        _warn(f"couldn't check grid {label}'s access token ({_reason(exc)}); launching anyway.")
+        return token
+
+    if refreshed:
+        # The refresh already ran and the grid still says no. A second exchange would mint another
+        # token carrying the same rejected membership, so it would only be a slower way to fail.
+        raise SystemExit(
+            f"Grid {label} rejected this machine's access token, including a freshly renewed one.\n"
+            f"Run `grid login` to sign in again."
+        )
+    try:
+        token = _refresh(rec, label)
+    except _RefreshFailed as failure:
+        raise SystemExit(failure.refusal(label, expiry_note or "was rejected by the grid")) from None
+    _note(f"Refreshed grid {label}'s access token (the grid rejected the stored one).")
+
+    try:
+        relay.check_credential(base, token)
+    except relay.RelayUnauthorized:
+        raise SystemExit(
+            f"Grid {label} rejected this machine's access token, and the renewed one too.\n"
+            f"Run `grid login` to sign in again."
+        ) from None
+    except relay.RelayError as exc:
+        if exc.status == 403:
+            raise SystemExit(_forbidden(label, token, exc)) from None
+        _warn(f"couldn't re-check grid {label}'s access token ({_reason(exc)}); launching anyway.")
+    return token
+
+
+def _forbidden(label: str, token: str, exc: Exception) -> str:
+    """The refusal for a 403 — which of the two it is, decided from the token, not from the message.
+
+    The relay answers 403 both for a token that lacks the inference scope and for a member who may no
+    longer use the grid, and the remedies are different. Which one applies is read off the token's own
+    ``scopes`` claim rather than by matching words in the relay's reply: a message is a response body,
+    and keying user-facing advice on its wording is the failure this whole feature exists to remove.
+    """
+    from remote import credentials
+
+    reason = _reason(exc)
+    scopes = credentials.claims_from_token(token).get("scopes")
+    if isinstance(scopes, list) and _INFERENCE_SCOPE not in scopes:
+        return (
+            f"Grid {label} accepted your sign-in, but this machine's token cannot run inference on "
+            f"it: {reason}\n"
+            # Named as roles, never as "ask the owner": the control plane's owner fallback synthesises
+            # roles=["admin"], whose scopes carry no inference — so this can land in front of the very
+            # person "the owner" would point at.
+            f"Inference is granted by the `consumer` and `both` roles; this token carries neither."
+        )
+    return (
+        f"Grid {label} refused this machine's access token: {reason}\n"
+        f"You are signed in, but not as a member who may use this grid — `grid login` will not "
+        f"change that."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Small shared pieces
+# ---------------------------------------------------------------------------
+
+def _token_expiry(token: str) -> int | None:
+    from remote import credentials
+
+    return credentials.token_expiry(token)
+
+
+_UNITS = ((86400, "day"), (3600, "hour"), (60, "minute"))
+
+
+def _expiry_phrase(exp: int, now: float) -> str:
+    """"expired 3 days ago" / "expires in 6 hours" — the half of the message that makes it actionable.
+
+    Without it the user is told a token is stale but not whether it went stale a year ago (a machine
+    left alone) or is about to (a session they should not start yet), which are different problems.
+    """
+    delta = int(abs(exp - now))
+    for size, unit in _UNITS:
+        if delta >= size:
+            count = delta // size
+            amount = f"{count} {unit}{'s' if count > 1 else ''}"
+            break
+    else:
+        amount = "less than a minute"
+    return f"expired {amount} ago" if exp <= now else f"expires in {amount}"
+
+
+def _reason(exc: Exception) -> str:
+    """The readable half of a relay/control-plane failure.
+
+    Both render as ``… failed (<status>): <body>``, and the body is usually FastAPI's
+    ``{"detail": "…"}`` — the only part a person can act on. Unwrapped when it is exactly that, and
+    otherwise handed over whole: a body we do not recognise is still evidence, and hiding it would
+    leave the user with a refusal that names nothing.
+    """
+    text = str(exc)
+    _, separator, body = text.partition("): ")
+    if not separator:
+        return text
+    try:
+        payload = json.loads(body)
+    except ValueError:
+        return text
+    detail = payload.get("detail") if isinstance(payload, dict) else None
+    return detail if isinstance(detail, str) and detail else text
+
+
+def _note(message: str) -> None:
+    """A line about something this command did. stderr, so `--print-env`'s stdout stays evaluable."""
+    print(message, file=sys.stderr, flush=True)
+
+
+def _warn(message: str) -> None:
+    _note(f"Warning: {message}")

--- a/cli/launch.py
+++ b/cli/launch.py
@@ -1,0 +1,67 @@
+"""`grid launch <target> [grid]` — start an app already pointed at a remote grid (ADR 0028).
+
+Remote-only: ``cli.dispatch`` gates it in local mode with the dialect as the reason (a local grid
+serves chat/completions, and Claude Code speaks only Anthropic Messages).
+
+This module is the only place that knows *which* grid a launch uses — it resolves the grid, its
+access token and its relay base with the same helpers ``grid info --env`` uses, then hands the target
+a value object. ``shared/launch`` therefore never imports ``cli``.
+"""
+from __future__ import annotations
+
+import argparse
+
+from shared.launch import registry
+from shared.launch.target import GridSession
+
+
+def _print_targets() -> int:
+    """Bare `grid launch`: what can be launched. Discovery, so it exits 0 and needs no account."""
+    print("Launch targets:")
+    for target in registry.TARGETS.values():
+        print(f"  {target.name}\t{target.label}")
+    print("\nStart one with `grid launch <target>`.")
+    return 0
+
+
+def cmd_launch(args: argparse.Namespace) -> int:
+    target_name = getattr(args, "target", None)
+    if not target_name:
+        return _print_targets()
+    target = registry.get(target_name)
+    if target is None:
+        # Before the session gate on purpose: a typo is not a sign-in problem, and reporting it as
+        # one sends the user to `grid login` for a mistake `grid login` cannot fix.
+        raise SystemExit(
+            f"Unknown launch target {target_name!r}. Choose from: {', '.join(registry.names())}."
+        )
+    # `remote.*` and the `cli` siblings are imported here, not at module top: `cli/parser.py` imports
+    # this module while the `cli` package is still initialising (same rule as `cli/remote_overview.py`).
+    from remote import credentials
+
+    from . import remote_grid, remote_overview
+
+    session_token = credentials.require_session()
+    rec = remote_grid._select(getattr(args, "grid", None))
+    label = str(rec.get("name") or rec.get("network_id") or "?")
+    # Before the overview read on purpose: a token missing *locally* is the familiar `grid login`
+    # failure, and a network round-trip cannot improve on it.
+    token = remote_grid.require_access_token(rec, label)
+    # The relay base comes from live status for the creator, or the login bundle for a member — the
+    # same helper (and the same "isn't up; run `grid up`" error) `grid info --env` uses.
+    base, _status = remote_grid.resolve_relay_base(
+        session_token, rec, remote_grid._network_id(rec), label
+    )
+    # Preflight's half of the read: which models the grid serves. The public overview, the same one
+    # `grid models` / `grid engines` render, so preflight and those commands can never disagree about
+    # what is live. Whether those models are *enough* is the target's call — it owns its model names.
+    #
+    # The route is public and ignores the bearer token, so this proves model presence, not credential
+    # validity: an expired token passes here and fails inside the app. Known and accepted (ADR 0028);
+    # the authenticated model-listing route is the recorded fix if it bites.
+    live_models = remote_overview.live_model_names(
+        remote_overview.fetch_overview(base, token, label)
+    )
+    return target.run(
+        GridSession(label=label, relay_base=base, access_token=token, live_models=live_models)
+    )

--- a/cli/launch.py
+++ b/cli/launch.py
@@ -73,7 +73,7 @@ def cmd_launch(args: argparse.Namespace) -> int:
     # this module while the `cli` package is still initialising (same rule as `cli/remote_overview.py`).
     from remote import credentials
 
-    from . import remote_grid, remote_overview
+    from . import grid_credential, remote_grid, remote_overview
 
     session_token = credentials.require_session()
     rec = remote_grid._select(getattr(args, "grid", None))
@@ -86,13 +86,14 @@ def cmd_launch(args: argparse.Namespace) -> int:
     base, _status = remote_grid.resolve_relay_base(
         session_token, rec, remote_grid._network_id(rec), label
     )
+    # Credential before models, and the order is not cosmetic (ADR 0029). A dead credential invalidates
+    # the model advice — the target's refusal sends the user off to `grid join` an engine, which cannot
+    # help while the token is dead — whereas a missing model says nothing about the credential. `rec` is
+    # a disk snapshot, so the possibly-refreshed token is what comes back; `rec`'s would be stale.
+    token = grid_credential.ensure_usable(rec, label, token, base)
     # Preflight's half of the read: which models the grid serves. The public overview, the same one
     # `grid models` / `grid engines` render, so preflight and those commands can never disagree about
     # what is live. Whether those models are *enough* is the target's call — it owns its model names.
-    #
-    # The route is public and ignores the bearer token, so this proves model presence, not credential
-    # validity: an expired token passes here and fails inside the app. Known and accepted (ADR 0028);
-    # the authenticated model-listing route is the recorded fix if it bites.
     live_models = remote_overview.live_model_names(
         remote_overview.fetch_overview(base, token, label)
     )

--- a/cli/launch.py
+++ b/cli/launch.py
@@ -24,10 +24,44 @@ def _print_targets() -> int:
     return 0
 
 
+def _list_targets_or_refuse(print_env: bool, forward: tuple[str, ...]) -> int:
+    """Bare `grid launch` — the discovery listing, unless the user asked for something it cannot do.
+
+    Both refusals exist because the listing exits **0**. Without them a user who named no app gets a
+    helpful-looking list and a success code, with nothing to tell them that the flag or the arguments
+    they typed went nowhere — the kind of failure found only by eventually wondering why.
+    """
+    choices = ", ".join(registry.names())
+    if print_env:
+        raise SystemExit(
+            "`--print-env` needs a launch target: `grid launch <target> --print-env`. "
+            f"Choose from: {choices}."
+        )
+    if forward:
+        raise SystemExit(
+            f"Nothing to pass {' '.join(forward)} to: `grid launch` on its own lists the apps it can "
+            f"start. Name one — `grid launch <target> -- …`. Choose from: {choices}."
+        )
+    return _print_targets()
+
+
 def cmd_launch(args: argparse.Namespace) -> int:
+    # Both arrive from outside the parser: `forward` from `cli.dispatch.split_forwarded` (argparse
+    # cannot hold it — see there), `print_env` from the parser itself.
+    forward = tuple(getattr(args, "forward", ()) or ())
+    print_env = bool(getattr(args, "print_env", False))
+    if print_env and forward:
+        # Before everything else, because it needs nothing else to be true: the two contradict each
+        # other whatever grid, target or account is behind them. Refused rather than ignored —
+        # printing a block that drops the arguments the user typed, and exiting 0 while doing it, is
+        # a silent failure dressed as a success.
+        raise SystemExit(
+            "`--print-env` prints the environment instead of starting the app, so the arguments "
+            "after `--` have nothing to reach. Pass one or the other."
+        )
     target_name = getattr(args, "target", None)
     if not target_name:
-        return _print_targets()
+        return _list_targets_or_refuse(print_env, forward)
     target = registry.get(target_name)
     if target is None:
         # Before the session gate on purpose: a typo is not a sign-in problem, and reporting it as
@@ -62,6 +96,10 @@ def cmd_launch(args: argparse.Namespace) -> int:
     live_models = remote_overview.live_model_names(
         remote_overview.fetch_overview(base, token, label)
     )
-    return target.run(
-        GridSession(label=label, relay_base=base, access_token=token, live_models=live_models)
+    session = GridSession(
+        label=label, relay_base=base, access_token=token, live_models=live_models
     )
+    if print_env:
+        return target.print_env(session)
+    # Whatever the user typed after `--`, already taken out of argv by `cli.dispatch.split_forwarded`.
+    return target.run(session, forward)

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -626,9 +626,9 @@ def _add_launch(sub) -> None:
             "\n"
             "Two words are the exception: `--local` and `--remote` are this CLI's one-shot mode\n"
             "override and are removed from anywhere on the command line, so they cannot be\n"
-            "forwarded to the app. `-- --local` does not reach the app and instead switches this\n"
-            "command to local mode, where it refuses — so a forwarded `--local` is reported as a\n"
-            "mode error, not as a missing argument."
+            "forwarded to the app — a warning says so when one is taken. `-- --local` also\n"
+            "switches this command to local mode, where it refuses, so it is reported as a mode\n"
+            "error rather than as a missing argument."
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -34,6 +34,7 @@ from .grid import (
     cmd_up,
     cmd_version,
 )
+from .launch import cmd_launch
 from .mode import cmd_mode, cmd_use
 from .models import cmd_catalog, cmd_ctx, cmd_pull, cmd_rm
 from .provider import cmd_engines, cmd_join, cmd_leave, cmd_models
@@ -78,6 +79,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_price(sub)
     _add_router(sub)
     _add_engine_setup(sub)
+    _add_launch(sub)
     _add_train(sub)
 
     return parser
@@ -605,6 +607,18 @@ def _add_remote_use_flags(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         help="Remote only: let your own engine serve this request.",
     )
+def _add_launch(sub) -> None:
+    launch = sub.add_parser("launch", help="Start an app on your grid (claude)")
+    # Two optional positionals, `target` first: argparse fills them left to right, so
+    # `grid launch claude` is target=claude/grid=None and `grid launch claude team` names both.
+    # `grid` matches info/models/engines verbatim — a name or id, omitted for the active grid.
+    launch.add_argument("target", nargs="?", default=None,
+                        help="Launch target. Omit to list what can be launched.")
+    launch.add_argument("grid", nargs="?", default=None,
+                        help="Grid name or id (ag-…). Omit for the active grid.")
+    launch.set_defaults(handler=cmd_launch)
+
+
 def _add_train(sub) -> None:
     from .train import (
         cmd_train_autopilot,

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -57,6 +57,12 @@ def build_parser() -> argparse.ArgumentParser:
             "Use --local/--remote before any command to override the active mode for that one run."
         ),
     )
+    # ⚠ Every global flag here must be **valueless** (`store_true`/`version`). `cli.dispatch.
+    # split_forwarded` finds the subcommand as the first non-option token, so a global flag that took
+    # a separate value would make that value look like the command word — `grid launch claude -- -p`
+    # would stop being recognised as a passthrough and argparse would bind `-p` to the `grid`
+    # positional again, which is the exact bug that function exists to prevent. A global flag that
+    # needs a value must be spelled `--flag=value`, or `split_forwarded` must learn about it.
     parser.add_argument("--version", action="version", version=f"grid {__version__}")
     parser.add_argument(
         "--json",
@@ -608,7 +614,24 @@ def _add_remote_use_flags(parser: argparse.ArgumentParser) -> None:
         help="Remote only: let your own engine serve this request.",
     )
 def _add_launch(sub) -> None:
-    launch = sub.add_parser("launch", help="Start an app on your grid (claude)")
+    launch = sub.add_parser(
+        "launch",
+        help="Start an app on your grid (claude)",
+        # The separator is invisible in a usage line, and the one thing it cannot carry is invisible
+        # everywhere — so both are spelled out here, which is the only place a user goes looking.
+        epilog=(
+            "Anything after `--` is passed to the app unchanged:\n"
+            "  grid launch claude -- --continue\n"
+            "  grid launch claude -- -p 'summarise this repo'\n"
+            "\n"
+            "Two words are the exception: `--local` and `--remote` are this CLI's one-shot mode\n"
+            "override and are removed from anywhere on the command line, so they cannot be\n"
+            "forwarded to the app. `-- --local` does not reach the app and instead switches this\n"
+            "command to local mode, where it refuses — so a forwarded `--local` is reported as a\n"
+            "mode error, not as a missing argument."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     # Two optional positionals, `target` first: argparse fills them left to right, so
     # `grid launch claude` is target=claude/grid=None and `grid launch claude team` names both.
     # `grid` matches info/models/engines verbatim — a name or id, omitted for the active grid.
@@ -616,7 +639,17 @@ def _add_launch(sub) -> None:
                         help="Launch target. Omit to list what can be launched.")
     launch.add_argument("grid", nargs="?", default=None,
                         help="Grid name or id (ag-…). Omit for the active grid.")
-    launch.set_defaults(handler=cmd_launch)
+    launch.add_argument(
+        "--print-env",
+        action="store_true",
+        help="Print the environment as shell exports instead of starting the app. "
+             "Prints your grid's access token.",
+    )
+    # `forward` is never parsed from here — `cli.dispatch.split_forwarded` takes everything after the
+    # first `--` out of argv before this parser runs (argparse would bind the app's own flags to the
+    # two positionals above). The default is what makes `grid launch claude --`, with nothing after
+    # it, identical to no `--` at all.
+    launch.set_defaults(handler=cmd_launch, forward=())
 
 
 def _add_train(sub) -> None:

--- a/cli/remote_grid.py
+++ b/cli/remote_grid.py
@@ -91,6 +91,22 @@ def _network_id(rec: dict[str, Any]) -> str:
     return str(nid)
 
 
+def require_access_token(rec: dict[str, Any], label: str) -> str:
+    """The grid's per-grid access token, or the familiar "run `grid login`" guidance.
+
+    One source for the sentence, shared by `grid info --env` and `grid launch` — a launch that
+    proceeded with an empty bearer would surface inside the launched app as an auth error that names
+    neither the grid nor the fix. (Three older copies of this sentence live in `remote_request.py`,
+    `remote_price.py` and `remote_provider.py`; folding those in is out of scope here.)
+    """
+    token = rec.get("access_token")
+    if not token:
+        raise SystemExit(
+            f"Grid {label} has no access token locally. Run `grid login` to refresh your grids."
+        )
+    return str(token)
+
+
 def _grid_url(live: dict[str, Any], rec: dict[str, Any]) -> str:
     """The grid's relay address. Prefer the live response; fall back to the stored bundle — a
     login-fetched bundle carries it as ``lan_signaling_url`` (a create reply as ``signaling_url``)."""
@@ -235,11 +251,7 @@ def cmd_remote_info(args: argparse.Namespace) -> int:
     if args.env:
         rec = _select(args.grid)
         label = rec.get("name") or rec.get("network_id")
-        token = rec.get("access_token")
-        if not token:
-            raise SystemExit(
-                f"Grid {label} has no access token locally. Run `grid login` to refresh your grids."
-            )
+        token = require_access_token(rec, label)
         # The relay base comes from live status for the creator, or the login bundle for a member —
         # resolve_relay_base handles both (the bundle carries the token but not the address).
         base, _status = resolve_relay_base(session, rec, _network_id(rec), label)

--- a/cli/remote_grid.py
+++ b/cli/remote_grid.py
@@ -18,7 +18,7 @@ import json
 import re
 from typing import Any
 
-from shared import state
+from shared import shell, state
 
 
 # Default network type for `grid up` on create (DECISIONS D11; the other choice is
@@ -259,8 +259,12 @@ def cmd_remote_info(args: argparse.Namespace) -> int:
         # user-requested disclosure of the caller's own token to their own shell — like
         # `gh auth token`. Every other path (ls, info without --env, all --json) stays token-free.
         base_url = base.rstrip("/") + "/relay/v1"
-        print(f'export OPENAI_BASE_URL="{base_url}"')
-        print(f'export OPENAI_API_KEY="{token}"')
+        # `shell.quote`, not an f-string in double quotes: this block exists to be evaluated, and the
+        # token is an opaque credential this repo neither mints nor validates while the base arrives
+        # from the control plane. A value holding `"`, `$`, a backtick or a backslash would break out
+        # of a double-quoted context and be *executed* by the eval this command invites.
+        print(f"export OPENAI_BASE_URL={shell.quote(base_url)}")
+        print(f"export OPENAI_API_KEY={shell.quote(token)}")
         return 0
     rec = _select(args.grid)
     # Status is creator-only; a member sees `{}` here and just gets a blank run-state (never an error).

--- a/cli/remote_overview.py
+++ b/cli/remote_overview.py
@@ -38,7 +38,7 @@ def _fetch_overview(args: argparse.Namespace) -> dict[str, Any]:
     Lighter than the consumer ``remote_request._resolve``: the overview is public, so this needs only
     a signed-in session and a resolvable relay base (no access-token gate).
     """
-    from remote import credentials, relay
+    from remote import credentials
 
     from . import remote_grid
 
@@ -48,6 +48,19 @@ def _fetch_overview(args: argparse.Namespace) -> dict[str, Any]:
     label = rec.get("name") or network_id
     base, _status = remote_grid.resolve_relay_base(session, rec, network_id, label)
     token = str(rec.get("access_token") or "")  # public route — token optional
+    return fetch_overview(base, token, str(label))
+
+
+def fetch_overview(base: str, token: str, label: str) -> dict[str, Any]:
+    """The public overview at ``base``, or a clean ``SystemExit`` naming grid ``label``.
+
+    Split out of ``_fetch_overview`` so a caller that has already resolved its grid — `grid launch`'s
+    preflight (ADR 0028) — reads the grid through *this* code path rather than a second copy that
+    could drift away from it. The guards below are the trust boundary: the body is whatever the relay
+    returned, so a non-JSON 2xx or a non-dict envelope becomes a message, never a traceback.
+    """
+    from remote import relay
+
     try:
         with relay.open_consumer_client(base, token, timeout=_OVERVIEW_TIMEOUT) as client:
             resp = client.get("/relay/v1/grid/overview")
@@ -76,6 +89,21 @@ def _nodes_from(overview: dict[str, Any]) -> list[dict[str, Any]]:
 def _nodes(args: argparse.Namespace) -> list[dict[str, Any]]:
     """The active remote grid's live engine nodes (fetches the overview)."""
     return _nodes_from(_fetch_overview(args))
+
+
+def live_model_names(overview: dict[str, Any]) -> tuple[str, ...]:
+    """Every model id the grid currently serves, first-seen order, deduped across engines.
+
+    The same reading ``cmd_remote_models`` renders, through the same defended readers — so a malformed
+    ``nodes`` or a node whose ``models`` isn't a list degrades to empty here exactly as it does there.
+
+    ``auto`` is not included even when the grid has routing enabled: it is the reserved name that
+    never matches an engine-advertised model (CONTEXT-MAP.md), so it can never be what a caller is
+    asking about when it asks which models exist.
+    """
+    return tuple(dict.fromkeys(
+        model for node in _nodes_from(overview) for model in _node_models(node)
+    ))
 
 
 def _node_models(node: dict[str, Any]) -> list[str]:

--- a/docs/adr/0017-auto-router-resilience.md
+++ b/docs/adr/0017-auto-router-resilience.md
@@ -43,6 +43,19 @@ Choices a future reader will otherwise re-litigate:
   provider would fail identically), extended from re-dispatch to the health classifier. The broader
   *union blast-radius on a genuine failure* — one engine's real 5xx still demoting its siblings under a
   shared `node_id` — is a pre-existing property left as a separate follow-up, not closed here.
+  **Amendment (2026-07-27, prod):** the model-level classifier also reads *"no provider(s) available for
+  [this] model"* — how an **aggregating** upstream reports a model it has lost: an API-engine proxy
+  fronting many vendors, or a nested grid emitting this relay's own `no_providers_available` wording. It
+  arrives as a **5xx, not a 404**, and carries none of the existing markers, so it took the box-level
+  path: on Nightshift a dead `deepreinforce-ai/ornith-1.0-397b` demoted its whole three-model node every
+  ~10 minutes and took its two healthy siblings offline with it — this ADR's own opening symptom,
+  reached through a phrasing gap rather than a design gap. Provider-side servability reconciliation
+  (issue 03) cannot cover it: that runs **at startup**, and the model died afterwards — which is exactly
+  the case `servability.py` names the master-side prune as the reactive net for. The rule is
+  deliberately narrow: the `for [this] model` tail is what makes it model-level, so a box reporting no
+  provider or capacity **at all** (no model reference) still demotes the node. Accepted cost of the
+  widening: an upstream that has lost *every* model now burns the failure threshold **per model**
+  instead of once per node before that node goes quiet — bounded by (models × threshold).
 
 - **An empty candidate pool returns one of three answers, by cause — a demotion-emptied pool is now a
   503, not a 400.** No live model → 503 `no_providers_available`; otherwise-capable providers all

--- a/docs/adr/0028-launch-hands-an-app-the-grid.md
+++ b/docs/adr/0028-launch-hands-an-app-the-grid.md
@@ -84,6 +84,9 @@ already reads it. See the consequence below.
   ignores the Bearer token. A locally-absent token is still caught (the same check and the same
   "run `grid login`" message `info --env` uses), but an *expired* one passes preflight and fails
   inside the app. Accepted knowingly; the authenticated route above is the fix if it bites.
+  **It bit — [ADR 0029](./0029-the-credential-is-checked-before-it-is-handed-over.md) takes that fix,
+  and adds the offline expiry check and the in-place refresh the authenticated route alone cannot
+  give.**
 - **`settings.json` outranks us.** Claude Code's user settings can carry an `env` block whose values
   override a shell export. A user with `ANTHROPIC_BASE_URL` there silently defeats `grid launch`, so
   the command reads that file and warns — it does not edit it.

--- a/docs/adr/0028-launch-hands-an-app-the-grid.md
+++ b/docs/adr/0028-launch-hands-an-app-the-grid.md
@@ -1,0 +1,101 @@
+---
+status: accepted
+---
+
+# `grid launch` hands a third-party app the grid, in that app's process and nowhere else
+
+A user can already drive Claude Code against a remote grid, and people do — but the recipe is
+folklore. It starts at `grid info --env`, which prints `OPENAI_BASE_URL="{base}/relay/v1"` and
+`OPENAI_API_KEY="{access_token}"` (`cli/remote_grid.cmd_remote_info`), and then asks the user to know
+four undocumented things: that Claude Code speaks the Anthropic dialect, so the endpoint is the same
+base **without** `/v1` (the client appends `/v1/messages` itself); that the same token goes into both
+`ANTHROPIC_AUTH_TOKEN` and `ANTHROPIC_API_KEY`; that Claude Code resolves a model per *tier*, so
+seven more variables must be set or it asks the grid for a model named `claude-opus-…` that no engine
+serves; and that all of it must be exported into the shell before the binary starts.
+
+Nothing about that chain is discoverable, and every step of it is a place to get one string wrong and
+receive an authentication or model error that names none of the actual causes.
+
+## Decision
+
+> **`grid launch <target>` starts a third-party app already pointed at the active grid. The endpoint,
+> the credential and the model names are set in the *child process environment only* — never exported
+> to the user's shell, never written to a config file, never to `os.environ` of the CLI itself.**
+
+The verb is new and the noun is new: a **launch target** is an app `grid launch` starts for the user.
+`claude` (Claude Code) is the first and, in this slice, the only one.
+
+The scope is deliberately "hand over and get out of the way". `grid launch` does not configure the
+app, does not own its settings, and leaves nothing behind — so there is no `--restore` to undo, and
+closing the app is the whole cleanup.
+
+### The env block
+
+| variable | value |
+|---|---|
+| `ANTHROPIC_BASE_URL` | `resolve_relay_base(...)` + `/relay` — **no** `/v1` |
+| `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_API_KEY` | the grid's `access_token` |
+| `ANTHROPIC_MODEL`, `ANTHROPIC_SMALL_FAST_MODEL`, `CLAUDE_CODE_SUBAGENT_MODEL` | the tier table |
+| `ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU,FABLE}_MODEL` | the tier table |
+
+The tier table is **one hardcoded constant** in this slice, not discovered from the grid. It is the
+single place a later slice replaces with discovery, and it is the reason the preflight below exists.
+
+## Considered options
+
+**`grid agent run claude`, rejected.** `agent` already names something else here — hermes and codex,
+the agents the CLI *itself* drives to run tools in `grid chat` (`cli/agent.py`). A launch target is
+the mirror image: the user drives it and the CLI only mints its environment. Overloading the word
+would also have produced `grid agent install codex` and `grid agent run codex` side by side, meaning
+different things, while `codex` is *already* a third thing — an API engine kind
+([ADR 0015](./0015-codex-subscription-engine.md)).
+
+**Local mode, rejected for now.** `local/server.py` serves `/v1/chat/completions`, `/v1/completions`,
+`/v1/models` and media — there is no `/v1/messages`, and Claude Code speaks nothing else. Adding it
+would mean carrying grid-src's Anthropic↔OpenAI translation (its own module, including a
+stream-rebuilding state machine) into this repo across a seam that has no code dependency, which is
+exactly the class of hand-duplication that compiles, passes every test, and diverges at runtime. So
+in local mode the command refuses, and it says *why* — the dialect — rather than "not supported".
+
+**An isolated config dir (`CLAUDE_CONFIG_DIR`), rejected.** It would keep grid sessions clear of the
+user's Anthropic account, at the price of handing them a Claude Code with none of their MCP servers,
+skills, permission allowlist or history. The value of the app is mostly in that accumulated
+configuration; a launch that strips it would send users straight back to exporting by hand.
+
+**A pinned, SHA-256-verified binary in `~/.grid/bin`, rejected** — the shape
+`shared/agent/codex_installer` uses. It fits Codex because Codex is a static asset on a GitHub
+release. Claude Code manages its own versions, so pinning would make this repo the owner of a number
+it does not control and would ship users a stale agent. `grid launch` instead offers to run the
+vendor's own installer, and only when attached to a TTY.
+
+**`auto` as the default model, rejected.** The grid's own router would need no configuration at all,
+but Claude Code issues many small requests per turn, so an advisor hop lands on all of them, and the
+model can differ turn to turn — which makes "it got worse today" unfalsifiable. `auto` stays
+available as an explicit model name; it is not the default.
+
+**An authenticated preflight, rejected.** `GET /relay/v1/models` requires `inference:models` and
+would prove the token *and* list the models in one call. The public
+`GET /relay/v1/grid/overview` was chosen instead because `cli/remote_overview._fetch_overview`
+already reads it. See the consequence below.
+
+## Consequences
+
+- **Preflight proves model presence, not credential validity.** The overview route is public and
+  ignores the Bearer token. A locally-absent token is still caught (the same check and the same
+  "run `grid login`" message `info --env` uses), but an *expired* one passes preflight and fails
+  inside the app. Accepted knowingly; the authenticated route above is the fix if it bites.
+- **`settings.json` outranks us.** Claude Code's user settings can carry an `env` block whose values
+  override a shell export. A user with `ANTHROPIC_BASE_URL` there silently defeats `grid launch`, so
+  the command reads that file and warns — it does not edit it.
+- **`--print-env` is the second deliberate exception** to the rule that no command prints a token
+  ([ADR 0003](./0003-remote-grid-lifecycle.md) §6). It carries the same justification as
+  `info --env`: an explicit, user-requested disclosure of the caller's own token to the caller's own
+  shell. Every other path stays token-free.
+- **A missing tier model fails at launch, loudly, not at request time.** With the tier table
+  hardcoded, a grid that does not serve it is a launch-time refusal naming what is missing and what
+  the grid does serve. The two tiers every session uses are required; the `/model`-only tiers fall
+  back to the main model rather than blocking the launch or being left unset — unset would send
+  Claude Code asking for a real Anthropic model name that no grid serves.
+- **`--local` / `--remote` are stripped from anywhere in argv** by `cli.dispatch.resolve_override`,
+  including after the `--` separator, so those two exact tokens cannot be passed through to the
+  launched app.

--- a/docs/adr/0028-launch-hands-an-app-the-grid.md
+++ b/docs/adr/0028-launch-hands-an-app-the-grid.md
@@ -35,11 +35,32 @@ closing the app is the whole cleanup.
 |---|---|
 | `ANTHROPIC_BASE_URL` | `resolve_relay_base(...)` + `/relay` — **no** `/v1` |
 | `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_API_KEY` | the grid's `access_token` |
-| `ANTHROPIC_MODEL`, `ANTHROPIC_SMALL_FAST_MODEL`, `CLAUDE_CODE_SUBAGENT_MODEL` | the tier table |
-| `ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU,FABLE}_MODEL` | the tier table |
+| ~~`ANTHROPIC_MODEL`, `ANTHROPIC_SMALL_FAST_MODEL`, `CLAUDE_CODE_SUBAGENT_MODEL`~~ | ~~the tier table~~ |
+| ~~`ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU,FABLE}_MODEL`~~ | ~~the tier table~~ |
 
 The tier table is **one hardcoded constant** in this slice, not discovered from the grid. It is the
 single place a later slice replaces with discovery, and it is the reason the preflight below exists.
+
+> ### Amended — the seven model variables are no longer set
+>
+> The env block is now **three keys**: the base URL and the two token variables. The tier table, the
+> required/optional split, the remap, and the preflight that checked those names are all gone.
+>
+> The decision above was made to stop Claude Code asking a grid for a real Anthropic model name no
+> grid serves. It bought that by making this command decide which model a user's session runs on —
+> a choice it has no standing to make, and one that silently overrode the user's own `settings.json`,
+> their `/model` default and any `ANTHROPIC_MODEL` already in their shell. Handing an app the grid is
+> the feature; choosing their model for them was never part of it.
+>
+> **What this costs, stated plainly:** a model the grid does not serve now fails at the user's first
+> prompt instead of at launch, and Grid cannot warn about it in advance, because it no longer knows
+> what the app is going to ask for. That is the trade — the launcher stops being wrong about the
+> model, and stops being able to be right about it.
+>
+> Preflight survives only as the one model fact that holds whatever the app asks: a grid serving
+> nothing can serve nothing, so an empty grid is still refused before the app starts. Everything else
+> in this ADR — the child-process-only environment, the base URL with no `/v1`, both token variables,
+> the rejected alternatives, `--print-env`'s carve-out — stands unchanged.
 
 ## Considered options
 
@@ -94,11 +115,14 @@ already reads it. See the consequence below.
   ([ADR 0003](./0003-remote-grid-lifecycle.md) §6). It carries the same justification as
   `info --env`: an explicit, user-requested disclosure of the caller's own token to the caller's own
   shell. Every other path stays token-free.
-- **A missing tier model fails at launch, loudly, not at request time.** With the tier table
+- ~~**A missing tier model fails at launch, loudly, not at request time.** With the tier table
   hardcoded, a grid that does not serve it is a launch-time refusal naming what is missing and what
   the grid does serve. The two tiers every session uses are required; the `/model`-only tiers fall
   back to the main model rather than blocking the launch or being left unset — unset would send
-  Claude Code asking for a real Anthropic model name that no grid serves.
+  Claude Code asking for a real Anthropic model name that no grid serves.~~
+  **Reversed by the amendment above.** No model variable is set, so a model the grid does not serve
+  fails at the first request — the launcher no longer knows what will be asked for. Only an empty
+  grid is still a launch-time refusal.
 - **`--local` / `--remote` are stripped from anywhere in argv** by `cli.dispatch.resolve_override`,
   including after the `--` separator, so those two exact tokens cannot be passed through to the
   launched app.

--- a/docs/adr/0029-the-credential-is-checked-before-it-is-handed-over.md
+++ b/docs/adr/0029-the-credential-is-checked-before-it-is-handed-over.md
@@ -1,0 +1,165 @@
+---
+status: accepted
+---
+
+# `grid launch` checks the credential before it hands it over, and refreshes it in place when it can
+
+[ADR 0028](./0028-launch-hands-an-app-the-grid.md) chose the **public** `GET /relay/v1/grid/overview`
+for the launch preflight, because `cli/remote_overview` already read it, and recorded the cost in its
+first consequence: *"Preflight proves model presence, not credential validity … Accepted knowingly;
+the authenticated route above is the fix if it bites."* This is that fix.
+
+It bites harder than "the user sees an error later", because of **where** the error lands and **what
+it looks like when it gets there**. The relay's 401 leaves through `_run_anthropic_endpoint`, which
+re-dresses it in Anthropic's envelope with `error_type_for_status(401)` = `authentication_error` — the
+vendor's own "your credentials are bad" type. Claude Code reads that as an Anthropic auth problem, at
+the first prompt, after the app owns the terminal and the launcher is gone. The only thread back to
+the real cause is the substring `Invalid Grid token: …` inside the message. Nothing names `grid`, and
+the command that fixes it is in another terminal.
+
+The class is also wider than the word "expired". A grid token is rejected for five different reasons,
+and only some are repairable:
+
+| cause | the relay says | repairable locally |
+|---|---|---|
+| past `exp` (365 d) | `Invalid Grid token: …` (401) | yes — refresh |
+| member roles changed → `member_epoch` bump | `Grid member token epoch is stale` (401) | yes — refresh |
+| membership/denylist rotated → `network_epoch` bump | `Grid network token epoch is stale` (401) | yes — refresh |
+| removed / inactive / denied | 403 | **no** |
+| token carries no inference scope | 403 `Missing required scope: …` | **no** |
+
+On an active shared grid the two epoch bumps are likelier than a 365-day expiry, so a fix aimed only
+at `exp` would solve the smaller half.
+
+## Decision
+
+> **No launch hands over a credential it has not checked. The check is offline first and authenticated
+> second; a credential that is merely stale is refreshed in place, silently, and one that cannot be
+> repaired is refused before the app starts — naming the cause and the command that fixes it.**
+
+Three layers, one refresh budget for the whole run:
+
+| | what it does | what only it catches |
+|---|---|---|
+| 1 | decode the JWT's `exp`, compare to the clock with a **24 h margin** | a token that is valid *now* and dies mid-session |
+| 2 | exchange the refresh token for a fresh one | — (this is the repair, not a check) |
+| 3 | `GET /relay/v1/models`, body discarded | epoch staleness, revocation, missing scope, a slow clock |
+
+Neither check subsumes the other, which is why both ship. The probe returns **200** for a token with
+four minutes left on it, so only layer 1 protects a work session; and layer 1 cannot see an epoch
+bump, a revocation, or its own clock being wrong, so only layer 3 protects against those.
+
+The margin is 24 h rather than `remote/serve.py`'s `_CODEX_EXPIRY_MARGIN = 600.0` because what is
+being protected is a human work session, not a poll iteration. It is 0.27 % of a 365-day token's life,
+so it cannot cause spurious refreshes in practice.
+
+**`inference:models` is a sound proxy for `inference:create`.** `role_scopes` only ever writes the
+inference scopes as one bundle (`scopes.update(INFERENCE_SCOPES)`), so a token holds
+`inference:models` — which the probe needs — exactly when it holds the `inference:create` that
+`/messages` needs. The probe therefore produces no refusal the app would not have produced itself.
+
+### The order: credential, then models
+
+Preflight's two halves swap. The asymmetry is the reason: a dead credential invalidates the model
+advice — *"run `grid join` on an engine that serves `claude:opus`"* sends the user off to do work that
+will not help — while a missing model does not invalidate the credential advice.
+
+### A one-shot command may now refresh, which reverses a recorded decision
+
+`cli/remote_request.py` states, and has always stated, that *"refresh-on-401 stays in the long-running
+serve loop ([ADR 0004](./0004-remote-provider-serve.md)), not on this one-shot path"*. That decision
+stands for `chat`/`image`/`edit`/`video` and is not touched here. `launch` is exempt on a mechanism,
+not on a preference:
+
+- A `grid chat` failure costs **one re-run**. It surfaces in about a second, in the user's own
+  terminal, through a message the CLI wrote. "Run `grid login`, then retry" is a complete remedy.
+- A `grid launch` failure is handed to **a different, long-lived process** whose error surface we do
+  not control, and it surfaces minutes later dressed as the vendor's own auth error. The credential
+  has to be good for the *session's* lifetime, not for one request — which is a different requirement,
+  and the only one of the two that a margin and a repair can satisfy.
+
+### The write contract
+
+`grid launch`, `--print-env` included, now writes `~/.grid/credentials.toml`.
+
+ADR 0028's *"never exported to the user's shell, never written to a config file, never to
+`os.environ`"* is a rule about **what the app is given** — the endpoint, the credential and the model
+names — not about Grid's own credential store, which `grid login` and `grid sync` already rewrite.
+Refreshing our own cached credential is maintenance of our own state; nothing is left behind for the
+*app*, closing it remains the entire cleanup, and there is still no `--restore`. `--print-env` still
+starts nothing: a probe is a read, unlike resolving the binary, which can spawn an installer and is
+therefore still skipped there.
+
+### Failing open, and the clause that bounds it
+
+The rule this feature already follows elsewhere (`shared/launch/claude_install._warn_unchecked`,
+`shared/launch/claude._settings_paths`) is that **a check that could not run says so, and never costs
+the user a launch _that would have worked_.** The italicised clause decides every ambiguous case:
+
+- Token **already expired**, and the refresh fails → **refuse**. The launch would not have worked, so
+  failing open would only guarantee the in-app failure this exists to prevent. A refresh that failed
+  because the *control plane* is broken (503, transport) still refuses, but says so and says retry —
+  it does not send the user to `grid login`, which fixes nothing.
+- Token **within the margin** but still valid, and the refresh fails → **warn and launch**. The
+  credential works right now; a control-plane outage must not take a working launch away.
+- Probe throttled (429), 5xx, transport, timeout → **warn and launch**. Nothing was learned.
+- Token is not a decodable JWT → **"cannot tell", not "expired"** — fall through to the probe.
+
+## Considered options
+
+**Refuse instead of refresh, rejected.** It would bring back the recipe this feature exists to
+delete: *"your token expired — run `grid login`, then `grid launch` again."* And `grid login` opens a
+browser to obtain something the stored refresh token already yields offline.
+
+**`grid sync` as the remedy, rejected.** It re-issues every bundle, but it authenticates with the
+**session** token (24 h) while the access token lives 365 d and the refresh token 2 y — so it is
+expired in precisely the situation where the access token is, and fails exactly when it is needed. The
+refresh exchange is unauthenticated by design (the refresh token *is* the credential), which is what
+makes it the only remedy that reliably works.
+
+**The offline check alone, rejected.** Cheapest and catches the named case, but cannot see an epoch
+bump, a revocation or a missing scope — and a machine whose clock runs slow reads an expired token as
+valid, which is the one failure mode a clock-based check cannot self-diagnose.
+
+**The probe alone, rejected.** It answers 200 for a token that expires in four minutes, so it cannot
+protect a session that outlives the token. It is a check of *now*; a launch is a bet on *later*.
+
+**Letting the probe supply the model list too, rejected.** `GET /relay/v1/models` returns the models,
+so folding preflight into it would cost no extra round-trip at all. But `grid models` and
+`grid engines` render the **overview**, and preflight sharing that read is what lets its refusal say
+*"Models on `<grid>`: …"* and mean the same thing the user's next command will print. Buying back one
+round-trip by making the refusal and the diagnostic disagree is a bad trade.
+
+**Reading the stored `expires_at`, rejected.** The login bundle carries it, but
+`credentials.update_network_tokens` does not rewrite it, so it is wrong for every token the serve loop
+has ever refreshed. The JWT is self-describing and cannot drift.
+
+**Validating with a real `/messages` request, rejected.** It would prove the credential end to end for
+the exact route the app uses — by creating and billing a job.
+
+## Consequences
+
+- **`grid launch` mutates `~/.grid/credentials.toml`** when, and only when, the stored credential
+  needed repairing. A healthy token writes nothing.
+- **A concurrently running serve loop's in-memory refresh token goes stale** the moment a launch
+  rotates it, and stays stale until that loop's next 401 — at which point
+  `remote/serve.py:_ServeState.refresh` re-reads the file and adopts the token this process stored,
+  which it already does for exactly this reason. So it self-heals, but not immediately, and a reader
+  should not have to rediscover that.
+- **Refresh-token rotation is unconditional and destructive.** The control plane mints a new refresh
+  token on *every* exchange and the old one stops matching at once, while
+  `credentials.update_network_tokens`' `refresh_token` parameter is **optional** — so any caller that
+  persists only the access token permanently destroys the account's refresh credential on that
+  machine, sending every later launch *and* the serve loop back to `grid login`. Recorded here because
+  the failure is silent, is not what the caller was thinking about, and passes any test written about
+  the access token.
+- **Every launch costs one authenticated relay round-trip**, bounded by an explicit per-phase timeout
+  so the fail-open branch is reached in ~8 s rather than the 15 s a one-shot relay call uses. The
+  overview read is unchanged and still public.
+- **The 403 outcomes have no local remedy** and are refused as such. The scope refusal names the roles
+  that grant inference (`consumer`, `both`) rather than telling the user to ask the grid's owner: the
+  control plane's owner fallback synthesises `roles=["admin"]`, whose scopes carry no inference at
+  all, so this refusal can land in front of the owner.
+- **`grid info --env` still hands out an unchecked token** for OpenAI clients, with the identical
+  failure mode. It is [ADR 0005](./0005-remote-consume.md)'s surface, so it is not changed here; the
+  gate is shaped to be its second caller.

--- a/docs/claude-code-quickstart.md
+++ b/docs/claude-code-quickstart.md
@@ -1,0 +1,214 @@
+# Claude Code quickstart — run Claude Code on your own grid
+
+This walks the whole path end to end: install `grid`, sign in, choose a remote grid, and start
+**Claude Code** already pointed at it. One command does the last part:
+
+```bash
+grid launch claude
+```
+
+The endpoint, the credential and the model names go into Claude Code's own process environment and
+nowhere else — nothing is exported to your shell, nothing is written to any config file, and closing
+the app is the entire cleanup. Reference detail lives in [cli.md](./cli.md#launch) and
+[ADR 0028](./adr/0028-launch-hands-an-app-the-grid.md).
+
+Two roles appear below. The **provider** serves the models Claude Code will use. The **consumer**
+runs `grid launch claude`. They can be the same person on the same machine — the steps don't change.
+
+## What you need
+
+- The `grid` CLI, in **remote** mode, signed in, with an active grid (below).
+- Claude Code. You don't have to install it first: `grid launch claude` searches your `PATH` and the
+  two places Claude Code installs itself into, and offers to run the vendor's own installer if it
+  finds nothing.
+- A grid that serves the models this release names — `claude:opus` and `claude:haiku` at minimum.
+  See step 3; this is the single most common reason a first attempt fails.
+
+**`grid launch` is remote-only, and the reason is the dialect.** Claude Code speaks the Anthropic
+Messages dialect and nothing else. A remote grid's relay translates a Messages request to
+`chat/completions` before it routes, so any chat model can back the app. A local grid has no
+`/v1/messages` at all, so in `local` mode the command refuses and names that — it is a design
+boundary, not a missing flag.
+
+## 1. Install grid and sign in
+
+```bash
+curl -fsSL https://grid.autonomous.ai/install.sh | bash   # macOS / Linux
+grid mode remote                                          # persist remote mode
+grid login                                                # device-code sign-in to the hosted relay
+```
+
+`grid login` prints a sign-in URL and code and opens a browser at it; `--no-browser` prints the URL
+instead, for a headless box.
+
+## 2. Choose a grid
+
+```bash
+grid ls                    # grids you can reach
+grid use <name>            # pick the active grid
+grid                       # overview: mode, active grid, engines, models
+```
+
+`grid use` is the one place you choose where work runs — `grid launch claude` follows it. To launch
+against a different grid just once, name it: `grid launch claude <name>` (a grid name or an `ag-…`
+id, exactly like `grid info` / `grid models` / `grid engines`).
+
+The grid must be **up** (`grid up`) and your sign-in must be a member of it.
+
+## 3. Check the grid serves the models — the fixed names
+
+**This release fixes the model names.** Claude Code resolves a model per tier, and each tier is
+pinned to one name:
+
+| Claude Code tier | model on your grid | required? |
+|---|---|---|
+| main (`ANTHROPIC_MODEL`) | `claude:opus` | **yes** |
+| small/fast, and subagents | `claude:haiku` | **yes** |
+| `/model sonnet` | `claude:sonnet` | no — remapped to the main tier's model |
+| `/model fable` | `claude:fable` | no — remapped to the main tier's model |
+
+So the grid has to serve those names. **`grid models` is the authoritative list of what a grid
+serves** — run it before your first launch:
+
+```bash
+grid models                # bare model ids, one per line
+```
+
+A grid ready to run a session:
+
+```text
+claude:opus
+claude:haiku
+glm-5.2
+```
+
+The two required tiers are checked before anything starts (preflight, no off switch), so a grid that
+can't run one refuses up front instead of failing inside the app at your first prompt:
+
+```text
+Grid team can't run Claude Code: it doesn't serve claude:opus.
+Models on team: claude:haiku, glm-5.2.
+Run `grid join` on an engine that serves claude:opus, then `grid launch claude` again.
+```
+
+A missing *optional* tier is not a blocker — it is remapped onto the main tier's model, with one line
+saying so, so `/model sonnet` inside the app never dead-ends:
+
+```text
+Grid team doesn't serve the sonnet, fable tiers — `/model` there resolves to claude:opus.
+```
+
+### Serving those names (the provider's side)
+
+There is no `claude` engine kind to join in this release. Because the relay translates Messages to
+`chat/completions` before routing, **any chat model can back Claude Code** — so a provider publishes
+its own models under the fixed names, with `grid join`'s alias form:
+
+```bash
+# advertise this box's two models to the grid under the names Claude Code asks for
+grid join research --at http://192.168.1.20:8000/v1 \
+  -m qwen36-30b=claude:opus -m gemma4-4b=claude:haiku
+```
+
+`-m real=advertised` is shorthand for `--advertise-as`; both do the same thing. Aliasing is
+**single-engine only** — one join, one engine, aliases for every `-m` in that command, and not an
+append onto an identity already serving. Details and the mode gating are in
+[cli.md → `grid join` in remote mode](./cli.md#grid-join-in-remote-mode).
+
+Then confirm from the consumer's side with `grid models` again.
+
+## 4. Launch
+
+```bash
+grid launch claude
+```
+
+One line on stderr names the grid and the model, then Claude Code owns the terminal exactly as it
+does when you run the binary yourself — same Ctrl-C, same exit code:
+
+```text
+Starting Claude Code on grid team (model claude:opus).
+```
+
+Not sure what can be launched? Bare `grid launch` lists the targets and exits 0:
+
+```bash
+grid launch
+```
+
+```text
+Launch targets:
+  claude	Claude Code
+
+Start one with `grid launch <target>`.
+```
+
+### Passing Claude Code its own arguments
+
+Everything after the **first** `--` goes to the app, in order and unread — the launcher is never a
+ceiling on the app:
+
+```bash
+grid launch claude -- --continue
+grid launch claude -- -p 'summarise this repo'
+grid launch claude research -- --continue      # …on a grid other than the active one
+```
+
+Two words are the exception: `--local` and `--remote` are grid's own one-shot mode override and are
+stripped from anywhere on the line, separator included, so neither reaches the app. A warning says so
+when one is taken.
+
+### Managing your own shell instead
+
+`--print-env` prints exactly what a launch would inject and starts nothing:
+
+```bash
+grid launch claude --print-env
+```
+
+```bash
+export ANTHROPIC_BASE_URL='https://relay.example/relay'
+export ANTHROPIC_AUTH_TOKEN='<your access token>'
+export ANTHROPIC_API_KEY='<your access token>'
+export ANTHROPIC_MODEL='claude:opus'
+export ANTHROPIC_SMALL_FAST_MODEL='claude:haiku'
+export CLAUDE_CODE_SUBAGENT_MODEL='claude:haiku'
+export ANTHROPIC_DEFAULT_OPUS_MODEL='claude:opus'
+export ANTHROPIC_DEFAULT_SONNET_MODEL='claude:sonnet'
+export ANTHROPIC_DEFAULT_HAIKU_MODEL='claude:haiku'
+export ANTHROPIC_DEFAULT_FABLE_MODEL='claude:fable'
+```
+
+Note the base URL carries **no** `/v1` — Claude Code appends `/v1/messages` itself, so the `/v1` that
+`grid info --env` prints for OpenAI clients would 404 every request here. That one character is why
+this command exists.
+
+Like `grid info --env`, this prints your access token; unlike it, warnings stay on stderr, so
+`eval "$(grid launch claude --print-env)"` evaluates only the exports.
+
+## What to expect on this path
+
+- **Your real Claude Code.** MCP servers, skills, permission allowlist, project history — all of it,
+  unchanged. Nothing is isolated and nothing is written on your behalf.
+- **Your own settings can override it.** Claude Code's `settings.json` `env` block outranks an
+  injected variable, so a stray `ANTHROPIC_BASE_URL` there silently defeats the launch. The command
+  reads that file and warns in one line — it never edits it.
+- **Preflight proves models, not your token.** It reads the grid's public overview (the same read
+  `grid models` renders), which ignores the bearer token. A *missing* token is caught first with the
+  usual `grid login` guidance; an *expired* one passes preflight and fails inside the app.
+- **`auto` is not the default, and there is no `--model` flag in this release.** Claude Code issues
+  many small requests per turn, so routing each one through the grid's advisor would add a hop to
+  every one and let the model change turn to turn — which makes "it got worse today" unfalsifiable.
+  The tier table in step 3 is what you get.
+- **Nothing to undo.** No config file, no shell export, no `--restore`. Quit the app and it's over.
+
+## If it doesn't launch
+
+| what you see | what it means |
+|---|---|
+| "is a remote-mode command" | You're in local mode. Run `grid mode remote` (or pass `--remote`) — a local grid does not serve the Anthropic Messages dialect. |
+| "You're not signed in" | No stored credential on this machine. Run `grid login`. |
+| "can't run Claude Code: it doesn't serve …" | Preflight. Compare against `grid models`, then serve the missing name (step 3). |
+| "Claude Code isn't installed" | Nothing on your `PATH` or in either place Claude Code installs to. On a terminal you're offered the vendor's installer; with no terminal (CI, a script) the install command is printed and the launch exits non-zero. |
+| "Warning: Claude Code's own settings set …" | An `env` block in your `settings.json` overrides what was injected. Remove the colliding key — `grid launch` never edits that file. |
+| Requests fail *inside* the app | Most likely an expired token, which preflight cannot see. `grid launch claude --print-env` shows exactly what was handed over. |

--- a/docs/claude-code-quickstart.md
+++ b/docs/claude-code-quickstart.md
@@ -193,9 +193,13 @@ Like `grid info --env`, this prints your access token; unlike it, warnings stay 
 - **Your own settings can override it.** Claude Code's `settings.json` `env` block outranks an
   injected variable, so a stray `ANTHROPIC_BASE_URL` there silently defeats the launch. The command
   reads that file and warns in one line — it never edits it.
-- **Preflight proves models, not your token.** It reads the grid's public overview (the same read
-  `grid models` renders), which ignores the bearer token. A *missing* token is caught first with the
-  usual `grid login` guidance; an *expired* one passes preflight and fails inside the app.
+- **Your credential is checked, and quietly repaired.** Before anything is handed over, `grid launch`
+  reads the token's own expiry and asks the grid whether it will accept it. An expired token — or one
+  the grid refuses because your membership changed — is **refreshed in place** and the launch carries
+  on, with one line on stderr. Nothing that cannot be repaired reaches the app: it is refused here,
+  naming which of "sign in again", "ask about your membership" or "try again shortly" applies.
+- **A check that fails open never costs you a launch.** If the grid is unreachable, rate-limiting, or
+  erroring, `grid launch` says so and starts the app anyway rather than guessing your token is bad.
 - **`auto` is not the default, and there is no `--model` flag in this release.** Claude Code issues
   many small requests per turn, so routing each one through the grid's advisor would add a hop to
   every one and let the model change turn to turn — which makes "it got worse today" unfalsifiable.
@@ -211,4 +215,5 @@ Like `grid info --env`, this prints your access token; unlike it, warnings stay 
 | "can't run Claude Code: it doesn't serve …" | Preflight. Compare against `grid models`, then serve the missing name (step 3). |
 | "Claude Code isn't installed" | Nothing on your `PATH` or in either place Claude Code installs to. On a terminal you're offered the vendor's installer; with no terminal (CI, a script) the install command is printed and the launch exits non-zero. |
 | "Warning: Claude Code's own settings set …" | An `env` block in your `settings.json` overrides what was injected. Remove the colliding key — `grid launch` never edits that file. |
-| Requests fail *inside* the app | Most likely an expired token, which preflight cannot see. `grid launch claude --print-env` shows exactly what was handed over. |
+| "couldn't check … launching anyway" | The credential check could not reach the grid, so it was skipped rather than guessed at. If the app then fails to authenticate, that warning is why. |
+| Requests fail *inside* the app | The credential is checked and renewed before hand-over, so this is more likely a model or settings problem. `grid launch claude --print-env` shows exactly what was handed over. |

--- a/docs/claude-code-quickstart.md
+++ b/docs/claude-code-quickstart.md
@@ -7,9 +7,9 @@ This walks the whole path end to end: install `grid`, sign in, choose a remote g
 grid launch claude
 ```
 
-The endpoint, the credential and the model names go into Claude Code's own process environment and
-nowhere else — nothing is exported to your shell, nothing is written to any config file, and closing
-the app is the entire cleanup. Reference detail lives in [cli.md](./cli.md#launch) and
+The endpoint and the credential go into Claude Code's own process environment and nowhere else —
+nothing is exported to your shell, nothing is written to any config file, and closing the app is
+the entire cleanup. The model stays your choice (step 3). Reference detail lives in [cli.md](./cli.md#launch) and
 [ADR 0028](./adr/0028-launch-hands-an-app-the-grid.md).
 
 Two roles appear below. The **provider** serves the models Claude Code will use. The **consumer**
@@ -21,8 +21,8 @@ runs `grid launch claude`. They can be the same person on the same machine — t
 - Claude Code. You don't have to install it first: `grid launch claude` searches your `PATH` and the
   two places Claude Code installs itself into, and offers to run the vendor's own installer if it
   finds nothing.
-- A grid that serves the models this release names — `claude:opus` and `claude:haiku` at minimum.
-  See step 3; this is the single most common reason a first attempt fails.
+- A grid that serves a model you can point Claude Code at. `grid launch` picks no model for you,
+  so see step 3 — asking for a model the grid doesn't serve is the most common first failure.
 
 **`grid launch` is remote-only, and the reason is the dialect.** Claude Code speaks the Anthropic
 Messages dialect and nothing else. A remote grid's relay translates a Messages request to
@@ -55,64 +55,55 @@ id, exactly like `grid info` / `grid models` / `grid engines`).
 
 The grid must be **up** (`grid up`) and your sign-in must be a member of it.
 
-## 3. Check the grid serves the models — the fixed names
+## 3. Pick a model the grid serves
 
-**This release fixes the model names.** Claude Code resolves a model per tier, and each tier is
-pinned to one name:
+**`grid launch` chooses no model for you.** It sets the endpoint and the credential and nothing else,
+so Claude Code resolves a model exactly as it does everywhere else: its own defaults, your
+`settings.json`, and `/model` inside the app. That choice stays yours — but it means **you** have to
+point it at something the grid actually serves.
 
-| Claude Code tier | model on your grid | required? |
-|---|---|---|
-| main (`ANTHROPIC_MODEL`) | `claude:opus` | **yes** |
-| small/fast, and subagents | `claude:haiku` | **yes** |
-| `/model sonnet` | `claude:sonnet` | no — remapped to the main tier's model |
-| `/model fable` | `claude:fable` | no — remapped to the main tier's model |
-
-So the grid has to serve those names. **`grid models` is the authoritative list of what a grid
-serves** — run it before your first launch:
+`grid models` is the authoritative list:
 
 ```bash
 grid models                # bare model ids, one per line
 ```
 
-A grid ready to run a session:
-
 ```text
-claude:opus
-claude:haiku
 glm-5.2
+qwen36-30b
 ```
 
-The two required tiers are checked before anything starts (preflight, no off switch), so a grid that
-can't run one refuses up front instead of failing inside the app at your first prompt:
-
-```text
-Grid team can't run Claude Code: it doesn't serve claude:opus.
-Models on team: claude:haiku, glm-5.2.
-Run `grid join` on an engine that serves claude:opus, then `grid launch claude` again.
-```
-
-A missing *optional* tier is not a blocker — it is remapped onto the main tier's model, with one line
-saying so, so `/model sonnet` inside the app never dead-ends:
-
-```text
-Grid team doesn't serve the sonnet, fable tiers — `/model` there resolves to claude:opus.
-```
-
-### Serving those names (the provider's side)
-
-There is no `claude` engine kind to join in this release. Because the relay translates Messages to
-`chat/completions` before routing, **any chat model can back Claude Code** — so a provider publishes
-its own models under the fixed names, with `grid join`'s alias form:
+Then tell Claude Code to use one — in your `settings.json`, or in the shell you launch from:
 
 ```bash
-# advertise this box's two models to the grid under the names Claude Code asks for
-grid join research --at http://192.168.1.20:8000/v1 \
-  -m qwen36-30b=claude:opus -m gemma4-4b=claude:haiku
+ANTHROPIC_MODEL=glm-5.2 grid launch claude
 ```
 
-`-m real=advertised` is shorthand for `--advertise-as`; both do the same thing. Aliasing is
-**single-engine only** — one join, one engine, aliases for every `-m` in that command, and not an
-append onto an identity already serving. Details and the mode gating are in
+The one thing checked in advance is that the grid is serving *something*; what it is, and whether the
+app asks for it, is not something `grid launch` can know:
+
+```text
+Grid team serves no models yet, so Claude Code has nothing to talk to.
+Run `grid join` on a machine with an engine, then `grid launch claude` again.
+```
+
+A model the grid doesn't serve therefore fails at your **first prompt**, not at launch. `grid models`
+before your first run is the way to avoid it.
+
+### Serving models to the grid (the provider's side)
+
+There is no `claude` engine kind to join in this release, and you don't need one. Because the relay
+translates Messages to `chat/completions` before routing, **any chat model can back Claude Code** —
+so an ordinary join is all it takes:
+
+```bash
+grid join research --at http://192.168.1.20:8000/v1 -m qwen36-30b -m gemma4-4b
+```
+
+If you prefer the app to see different names than the engine serves, `grid join` can advertise
+aliases — `-m real=advertised`, or the equivalent `--advertise-as`. Aliasing is **single-engine
+only**: one join, one engine, aliases for every `-m` in that command, and not an append onto an
+identity already serving. Details and the mode gating are in
 [cli.md → `grid join` in remote mode](./cli.md#grid-join-in-remote-mode).
 
 Then confirm from the consumer's side with `grid models` again.
@@ -123,11 +114,11 @@ Then confirm from the consumer's side with `grid models` again.
 grid launch claude
 ```
 
-One line on stderr names the grid and the model, then Claude Code owns the terminal exactly as it
-does when you run the binary yourself — same Ctrl-C, same exit code:
+One line on stderr names the grid, then Claude Code owns the terminal exactly as it does when you
+run the binary yourself — same Ctrl-C, same exit code:
 
 ```text
-Starting Claude Code on grid team (model claude:opus).
+Starting Claude Code on grid team.
 ```
 
 Not sure what can be launched? Bare `grid launch` lists the targets and exits 0:
@@ -170,13 +161,6 @@ grid launch claude --print-env
 export ANTHROPIC_BASE_URL='https://relay.example/relay'
 export ANTHROPIC_AUTH_TOKEN='<your access token>'
 export ANTHROPIC_API_KEY='<your access token>'
-export ANTHROPIC_MODEL='claude:opus'
-export ANTHROPIC_SMALL_FAST_MODEL='claude:haiku'
-export CLAUDE_CODE_SUBAGENT_MODEL='claude:haiku'
-export ANTHROPIC_DEFAULT_OPUS_MODEL='claude:opus'
-export ANTHROPIC_DEFAULT_SONNET_MODEL='claude:sonnet'
-export ANTHROPIC_DEFAULT_HAIKU_MODEL='claude:haiku'
-export ANTHROPIC_DEFAULT_FABLE_MODEL='claude:fable'
 ```
 
 Note the base URL carries **no** `/v1` — Claude Code appends `/v1/messages` itself, so the `/v1` that
@@ -200,10 +184,11 @@ Like `grid info --env`, this prints your access token; unlike it, warnings stay 
   naming which of "sign in again", "ask about your membership" or "try again shortly" applies.
 - **A check that fails open never costs you a launch.** If the grid is unreachable, rate-limiting, or
   erroring, `grid launch` says so and starts the app anyway rather than guessing your token is bad.
-- **`auto` is not the default, and there is no `--model` flag in this release.** Claude Code issues
-  many small requests per turn, so routing each one through the grid's advisor would add a hop to
-  every one and let the model change turn to turn — which makes "it got worse today" unfalsifiable.
-  The tier table in step 3 is what you get.
+- **The model is yours, including `auto`.** `grid launch` sets no model variable, so if your grid's
+  owner has enabled auto-routing you can set `ANTHROPIC_MODEL=auto` yourself and let the grid pick.
+  Worth knowing before you do: Claude Code issues many small requests per turn, so an advisor hop
+  lands on all of them and the model can change turn to turn — which makes "it got worse today"
+  hard to pin down.
 - **Nothing to undo.** No config file, no shell export, no `--restore`. Quit the app and it's over.
 
 ## If it doesn't launch
@@ -212,7 +197,8 @@ Like `grid info --env`, this prints your access token; unlike it, warnings stay 
 |---|---|
 | "is a remote-mode command" | You're in local mode. Run `grid mode remote` (or pass `--remote`) — a local grid does not serve the Anthropic Messages dialect. |
 | "You're not signed in" | No stored credential on this machine. Run `grid login`. |
-| "can't run Claude Code: it doesn't serve …" | Preflight. Compare against `grid models`, then serve the missing name (step 3). |
+| "serves no models yet" | Nothing is joined to the grid. `grid join` on a machine with an engine (step 3). |
+| A model error at your first prompt | The app asked for a model this grid doesn't serve — `grid launch` sets no model, so it can't catch this for you. Compare `grid models` against what your Claude Code config resolves to. |
 | "Claude Code isn't installed" | Nothing on your `PATH` or in either place Claude Code installs to. On a terminal you're offered the vendor's installer; with no terminal (CI, a script) the install command is printed and the launch exits non-zero. |
 | "Warning: Claude Code's own settings set …" | An `env` block in your `settings.json` overrides what was injected. Remove the colliding key — `grid launch` never edits that file. |
 | "couldn't check … launching anyway" | The credential check could not reach the grid, so it was skipped rather than guessed at. If the app then fails to authenticate, that warning is why. |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -613,14 +613,9 @@ grid launch claude --print-env
 export ANTHROPIC_BASE_URL='https://relay.example/relay'
 export ANTHROPIC_AUTH_TOKEN='<your access token>'
 export ANTHROPIC_API_KEY='<your access token>'
-export ANTHROPIC_MODEL='claude:opus'
-export ANTHROPIC_SMALL_FAST_MODEL='claude:haiku'
-export CLAUDE_CODE_SUBAGENT_MODEL='claude:haiku'
-export ANTHROPIC_DEFAULT_OPUS_MODEL='claude:opus'
-export ANTHROPIC_DEFAULT_SONNET_MODEL='claude:sonnet'
-export ANTHROPIC_DEFAULT_HAIKU_MODEL='claude:haiku'
-export ANTHROPIC_DEFAULT_FABLE_MODEL='claude:fable'
 ```
+
+Three keys — an endpoint and a credential, and nothing else.
 
 The base carries the relay prefix and **no** `/v1`: Claude Code appends `/v1/messages` itself, so the
 `/v1` that `grid info --env` prints for OpenAI clients would 404 every request here. This is the
@@ -630,32 +625,29 @@ warning goes to stderr, so `eval "$(grid launch claude --print-env)"` evaluates 
 `--print-env` and `--` are mutually exclusive: with nothing started, the arguments after `--` have
 nothing to reach, so the combination is refused rather than silently dropped.
 
-**The model names are fixed in this release** — `claude:opus`, `claude:sonnet`, `claude:haiku`,
-`claude:fable`, one per Claude Code tier — so the grid has to serve them. `grid models` is the
-authoritative list of what a grid serves. Preflight always runs, has no off switch, and never asks a
-question. `claude:opus` (main) and `claude:haiku` (small/fast, which the subagent tier mirrors) are
-**required** — every session uses both — so a grid without them is refused before anything starts,
-naming what is missing and what the grid does serve:
+**No model is chosen for you.** `grid launch` sets no `ANTHROPIC_MODEL` and none of its siblings, so
+Claude Code resolves a model the way it does everywhere else — its own defaults, your
+`settings.json`, and `/model` inside the app. Which model a session runs on is your choice, and the
+grid answers for whatever it is asked. Use `grid models` to see what the grid serves, and point the
+app at one of those names.
+
+The trade is worth naming: a model the grid does not serve now fails at your **first prompt** rather
+than at launch. Grid cannot check it in advance, because it no longer knows what the app is going to
+ask for.
+
+Preflight is therefore down to the one model fact that holds whatever the app asks: a grid serving
+nothing can serve nothing. It always runs, has no off switch, and never asks a question:
 
 ```text
-Grid team can't run Claude Code: it doesn't serve claude:opus.
-Models on team: claude:haiku, glm-5.2.
-Run `grid join` on an engine that serves claude:opus, then `grid launch claude` again.
+Grid team serves no models yet, so Claude Code has nothing to talk to.
+Run `grid join` on a machine with an engine, then `grid launch claude` again.
 ```
 
-The other two tiers are reachable only through the app's own `/model` picker, so a grid that does not
-serve one has it pointed at the main tier's model, with one line saying so — a rarely used tier never
-blocks a launch:
-
-```text
-Grid team doesn't serve the sonnet, fable tiers — `/model` there resolves to claude:opus.
-```
-
-Preflight reads the grid's **public overview**, the same read `grid models` and `grid engines`
-render, so the two can never disagree about what is live.
+It reads the grid's **public overview**, the same read `grid models` and `grid engines` render, so
+the two can never disagree about what is live.
 
 **The credential is checked first, and repaired if it can be.** The order is deliberate: a dead token
-invalidates the model advice above, while a missing model says nothing about the token. `grid launch`
+invalidates the "your grid is empty" advice above, while an empty grid says nothing about the token. `grid launch`
 reads the token's own expiry offline, and asks the grid — `GET /relay/v1/models`, one round-trip —
 whether it will actually accept it. A token that has expired, is within a day of expiring, or is
 refused by the grid is **refreshed in place** and the launch continues, with one line on stderr:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -652,9 +652,29 @@ Grid team doesn't serve the sonnet, fable tiers — `/model` there resolves to c
 ```
 
 Preflight reads the grid's **public overview**, the same read `grid models` and `grid engines`
-render, so the two can never disagree about what is live. That route ignores the bearer token, so it
-proves **model presence, not credential validity**: an absent token is caught first with the usual
-`grid login` guidance, but an expired one passes preflight and fails inside the app.
+render, so the two can never disagree about what is live.
+
+**The credential is checked first, and repaired if it can be.** The order is deliberate: a dead token
+invalidates the model advice above, while a missing model says nothing about the token. `grid launch`
+reads the token's own expiry offline, and asks the grid — `GET /relay/v1/models`, one round-trip —
+whether it will actually accept it. A token that has expired, is within a day of expiring, or is
+refused by the grid is **refreshed in place** and the launch continues, with one line on stderr:
+
+```text
+Refreshed grid team's access token (it expired 3 days ago).
+```
+
+That covers the whole family a grid rejects a token for — a passed expiry, a `member_epoch` or
+`network_epoch` bumped by a membership change, a rotated key. What it cannot repair, it refuses
+before the app starts, saying which: a dead refresh credential (`grid login`), a membership that no
+longer permits inference (`grid login` will not help — the `consumer` and `both` roles grant it), or a
+control plane that could not mint a token (nothing is wrong with your sign-in; try again).
+
+A check that could not run never costs you a launch that would have worked: a throttled, failing or
+unreachable relay warns and launches anyway, and so does a renewal that fails while the current token
+is still valid. This is the one thing `grid launch` writes — a refreshed token goes back into
+`~/.grid/credentials.toml`, the same store `grid login` and `grid sync` maintain. Nothing is written
+for the *app*. See [ADR 0029](./adr/0029-the-credential-is-checked-before-it-is-handed-over.md).
 
 Everything else is left alone. The app runs on your real configuration — MCP servers, skills,
 permissions, history — which also means Claude Code's own `settings.json` `env` block **outranks**
@@ -665,7 +685,8 @@ names the grid and the model before the app takes the screen, and the app's exit
 command's.
 
 Step by step: [Claude Code quickstart](./claude-code-quickstart.md) ·
-[ADR 0028](./adr/0028-launch-hands-an-app-the-grid.md).
+[ADR 0028](./adr/0028-launch-hands-an-app-the-grid.md) ·
+[ADR 0029](./adr/0029-the-credential-is-checked-before-it-is-handed-over.md).
 
 ## Training
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -14,6 +14,7 @@ kind      an engine's type (ollama, vllm, mlx, llama.cpp, comfyui) — filter au
 join      connect this machine or engine to a grid
 model     a live capability exposed by joined engines
 mode      which world the CLI targets: `local` (default) or `remote`
+launch    start an app already pointed at your grid; the app it starts is a launch target
 pack      a bundled starting point for training on business data (`grid train packs`)
 adapter   the small add-on layer a training run produces (LoRA) — what moves between machines
 gate      the check that refuses to serve a trained model unless it beat the one you serve
@@ -114,8 +115,11 @@ persisted mode > `local`. `grid use <name>` sets the persistent default grid, so
 stale selection (its grid was removed) is ignored.
 
 In `remote` mode the grid lifecycle (`up`/`down`/`ls`/`info`), live reads (`engines`/`models`),
-sign-in (`login`/`logout`), serving (`join`/`leave`), consuming (`chat`/`image`/`edit`/`video`), and
-membership admin (`grid members`) all work. `grid members` is remote-only — in `local` mode it exits with guidance to switch. The shared
+sign-in (`login`/`logout`), serving (`join`/`leave`), consuming (`chat`/`image`/`edit`/`video`),
+handing an app the grid (`grid launch`), and
+membership admin (`grid members`) all work. `grid members` and `grid launch` are remote-only — in
+`local` mode each exits with guidance to switch, naming its own reason (sign-in for `members`, the
+dialect the launched app speaks for `launch` — see [Launch](#launch)). The shared
 local commands (`catalog`, `pull`, `rm`/`remove`, `ctx`, `device-info`, `engine …`, `agent …`,
 `train …`) work in either mode. A machine with no state
 file behaves exactly as a `local`-only install.
@@ -544,6 +548,124 @@ model the grid ranked and had free, and the `X-Grid-Routed-Model` response heade
 Codex apps; `grid chat -m codex:…` is refused client-side, before any network call, with the
 guidance to point a Codex-compatible app at the grid instead
 ([Pointing a Codex app at your grid](#pointing-a-codex-app-at-your-grid-using-codex-models)).
+
+## Launch
+
+```
+grid launch                                    # list the apps that can be launched
+grid launch <target> [grid]                    # start one, already pointed at the grid
+grid launch <target> [grid] --print-env        # print the environment instead; start nothing
+grid launch <target> [grid] -- <app args…>     # forward everything after `--` to the app
+```
+
+`grid launch` starts a **third-party app already pointed at your grid**. The endpoint, the credential
+and the model names go into that app's own process environment and nowhere else — never exported to
+your shell, never written to a config file. Closing the app is the entire cleanup, which is why there
+is no `--restore`. One **launch target** ships today: `claude` (Claude Code).
+
+Bare `grid launch` lists the targets and exits 0 — it is discovery, not an error:
+
+```text
+Launch targets:
+  claude	Claude Code
+
+Start one with `grid launch <target>`.
+```
+
+**Remote-only, and the dialect is the reason.** Claude Code speaks the Anthropic Messages dialect and
+nothing else. A local grid serves `chat/completions`, `completions`, `models` and media — there is no
+`/v1/messages` on it at all — so this is a design boundary, not a missing flag, and `local` mode says
+which one:
+
+```text
+`grid launch` is a remote-mode command. Run `grid mode remote` (or pass --remote) to launch an app
+that speaks the Anthropic Messages dialect, which a local grid does not serve.
+```
+
+A remote grid's relay translates a Messages request to `chat/completions` before it routes, which is
+why any chat model on a remote grid can back the app. Teaching the local server the same dialect
+would mean hand-carrying that translation across a seam with no code dependency — rejected in
+[ADR 0028](./adr/0028-launch-hands-an-app-the-grid.md).
+
+**`[grid]`** matches `info`/`models`/`engines` verbatim: a grid name or `ag-…` id, omitted for the
+active grid — so `grid use` stays the one place you choose where work runs.
+
+**`--`** hands everything after the **first** separator to the app, in order and unread:
+
+```bash
+grid launch claude -- --continue
+grid launch claude -- -p 'summarise this repo'
+grid launch claude research -- --continue      # …on a grid other than the active one
+```
+
+Two words are the exception. `--local` and `--remote` are this CLI's one-shot mode override and are
+stripped from **anywhere** on the line, separator included, so neither can reach the app; a warning
+says so when one is taken. `-- --local` additionally flips the run to local mode, where the command
+refuses — reported as a mode error rather than as a missing argument.
+
+**`--print-env`** prints exactly what a launch would inject, as shell exports, and starts nothing:
+
+```bash
+grid launch claude --print-env
+```
+
+```bash
+export ANTHROPIC_BASE_URL='https://relay.example/relay'
+export ANTHROPIC_AUTH_TOKEN='<your access token>'
+export ANTHROPIC_API_KEY='<your access token>'
+export ANTHROPIC_MODEL='claude:opus'
+export ANTHROPIC_SMALL_FAST_MODEL='claude:haiku'
+export CLAUDE_CODE_SUBAGENT_MODEL='claude:haiku'
+export ANTHROPIC_DEFAULT_OPUS_MODEL='claude:opus'
+export ANTHROPIC_DEFAULT_SONNET_MODEL='claude:sonnet'
+export ANTHROPIC_DEFAULT_HAIKU_MODEL='claude:haiku'
+export ANTHROPIC_DEFAULT_FABLE_MODEL='claude:fable'
+```
+
+The base carries the relay prefix and **no** `/v1`: Claude Code appends `/v1/messages` itself, so the
+`/v1` that `grid info --env` prints for OpenAI clients would 404 every request here. This is the
+**second** command that prints your access token — `grid info --env` is the first — and carries the
+same justification: an explicit, user-requested disclosure of your own token to your own shell. Every
+warning goes to stderr, so `eval "$(grid launch claude --print-env)"` evaluates only exports.
+`--print-env` and `--` are mutually exclusive: with nothing started, the arguments after `--` have
+nothing to reach, so the combination is refused rather than silently dropped.
+
+**The model names are fixed in this release** — `claude:opus`, `claude:sonnet`, `claude:haiku`,
+`claude:fable`, one per Claude Code tier — so the grid has to serve them. `grid models` is the
+authoritative list of what a grid serves. Preflight always runs, has no off switch, and never asks a
+question. `claude:opus` (main) and `claude:haiku` (small/fast, which the subagent tier mirrors) are
+**required** — every session uses both — so a grid without them is refused before anything starts,
+naming what is missing and what the grid does serve:
+
+```text
+Grid team can't run Claude Code: it doesn't serve claude:opus.
+Models on team: claude:haiku, glm-5.2.
+Run `grid join` on an engine that serves claude:opus, then `grid launch claude` again.
+```
+
+The other two tiers are reachable only through the app's own `/model` picker, so a grid that does not
+serve one has it pointed at the main tier's model, with one line saying so — a rarely used tier never
+blocks a launch:
+
+```text
+Grid team doesn't serve the sonnet, fable tiers — `/model` there resolves to claude:opus.
+```
+
+Preflight reads the grid's **public overview**, the same read `grid models` and `grid engines`
+render, so the two can never disagree about what is live. That route ignores the bearer token, so it
+proves **model presence, not credential validity**: an absent token is caught first with the usual
+`grid login` guidance, but an expired one passes preflight and fails inside the app.
+
+Everything else is left alone. The app runs on your real configuration — MCP servers, skills,
+permissions, history — which also means Claude Code's own `settings.json` `env` block **outranks**
+what is injected; the command reads that file and warns in one line, and never edits it. A missing
+binary on an interactive run offers the **vendor's own installer**; with no terminal it prints the
+install command and exits non-zero rather than prompting where no one can answer. One line on stderr
+names the grid and the model before the app takes the screen, and the app's exit code becomes the
+command's.
+
+Step by step: [Claude Code quickstart](./claude-code-quickstart.md) ·
+[ADR 0028](./adr/0028-launch-hands-an-app-the-grid.md).
 
 ## Training
 

--- a/remote/control_plane.py
+++ b/remote/control_plane.py
@@ -26,6 +26,27 @@ from . import credentials
 _TIMEOUT = float(os.getenv("GRID_CONTROL_PLANE_TIMEOUT", "30"))
 
 
+class ControlPlaneError(SystemExit):
+    """A control-plane call that failed, carrying the status when there was one.
+
+    **A ``SystemExit`` subclass, deliberately.** Every failure here has always been a ``SystemExit``
+    — this repo's clean-error idiom — and callers rely on it in two different ways: the serve loop's
+    token refresh catches ``SystemExit`` so it does not die mid-loop
+    (``remote/serve._ServeState.refresh``), and ``grid sync`` classifies an expired session by
+    matching the *rendered message* (``cli/auth._SESSION_EXPIRED_RE``). Subclassing keeps both working
+    untouched, with the same type and the same text; only a caller that wants the status reads it.
+
+    ``status`` is the HTTP status when the control plane answered, and ``None`` when it did not — a
+    request that never got an answer has no status, and the difference decides whether a caller may
+    treat the failure as a verdict about the credential or merely as "we could not ask". Same shape
+    as ``relay.RelayError.status``, for the same reason.
+    """
+
+    def __init__(self, *args: Any, status: int | None = None) -> None:
+        super().__init__(*args)
+        self.status = status
+
+
 def _client(api_url: str | None = None, token: str | None = None) -> httpx.Client:
     headers = {"User-Agent": "grid-cli"}
     if token:
@@ -199,20 +220,29 @@ def get_router_catalog(session_token: str, api_url: str | None = None) -> dict[s
 
 
 def _send(client: httpx.Client, method: str, url: str, **kwargs: Any) -> httpx.Response:
-    """One request with both failure modes surfaced as a clean SystemExit (never a traceback):
-    a transport/connection error before a response, and a >=400 status after one."""
+    """One request with both failure modes surfaced as a clean ``ControlPlaneError`` (never a
+    traceback): a transport/connection error before a response, and a >=400 status after one.
+
+    Both are ``SystemExit`` subclasses carrying the same messages they always did, so this is
+    transparent to every caller that does not ask for ``.status``.
+    """
     try:
         resp = client.request(method, url, **kwargs)
     except httpx.HTTPError as exc:
-        raise SystemExit(f"Cannot reach the control plane ({method} {url}): {exc}") from None
+        # No answer, so no status — `status=None` is what says "we could not ask", as distinct from
+        # "we asked and were refused".
+        raise ControlPlaneError(f"Cannot reach the control plane ({method} {url}): {exc}") from None
     _raise(resp)
     return resp
 
 
 def _raise(resp: httpx.Response) -> None:
     if resp.status_code >= 400:
-        raise SystemExit(
-            f"{resp.request.method} {resp.request.url} failed ({resp.status_code}): {resp.text[:400]}"
+        # The message is byte-for-byte what it has always been: `cli/auth._SESSION_EXPIRED_RE`
+        # anchors on this exact rendering, so the format is a contract, not a detail.
+        raise ControlPlaneError(
+            f"{resp.request.method} {resp.request.url} failed ({resp.status_code}): {resp.text[:400]}",
+            status=resp.status_code,
         )
 
 

--- a/remote/credentials.py
+++ b/remote/credentials.py
@@ -153,6 +153,62 @@ def require_session() -> str:
     return str(token)
 
 
+def claims_from_token(access_token: object) -> dict[str, Any]:
+    """A per-grid access token's JWT payload claims, or ``{}`` for anything unusable.
+
+    **No signature check, ever.** The relay verifies server-side; every caller here reads these claims
+    only to decide *our own* behaviour — which node to address, whether to refresh before handing the
+    token to an app — never to grant anything. That is what makes an unverified read safe: a forged
+    claim can only make this CLI do more work, never let it past a gate.
+
+    Total by contract: unusable input is an empty mapping, not an exception, so a caller can decide
+    what "we could not tell" means for it. Three shapes are guarded, all of which a naive
+    ``split(".")[1]`` handles wrongly rather than loudly:
+
+    - **A value that isn't a string.** The store's loader is ``str | None``-shaped, so a half-written
+      bundle lands here and ``None.split`` would be an ``AttributeError`` escaping this contract.
+    - **A segment count that isn't 3.** ``split(".")[1]`` decodes segment 1 of a *four*-segment string
+      perfectly happily, so without this a token of the wrong shape yields real-looking claims.
+    - **A payload that is valid JSON but not an object.** ``json.loads`` returns an int/list/None and
+      the caller's ``.get`` then explodes far from here.
+
+    (``remote/codex_auth._payload`` guards the same three for the codex seat and is deliberately not
+    shared with this: the two have opposite error contracts — that one *raises* a typed error, because
+    a seat that cannot be identified must fail a join, while an unreadable grid token here has to
+    degrade so the caller can fall through to the network check that knows better. Merging them would
+    force one contract to carry the other's.)
+    """
+    if not isinstance(access_token, str):
+        return {}
+    segments = access_token.split(".")
+    if len(segments) != 3:
+        return {}
+    payload = segments[1]
+    payload += "=" * (-len(payload) % 4)  # restore the base64 padding a JWT strips
+    try:
+        # binascii.Error, json.JSONDecodeError and UnicodeDecodeError all subclass ValueError;
+        # RecursionError covers a deeply-nested payload. Between them the decode is total.
+        claims = json.loads(base64.urlsafe_b64decode(payload))
+    except (ValueError, RecursionError):
+        return {}
+    return claims if isinstance(claims, dict) else {}
+
+
+def token_expiry(access_token: object) -> int | None:
+    """The token's ``exp`` claim as POSIX seconds, or ``None`` when it does not say.
+
+    **Never reads the clock.** Whether that instant has passed is the caller's decision, and it has to
+    be: the refresh path reads claims back out of an already-expired token, so a helper that rejected
+    expired tokens would brick precisely the case refresh exists for (the discipline
+    ``codex_auth.decode_seat`` records for the same reason).
+
+    ``isinstance(True, int)`` is True in Python, so ``bool`` is excluded explicitly — otherwise
+    ``exp: true`` becomes ``1``, epoch 1970, and every caller refreshes eagerly forever.
+    """
+    exp = claims_from_token(access_token).get("exp")
+    return exp if isinstance(exp, int) and not isinstance(exp, bool) else None
+
+
 def node_id_from_token(access_token: str) -> str:
     """The provider node_id, read from a per-grid access token's JWT ``node_id`` claim.
 
@@ -160,16 +216,8 @@ def node_id_from_token(access_token: str) -> str:
     id is rejected with 403 "Cannot access another node". So node_id is NOT ours to invent (a random
     ``node-<uuid>`` is exactly what the relay refuses, and the run record's ``node_id`` field is a
     junk display value); it must come from the token. The serve loop (``remote/serve.py``) registers
-    under it; ``grid leave`` addresses its backstop deregister to it. Decode the JWT payload
-    best-effort and read the claim — no signature check (the relay verifies server-side; we only need
-    the claim to address our own node). Returns "" when the token isn't a decodable JWT carrying a
-    node_id, so the caller can surface a clean re-login error.
+    under it; ``grid leave`` addresses its backstop deregister to it. Returns "" when the token isn't
+    a decodable JWT carrying a node_id, so the caller can surface a clean re-login error.
     """
-    try:
-        payload = access_token.split(".")[1]
-        payload += "=" * (-len(payload) % 4)  # restore the base64 padding a JWT strips
-        claims = json.loads(base64.urlsafe_b64decode(payload))
-    except (IndexError, ValueError, json.JSONDecodeError):
-        return ""
-    node_id = claims.get("node_id") if isinstance(claims, dict) else None
+    node_id = claims_from_token(access_token).get("node_id")
     return str(node_id) if node_id else ""

--- a/remote/relay.py
+++ b/remote/relay.py
@@ -40,6 +40,14 @@ _REGISTER_TIMEOUT = 15.0
 # `_price_oneshot`. Widening a deadline is not free there, so it is not widened.
 _SERVE_REGISTER_TIMEOUT = httpx.Timeout(connect=10.0, read=15.0, write=15.0, pool=5.0)
 
+# `check_credential`'s deadline, and the tightest in this module — because of what happens when it is
+# hit. Every other call here either retries or fails the command; this one **falls open** and launches
+# the app anyway (ADR 0029), so the deadline is time a user spends staring at nothing before a launch
+# that was always going to happen. Stated per phase for the reason recorded above: a bare float
+# applies to all four independently, and the phase that actually matters here is `read` — a relay that
+# accepts the connection and then never answers is exactly the shape a connect timeout cannot see.
+_CREDENTIAL_CHECK_TIMEOUT = httpx.Timeout(connect=5.0, read=8.0, write=5.0, pool=5.0)
+
 
 class RelayUnauthorized(Exception):
     """The relay rejected the access token (401) — the caller should refresh and retry."""
@@ -85,6 +93,33 @@ def _guard(resp: httpx.Response, what: str) -> None:
         raise RelayUnauthorized()
     if resp.status_code >= 400:
         raise RelayError(f"{what} failed ({resp.status_code}): {resp.text[:200]}", status=resp.status_code)
+
+
+def check_credential(signaling_url: str, access_token: str) -> None:
+    """Prove ``access_token`` end-to-end against this grid's relay, or raise saying how it failed.
+
+    Filed with the ``_guard``-mapped calls above rather than the one-shot pricing helpers below, whose
+    stated convention is that any failure is a clean ``SystemExit``. That convention is wrong for this
+    one: its caller (``cli/grid_credential``) has *three* different answers — refresh and retry (401),
+    refuse (403), warn and launch anyway (429 / 5xx / no answer at all) — and a ``SystemExit`` can
+    carry none of them (ADR 0029).
+
+    ``GET /relay/v1/models`` is chosen for what it *requires*, not for what it returns; the body is
+    discarded. It demands ``inference:models``, and the control plane grants the inference scopes only
+    as one bundle, so a token passes here exactly when it holds the ``inference:create`` that
+    ``POST /messages`` needs — no refusal this raises is one the launched app would not have hit.
+    Verification runs the full server-side gate: signature, ``exp``, network and network-type match,
+    scope, the member allowlist snapshot, the denylist, and both epoch-staleness checks.
+    """
+    try:
+        with _client(signaling_url, access_token, timeout=_CREDENTIAL_CHECK_TIMEOUT) as client:
+            resp = client.get("/relay/v1/models")
+    except (httpx.HTTPError, httpx.InvalidURL) as exc:
+        # `InvalidURL` is not an `HTTPError` subclass (the trap `deregister_node` records). Both mean
+        # nothing was learned about the token, so both must reach the caller as a status-less
+        # `RelayError` — the value that makes it warn and launch rather than refuse.
+        raise RelayError(f"credential check transport error: {exc}") from None
+    _guard(resp, "credential check")
 
 
 def register_node(

--- a/shared/launch/__init__.py
+++ b/shared/launch/__init__.py
@@ -1,0 +1,7 @@
+"""Launch targets: the apps `grid launch` starts for the user, pointed at their active grid.
+
+A **launch target** (CONTEXT-MAP.md) is named by the user rather than configured by them — they say
+`claude`, not an endpoint and a credential. This package owns the targets and the one OS-facing seam
+they act through; resolving *which* grid, and its token and relay base, is the CLI's job
+(`cli/launch.py`), so nothing here imports `cli`. See ADR 0028.
+"""

--- a/shared/launch/claude.py
+++ b/shared/launch/claude.py
@@ -1,0 +1,304 @@
+"""The `claude` launch target: Claude Code, pointed at a grid.
+
+ADR 0028: everything the app needs arrives in **its own process environment** — never exported to the
+user's shell, never written to a config file, never into this CLI's `os.environ`. Closing the app is
+the entire cleanup, which is why there is nothing here to restore.
+"""
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import NoReturn
+
+from . import system
+from .target import GridSession
+
+BINARY = "claude"
+
+# Where a user without the app is sent. The vendor's own page, never a repackaged copy — and no pinned
+# version anywhere, because Claude Code manages its own (ADR 0028).
+INSTALL_URL = "https://claude.com/claude-code"
+
+# The model each Claude Code tier resolves to on a grid. THE one constant: the single site a later
+# discovery slice replaces, so no other module may name these models (a test enforces it). The
+# `claude:*` family because those names map 1:1 onto Claude Code's own tiers — `/model haiku` inside
+# the app then resolves to a model the grid actually serves, rather than to a real Anthropic model
+# name no grid has ever heard of.
+MODEL_TIERS = {
+    "main": "claude:opus",
+    "small_fast": "claude:haiku",
+    "opus": "claude:opus",
+    "sonnet": "claude:sonnet",
+    "haiku": "claude:haiku",
+    "fable": "claude:fable",
+}
+
+# The tiers every session uses: the main model, and the small/fast one the subagent tier mirrors. A
+# grid that does not serve these cannot run a session at all, so their absence is a refusal. Every
+# other tier is reachable only through `/model`, so its absence is a remap (below), not a blocker.
+REQUIRED_TIERS = ("main", "small_fast")
+
+# Claude Code appends `/v1/messages` itself, so the base carries the relay prefix and **no** `/v1`.
+# Leave `/v1` on — as `grid info --env` prints it for OpenAI clients — and every request 404s.
+_RELAY_SUFFIX = "/relay"
+
+
+def _refuse_missing_required(session: GridSession, missing: list[str]) -> NoReturn:
+    """Refuse a grid that cannot run a session, in a message that is actionable on its own.
+
+    Both halves are load-bearing. Without the missing names the user cannot tell which tier failed;
+    without what the grid *does* serve they cannot tell whether they mistyped a grid, joined the wrong
+    engine, or never joined one — and they would have to run a second command to find out.
+    """
+    # Deduped: two tiers may want the same model, and naming it twice reads as two problems.
+    wanted = ", ".join(dict.fromkeys(MODEL_TIERS[tier] for tier in missing))
+    served = ", ".join(session.live_models)
+    raise SystemExit(
+        f"Grid {session.label} can't run Claude Code: it doesn't serve {wanted}.\n"
+        + (f"Models on {session.label}: {served}.\n" if served
+           else f"Grid {session.label} serves no models yet.\n")
+        # Both commands named, because neither alone is the whole way out: `grid join` runs on the
+        # machine that will serve the models, and the launch is retried here.
+        + f"Run `grid join` on an engine that serves {wanted}, "
+        f"then `grid launch {BINARY}` again."
+    )
+
+
+@dataclass(frozen=True)
+class _Tiers:
+    """What each Claude Code tier resolves to on one particular grid."""
+
+    #: Every tier in ``MODEL_TIERS``, mapped to the model this grid will actually be asked for. Always
+    #: complete — a remapped tier carries the main tier's model, never an empty string.
+    models: dict[str, str]
+    #: The optional tiers this grid does not serve, which now point at the main tier's model.
+    remapped: tuple[str, ...]
+
+
+def _resolve_tiers(session: GridSession) -> _Tiers:
+    """What each tier will actually resolve to on this grid — or a refusal (ADR 0028).
+
+    Preflight always runs: there is no flag that skips it and it never asks a question, because the
+    alternative is discovering the answer inside Claude Code, where the error names a model and
+    nothing else.
+    """
+    live = set(session.live_models)
+    missing_required = [tier for tier in REQUIRED_TIERS if MODEL_TIERS[tier] not in live]
+    if missing_required:
+        _refuse_missing_required(session, missing_required)
+    # Past the refusal, so the main tier's model is known to be live and is a safe destination for
+    # every `/model`-only tier this grid happens not to serve.
+    main = MODEL_TIERS["main"]
+    models = {tier: (model if model in live else main) for tier, model in MODEL_TIERS.items()}
+    return _Tiers(
+        models=models,
+        remapped=tuple(tier for tier, model in MODEL_TIERS.items() if model not in live),
+    )
+
+
+def _environment(session: GridSession, tiers: _Tiers) -> dict[str, str]:
+    """The keys Claude Code is handed, layered over the inherited environment by ``run``.
+
+    Every tier variable is always present, remapped or not: leaving one unset would send Claude Code
+    back to a real Anthropic model name that no grid serves.
+
+    `GRID_TOKEN` is absent deliberately: it appears in the hand-rolled recipe, but it is a shell
+    convenience variable this app never reads. Telemetry variables are absent too — whether Grid
+    should disable Claude Code's error reporting is an open product question (ADR 0028), and leaving
+    it out is how that stays a question instead of a silent default.
+    """
+    model = tiers.models
+    return {
+        # `rstrip` before the suffix: a stored relay address with a trailing slash would otherwise
+        # produce a doubled slash the client sends verbatim.
+        "ANTHROPIC_BASE_URL": session.relay_base.rstrip("/") + _RELAY_SUFFIX,
+        # Both, because which one Claude Code reads depends on the path it takes to authenticate.
+        "ANTHROPIC_AUTH_TOKEN": session.access_token,
+        "ANTHROPIC_API_KEY": session.access_token,
+        "ANTHROPIC_MODEL": model["main"],
+        "ANTHROPIC_SMALL_FAST_MODEL": model["small_fast"],
+        "CLAUDE_CODE_SUBAGENT_MODEL": model["small_fast"],
+        "ANTHROPIC_DEFAULT_OPUS_MODEL": model["opus"],
+        "ANTHROPIC_DEFAULT_SONNET_MODEL": model["sonnet"],
+        "ANTHROPIC_DEFAULT_HAIKU_MODEL": model["haiku"],
+        "ANTHROPIC_DEFAULT_FABLE_MODEL": model["fable"],
+    }
+
+
+# Claude Code's own configuration directory, overridable by this variable — the app's own contract,
+# not ours. `~/.claude` is the default it falls back to.
+_CONFIG_DIR_VAR = "CLAUDE_CONFIG_DIR"
+_DEFAULT_CONFIG_DIR = ".claude"
+_SETTINGS_FILES = ("settings.json", "settings.local.json")
+# A settings file is a small JSON document. The cap is the second guard on an attacker-influenced
+# read (see `_settings_env`): the regular-file check already rules out devices and FIFOs, and this
+# bounds a merely enormous regular file. Generous by three orders of magnitude for real settings.
+_MAX_SETTINGS_BYTES = 1024 * 1024
+
+
+def _settings_paths() -> tuple[tuple[Path, ...], tuple[str, ...]]:
+    """The settings files whose ``env`` block outranks what we hand the child, and the locations that
+    could not be worked out at all.
+
+    The user's own settings first, then the project's — Claude Code reads both, and from inside the
+    app a value from either looks identical, so both have to be checked or the warning is a
+    half-truth. Deduped by path, because ``CLAUDE_CONFIG_DIR`` can legitimately point at the very
+    directory the user is standing in.
+
+    The two locations resolve **independently**, and neither may raise. This whole check is an
+    ancillary nicety, reached only after preflight and the binary check have already decided the
+    launch would succeed — so a location that cannot be resolved must cost the user a warning line,
+    never the launch. Both failures are real: ``Path.cwd()`` raises once the shell's directory has
+    been removed (a deleted worktree, a cleaned temp dir), and ``Path.home()`` raises on a container
+    running as a UID with no passwd entry and no ``HOME``. Losing the cwd must still leave the
+    user-level file checked, which is why these are not one ``try``.
+    """
+    paths: list[Path] = []
+    unresolved: list[str] = []
+    configured = os.environ.get(_CONFIG_DIR_VAR)
+    try:
+        user_dir = Path(configured) if configured else Path.home() / _DEFAULT_CONFIG_DIR
+    except RuntimeError as exc:  # no HOME, and the UID has no home directory to fall back on
+        unresolved.append(f"your home directory ({exc})")
+    else:
+        # Only `settings.json` at the user level: `settings.local.json` is a project-scoped file.
+        paths.append(user_dir / _SETTINGS_FILES[0])
+    try:
+        project_dir = Path.cwd() / _DEFAULT_CONFIG_DIR
+    except OSError as exc:
+        unresolved.append(f"the current directory ({exc})")
+    else:
+        paths += [project_dir / name for name in _SETTINGS_FILES]
+    return tuple(dict.fromkeys(paths)), tuple(unresolved)
+
+
+def _settings_env(path: Path) -> tuple[dict[str, object], str | None]:
+    """One settings file's ``env`` block, and why it could not be read.
+
+    Exactly one of the two is meaningful: a missing file is ``({}, None)`` — the ordinary case, and
+    silent. A file that exists but cannot be parsed returns the reason instead of pretending it was
+    empty: "we could not check" is a different fact from "there is nothing to warn about", and a user
+    whose settings are silently ignored by *both* Claude Code and this check deserves to know.
+
+    Both guards below exist because this path is **attacker-influenced**: `grid launch` is run from
+    inside whatever checkout the user is standing in, and git stores a symlink in four bytes, so a
+    hostile repository can ship `.claude/settings.json` pointing anywhere. Reading `/dev/zero` never
+    reaches EOF and opening a FIFO with no writer never returns — either would hang the launch before
+    preflight ran. The *target* is what must be a regular file: symlinks stay allowed, because dotfile
+    managers legitimately symlink these files and rejecting the link would break them for no gain.
+    """
+    try:
+        # Follows the symlink on purpose — the question is what the path resolves *to*.
+        if not stat.S_ISREG(os.stat(path).st_mode):
+            return {}, "not a regular file"
+        with path.open("rb") as handle:
+            # One byte past the cap, so "exactly at the cap" is still readable and anything larger is
+            # detectable without holding the whole file.
+            body = handle.read(_MAX_SETTINGS_BYTES + 1)
+    except FileNotFoundError:  # includes a symlink whose target is gone: absent, not broken
+        return {}, None
+    except OSError as exc:
+        return {}, str(exc)
+    if len(body) > _MAX_SETTINGS_BYTES:
+        return {}, f"larger than {_MAX_SETTINGS_BYTES} bytes"
+    try:
+        raw = json.loads(body.decode("utf-8"))
+    except (ValueError, UnicodeDecodeError) as exc:
+        return {}, str(exc)
+    # A settings file whose `env` is absent or not an object simply sets no variables — that is
+    # Claude Code's reading of it too, so it is not something to report.
+    env = raw.get("env") if isinstance(raw, dict) else None
+    return (env if isinstance(env, dict) else {}), None
+
+
+def _warn_on_setting_overrides(session: GridSession, injected: Iterable[str]) -> None:
+    """Warn — once — when the user's Claude Code settings would override what this launch injects.
+
+    Reported, never repaired. Editing another tool's configuration file on a user's behalf is exactly
+    the kind of side effect ADR 0028 exists to rule out: closing the app is meant to be the entire
+    cleanup.
+    """
+    ours = set(injected)
+    collisions: list[str] = []
+    paths, unreadable = _settings_paths()
+    unreadable = list(unreadable)
+    for path in paths:
+        env, unreadable_reason = _settings_env(path)
+        if unreadable_reason is not None:
+            unreadable.append(f"{path} ({unreadable_reason})")
+            continue
+        collisions += [f"{key} in {path}" for key in env if key in ours]
+    if collisions:
+        print(
+            f"Warning: Claude Code's own settings set {'; '.join(collisions)} — settings override "
+            f"what `grid launch` injects, so this session may not reach grid {session.label}.",
+            file=sys.stderr,
+            flush=True,
+        )
+    if unreadable:
+        # Not silence: this check is the only thing standing between the user and a launch that looks
+        # like a broken grid, so a check that could not run says so.
+        print(
+            f"Warning: couldn't read {'; '.join(unreadable)} to check for overriding "
+            f"environment values; launching anyway.",
+            file=sys.stderr,
+            flush=True,
+        )
+
+
+@dataclass(frozen=True)
+class ClaudeCode:
+    """Claude Code as a launch target."""
+
+    name: str = "claude"
+    label: str = "Claude Code"
+
+    def run(self, session: GridSession) -> int:
+        # First, before anything touches the machine: will this session actually work? A grid that
+        # cannot serve the required tiers is a refusal here, not an API error at the first prompt.
+        tiers = _resolve_tiers(session)
+        # Resolved here rather than checked by the caller first: one call, no window in which the app
+        # can leave PATH between a check and its use. Issue 04 widens this to the two conventional
+        # install locations and turns the refusal below into an offer to install.
+        binary = system.find_executable(BINARY)
+        if binary is None:
+            raise SystemExit(
+                f"{self.label} isn't installed, or isn't on your PATH (looked for {BINARY!r}). "
+                f"Install it from {INSTALL_URL}, then run `grid launch {self.name}` again."
+            )
+        # After the binary check, so a machine without the app gets one clean error rather than a
+        # preamble about tiers it will never use.
+        if tiers.remapped:
+            print(
+                f"Grid {session.label} doesn't serve the {', '.join(tiers.remapped)} "
+                f"tier{'s' if len(tiers.remapped) > 1 else ''} — `/model` there resolves to "
+                f"{tiers.models['main']}.",
+                file=sys.stderr,
+                flush=True,
+            )
+        env = _environment(session, tiers)
+        _warn_on_setting_overrides(session, env)
+        # One line, printed by the target because only it knows which model it is about to ask for.
+        # After this the app owns the terminal, and the user can no longer tell which grid they are on.
+        #
+        # stderr, not stdout: this is a diagnostic about the launcher, while stdout belongs to the app.
+        # A user still sees it on a terminal, and a script capturing the app's output (once issue 05
+        # forwards arguments, `grid launch claude -p … | jq`) gets that output unpolluted.
+        # `flush` is load-bearing: the child inherits this stream, and block-buffered output would
+        # otherwise hold the line until exit — printing it *after* everything the app wrote.
+        print(
+            f"Starting {self.label} on grid {session.label} (model {tiers.models['main']}).",
+            file=sys.stderr,
+            flush=True,
+        )
+        # The inherited environment with this grid's keys layered over it. `os.environ` is read, never
+        # assigned to, so the CLI's own environment is untouched and no file is written.
+        return system.spawn([binary], {**os.environ, **env})
+
+
+CLAUDE = ClaudeCode()

--- a/shared/launch/claude.py
+++ b/shared/launch/claude.py
@@ -10,7 +10,7 @@ import json
 import os
 import stat
 import sys
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import NoReturn
@@ -246,6 +246,39 @@ def _warn_on_setting_overrides(session: GridSession, injected: Iterable[str]) ->
         )
 
 
+def _note_remapped(session: GridSession, tiers: _Tiers) -> None:
+    """Say which `/model`-only tiers this grid does not serve and where they now point.
+
+    Shared by both paths on purpose: `--print-env` hands the user the very same remapped values, so
+    a remap that were announced only on a launch would make the printed block quietly different from
+    what it claims to be.
+    """
+    if not tiers.remapped:
+        return
+    print(
+        f"Grid {session.label} doesn't serve the {', '.join(tiers.remapped)} "
+        f"tier{'s' if len(tiers.remapped) > 1 else ''} — `/model` there resolves to "
+        f"{tiers.models['main']}.",
+        file=sys.stderr,
+        flush=True,
+    )
+
+
+def _shell_quote(value: str) -> str:
+    """``value`` as a single, always-quoted shell word.
+
+    Not ``shlex.quote``: that leaves a value with no shell-special character bare, and this block is
+    quoted **uniformly** so that a reader copying one line out of it never has to judge which values
+    needed it — and so that a token which becomes shell-special after a credential rotation cannot
+    turn a working recipe into a silently different one.
+
+    Single quotes because a shell expands nothing inside them — no ``$``, no backtick, no backslash.
+    The only character that cannot appear between them is the quote itself, so it is closed, escaped
+    and reopened, which is the portable POSIX spelling.
+    """
+    return "'" + value.replace("'", "'\\''") + "'"
+
+
 @dataclass(frozen=True)
 class ClaudeCode:
     """Claude Code as a launch target."""
@@ -253,7 +286,33 @@ class ClaudeCode:
     name: str = "claude"
     label: str = "Claude Code"
 
-    def run(self, session: GridSession) -> int:
+    def print_env(self, session: GridSession) -> int:
+        """Print what ``run`` would inject, as shell exports, and start nothing.
+
+        Preflight runs first and refuses on exactly the conditions a launch refuses on: exports for a
+        grid that cannot serve them would move the failure into the app, which is the trap preflight
+        exists to close.
+
+        The app itself is deliberately **not** resolved here. Resolving it can offer to run the
+        vendor's installer, and an installer is a spawn — this command's whole contract is that it
+        starts nothing. A user printing exports is managing their own shell, where the binary may
+        legitimately arrive later or under a name only they know.
+        """
+        tiers = _resolve_tiers(session)
+        _note_remapped(session, tiers)
+        env = _environment(session, tiers)
+        # Diagnostics on stderr, so stdout stays a block a shell can evaluate unfiltered.
+        _warn_on_setting_overrides(session, env)
+        # This prints the grid's access token, making `--print-env` the **second** deliberate
+        # exception to "no command prints a token" (ADR 0003 §6). It carries the same justification
+        # as `grid info --env` (cli/remote_grid.cmd_remote_info), the first: an explicit,
+        # user-requested disclosure of the caller's own token to the caller's own shell, like
+        # `gh auth token`. Every other launch path stays token-free.
+        for key, value in env.items():
+            print(f"export {key}={_shell_quote(value)}")
+        return 0
+
+    def run(self, session: GridSession, argv: Sequence[str] = ()) -> int:
         # First, before anything touches the machine: will this session actually work? A grid that
         # cannot serve the required tiers is a refusal here, not an API error at the first prompt.
         tiers = _resolve_tiers(session)
@@ -263,14 +322,7 @@ class ClaudeCode:
         binary = claude_install.resolve_or_install(self.label)
         # After the binary check, so a machine without the app gets one clean error rather than a
         # preamble about tiers it will never use.
-        if tiers.remapped:
-            print(
-                f"Grid {session.label} doesn't serve the {', '.join(tiers.remapped)} "
-                f"tier{'s' if len(tiers.remapped) > 1 else ''} — `/model` there resolves to "
-                f"{tiers.models['main']}.",
-                file=sys.stderr,
-                flush=True,
-            )
+        _note_remapped(session, tiers)
         env = _environment(session, tiers)
         _warn_on_setting_overrides(session, env)
         # One line, printed by the target because only it knows which model it is about to ask for.
@@ -288,7 +340,10 @@ class ClaudeCode:
         )
         # The inherited environment with this grid's keys layered over it. `os.environ` is read, never
         # assigned to, so the CLI's own environment is untouched and no file is written.
-        return system.spawn([binary], {**os.environ, **env})
+        #
+        # `argv` is appended unread (issue 05): it is the app's own command line, and the launcher
+        # interpreting any of it would be a flag the app could no longer be given.
+        return system.spawn([binary, *argv], {**os.environ, **env})
 
 
 CLAUDE = ClaudeCode()

--- a/shared/launch/claude.py
+++ b/shared/launch/claude.py
@@ -15,6 +15,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import NoReturn
 
+from shared import shell
+
 from . import claude_install, system
 from .claude_install import BINARY, INSTALL_URL  # noqa: F401  (re-exported: the app's own identity)
 from .target import GridSession
@@ -264,21 +266,6 @@ def _note_remapped(session: GridSession, tiers: _Tiers) -> None:
     )
 
 
-def _shell_quote(value: str) -> str:
-    """``value`` as a single, always-quoted shell word.
-
-    Not ``shlex.quote``: that leaves a value with no shell-special character bare, and this block is
-    quoted **uniformly** so that a reader copying one line out of it never has to judge which values
-    needed it — and so that a token which becomes shell-special after a credential rotation cannot
-    turn a working recipe into a silently different one.
-
-    Single quotes because a shell expands nothing inside them — no ``$``, no backtick, no backslash.
-    The only character that cannot appear between them is the quote itself, so it is closed, escaped
-    and reopened, which is the portable POSIX spelling.
-    """
-    return "'" + value.replace("'", "'\\''") + "'"
-
-
 @dataclass(frozen=True)
 class ClaudeCode:
     """Claude Code as a launch target."""
@@ -309,7 +296,7 @@ class ClaudeCode:
         # user-requested disclosure of the caller's own token to the caller's own shell, like
         # `gh auth token`. Every other launch path stays token-free.
         for key, value in env.items():
-            print(f"export {key}={_shell_quote(value)}")
+            print(f"export {key}={shell.quote(value)}")
         return 0
 
     def run(self, session: GridSession, argv: Sequence[str] = ()) -> int:

--- a/shared/launch/claude.py
+++ b/shared/launch/claude.py
@@ -15,14 +15,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import NoReturn
 
-from . import system
+from . import claude_install, system
+from .claude_install import BINARY, INSTALL_URL  # noqa: F401  (re-exported: the app's own identity)
 from .target import GridSession
-
-BINARY = "claude"
-
-# Where a user without the app is sent. The vendor's own page, never a repackaged copy — and no pinned
-# version anywhere, because Claude Code manages its own (ADR 0028).
-INSTALL_URL = "https://claude.com/claude-code"
 
 # The model each Claude Code tier resolves to on a grid. THE one constant: the single site a later
 # discovery slice replaces, so no other module may name these models (a test enforces it). The
@@ -263,14 +258,9 @@ class ClaudeCode:
         # cannot serve the required tiers is a refusal here, not an API error at the first prompt.
         tiers = _resolve_tiers(session)
         # Resolved here rather than checked by the caller first: one call, no window in which the app
-        # can leave PATH between a check and its use. Issue 04 widens this to the two conventional
-        # install locations and turns the refusal below into an offer to install.
-        binary = system.find_executable(BINARY)
-        if binary is None:
-            raise SystemExit(
-                f"{self.label} isn't installed, or isn't on your PATH (looked for {BINARY!r}). "
-                f"Install it from {INSTALL_URL}, then run `grid launch {self.name}` again."
-            )
+        # can leave PATH between a check and its use — which is also why `LaunchTarget` has no separate
+        # installed-check member for the offer below to sit behind.
+        binary = claude_install.resolve_or_install(self.label)
         # After the binary check, so a machine without the app gets one clean error rather than a
         # preamble about tiers it will never use.
         if tiers.remapped:

--- a/shared/launch/claude.py
+++ b/shared/launch/claude.py
@@ -13,7 +13,6 @@ import sys
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import NoReturn
 
 from shared import shell
 
@@ -21,95 +20,50 @@ from . import claude_install, system
 from .claude_install import BINARY, INSTALL_URL  # noqa: F401  (re-exported: the app's own identity)
 from .target import GridSession
 
-# The model each Claude Code tier resolves to on a grid. THE one constant: the single site a later
-# discovery slice replaces, so no other module may name these models (a test enforces it). The
-# `claude:*` family because those names map 1:1 onto Claude Code's own tiers — `/model haiku` inside
-# the app then resolves to a model the grid actually serves, rather than to a real Anthropic model
-# name no grid has ever heard of.
-MODEL_TIERS = {
-    "main": "claude:opus",
-    "small_fast": "claude:haiku",
-    "opus": "claude:opus",
-    "sonnet": "claude:sonnet",
-    "haiku": "claude:haiku",
-    "fable": "claude:fable",
-}
-
-# The tiers every session uses: the main model, and the small/fast one the subagent tier mirrors. A
-# grid that does not serve these cannot run a session at all, so their absence is a refusal. Every
-# other tier is reachable only through `/model`, so its absence is a remap (below), not a blocker.
-REQUIRED_TIERS = ("main", "small_fast")
-
 # Claude Code appends `/v1/messages` itself, so the base carries the relay prefix and **no** `/v1`.
 # Leave `/v1` on — as `grid info --env` prints it for OpenAI clients — and every request 404s.
 _RELAY_SUFFIX = "/relay"
 
 
-def _refuse_missing_required(session: GridSession, missing: list[str]) -> NoReturn:
-    """Refuse a grid that cannot run a session, in a message that is actionable on its own.
+def _require_live_models(session: GridSession) -> None:
+    """Refuse a grid that is serving nothing at all — the whole of preflight now.
 
-    Both halves are load-bearing. Without the missing names the user cannot tell which tier failed;
-    without what the grid *does* serve they cannot tell whether they mistyped a grid, joined the wrong
-    engine, or never joined one — and they would have to run a second command to find out.
+    ADR 0028 checked something much narrower: it injected a fixed model per Claude Code tier and
+    refused a grid that did not serve those exact names. That table is gone (see ``_environment``),
+    and with it any basis for this command to have an opinion about *which* model the app should ask
+    for — so the only model fact still worth checking is the one that is true whatever the app asks:
+    a grid with no live engines can serve nothing, and the launch would fail at the first prompt with
+    an error naming a model rather than an empty grid.
+
+    Still no off switch and still no question: the alternative is finding out inside Claude Code,
+    where the error names neither the grid nor the way out.
     """
-    # Deduped: two tiers may want the same model, and naming it twice reads as two problems.
-    wanted = ", ".join(dict.fromkeys(MODEL_TIERS[tier] for tier in missing))
-    served = ", ".join(session.live_models)
+    if session.live_models:
+        return
     raise SystemExit(
-        f"Grid {session.label} can't run Claude Code: it doesn't serve {wanted}.\n"
-        + (f"Models on {session.label}: {served}.\n" if served
-           else f"Grid {session.label} serves no models yet.\n")
-        # Both commands named, because neither alone is the whole way out: `grid join` runs on the
-        # machine that will serve the models, and the launch is retried here.
-        + f"Run `grid join` on an engine that serves {wanted}, "
-        f"then `grid launch {BINARY}` again."
+        f"Grid {session.label} serves no models yet, so Claude Code has nothing to talk to.\n"
+        # `grid join` runs on the machine that will serve the model, and the launch is retried here —
+        # neither command alone is the whole way out.
+        f"Run `grid join` on a machine with an engine, then `grid launch {BINARY}` again."
     )
 
 
-@dataclass(frozen=True)
-class _Tiers:
-    """What each Claude Code tier resolves to on one particular grid."""
-
-    #: Every tier in ``MODEL_TIERS``, mapped to the model this grid will actually be asked for. Always
-    #: complete — a remapped tier carries the main tier's model, never an empty string.
-    models: dict[str, str]
-    #: The optional tiers this grid does not serve, which now point at the main tier's model.
-    remapped: tuple[str, ...]
-
-
-def _resolve_tiers(session: GridSession) -> _Tiers:
-    """What each tier will actually resolve to on this grid — or a refusal (ADR 0028).
-
-    Preflight always runs: there is no flag that skips it and it never asks a question, because the
-    alternative is discovering the answer inside Claude Code, where the error names a model and
-    nothing else.
-    """
-    live = set(session.live_models)
-    missing_required = [tier for tier in REQUIRED_TIERS if MODEL_TIERS[tier] not in live]
-    if missing_required:
-        _refuse_missing_required(session, missing_required)
-    # Past the refusal, so the main tier's model is known to be live and is a safe destination for
-    # every `/model`-only tier this grid happens not to serve.
-    main = MODEL_TIERS["main"]
-    models = {tier: (model if model in live else main) for tier, model in MODEL_TIERS.items()}
-    return _Tiers(
-        models=models,
-        remapped=tuple(tier for tier, model in MODEL_TIERS.items() if model not in live),
-    )
-
-
-def _environment(session: GridSession, tiers: _Tiers) -> dict[str, str]:
+def _environment(session: GridSession) -> dict[str, str]:
     """The keys Claude Code is handed, layered over the inherited environment by ``run``.
 
-    Every tier variable is always present, remapped or not: leaving one unset would send Claude Code
-    back to a real Anthropic model name that no grid serves.
+    **No model variable is set, deliberately.** ADR 0028 injected seven — one per Claude Code tier,
+    from a hardcoded table — so that the app would ask the grid for names the grid served. That put
+    this command in charge of a choice it has no standing to make: which model a user's session runs
+    on. Left unset, Claude Code resolves models the way it does everywhere else — its own defaults,
+    the user's `settings.json`, and `/model` — and the grid answers for whatever it is asked. The
+    cost is recorded where the decision is: a grid that does not serve what the app asks for now
+    fails at the first prompt rather than at launch.
 
-    `GRID_TOKEN` is absent deliberately: it appears in the hand-rolled recipe, but it is a shell
-    convenience variable this app never reads. Telemetry variables are absent too — whether Grid
-    should disable Claude Code's error reporting is an open product question (ADR 0028), and leaving
-    it out is how that stays a question instead of a silent default.
+    `GRID_TOKEN` is absent for a different reason: it appears in the hand-rolled recipe, but it is a
+    shell convenience variable this app never reads. Telemetry variables are absent too — whether
+    Grid should disable Claude Code's error reporting is an open product question (ADR 0028), and
+    leaving it out is how that stays a question instead of a silent default.
     """
-    model = tiers.models
     return {
         # `rstrip` before the suffix: a stored relay address with a trailing slash would otherwise
         # produce a doubled slash the client sends verbatim.
@@ -117,13 +71,6 @@ def _environment(session: GridSession, tiers: _Tiers) -> dict[str, str]:
         # Both, because which one Claude Code reads depends on the path it takes to authenticate.
         "ANTHROPIC_AUTH_TOKEN": session.access_token,
         "ANTHROPIC_API_KEY": session.access_token,
-        "ANTHROPIC_MODEL": model["main"],
-        "ANTHROPIC_SMALL_FAST_MODEL": model["small_fast"],
-        "CLAUDE_CODE_SUBAGENT_MODEL": model["small_fast"],
-        "ANTHROPIC_DEFAULT_OPUS_MODEL": model["opus"],
-        "ANTHROPIC_DEFAULT_SONNET_MODEL": model["sonnet"],
-        "ANTHROPIC_DEFAULT_HAIKU_MODEL": model["haiku"],
-        "ANTHROPIC_DEFAULT_FABLE_MODEL": model["fable"],
     }
 
 
@@ -248,24 +195,6 @@ def _warn_on_setting_overrides(session: GridSession, injected: Iterable[str]) ->
         )
 
 
-def _note_remapped(session: GridSession, tiers: _Tiers) -> None:
-    """Say which `/model`-only tiers this grid does not serve and where they now point.
-
-    Shared by both paths on purpose: `--print-env` hands the user the very same remapped values, so
-    a remap that were announced only on a launch would make the printed block quietly different from
-    what it claims to be.
-    """
-    if not tiers.remapped:
-        return
-    print(
-        f"Grid {session.label} doesn't serve the {', '.join(tiers.remapped)} "
-        f"tier{'s' if len(tiers.remapped) > 1 else ''} — `/model` there resolves to "
-        f"{tiers.models['main']}.",
-        file=sys.stderr,
-        flush=True,
-    )
-
-
 @dataclass(frozen=True)
 class ClaudeCode:
     """Claude Code as a launch target."""
@@ -285,9 +214,8 @@ class ClaudeCode:
         starts nothing. A user printing exports is managing their own shell, where the binary may
         legitimately arrive later or under a name only they know.
         """
-        tiers = _resolve_tiers(session)
-        _note_remapped(session, tiers)
-        env = _environment(session, tiers)
+        _require_live_models(session)
+        env = _environment(session)
         # Diagnostics on stderr, so stdout stays a block a shell can evaluate unfiltered.
         _warn_on_setting_overrides(session, env)
         # This prints the grid's access token, making `--print-env` the **second** deliberate
@@ -300,28 +228,26 @@ class ClaudeCode:
         return 0
 
     def run(self, session: GridSession, argv: Sequence[str] = ()) -> int:
-        # First, before anything touches the machine: will this session actually work? A grid that
-        # cannot serve the required tiers is a refusal here, not an API error at the first prompt.
-        tiers = _resolve_tiers(session)
+        # First, before anything touches the machine: can this grid serve anything at all? An empty
+        # grid is a refusal here, not an API error at the first prompt.
+        _require_live_models(session)
         # Resolved here rather than checked by the caller first: one call, no window in which the app
         # can leave PATH between a check and its use — which is also why `LaunchTarget` has no separate
         # installed-check member for the offer below to sit behind.
         binary = claude_install.resolve_or_install(self.label)
-        # After the binary check, so a machine without the app gets one clean error rather than a
-        # preamble about tiers it will never use.
-        _note_remapped(session, tiers)
-        env = _environment(session, tiers)
+        env = _environment(session)
         _warn_on_setting_overrides(session, env)
-        # One line, printed by the target because only it knows which model it is about to ask for.
-        # After this the app owns the terminal, and the user can no longer tell which grid they are on.
+        # One line, because after it the app owns the terminal and the user can no longer tell which
+        # grid they are on. It names the grid and nothing else: this command no longer chooses a model
+        # (see `_environment`), so naming one here would be a claim it cannot keep.
         #
         # stderr, not stdout: this is a diagnostic about the launcher, while stdout belongs to the app.
-        # A user still sees it on a terminal, and a script capturing the app's output (once issue 05
-        # forwards arguments, `grid launch claude -p … | jq`) gets that output unpolluted.
+        # A user still sees it on a terminal, and a script capturing the app's output
+        # (`grid launch claude -p … | jq`) gets that output unpolluted.
         # `flush` is load-bearing: the child inherits this stream, and block-buffered output would
         # otherwise hold the line until exit — printing it *after* everything the app wrote.
         print(
-            f"Starting {self.label} on grid {session.label} (model {tiers.models['main']}).",
+            f"Starting {self.label} on grid {session.label}.",
             file=sys.stderr,
             flush=True,
         )

--- a/shared/launch/claude_install.py
+++ b/shared/launch/claude_install.py
@@ -1,0 +1,246 @@
+"""Where Claude Code is on this machine, and how to get it if it is not.
+
+Separate from ``claude.py`` — that module answers "what is the app handed", this one answers "is there
+an app at all". They fail in different ways and change for different reasons.
+
+ADR 0028 rejected the shape ``shared/agent/codex_installer`` uses (a pinned, SHA-256-verified binary
+under the Grid home). That fits Codex because Codex is a static release asset; Claude Code manages its
+own versions, so pinning would make this repo the owner of a number it does not control and would ship
+users a stale agent. So nothing here names a version or a checksum: the offer is to run the **vendor's
+own installer**, which does its own verification.
+"""
+from __future__ import annotations
+
+import os
+import platform
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import NoReturn
+
+from . import system
+
+BINARY = "claude"
+
+# Where a user without the app is sent. The vendor's own page, never a repackaged copy — and no pinned
+# version anywhere, because Claude Code manages its own (ADR 0028).
+INSTALL_URL = "https://claude.com/claude-code"
+
+# The vendor's own official installer, their published one-liner unchanged. A module constant with no
+# interpolation of anything: the one value a shell string could ever take here is the app's own name,
+# which is also a constant, so there is no site where user input could reach `bash -c`.
+_POSIX_INSTALL = "curl -fsSL https://claude.ai/install.sh | bash"
+
+# What is actually run adds two guards to that line. Neither changes which script executes; both only
+# narrow how it can go wrong, which is why the *printed* instruction stays the vendor's own.
+#
+# `--proto '=https'`: `-L` follows redirects, and without this a redirect could walk the download down
+# to plain HTTP. This repo's own `install.sh` pins it on every network `curl` it makes, including the
+# structurally identical `curl … astral.sh/uv/install.sh | sh` — so this is the house rule, not
+# belt-and-braces.
+#
+# `set -o pipefail`: without it the pipeline reports `bash`'s status, and a failed `curl` feeds `bash`
+# an empty script that exits 0 — measured, not assumed. The install then "succeeds" having done
+# nothing, and the user is told to open a new shell when the real problem was the network.
+_POSIX_INSTALL_ARGV = (
+    "/bin/bash",
+    "-c",
+    "set -o pipefail; curl -fsSL --proto '=https' https://claude.ai/install.sh | bash",
+)
+
+# That script refuses Windows itself ("Windows is not supported by this script"), and Windows has a
+# separate PowerShell installer. Running *that* is not built here: a Windows user gets the printed
+# command instead, through the same branch a machine with no terminal already takes. Kept as text so
+# the instruction a Windows user reads is still the right one.
+_WINDOWS_INSTALL = "irm https://claude.ai/install.ps1 | iex"
+
+
+def _is_windows() -> bool:
+    return platform.system() == "Windows"
+
+
+def install_command() -> tuple[str, ...] | None:
+    """The vendor's installer as an argument vector, or ``None`` where we do not run it ourselves."""
+    return None if _is_windows() else _POSIX_INSTALL_ARGV
+
+
+def install_instruction() -> str:
+    """The installer as a line a user can paste — what we print wherever we will not run it."""
+    return _WINDOWS_INSTALL if _is_windows() else _POSIX_INSTALL
+
+
+def install_locations() -> tuple[tuple[Path, ...], str | None]:
+    """The two conventional places Claude Code installs itself in the order they are tried, and why
+    they could not be worked out at all.
+
+    Both were read off the app rather than guessed: ``~/.local/bin/claude`` is the launcher the native
+    installer manages (a symlink into ``~/.local/share/claude/versions/``), and ``~/.claude/local/claude``
+    is the older local install. Neither is on every user's ``PATH``, which is the whole reason they are
+    searched.
+
+    Two homes are refused, and **reported rather than silently dropped** — a caller that quietly
+    searched nothing would go on to say it found nothing "in either place", which is a claim about a
+    check that never ran:
+
+    - **No home at all.** ``Path.home()`` raises ``RuntimeError`` on a container running as a UID with
+      no passwd entry and no ``HOME``, the same failure ``claude._settings_paths`` guards against.
+    - **A relative home.** ``Path.home()`` is only as good as ``HOME``, and ``HOME=.`` yields ``.`` —
+      so the candidates would resolve against the *current directory*. A repository that ships
+      ``.local/bin/claude`` would then have its own binary run with the grid's token in its
+      environment, which is the ``_settings_env`` threat model with execution on the end of it.
+    """
+    try:
+        home = Path.home()
+    except RuntimeError as exc:
+        return (), f"your home directory could not be resolved ({exc})"
+    if not home.is_absolute():
+        return (), f"your home directory is not an absolute path ({str(home)!r})"
+    name = f"{BINARY}.exe" if _is_windows() else BINARY
+    return (home / ".local" / "bin" / name, home / ".claude" / "local" / name), None
+
+
+@dataclass(frozen=True)
+class Resolution:
+    """Where Claude Code is, and what stood in the way of finding out."""
+
+    #: The runnable command, or ``None`` when nothing was found *and* nothing obstructed the search.
+    binary: str | None
+    #: One line per place that could not be looked at, and why. Empty on an ordinary miss — which is
+    #: what makes a non-empty value mean "this answer is incomplete" rather than "this answer is no".
+    unchecked: tuple[str, ...]
+
+
+def resolve() -> Resolution:
+    """Claude Code on this machine: ``PATH`` first, then the conventional locations, first hit wins.
+
+    ``PATH`` going first means it can resolve to a third-party wrapper rather than the vendor's own
+    install. That is accepted deliberately — it is what the user's own ``PATH`` says they want, and it
+    is what ollama's equivalent does — so nothing here tries to detect or second-guess one.
+
+    An obstructed candidate never ends the search: the whole point of a second location is that the
+    first one may be unusable, so what cannot be checked is collected and carried out alongside the
+    answer instead of raising over it.
+    """
+    found = system.find_executable(BINARY)
+    if found is not None:
+        return Resolution(binary=found, unchecked=())
+    locations, unresolved = install_locations()
+    unchecked = [unresolved] if unresolved else []
+    for candidate in locations:
+        found, reason = system.executable_at(candidate)
+        if found is not None:
+            return Resolution(binary=found, unchecked=tuple(unchecked))
+        if reason is not None:
+            unchecked.append(f"{candidate} ({reason})")
+    return Resolution(binary=None, unchecked=tuple(unchecked))
+
+
+def _warn_unchecked(unchecked: tuple[str, ...]) -> None:
+    """Say what could not be looked at, on a run that is otherwise going ahead.
+
+    stderr, and never fatal: an app was found, so this is a caveat on a working launch rather than a
+    problem with it. It still has to be said — the one thing worse than an incomplete search is an
+    incomplete search that looked complete, because that is what sends a user hunting for the wrong
+    fault when the app they get is not the one they expected.
+    """
+    if unchecked:
+        print(
+            f"Warning: couldn't check {'; '.join(unchecked)} for {BINARY}.",
+            file=sys.stderr,
+            flush=True,
+        )
+
+
+def _unchecked_note(unchecked: tuple[str, ...]) -> str:
+    """The line that keeps "isn't installed" honest when the search was incomplete.
+
+    Without it every refusal claims a completed search. A user whose `~/.local/bin` is unreadable, or
+    whose home cannot be resolved, would be told the app is not installed when what actually happened
+    is that we could not look — and would then be handed an installer that fails the same way.
+    """
+    if not unchecked:
+        return ""
+    return "\nCouldn't check: " + "; ".join(unchecked) + "."
+
+
+def _refuse_uninstalled(lead: str, unchecked: tuple[str, ...] = ()) -> NoReturn:
+    """Stop, telling the user exactly what to run — the one exit from every no-install outcome.
+
+    ``lead`` is the only part that differs between them ("isn't installed" vs "not installing"), and
+    the rest is shared on purpose: whichever way a user arrives here, the next thing they need is the
+    command, and it should not read differently depending on how they got here.
+    """
+    raise SystemExit(
+        f"{lead}{_unchecked_note(unchecked)}\n"
+        f"  {install_instruction()}\n"
+        f"Then run `grid launch {BINARY}` again, or see {INSTALL_URL}."
+    )
+
+
+def resolve_or_install(label: str) -> str:
+    """Claude Code on this machine, installing it first if the user asks for that.
+
+    The offer is the point of this function: a machine without the app is the *first-run* state, and a
+    dead end there is a user who never sees the feature work at all.
+
+    It asks only where an answer can be given. A prompt on a machine with no terminal is worse than no
+    prompt: it blocks until something kills it, and the operator reads a hang instead of the one line
+    that fixes their problem. So a non-interactive run — and a platform whose installer we do not run
+    ourselves — prints the command and exits non-zero, which is what automation can act on.
+    """
+    resolution = resolve()
+    if resolution.binary is not None:
+        # Found, but perhaps not everywhere we meant to look. The launch proceeds — this is a working
+        # app — and the incomplete search is a warning rather than a refusal, on stderr because stdout
+        # belongs to the app that is about to start.
+        _warn_unchecked(resolution.unchecked)
+        return resolution.binary
+    command = install_command()
+    if command is None or not system.interactive():
+        _refuse_uninstalled(f"{label} isn't installed.", resolution.unchecked)
+    # stdout, unlike the launch banner: this is one half of a conversation whose other half is the
+    # prompt below, and `input` writes that to stdout. Reached only when `interactive()` already said
+    # stdout is a terminal, so it can never land in a pipe the app's own output was meant to fill.
+    _warn_unchecked(resolution.unchecked)
+    print(f"{label} isn't installed. `grid launch` can install it with the official installer:",
+          flush=True)
+    print(f"  {install_instruction()}", flush=True)
+    if not system.confirm(f"Install {label} now?"):
+        _refuse_uninstalled(f"Not installing {label}.", resolution.unchecked)
+    # `os.environ` verbatim, and never the environment the app is about to be handed: the installer
+    # talks to the vendor, not to the grid, so giving it the grid's bearer token would be an exposure
+    # bought for nothing. Through `spawn` because the installer is a foreground child that owns the
+    # terminal exactly like the app does — it runs the vendor's own TUI, and a Ctrl-C during it must
+    # reach it rather than us.
+    try:
+        code = system.spawn(command, os.environ)
+    except SystemExit as exc:
+        # `spawn`'s own message names `argv[0]` — here `/bin/bash`, which says nothing about Claude
+        # Code, nothing about an installer, and nothing about what to do. The *worst* failure (the
+        # installer could not even start) would otherwise get the least actionable message of any
+        # branch in this function.
+        raise SystemExit(
+            f"Couldn't run the {label} installer: {exc}\n"
+            f"  {install_instruction()}\n"
+            f"Run that yourself, or see {INSTALL_URL}."
+        ) from exc
+    if code != 0:
+        raise SystemExit(
+            f"The {label} installer exited {code}; nothing was launched. "
+            f"Install it yourself with `{install_instruction()}` or from {INSTALL_URL}, "
+            f"then run `grid launch {BINARY}` again."
+        )
+    # The whole resolution again, not just `PATH`. The installer writes its launcher into
+    # `~/.local/bin` and appends a `PATH` line to a shell rc file — neither of which reaches a process
+    # that is already running. So `PATH` is still as stale as it was a moment ago, and asking it alone
+    # would tell a user who just watched the install succeed that the app is not installed.
+    resolution = resolve()
+    if resolution.binary is None:
+        raise SystemExit(
+            f"The {label} installer finished, but no `{BINARY}` turned up on your PATH or in either "
+            f"place it installs to.{_unchecked_note(resolution.unchecked)}\n"
+            f"Open a new shell and run `grid launch {BINARY}` again; if that still fails, the install "
+            f"did not land — see {INSTALL_URL}."
+        )
+    _warn_unchecked(resolution.unchecked)
+    return resolution.binary

--- a/shared/launch/registry.py
+++ b/shared/launch/registry.py
@@ -1,0 +1,23 @@
+"""The launch-target registry: every app `grid launch` knows how to start.
+
+One entry today. A second target is a new module plus a line in ``TARGETS`` — the targets know
+nothing about this table, so adding one cannot change an existing one.
+"""
+from __future__ import annotations
+
+from . import claude
+from .target import LaunchTarget
+
+TARGETS: dict[str, LaunchTarget] = {
+    claude.CLAUDE.name: claude.CLAUDE,
+}
+
+
+def names() -> tuple[str, ...]:
+    """Every registered target name, in registration order."""
+    return tuple(TARGETS)
+
+
+def get(name: str) -> LaunchTarget | None:
+    """The target registered under ``name``, or ``None`` — the caller renders the error."""
+    return TARGETS.get(name)

--- a/shared/launch/system.py
+++ b/shared/launch/system.py
@@ -1,16 +1,21 @@
-"""The one OS-facing seam a launch acts through: find the app, run it, report its exit code.
+"""The one OS-facing seam a launch acts through: find the app, ask about it, run it, report its code.
 
-Two module-level functions rather than a class, so a test substitutes them and asserts on the argument
-vector and environment the child was handed — that pair is the whole observable contract of a launch,
-and there is nothing meaningful below it to test. Issue 04 adds the TTY pair (interactive-check and
-confirm) here, when the install prompt that calls them lands; they are absent now because nothing in
-this slice would call them.
+Module-level functions rather than a class, so a test substitutes them and asserts on the argument
+vector and environment the child was handed — that pair is the whole observable contract of a launch.
+
+Each is the smallest primitive that still hides an OS detail, and *policy* stays above them: these
+answer "is there a runnable file here" and "did the user say yes", never "where should we look" or
+"what should we do about it". That is what lets one target search two install locations and the next
+target search none, with nothing here to change.
 """
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
+import sys
 from collections.abc import Mapping, Sequence
+from pathlib import Path
 
 # A shell reports a signal-killed foreground process as 128 + the signal number. SIGINT is 2.
 _SIGNAL_EXIT_BASE = 128
@@ -20,6 +25,66 @@ SIGINT_EXIT_CODE = _SIGNAL_EXIT_BASE + 2
 def find_executable(name: str) -> str | None:
     """``name`` resolved on ``PATH``, or ``None`` when it is not there."""
     return shutil.which(name)
+
+
+def executable_at(path: Path) -> tuple[str | None, str | None]:
+    """``path`` as a runnable command, and why that could not be determined. At most one is not None.
+
+    The companion to ``find_executable`` for a candidate an app is known to install itself into, where
+    there is no name to search for — only a place to look. *Which* places is the target's own
+    knowledge, not this module's.
+
+    Symlinks are followed on purpose: the conventional location for a self-updating app is a launcher
+    symlink into a versioned directory, so refusing links would reject the ordinary install.
+
+    **Nothing here and could-not-look are separate answers**, the same distinction ``claude._settings_env``
+    draws for the same reason. ``Path.is_file`` hides only the errnos that *mean* absent — ENOENT,
+    ENOTDIR, EBADF, ELOOP — so a dangling symlink or a missing parent is a plain ``(None, None)``.
+    Everything else is a real obstacle: a ``~/.local/bin`` whose traverse bit is stripped raises
+    ``PermissionError``, and reporting that as "not installed" would tell a user who *has* the app that
+    they do not, then offer an install that hits the same wall.
+
+    It still never raises, because a caller with two candidates must be able to try the second one.
+    """
+    try:
+        if path.is_file() and os.access(path, os.X_OK):
+            return str(path), None
+    except OSError as exc:
+        return None, exc.strerror or str(exc)
+    return None, None
+
+
+# The TTY pair below duplicates a private one in `cli/provider.py` (`_interactive` / `_confirm`).
+# `interactive` is byte-for-byte identical to `_interactive`; `confirm` shares the prompt shape but
+# **not** the body — it treats EOF and Ctrl-C as a decline, which the provider's version does not, so
+# there those two escape as a traceback. The duplication is deliberate and recorded rather than fixed:
+# `shared/launch` must not import `cli`, so consolidating would mean moving the provider's pair into
+# `shared/` and re-pointing its callers — a change to the join path, in a slice about launching an app.
+# Explicitly out of scope, and `cli/provider.py` is left untouched.
+
+
+def interactive() -> bool:
+    """Whether there is a person on the other end who could answer a question.
+
+    Both streams, because a question needs both halves: stdout carries the prompt (``input`` writes it
+    there) and stdin carries the answer. Requiring stdout in particular is what keeps the prompt out of
+    a captured pipe — ``grid launch claude … | jq`` gets the app's output, never a half-written
+    question waiting on input that will never come.
+    """
+    return sys.stdin.isatty() and sys.stdout.isatty()
+
+
+def confirm(question: str) -> bool:
+    """Ask ``question`` and return whether the answer was yes. Anything but an explicit yes is no.
+
+    ``EOFError`` and ``KeyboardInterrupt`` are answers, not faults: a user who hits Ctrl-D or Ctrl-C at
+    a prompt has declined, and the caller's clean refusal is the right outcome for both. Letting either
+    escape would turn "no thanks" into a traceback.
+    """
+    try:
+        return input(f"{question} [y/N] ").strip().lower() == "y"
+    except (EOFError, KeyboardInterrupt):
+        return False
 
 
 def spawn(argv: Sequence[str], env: Mapping[str, str]) -> int:

--- a/shared/launch/system.py
+++ b/shared/launch/system.py
@@ -1,0 +1,58 @@
+"""The one OS-facing seam a launch acts through: find the app, run it, report its exit code.
+
+Two module-level functions rather than a class, so a test substitutes them and asserts on the argument
+vector and environment the child was handed — that pair is the whole observable contract of a launch,
+and there is nothing meaningful below it to test. Issue 04 adds the TTY pair (interactive-check and
+confirm) here, when the install prompt that calls them lands; they are absent now because nothing in
+this slice would call them.
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+from collections.abc import Mapping, Sequence
+
+# A shell reports a signal-killed foreground process as 128 + the signal number. SIGINT is 2.
+_SIGNAL_EXIT_BASE = 128
+SIGINT_EXIT_CODE = _SIGNAL_EXIT_BASE + 2
+
+
+def find_executable(name: str) -> str | None:
+    """``name`` resolved on ``PATH``, or ``None`` when it is not there."""
+    return shutil.which(name)
+
+
+def spawn(argv: Sequence[str], env: Mapping[str, str]) -> int:
+    """Run ``argv`` in the foreground to completion with exactly ``env``, returning its exit code.
+
+    The child inherits this process's stdio and process group, so it owns the terminal and a Ctrl-C is
+    delivered straight to it by the terminal — which is the whole point: the app must behave the way it
+    does when the user runs the binary themselves.
+
+    ``subprocess.run`` cannot be used for that. Its implementation wraps the wait in a bare ``except:``
+    that calls ``process.kill()``, so the ``KeyboardInterrupt`` the same signal raises *here* SIGKILLs
+    the app in the middle of the shutdown it had already started — verified against a real child that
+    traps SIGINT: its cleanup never finished. So the child is waited for again instead.
+
+    Every signal death is reported the way a shell reports it, 128 + the signal number, so what this
+    returns always *is* an exit code.
+    """
+    try:
+        process = subprocess.Popen(list(argv), env=dict(env))
+    except OSError as exc:
+        # A binary that resolved but cannot be executed (deleted, or not executable): a clean error
+        # naming it, never a traceback out of subprocess.
+        raise SystemExit(f"Could not start {argv[0]}: {exc}") from exc
+    try:
+        code = process.wait()
+    except KeyboardInterrupt:
+        try:
+            code = process.wait()  # the app already has the signal; let it finish on its own terms
+        except KeyboardInterrupt:
+            # A second Ctrl-C: the user wants their shell back more than they want a clean app exit.
+            # The child keeps every signal the terminal already sent it — killing it here would be the
+            # very thing this function exists to avoid — so stop waiting and report the interrupt.
+            return SIGINT_EXIT_CODE
+    # A child killed by a signal has no exit status; POSIX reports ``-signum``. Passing that out would
+    # reach the shell as 256-signum (SIGKILL → 247), so it is normalised to what a shell would say.
+    return _SIGNAL_EXIT_BASE - code if code < 0 else code

--- a/shared/launch/target.py
+++ b/shared/launch/target.py
@@ -1,0 +1,45 @@
+"""What a launch target is, and what it is told about the grid it is being pointed at."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class GridSession:
+    """The grid a target is being pointed at — everything a target is allowed to know about it.
+
+    Deliberately narrow: a label to name in the target's own output, the relay base, the grid's
+    access token, and the models it currently serves. A target never sees the credentials file, the
+    control-plane session token, or the stored grid record.
+    """
+
+    label: str
+    relay_base: str
+    access_token: str
+    #: The model ids the grid serves right now, in the grid's own order — read from the public
+    #: overview by `cli/launch.py`. A target compares this against whatever models it needs and
+    #: decides for itself: the CLI cannot, because a target's model names are the target's own
+    #: (ADR 0028). Empty means the grid serves nothing, which is a refusal, not a missing read.
+    live_models: tuple[str, ...]
+
+
+class LaunchTarget(Protocol):
+    """An app `grid launch` can start.
+
+    The boundary is deliberate: the obvious second target (Codex) configures itself through a **file**
+    rather than environment variables, so only ``run`` knows how a target is configured. That
+    difference stays inside the target instead of leaking into the command.
+
+    ``run`` also resolves the app itself and refuses cleanly when it is absent — one call, and no
+    window in which the app can leave ``PATH`` between a separate installed-check and its use. Issue 04
+    adds the installed-check as its own member, when the install offer that must ask *before* running
+    arrives to call it.
+    """
+
+    name: str
+    label: str
+
+    def run(self, session: GridSession) -> int:
+        """Start the app pointed at ``session``, and return its exit code."""
+        ...

--- a/shared/launch/target.py
+++ b/shared/launch/target.py
@@ -31,10 +31,13 @@ class LaunchTarget(Protocol):
     rather than environment variables, so only ``run`` knows how a target is configured. That
     difference stays inside the target instead of leaking into the command.
 
-    ``run`` also resolves the app itself and refuses cleanly when it is absent — one call, and no
-    window in which the app can leave ``PATH`` between a separate installed-check and its use. Issue 04
-    adds the installed-check as its own member, when the install offer that must ask *before* running
-    arrives to call it.
+    ``run`` also resolves the app itself, and offers to install it when it is absent — one call, and no
+    window in which the app can leave ``PATH`` between a separate installed-check and its use.
+
+    There is deliberately **no** ``is_installed`` member, though the feature's PRD sketched one. The
+    install offer has to happen where the binary is resolved, because only a target knows its own
+    binary, its own install locations and its own installer — so a member for it would have no caller,
+    and would reopen the check-then-run gap the single call closes.
     """
 
     name: str

--- a/shared/launch/target.py
+++ b/shared/launch/target.py
@@ -1,6 +1,7 @@
 """What a launch target is, and what it is told about the grid it is being pointed at."""
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Protocol
 
@@ -43,6 +44,23 @@ class LaunchTarget(Protocol):
     name: str
     label: str
 
-    def run(self, session: GridSession) -> int:
-        """Start the app pointed at ``session``, and return its exit code."""
+    def run(self, session: GridSession, argv: Sequence[str] = ()) -> int:
+        """Start the app pointed at ``session`` with ``argv`` appended, and return its exit code.
+
+        ``argv`` is whatever the user typed after ``--``. It is the app's own command line and is
+        passed on unread: the launcher must never become a ceiling on the app it launches, and
+        anything it interpreted here would be a flag the app could no longer receive.
+        """
+        ...
+
+    def print_env(self, session: GridSession) -> int:
+        """Describe the same configuration ``run`` would apply, without starting anything.
+
+        On the target rather than in the command for two reasons. The preflight that decides whether
+        a grid can run this app at all already lives here, so `--print-env` inherits it instead of
+        re-implementing it — printing exports for a grid that cannot serve them would reproduce
+        exactly the trap preflight exists to close. And a target that configures itself through a
+        **file** rather than the environment (Codex, the reason this protocol exists) answers for its
+        own mechanism, instead of the command assuming every target is env-shaped.
+        """
         ...

--- a/shared/shell.py
+++ b/shared/shell.py
@@ -1,0 +1,25 @@
+"""Rendering a value for a shell to read back.
+
+One function, in `shared/` rather than beside either of its callers, because both places that print
+shell exports are **token-printing carve-outs** (ADR 0003 §6) — `grid info --env` and
+`grid launch <target> --print-env`. A block a user is invited to `eval` has exactly one correct
+quoting, and two copies of it is one copy that goes stale on the day a credential starts containing
+a character nobody expected.
+"""
+from __future__ import annotations
+
+
+def quote(value: str) -> str:
+    """``value`` as a single, always-quoted shell word.
+
+    Not ``shlex.quote``: that leaves a value with no shell-special character bare. A block printed
+    for a human has to be quoted **uniformly**, so a reader copying one line out of it never has to
+    judge which values needed it — and so that a credential which becomes shell-special after a
+    rotation cannot silently turn a working recipe into a different one.
+
+    Single quotes because a shell expands nothing between them — no ``$``, no backtick, no
+    backslash, no history ``!``. The only character that cannot appear there is the quote itself, so
+    it is closed, escaped and reopened, which is the portable POSIX spelling and leaves the quoting
+    balanced for every possible input.
+    """
+    return "'" + value.replace("'", "'\\''") + "'"

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -10745,6 +10745,60 @@ def test_every_command_is_classified_for_dispatch():
     assert not unclassified, f"unclassified commands: {unclassified}"
 
 
+def test_local_gate_message_is_byte_for_byte_for_a_command_with_no_reason(monkeypatch, tmp_path):
+    """Every remote-only command that registers no reason of its own keeps today's sentence.
+
+    All six commands the gate guards today are gated because they need a signed-in account, so
+    "to sign in." is their reason and the message must not move by a byte. A command whose reason
+    is *not* sign-in registers its own and is covered by its own test instead.
+    """
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))  # default mode is local
+    argvs = {
+        "login": ["login"],
+        "logout": ["logout"],
+        "sync": ["sync"],
+        "members": ["members", "list"],
+        "price": ["price", "show"],
+        "router": ["router", "status"],
+    }
+    # A reason must be None or real text. An empty one would be masked by the `or` in ``local_stub``
+    # *and* skipped by the `is None` filter below — the one state that is invisible in both
+    # directions, so it is refused here rather than left to be discovered in a transcript.
+    assert all(r is None or r.strip() for r in dispatch.REMOTE_ONLY.values()), \
+        f"empty gate reason(s): {[c for c, r in dispatch.REMOTE_ONLY.items() if r is not None and not r.strip()]}"
+    defaulted = {c for c, reason in dispatch.REMOTE_ONLY.items() if reason is None}
+    assert defaulted, "nothing takes the default reason any more: delete this lock, don't let it pass vacuously"
+    assert defaulted <= set(argvs), f"no argv here for defaulted command(s): {defaulted - set(argvs)}"
+
+    for command in sorted(defaulted):
+        with pytest.raises(SystemExit) as exc:
+            cli.main(argvs[command])
+        assert str(exc.value) == (
+            f"`grid {command}` is a remote-mode command. "
+            "Run `grid mode remote` (or pass --remote) to sign in."
+        )
+
+
+def test_local_gate_prints_a_commands_own_reason_when_it_registers_one(monkeypatch, tmp_path):
+    """A remote-only command can register its own reason, and that reason is what the user sees.
+
+    Driven through an existing command with a substituted registry rather than a new command: this
+    slice adds no command and changes no classification (`grid launch`, whose reason is the Anthropic
+    Messages dialect, is a later slice). The `grid mode remote` signpost lives in the fixed part of
+    the sentence, so it must survive a custom reason.
+    """
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))  # default mode is local
+    monkeypatch.setattr(dispatch, "REMOTE_ONLY", {**dispatch.REMOTE_ONLY, "price": "to reach Mars."})
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["price", "show"])
+
+    assert str(exc.value) == (
+        "`grid price` is a remote-mode command. "
+        "Run `grid mode remote` (or pass --remote) to reach Mars."
+    )
+
+
 def test_active_selection_flows_through_select_grid(monkeypatch, tmp_path):
     monkeypatch.setenv("GRID_HOME", str(tmp_path))
     runtime.init_grid_config(name="home", port=8090)

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -22264,27 +22264,84 @@ def test_launch_with_no_target_lists_the_targets_and_exits_zero(monkeypatch, tmp
     assert "claude" in capsys.readouterr().out
 
 
-def _capture_launch(monkeypatch, *, binary="/usr/local/bin/claude", exit_code=0):
+def _launch_system():
+    """The one OS-facing seam module `shared/launch` acts through."""
+    from shared.launch import system
+
+    return system
+
+
+def _repo_root() -> Path:
+    """The checkout, resolved from a package rather than from the cwd — several launch tests `chdir`
+    into a temp project, and a relative path would then read nothing and pass vacuously."""
+    import shared
+
+    return Path(shared.__file__).resolve().parent.parent
+
+
+def _install_locations(monkeypatch, tmp_path):
+    """Point the two conventional Claude Code install locations at a temp home, and return them.
+
+    The two paths are spelled out here rather than read back from `claude_install`, which is the whole
+    value of the helper: they are an **external fact** about the app — verified against the strings of
+    the installed binary and the vendor's own setup documentation — so a test that asked the code under
+    test where it looks would agree with any answer it gave, order included.
+    """
+    home = tmp_path / "home"
+    home.mkdir(exist_ok=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    return home / ".local" / "bin" / "claude", home / ".claude" / "local" / "claude"
+
+
+def _capture_launch(monkeypatch, *, binary="/usr/local/bin/claude", exit_code=0, found=(),
+                    install_code=0, interactive=False, confirm=False):
     """Substitute the one OS-facing seam a launch acts through.
 
     Returns a dict filled with the child's ``argv`` and ``env`` — the pair that *is* this feature's
-    contract — plus ``looked_for``, the executable names resolution was asked about. Patching the
-    module attributes (not a `subprocess` global) keeps every other subprocess in the suite real.
-    """
-    from shared.launch import system
+    contract — plus ``looked_for``, every candidate resolution was asked about **in order**, and
+    ``spawns``, every (argv, env) pair in order (an install spawns twice). Patching the module
+    attributes (not a `subprocess` global) keeps every other subprocess in the suite real.
 
-    seen = {"looked_for": []}
+    ``binary`` is what `PATH` answers (``None`` = not on `PATH`); ``found`` is the set of fallback
+    install locations that exist. Stubbing the location check is **required even on the happy path**:
+    left real it would consult the developer's own `~/.local/bin/claude` and decide a test that is
+    about the grid. The TTY pair is stubbed for the same reason and one more: left real, a test that
+    reaches the install offer would read the suite's own stdin.
+    """
+    system = _launch_system()
+    # A mutable set, not a snapshot: an install test's fake installer adds to it, which is how "the
+    # binary that wasn't there is there now" is expressed without touching a real filesystem.
+    seen = {"looked_for": [], "spawns": [], "asked": [], "found": {str(path) for path in found}}
 
     def fake_find(name):
         seen["looked_for"].append(name)
         return binary
 
+    def fake_executable_at(path):
+        seen["looked_for"].append(str(path))
+        # (runnable path, why we couldn't tell) — a stub location is only ever one or the other.
+        return (str(path), None) if str(path) in seen["found"] else (None, None)
+
     def fake_spawn(argv, env):
         seen["argv"], seen["env"] = list(argv), dict(env)
-        return exit_code
+        seen["spawns"].append((list(argv), dict(env)))
+        # Which spawn is the installer is decided by whether an offer was actually *accepted*, not by
+        # whether `PATH` missed. Keying off `binary is None` would call the app's own launch an
+        # installer whenever the app was found in a fallback location — the exact path issue 04 adds —
+        # and silently hand back `install_code` in place of the app's exit code.
+        installing = bool(seen["asked"]) and confirm and len(seen["spawns"]) == 1
+        return install_code if installing else exit_code
+
+    def fake_confirm(question):
+        seen["asked"].append(question)
+        return confirm
 
     monkeypatch.setattr(system, "find_executable", fake_find)
+    monkeypatch.setattr(system, "executable_at", fake_executable_at)
     monkeypatch.setattr(system, "spawn", fake_spawn)
+    monkeypatch.setattr(system, "interactive", lambda: interactive)
+    monkeypatch.setattr(system, "confirm", fake_confirm)
     return seen
 
 
@@ -22815,18 +22872,506 @@ def test_launch_unknown_target_names_it_and_lists_the_available_ones(monkeypatch
     assert "login" not in message.lower(), f"a typo must not be reported as a sign-in problem: {message}"
 
 
-def test_launch_claude_when_the_binary_is_absent_is_a_clean_actionable_error(monkeypatch, tmp_path):
-    """No Claude Code on this machine is a clean error naming the app and where to get it — not a
-    traceback, and not a spawn of nothing. (Issue 04 turns this into an offer to install it.)"""
+def test_launch_stops_at_the_first_hit_and_prefers_path_over_the_install_locations(monkeypatch,
+                                                                                   tmp_path):
+    """`PATH` is asked first and, when it answers, nothing else is looked at.
+
+    Order is the decision, not an accident of implementation. A `PATH` entry can resolve to a
+    third-party wrapper rather than the vendor's own install, and that is **accepted**: it is what the
+    user's own `PATH` says they want, and second-guessing it would make `grid launch` disagree with
+    every other way they start the app. Searching the install locations first would silently overrule
+    them; searching them as well would spend two stat calls to reach the same answer.
+    """
     _seed_launchable_grid(monkeypatch, tmp_path)
-    seen = _capture_launch(monkeypatch, binary=None)
+    _install_locations(monkeypatch, tmp_path)
+    seen = _capture_launch(monkeypatch, binary="/opt/wrapper/claude")
+
+    assert cli.main(["launch", "claude"]) == 0
+    assert seen["argv"] == ["/opt/wrapper/claude"], "the PATH answer wins, wrapper or not"
+    assert seen["looked_for"] == ["claude"], (
+        f"a PATH hit must end the search, not merely start it: {seen['looked_for']}"
+    )
+
+
+def test_launch_finds_claude_code_in_the_native_installers_location_when_path_misses(monkeypatch,
+                                                                                     tmp_path):
+    """`PATH` is not the whole answer, and the gap is the ordinary case rather than an exotic one.
+
+    The native installer puts its launcher at `~/.local/bin/claude` and adds that directory to `PATH`
+    by editing a shell rc file — which never reaches a shell that was already running. So the very
+    first `grid launch claude` after an install, in the terminal the install ran in, resolves nothing
+    on `PATH` while a perfectly good binary sits in the conventional place.
+
+    The app's own exit code must still come back through this path — it is a launch like any other.
+    """
+    _seed_launchable_grid(monkeypatch, tmp_path)
+    native, _legacy = _install_locations(monkeypatch, tmp_path)
+    seen = _capture_launch(monkeypatch, binary=None, found=[native], exit_code=5)
+
+    assert cli.main(["launch", "claude"]) == 5, "the app's exit code, not an installer's"
+    assert seen["argv"] == [str(native)], f"the found binary must be the one spawned: {seen['argv']}"
+
+
+def test_launch_falls_back_to_the_legacy_install_location_only_after_the_native_one(monkeypatch,
+                                                                                    tmp_path):
+    """The older `~/.claude/local/claude` install is searched too, and searched **second**.
+
+    Both can exist at once on a machine that installed the old way and later ran the native installer,
+    and the native one is the copy that updates itself — so a box with both must get that one. This
+    asserts the order from the losing side, which the native-location test above cannot: there, an
+    implementation that checked the legacy path first would still find nothing there and pass.
+    """
+    _seed_launchable_grid(monkeypatch, tmp_path)
+    native, legacy = _install_locations(monkeypatch, tmp_path)
+    seen = _capture_launch(monkeypatch, binary=None, found=[legacy])
+
+    assert cli.main(["launch", "claude"]) == 0
+    assert seen["argv"] == [str(legacy)]
+    assert seen["looked_for"] == ["claude", str(native), str(legacy)], (
+        f"PATH, then native, then legacy — in that order: {seen['looked_for']}"
+    )
+
+
+def test_launch_with_no_binary_and_no_terminal_prints_the_command_and_never_prompts(monkeypatch,
+                                                                                    tmp_path):
+    """CI, a cron job, a script: nobody is there to answer, so asking is the one thing that must not
+    happen. A prompt written to a pipe blocks until the run's own timeout kills it, and the operator
+    reads a hang rather than the single line that would have fixed it.
+
+    So the install command is *printed* and the command exits non-zero: automation fails with an
+    instruction. (This replaces the issue-02 test that made a missing binary a plain terminal error —
+    that rule is the one this slice overturns.)
+    """
+    _seed_launchable_grid(monkeypatch, tmp_path)
+    _install_locations(monkeypatch, tmp_path)
+    seen = _capture_launch(monkeypatch, binary=None, interactive=False)
 
     with pytest.raises(SystemExit) as exc:
         cli.main(["launch", "claude"])
+
     message = str(exc.value)
     assert "Claude Code" in message
-    assert "claude.com" in message, f"the message must say where to get it: {message}"
-    assert "argv" not in seen, "nothing may be spawned when the app was never found"
+    assert "https://claude.ai/install.sh" in message, (
+        f"the command to run must be printed in full, not described: {message}"
+    )
+    assert seen["asked"] == [], "a machine with no terminal must never be asked a question"
+    assert seen["spawns"] == [], "nothing may run when there is no app and no consent"
+
+
+def test_launch_asks_before_installing_and_a_declined_offer_exits_cleanly(monkeypatch, tmp_path):
+    """Saying no is a supported answer, not a failure to handle.
+
+    Two halves. The question must actually be asked — an install that just happens is this command
+    downloading and running a vendor script on someone's machine without consent. And the refusal must
+    be a clean non-zero exit: non-zero because nothing was launched and a script must be able to tell,
+    clean because a traceback would read as a bug in `grid` rather than as the answer the user gave.
+    """
+    _seed_launchable_grid(monkeypatch, tmp_path)
+    _install_locations(monkeypatch, tmp_path)
+    seen = _capture_launch(monkeypatch, binary=None, interactive=True, confirm=False)
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["launch", "claude"])
+
+    assert seen["asked"], "an install must be offered, never performed unasked"
+    assert "Claude Code" in seen["asked"][0], f"the question must name the app: {seen['asked'][0]}"
+    assert exc.value.code != 0, "nothing launched, so the exit code must say so"
+    assert seen["spawns"] == [], "a declined install must run nothing at all"
+
+
+def _raiser(exception):
+    def raise_it(*args, **kwargs):
+        raise exception
+
+    return raise_it
+
+
+def test_launch_treats_ctrl_d_or_ctrl_c_at_the_install_prompt_as_a_decline(monkeypatch, tmp_path):
+    """The two ways a user leaves a prompt without typing a word.
+
+    `input()` raises `EOFError` on Ctrl-D — and on the far more common accident of a stdin that looked
+    interactive but had nothing behind it — and `KeyboardInterrupt` on Ctrl-C. Both are answers, and
+    both would otherwise escape as a traceback from inside the launcher, which is exactly the shape a
+    user reports as "grid crashed" when what they did was decline.
+
+    Asserted against the real `system.confirm`, because the whole behaviour lives there; the stub the
+    other tests use would happily hide it. It has to be captured **before** `_capture_launch` installs
+    that stub — reading it back afterwards returns the stub, and restoring that over itself makes the
+    test pass while proving nothing.
+    """
+    real_confirm = _launch_system().confirm
+
+    for interrupt in (EOFError, KeyboardInterrupt):
+        _seed_launchable_grid(monkeypatch, tmp_path)
+        _install_locations(monkeypatch, tmp_path)
+        _capture_launch(monkeypatch, binary=None, interactive=True)
+        monkeypatch.setattr(_launch_system(), "confirm", real_confirm)
+        monkeypatch.setattr("builtins.input", _raiser(interrupt))
+
+        with pytest.raises(SystemExit) as exc:
+            cli.main(["launch", "claude"])
+        assert exc.value.code != 0, f"{interrupt.__name__} at the prompt must not exit 0"
+        assert "Not installing" in str(exc.value), (
+            f"{interrupt.__name__} is a decline, so it must read as one: {exc.value}"
+        )
+
+
+def test_launch_installs_then_launches_in_the_same_invocation(monkeypatch, tmp_path):
+    """One confirmation, and the user is in Claude Code on their grid — the whole promise of the offer.
+
+    The load-bearing detail is *where* the re-resolve looks. The installer puts its launcher in
+    `~/.local/bin` and appends a `PATH` line to a shell rc file, and neither of those reaches a process
+    that is already running — so `PATH` is still exactly as stale after a successful install as it was
+    before, and this is the *ordinary* case, not an edge one. A re-resolve that asked `PATH` alone
+    would tell a user who just watched an install succeed that the app is not installed.
+
+    So `found` here deliberately stays empty until the installer plants the launcher.
+    """
+    _seed_launchable_grid(monkeypatch, tmp_path)
+    native, _legacy = _install_locations(monkeypatch, tmp_path)
+    seen = _capture_launch(monkeypatch, binary=None, interactive=True, confirm=True)
+
+    def install_then_land(argv, env):
+        seen["spawns"].append((list(argv), dict(env)))
+        seen["argv"], seen["env"] = list(argv), dict(env)
+        if len(seen["spawns"]) == 1:  # the installer: it plants the launcher, PATH untouched
+            seen["found"].add(str(native))
+        return 0
+
+    monkeypatch.setattr(_launch_system(), "spawn", install_then_land)
+
+    assert cli.main(["launch", "claude"]) == 0
+    installer, app = seen["spawns"]
+    assert installer[0][:2] == ["/bin/bash", "-c"] and len(installer[0]) == 3, installer[0]
+    script = installer[0][2]
+    assert "https://claude.ai/install.sh" in script, f"the vendor's own installer: {script}"
+    # Two guards on the vendor's line, neither of which changes which script runs. Asserted because
+    # both close a measured hole: `-L` without `--proto '=https'` can be redirected down to plain
+    # HTTP, and without `pipefail` a failed `curl` feeds `bash` an empty script that exits 0 — so the
+    # install "succeeds" having done nothing.
+    assert "--proto '=https'" in script, f"a redirect must not be able to leave HTTPS: {script}"
+    assert "set -o pipefail" in script, f"a failed download must not read as a success: {script}"
+    assert app[0] == [str(native)], f"then the freshly installed app, in one invocation: {app[0]}"
+
+
+def test_launch_hands_the_installer_no_grid_credential(monkeypatch, tmp_path):
+    """The installer pipes a script fetched over the network into a shell. Whatever else that is, it
+    must not be a thing holding the user's grid bearer token.
+
+    Nothing needs it — the installer talks to the vendor, never to the grid — so handing it over would
+    be a credential exposure bought for nothing. It holds today only because the environment block is
+    built after this point; a later reorder could give it away silently, which is what this pins.
+    """
+    _seed_launchable_grid(monkeypatch, tmp_path, access_token="SECRET-GRID-TOKEN")
+    native, _legacy = _install_locations(monkeypatch, tmp_path)
+    seen = _capture_launch(monkeypatch, binary=None, interactive=True, confirm=True)
+
+    def install_then_land(argv, env):
+        seen["spawns"].append((list(argv), dict(env)))
+        if len(seen["spawns"]) == 1:
+            seen["found"].add(str(native))
+        return 0
+
+    monkeypatch.setattr(_launch_system(), "spawn", install_then_land)
+
+    assert cli.main(["launch", "claude"]) == 0
+    installer_env = seen["spawns"][0][1]
+    leaked = [key for key, value in installer_env.items() if "SECRET-GRID-TOKEN" in str(value)]
+    assert leaked == [], f"the installer must carry no grid credential: {leaked}"
+    # The inherited environment and nothing else. Stated as equality rather than as "no ANTHROPIC_ key"
+    # because the launcher does not own that namespace: a developer running this suite from inside a
+    # `grid launch claude` session already has those variables, and an absence assertion would fail on
+    # their machine for a reason that has nothing to do with the code.
+    assert installer_env == dict(os.environ), "the installer gets the inherited environment, verbatim"
+    # ... while the app that follows it does get the grid's, so this is a real separation and not an
+    # assertion two empty environments would satisfy.
+    assert seen["spawns"][1][1]["ANTHROPIC_AUTH_TOKEN"] == "SECRET-GRID-TOKEN"
+
+
+def test_launch_stops_when_the_installer_fails_and_says_what_failed(monkeypatch, tmp_path):
+    """An installer that failed has left no app, so continuing would spawn nothing and report it as a
+    launch. The exit code is named because it is the only detail that separates "no network" from
+    "out of disk" from "the vendor's script rejected this platform" — the installer's own output has
+    already scrolled past by the time the user reads this line.
+    """
+    _seed_launchable_grid(monkeypatch, tmp_path)
+    _install_locations(monkeypatch, tmp_path)
+    seen = _capture_launch(monkeypatch, binary=None, interactive=True, confirm=True, install_code=7)
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["launch", "claude"])
+
+    assert "7" in str(exc.value), f"the failure must be named, not summarised: {exc.value}"
+    assert len(seen["spawns"]) == 1, "the installer ran; nothing else may have"
+
+
+def test_launch_names_claude_code_when_the_installer_cannot_even_start(monkeypatch, tmp_path):
+    """A `/bin/bash` that is missing or unexecutable — a minimal container, a locked-down image — makes
+    `spawn` raise its own error, which names `argv[0]` and nothing else.
+
+    Left alone, the *worst* failure in this function gets its least useful message: "Could not start
+    /bin/bash: No such file or directory" says nothing about Claude Code, nothing about an installer,
+    and gives no next step, while every other branch here names all three.
+    """
+    _seed_launchable_grid(monkeypatch, tmp_path)
+    _install_locations(monkeypatch, tmp_path)
+    seen = _capture_launch(monkeypatch, binary=None, interactive=True, confirm=True)
+
+    def cannot_exec(argv, env):
+        raise SystemExit(f"Could not start {argv[0]}: [Errno 2] No such file or directory")
+
+    monkeypatch.setattr(_launch_system(), "spawn", cannot_exec)
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["launch", "claude"])
+
+    message = str(exc.value)
+    assert "Claude Code" in message, f"the app must be named: {message}"
+    assert "https://claude.ai/install.sh" in message, f"and the way out given: {message}"
+    assert "/bin/bash" in message, "without losing the underlying reason"
+    assert seen["spawns"] == []
+
+
+def test_launch_says_to_open_a_new_shell_when_an_install_lands_somewhere_unsearched(monkeypatch,
+                                                                                    tmp_path):
+    """The installer reported success and still nothing resolves — a real state, not a paranoid one:
+    a package manager or a `CLAUDE_INSTALL_*` override can put the binary somewhere neither `PATH` nor
+    the two conventional locations reach.
+
+    Silence here would be the worst outcome available, because the previous line on screen says the
+    install succeeded. So it says exactly that, and names the next thing worth trying.
+    """
+    _seed_launchable_grid(monkeypatch, tmp_path)
+    _install_locations(monkeypatch, tmp_path)
+    seen = _capture_launch(monkeypatch, binary=None, interactive=True, confirm=True)
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["launch", "claude"])
+
+    message = str(exc.value)
+    assert "new shell" in message, f"the likeliest fix must be named: {message}"
+    assert len(seen["spawns"]) == 1, "the installer ran, and no app was spawned after it"
+
+
+def test_launch_never_offers_an_install_for_a_grid_that_could_not_run_the_app(monkeypatch, tmp_path):
+    """Order between the two refusals, and it only shows up on the machine that has neither.
+
+    Offering first would talk a user through downloading and installing an agent — minutes, and a
+    permanent change to their machine — and only then tell them their grid cannot run it. The grid's
+    models were already read before the target was called, so checking them first costs nothing;
+    installing first costs everything it takes to undo.
+    """
+    _seed_launchable_grid(monkeypatch, tmp_path, models=["glm-5.2"])
+    _install_locations(monkeypatch, tmp_path)
+    seen = _capture_launch(monkeypatch, binary=None, interactive=True, confirm=True)
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["launch", "claude"])
+
+    assert "claude:opus" in str(exc.value), f"the grid is what failed, so name it: {exc.value}"
+    assert seen["asked"] == [], "nobody may be offered an app their grid cannot run"
+    assert seen["spawns"] == []
+
+
+def test_launch_on_windows_prints_the_powershell_installer_instead_of_running_it(monkeypatch,
+                                                                                tmp_path):
+    """The vendor's shell installer refuses Windows itself — its own `MINGW*|MSYS*|CYGWIN*` branch says
+    "Windows is not supported by this script" — and Windows has a separate PowerShell one.
+
+    Running that is deliberately not built: it would be a second remote-script-execution path that only
+    the `test-windows` job could ever exercise end to end. Windows therefore takes the same
+    print-and-exit branch a machine with no terminal takes, so it costs no code of its own — but the
+    line it prints has to be the *PowerShell* one, or the instruction is worse than useless. The prompt
+    must not appear even though a terminal is attached: there is nothing behind a yes.
+    """
+    _seed_launchable_grid(monkeypatch, tmp_path)
+    _install_locations(monkeypatch, tmp_path)
+    seen = _capture_launch(monkeypatch, binary=None, interactive=True, confirm=True)
+
+    from shared.launch import claude_install
+
+    monkeypatch.setattr(claude_install.platform, "system", lambda: "Windows")
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["launch", "claude"])
+
+    message = str(exc.value)
+    assert "irm https://claude.ai/install.ps1 | iex" in message, (
+        f"a Windows user needs the Windows command: {message}"
+    )
+    assert "install.sh" not in message, "the bash installer refuses Windows; naming it would misdirect"
+    assert seen["asked"] == [], "no point asking a question whose yes we cannot honour"
+    assert seen["spawns"] == []
+
+
+def test_launch_only_accepts_a_runnable_file_at_an_install_location(tmp_path):
+    """The one piece of the OS seam with logic of its own, so the one piece worth exercising directly:
+    every launch test above substitutes `executable_at`, which would leave this unproven entirely.
+
+    All three negatives are shapes a real home produces. `~/.claude/local` **is** a directory, so a
+    `claude` inside it being a directory too is a plausible accident rather than a contrived one; a
+    non-executable file is what a half-finished download leaves; and a dangling symlink is what an
+    uninstall leaves when the launcher outlives the version it pointed into. Each must read as "not
+    here" and let the next candidate be tried — never as a hit that `spawn` then fails on, and never as
+    an exception that ends a launch which had somewhere else to look.
+    """
+    system = _launch_system()
+
+    runnable = tmp_path / "claude"
+    runnable.write_text("#!/bin/sh\n")
+    runnable.chmod(0o755)
+    assert system.executable_at(runnable) == (str(runnable), None)
+
+    not_executable = tmp_path / "not-executable"
+    not_executable.write_text("#!/bin/sh\n")
+    not_executable.chmod(0o644)
+    assert system.executable_at(not_executable) == (None, None)
+
+    directory = tmp_path / "a-directory"
+    directory.mkdir()
+    directory.chmod(0o755)
+    assert system.executable_at(directory) == (None, None), "+x on a directory means traverse"
+
+    dangling = tmp_path / "dangling"
+    dangling.symlink_to(tmp_path / "gone")
+    assert system.executable_at(dangling) == (None, None)
+
+    assert system.executable_at(tmp_path / "never-existed") == (None, None)
+
+    # ... and the one shape that is NOT "not here": an obstacle. Reported, so a caller can say the
+    # search was incomplete instead of concluding the app is missing.
+    blocked = tmp_path / "blocked"
+    blocked.mkdir()
+    (blocked / "claude").write_text("#!/bin/sh\n")
+    blocked.chmod(0o000)
+    try:
+        found, reason = system.executable_at(blocked / "claude")
+    finally:
+        blocked.chmod(0o755)
+    assert found is None and reason == "Permission denied", (found, reason)
+
+
+def test_launch_says_which_install_location_it_could_not_check(monkeypatch, tmp_path, capsys):
+    """"Couldn't look" is a different fact from "nothing there", and only one of them is "isn't
+    installed".
+
+    `Path.is_file()` hides ENOENT/ENOTDIR/ELOOP internally but **not** EACCES, so a `~/.local/bin`
+    whose traverse bit is stripped raises `PermissionError` here. Folding that into "not found" tells a
+    user who *has* Claude Code that they do not, and then offers to install it — an install that will
+    hit the same wall and fail with a vendor error about a path we never mentioned.
+
+    The search still continues to the next candidate, which is why this cannot simply raise: one
+    unreadable location must not cost the user a binary sitting in the other one.
+    """
+    real_executable_at = _launch_system().executable_at  # before the stub replaces it
+    _seed_launchable_grid(monkeypatch, tmp_path)
+    native, legacy = _install_locations(monkeypatch, tmp_path)
+    for path in (native, legacy):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("#!/bin/sh\n")
+        path.chmod(0o755)
+    native.parent.chmod(0o000)  # the app is really there; we just cannot traverse to it
+    try:
+        seen = _capture_launch(monkeypatch, binary=None)
+        monkeypatch.setattr(_launch_system(), "executable_at", real_executable_at)
+
+        assert cli.main(["launch", "claude"]) == 0, "the other location still answers"
+    finally:
+        native.parent.chmod(0o755)
+
+    assert seen["spawns"], "an unreadable location must not stop a launch that had another candidate"
+    warning = capsys.readouterr().err
+    assert str(native) in warning and "Permission denied" in warning, (
+        f"the location we could not check must be named, with why: {warning}"
+    )
+
+
+def test_launch_does_not_claim_to_have_checked_locations_it_never_resolved(monkeypatch, tmp_path):
+    """A container running as a UID with no passwd entry and no `HOME` has no resolvable home, so the
+    two conventional locations cannot even be named — the same failure `claude._settings_paths` already
+    handles by reporting it.
+
+    Returning an empty list there is not merely unreported: it makes the refusal *false*. The message
+    says no `claude` turned up "in either place it installs to", when neither place was ever looked at.
+    """
+    _seed_launchable_grid(monkeypatch, tmp_path)
+    seen = _capture_launch(monkeypatch, binary=None)
+
+    def no_home(cls):
+        raise RuntimeError("Could not determine home directory")
+
+    monkeypatch.setattr(Path, "home", classmethod(no_home))
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["launch", "claude"])
+
+    message = str(exc.value)
+    assert "home directory" in message, f"the reason the locations are unknown must be said: {message}"
+    assert seen["spawns"] == []
+
+
+def test_launch_refuses_to_search_install_locations_under_a_relative_home(monkeypatch, tmp_path):
+    """`Path.home()` returns whatever `HOME` says, and `HOME=.` makes it **relative** — verified, not
+    theorised. The two candidates would then resolve against the current directory, so a repository
+    that ships `.local/bin/claude` and any wrapper that scopes `HOME` to a relative value (a `.envrc`,
+    a Makefile target, a naive devcontainer sandbox) would get its own binary executed — with the
+    grid's `ANTHROPIC_AUTH_TOKEN` in its environment.
+
+    A relative home is never a real home, so it is refused rather than searched, and reported rather
+    than silently narrowed.
+    """
+    _seed_launchable_grid(monkeypatch, tmp_path)
+    planted = Path.cwd() / ".local" / "bin" / "claude"
+    planted.parent.mkdir(parents=True, exist_ok=True)
+    planted.write_text("#!/bin/sh\n")
+    planted.chmod(0o755)
+    real_executable_at = _launch_system().executable_at  # captured before the stub replaces it
+    seen = _capture_launch(monkeypatch, binary=None)
+    monkeypatch.setattr(_launch_system(), "executable_at", real_executable_at)
+    monkeypatch.setenv("HOME", ".")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: Path(".")))
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["launch", "claude"])
+
+    assert seen["spawns"] == [], "a binary found under a relative home must never be executed"
+    assert "home directory" in str(exc.value)
+
+
+def test_launch_pins_no_claude_code_version_and_no_checksum():
+    """ADR 0028 rejected the shape `shared/agent/codex_installer` uses — a pinned, SHA-256-verified
+    binary under the Grid home — for Claude Code specifically.
+
+    It fits Codex because Codex is a static release asset. Claude Code manages its own versions, so a
+    pin here would make this repo the owner of a number it does not control, and would quietly ship a
+    stale agent to everyone who installed through `grid launch`. The vendor's own installer already
+    verifies what it downloads; that ownership stays with the vendor.
+
+    Asserted structurally rather than by review, because the tempting way to write this feature is
+    exactly the rejected one, and it is a whole file's worth of code before anyone notices.
+    """
+    import re
+
+    for path in _repo_root().joinpath("shared/launch").glob("*.py"):
+        source = path.read_text(encoding="utf-8")
+        assert not re.search(r"[\"'][0-9a-f]{64}[\"']", source), f"a SHA-256 pin in {path}"
+        assert not re.search(r"[\"']v?\d+\.\d+\.\d+[\"']", source), f"a pinned version in {path}"
+
+
+def test_launch_left_the_providers_own_tty_helpers_alone():
+    """The install prompt needed an interactive-check and a confirm, and `cli/provider.py` already had
+    a private pair. Consolidating them is explicitly out of scope for this feature: `shared/launch`
+    cannot import `cli`, so it would mean moving the provider's pair into `shared/` and re-pointing its
+    callers — a change to the join path, made in a slice about launching an app.
+
+    So the duplication is deliberate, recorded in a comment beside the new pair, and pinned here: the
+    provider keeps its own, and this test fails if a later tidy-up quietly takes them away.
+    """
+    root = _repo_root()
+    provider = root.joinpath("cli/provider.py").read_text(encoding="utf-8")
+    assert "def _interactive()" in provider and "def _confirm(" in provider
+    launch_system = root.joinpath("shared/launch/system.py").read_text(encoding="utf-8")
+    assert "cli/provider.py" in launch_system, "the duplication must be flagged where it is duplicated"
 
 
 def test_launch_claude_prints_one_line_naming_the_grid_and_model_before_spawning(monkeypatch, tmp_path, capsys):

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -7,6 +7,7 @@ import datetime
 import errno
 import json
 import os
+import shlex
 import shutil
 import socket
 import stat
@@ -22839,9 +22840,15 @@ def test_launch_adding_a_second_target_needs_no_change_to_the_claude_target(monk
         name = "fake"
         label = "Fake App"
 
-        def run(self, session):
-            ran["session"] = session
+        def run(self, session, argv=()):
+            ran["session"], ran["argv"] = session, tuple(argv)
             return 7
+
+        def print_env(self, session):
+            # A file-configuring target is the reason this member is the target's and not the CLI's;
+            # this one simply proves the command routes to it and returns its answer unmodified.
+            ran["printed_for"] = session
+            return 4
 
     monkeypatch.setattr(registry, "TARGETS", {**registry.TARGETS, "fake": _FakeTarget()})
     _seed_launchable_grid(monkeypatch, tmp_path)
@@ -22856,6 +22863,12 @@ def test_launch_adding_a_second_target_needs_no_change_to_the_claude_target(monk
     assert ran["session"].access_token == "AT"
     assert ran["session"].label == "team"
     assert "argv" not in seen, "the Claude target must not be involved in another target's launch"
+
+    # Both protocol members reach the new target, with no Claude-shaped code in between.
+    assert cli.main(["launch", "fake", "--", "-x"]) == 7
+    assert ran["argv"] == ("-x",)
+    assert cli.main(["launch", "fake", "--print-env"]) == 4
+    assert ran["printed_for"].label == "team"
 
 
 def test_launch_unknown_target_names_it_and_lists_the_available_ones(monkeypatch, tmp_path):
@@ -23500,3 +23513,366 @@ def test_launch_gives_up_on_a_second_ctrl_c(monkeypatch, tmp_path, capsys):
     assert cli.main(["launch", "claude"]) == 130
     assert "kill" not in child.events  # still ours to wait for, not to kill
     capsys.readouterr()
+
+
+# ---------------------------------------------------------------------------
+# `grid launch` passthrough and `--print-env` — issue 05, ADR 0028
+# ---------------------------------------------------------------------------
+
+def test_launch_forwards_everything_after_the_separator_to_the_child(monkeypatch, tmp_path):
+    """Without this the launcher is a ceiling on the app: `--continue`, `-p`, every permission mode —
+    unreachable, and a user who needs one goes back to exporting by hand, which is the problem this
+    feature exists to remove.
+
+    Order and spelling are both asserted: the app parses these itself, so a reordered or rewritten
+    vector is a different command from the one the user typed.
+    """
+    _seed_launchable_grid(monkeypatch, tmp_path)
+    seen = _capture_launch(monkeypatch)
+
+    assert cli.main(["launch", "claude", "--", "--continue", "-p", "tell me"]) == 0
+    assert seen["argv"] == ["/usr/local/bin/claude", "--continue", "-p", "tell me"]
+
+
+def test_launch_cannot_forward_the_mode_override_and_says_so_where_a_user_looks(monkeypatch,
+                                                                                tmp_path, capsys):
+    """The one sharp edge in the passthrough, asserted as behaviour *and* as documentation.
+
+    `cli.dispatch.resolve_override` strips `--local`/`--remote` from **anywhere** in argv, separator
+    included, so those two exact words can never reach the app (ADR 0028). That is accepted — but a
+    limitation a user can only find by watching their flag vanish is a bug report waiting to happen,
+    so `grid launch --help` has to say it.
+    """
+    _seed_launchable_grid(monkeypatch, tmp_path)
+    seen = _capture_launch(monkeypatch)
+
+    assert cli.main(["launch", "claude", "--", "--remote"]) == 0
+    assert seen["argv"] == ["/usr/local/bin/claude"], "the override is stripped before the split"
+
+    with pytest.raises(SystemExit):
+        cli.build_parser().parse_args(["launch", "--help"])
+    helptext = capsys.readouterr().out
+    assert "--local" in helptext and "--remote" in helptext, helptext
+    # The separator itself must be documented too, or the escape hatch is undiscoverable.
+    assert "--" in helptext and "claude" in helptext
+    # ...and the *consequence*, not just the fact. `--local` does not merely fail to arrive: it is
+    # taken as this CLI's own mode override, and the command then refuses as a *remote-mode command*
+    # — a message about modes, for a flag the user was aiming at the app. Documenting only "cannot be
+    # forwarded" would leave that failure to be met through a message that points somewhere else.
+    assert "--local" in helptext and "refuse" in helptext.lower(), helptext
+
+
+def test_launch_forwarding_the_mode_override_fails_the_way_the_help_says(monkeypatch, tmp_path):
+    """The `--local` direction of the sharp edge, which is the one that actually misleads.
+
+    `-- --remote` is a harmless no-op on a remote-only command. `-- --local` flips this invocation's
+    mode, so the user is told `grid launch` is a remote-mode command — about a flag they were aiming
+    at Claude Code. The behaviour is accepted (ADR 0028); this pins it so it stays the documented one
+    rather than drifting into some other confusing shape.
+    """
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    state.set_mode("remote")
+    _capture_launch(monkeypatch)
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["launch", "claude", "--", "--local"])
+    assert "remote-mode command" in str(exc.value), str(exc.value)
+
+
+def test_launch_does_not_read_a_forwarded_word_as_its_grid_argument(monkeypatch, tmp_path):
+    """The mis-parse that decided the implementation, pinned.
+
+    `launch` has two optional positionals, so leaving the separator to argparse binds the first
+    forwarded word to *grid*: `launch claude -- lab` would silently launch against the wrong grid,
+    and `-- -p hi` would set `grid="-p"`. Verified against argparse, which is why the split happens
+    before the parser ever sees argv.
+    """
+    _seed_remote(monkeypatch, tmp_path, networks=[
+        {"network_id": "n1", "name": "team", "access_token": "AT-TEAM"},
+        {"network_id": "n2", "name": "lab", "access_token": "AT-LAB"}], active="team")
+    _mock_lifecycle(monkeypatch, status={"state": "running", "signaling_url": "https://relay.example"})
+    _mock_tier_overview(monkeypatch)
+    _isolate_claude_settings(monkeypatch, tmp_path)
+    seen = _capture_launch(monkeypatch)
+
+    assert cli.main(["launch", "claude", "--", "lab"]) == 0
+    assert seen["env"]["ANTHROPIC_AUTH_TOKEN"] == "AT-TEAM", "the active grid, not the forwarded word"
+    assert seen["argv"] == ["/usr/local/bin/claude", "lab"]
+
+
+def test_launch_does_not_act_on_its_own_flag_after_the_separator(monkeypatch, tmp_path, capsys):
+    """Past the separator the launcher stops reading: its own flags become the app's arguments.
+
+    `--print-env` is the sharpest case — the launcher's most behaviour-changing flag has to arrive at
+    the app as a plain argument, or `--` is not really a passthrough.
+    """
+    _seed_launchable_grid(monkeypatch, tmp_path)
+    seen = _capture_launch(monkeypatch)
+
+    assert cli.main(["launch", "claude", "--", "--print-env"]) == 0
+    assert seen["argv"] == ["/usr/local/bin/claude", "--print-env"]
+    assert "export " not in capsys.readouterr().out, "the flag was forwarded, not obeyed"
+
+
+def test_launch_with_an_empty_separator_is_identical_to_no_separator(monkeypatch, tmp_path):
+    """`grid launch claude --` with nothing after it must not become a different command — an empty
+    passthrough is no passthrough, not an empty string argument the app would have to parse."""
+    _seed_launchable_grid(monkeypatch, tmp_path)
+    seen = _capture_launch(monkeypatch)
+
+    assert cli.main(["launch", "claude", "--"]) == 0
+    with_separator = seen["argv"]
+
+    assert cli.main(["launch", "claude"]) == 0
+    assert with_separator == seen["argv"] == ["/usr/local/bin/claude"]
+
+
+def test_launch_forwards_a_second_separator_verbatim(monkeypatch, tmp_path):
+    """Only the first `--` is the launcher's. A later one is one of the app's own arguments — apps
+    have their own separators, and swallowing it would change the command the app receives."""
+    _seed_launchable_grid(monkeypatch, tmp_path)
+    seen = _capture_launch(monkeypatch)
+
+    assert cli.main(["launch", "claude", "--", "-p", "--", "hi"]) == 0
+    assert seen["argv"] == ["/usr/local/bin/claude", "-p", "--", "hi"]
+
+
+def test_launch_forwarding_to_no_target_at_all_is_refused(monkeypatch, tmp_path, capsys):
+    """`grid launch -- --continue` names no app, so there is nothing for the arguments to reach.
+
+    Bare `grid launch` is the discovery listing and exits 0, which is exactly what makes this a trap:
+    without the check the user gets a helpful-looking list, a zero exit code, and no hint that the
+    arguments they typed went nowhere.
+    """
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    state.set_mode("remote")
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["launch", "--", "--continue"])
+
+    message = str(exc.value)
+    assert "--continue" in message or "--" in message, message
+    assert "claude" in message, f"the way to fix it must be named: {message}"
+    assert "Launch targets:" not in capsys.readouterr().out, "not the discovery listing"
+
+
+def test_launch_passthrough_leaves_every_other_commands_separator_alone():
+    """The split is scoped to one command, and that scoping is the regression risk of this slice.
+
+    Every other command has always let argparse handle `--` itself, so a global split would silently
+    change what `grid chat -- hello` means. Asserted on the splitter directly: this is a property of
+    argv handling, and there is no command whose observable behaviour would show it more honestly.
+    """
+    assert dispatch.split_forwarded(["chat", "--", "hello"]) == (["chat", "--", "hello"], ())
+    assert dispatch.split_forwarded(["launch", "claude"]) == (["launch", "claude"], ())
+    assert dispatch.split_forwarded(["launch", "claude", "--", "-p"]) == (
+        ["launch", "claude"], ("-p",)
+    )
+    # A global flag may precede the subcommand, so the command word is the first non-option token.
+    assert dispatch.split_forwarded(["--json", "launch", "c", "--", "-p"]) == (
+        ["--json", "launch", "c"], ("-p",)
+    )
+
+
+def _printed_exports(text: str) -> dict[str, str]:
+    """The `export K=V` block, read back the way a shell would read it.
+
+    `shlex.split` in POSIX mode *is* the quoting contract under test: it applies the same quote and
+    escape rules a shell does, so a value this cannot recover is one a shell could not either.
+    """
+    out = {}
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        word, verb = shlex.split(line), line.split(" ", 1)[0]
+        assert verb == "export", f"the block must be evaluable as-is, not {line!r}"
+        assert len(word) == 2, f"one shell word per export, not {word!r}"
+        key, _, value = word[1].partition("=")
+        out[key] = value
+    return out
+
+
+def test_launch_print_env_prints_the_exports_and_never_spawns(monkeypatch, tmp_path, capsys):
+    """The supported version of the hand-rolled recipe: for a user who wants to manage their own
+    shell, and for anyone debugging what a launch would have injected.
+
+    "Does not spawn" is the whole contract, so the binary is never even looked for — resolving it
+    could offer to run the vendor's installer, and an installer is a spawn.
+    """
+    _seed_launchable_grid(monkeypatch, tmp_path)
+    seen = _capture_launch(monkeypatch)
+
+    assert cli.main(["launch", "claude", "--print-env"]) == 0
+
+    exports = _printed_exports(capsys.readouterr().out)
+    assert exports["ANTHROPIC_BASE_URL"] == "https://relay.example/relay"
+    assert exports["ANTHROPIC_AUTH_TOKEN"] == "AT"
+    assert "argv" not in seen, "nothing may be started"
+    assert seen["looked_for"] == [], "the app is not resolved, so no install can be offered"
+    assert seen["asked"] == []
+
+
+def test_launch_print_env_with_forwarded_arguments_is_refused(monkeypatch, tmp_path, capsys):
+    """The two escape hatches contradict each other: nothing is started, so arguments meant for the
+    app have nowhere to go.
+
+    Refused rather than ignored. Printing a block that silently drops what the user typed is the
+    failure they would find only by wondering why their flag did nothing — and a zero exit code would
+    tell a script it had worked.
+    """
+    _seed_launchable_grid(monkeypatch, tmp_path)
+    seen = _capture_launch(monkeypatch)
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["launch", "claude", "--print-env", "--", "--continue"])
+
+    message = str(exc.value)
+    assert "--print-env" in message and "--" in message, message
+    assert capsys.readouterr().out == "", "refused before anything was printed"
+    assert "argv" not in seen
+
+
+def test_launch_print_env_without_a_target_says_which_target(monkeypatch, tmp_path, capsys):
+    """Bare `grid launch` lists what can be launched, but there is no environment to print without
+    naming an app — so this is a clean instruction, not the discovery listing and not a traceback."""
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    state.set_mode("remote")  # deliberately signed out: this is a command-line error, not an auth one
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["launch", "--print-env"])
+
+    message = str(exc.value)
+    assert "--print-env" in message and "claude" in message, message
+    assert capsys.readouterr().out == "", "not the discovery listing"
+
+
+def test_launch_print_env_quotes_a_value_that_needs_no_quoting(monkeypatch, tmp_path, capsys):
+    """Every value is quoted, including the ones a shell would have accepted bare.
+
+    `shlex.quote` was rejected for exactly this: it leaves a safe value unquoted, so the block would
+    be quoted inconsistently — a reader copying one line out of it would have to judge which values
+    needed it, and a token that becomes shell-special after a rotation would silently change what a
+    working recipe means.
+    """
+    _seed_launchable_grid(monkeypatch, tmp_path, access_token="AT")
+    _capture_launch(monkeypatch)
+
+    assert cli.main(["launch", "claude", "--print-env"]) == 0
+
+    lines = capsys.readouterr().out.splitlines()
+    assert "export ANTHROPIC_AUTH_TOKEN='AT'" in lines, lines
+    assert all(line.split("=", 1)[1].startswith("'") for line in lines if line), lines
+
+
+@pytest.mark.skipif(shutil.which("sh") is None, reason="POSIX shell required")
+def test_launch_print_env_block_survives_a_shell_hostile_token(monkeypatch, tmp_path, capsys):
+    """"Shell-evaluable as-is" is proved by a real shell, not by our own idea of quoting.
+
+    A grid token is an opaque credential this repo does not mint, so it is never safe to assume which
+    characters it can contain — and the same block is what a script author is invited to `eval`. The
+    substitution below would run a command and the quote would end the word early, so a block that
+    survives this one survives anything a value can contain.
+    """
+    hostile = "it's $(echo pwned) `echo pwned` \"q\" \\ ;|&"
+    _seed_launchable_grid(monkeypatch, tmp_path, access_token=hostile)
+    _capture_launch(monkeypatch)
+
+    assert cli.main(["launch", "claude", "--print-env"]) == 0
+    block = capsys.readouterr().out
+
+    # `eval` rather than a sourced file: it is what a user pastes, and what `$(grid launch … )` does.
+    proof = subprocess.run(
+        ["sh", "-c", 'eval "$1"; printf %s "$ANTHROPIC_AUTH_TOKEN"', "sh", block],
+        capture_output=True, text=True, timeout=30,
+    )
+    assert proof.returncode == 0, proof.stderr
+    # Equality is the whole proof, and it is two proofs at once: the value round-tripped intact, and
+    # nothing expanded — an expanded block would have yielded `it's pwned pwned …`, not this.
+    assert proof.stdout == hostile, f"the shell recovered {proof.stdout!r}, not the token"
+    assert proof.stderr == "", proof.stderr
+
+
+def test_launch_print_env_prints_exactly_what_a_launch_would_inject(monkeypatch, tmp_path, capsys):
+    """The printed block and the child's environment are compared against **each other**, in one run.
+
+    `--print-env` is only worth having if it is the truth: a user debugging a launch reads it to find
+    out what the launch did. Asserting the keys against a literal list would let both paths drift
+    together into a lie, so the two are derived independently and diffed.
+    """
+    _seed_launchable_grid(monkeypatch, tmp_path)
+    for key in [k for k in os.environ if k.startswith(("ANTHROPIC_", "CLAUDE_CODE_"))]:
+        monkeypatch.delenv(key, raising=False)  # a dev's own Anthropic env must not mask the diff
+    seen = _capture_launch(monkeypatch)
+
+    assert cli.main(["launch", "claude", "--print-env"]) == 0
+    printed = _printed_exports(capsys.readouterr().out)
+
+    assert cli.main(["launch", "claude"]) == 0
+    injected = {k: v for k, v in seen["env"].items() if os.environ.get(k) != v}
+
+    assert printed == injected, "the printed block is not what the launch hands the app"
+
+
+def test_launch_print_env_runs_preflight_and_refuses_what_a_launch_refuses(monkeypatch, tmp_path,
+                                                                           capsys):
+    """Printing exports for a grid that cannot serve them would reproduce exactly the trap preflight
+    exists to close — the user evaluates the block, starts the app themselves, and meets a model
+    error that names nothing about their grid."""
+    _seed_launchable_grid(monkeypatch, tmp_path, models=["claude:haiku", "glm-5.2"])
+    _capture_launch(monkeypatch)
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["launch", "claude", "--print-env"])
+
+    message = str(exc.value)
+    assert "claude:opus" in message and "glm-5.2" in message, message
+    assert capsys.readouterr().out == "", "refused before a single export was printed"
+
+
+def test_launch_print_env_without_a_stored_token_gives_the_login_guidance(monkeypatch, tmp_path,
+                                                                         capsys):
+    """No token locally is the familiar failure here too, and — the point of this test — it must land
+    *before* anything is printed. A block with an empty token reads as valid and fails inside the app.
+    """
+    _seed_running_remote_grid(monkeypatch, tmp_path, access_token=None)
+    _capture_launch(monkeypatch)
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["launch", "claude", "--print-env"])
+    assert str(exc.value) == (
+        "Grid team has no access token locally. Run `grid login` to refresh your grids."
+    )
+    assert capsys.readouterr().out == ""
+
+
+def test_launch_print_env_keeps_its_warnings_off_the_evaluable_block(monkeypatch, tmp_path, capsys):
+    """Claude Code's settings outrank a shell export just as they outrank a launch, so the warning
+    still fires — but on stderr, or `eval "$(grid launch claude --print-env)"` would evaluate it."""
+    config, _project = _seed_launchable_grid(monkeypatch, tmp_path)
+    config.mkdir(parents=True, exist_ok=True)
+    (config / "settings.json").write_text(
+        json.dumps({"env": {"ANTHROPIC_BASE_URL": "https://api.anthropic.com"}}), encoding="utf-8"
+    )
+    _capture_launch(monkeypatch)
+
+    assert cli.main(["launch", "claude", "--print-env"]) == 0
+
+    captured = capsys.readouterr()
+    assert "ANTHROPIC_BASE_URL" in captured.err and "settings" in captured.err
+    # Every stdout line is still an export and nothing else — the block stays evaluable as-is.
+    assert set(_printed_exports(captured.out)) >= {"ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN"}
+
+
+def test_launch_print_env_records_why_it_is_allowed_to_print_a_token():
+    """The second deliberate hole in "no command prints a token" (ADR 0003 §6).
+
+    A carve-out whose reasoning is not written next to it is a hole nobody can audit — the next
+    reader cannot tell a considered exception from an oversight, and the third one gets added by
+    analogy. So the justification is required at the site, exactly as `info --env` carries it.
+    """
+    from shared.launch import claude as claude_target
+
+    source = Path(claude_target.__file__).read_text(encoding="utf-8")
+    body = source.split("def print_env", 1)[1].split("\n    def ", 1)[0]
+    assert "0003" in body, "the token-printing site must name the ADR it is an exception to"
+    assert "info --env" in body, "...and the carve-out it shares its justification with"

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -8866,6 +8866,14 @@ def _jwt(claims: dict) -> str:
     return f"header.{body}.sig"
 
 
+def _jwt_payload(raw: str) -> str:
+    """A JWT-shaped token whose payload segment carries ``raw`` verbatim — the sibling of ``_jwt`` for
+    the payloads a real ``json.dumps`` cannot produce: valid JSON that isn't an object, and bytes that
+    aren't JSON at all. Both are shapes a decoder has to survive rather than assume away."""
+    body = base64.urlsafe_b64encode(raw.encode()).decode().rstrip("=")
+    return f"header.{body}.sig"
+
+
 def _capture_relay_puts(monkeypatch, *, status=200):
     """Install a relay double that records every PUT as ``(path, role, models)`` and answers
     ``status``. Returns the growing list, so a test can assert exactly which deregister(s) the leave
@@ -11124,6 +11132,55 @@ def test_control_plane_refresh_network_token_raises_on_error(monkeypatch, tmp_pa
     assert "401" in str(exc.value)
 
 
+def test_control_plane_failures_carry_the_status_and_stay_systemexit(monkeypatch, tmp_path):
+    """A caller has to be able to tell 401 from 403 from 503 — the launch credential gate says three
+    different things about them (ADR 0029), and only one of them mentions `grid login`.
+
+    Substring-matching the message was the alternative, and it is the exact anti-pattern this feature
+    exists to remove. So the status rides the exception, the way ``relay.RelayError.status`` already
+    does. The message and the type hierarchy are unchanged on purpose: every existing caller catches
+    ``SystemExit`` (``serve._ServeState.refresh``) or matches the rendered message
+    (``cli/auth._SESSION_EXPIRED_RE``), and neither may notice this.
+    """
+    from cli.auth import _SESSION_EXPIRED_RE
+    from remote import control_plane
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    # One mock, re-aimed per iteration: `_mock_control_plane` patches the *module* attribute and reads
+    # the real client at call time, so a second call wraps the first and the first handler keeps
+    # answering (the trap `_mock_relay`'s import-bound `_real` default exists to close).
+    answer = {"status": 0}
+    _mock_control_plane(monkeypatch, lambda r: httpx.Response(answer["status"], text="nope"))
+    for status in (401, 403, 503):
+        answer["status"] = status
+        with pytest.raises(control_plane.ControlPlaneError) as exc:
+            control_plane.refresh_network_token(network_id="n1", refresh_token="RT1")
+        assert exc.value.status == status
+        assert isinstance(exc.value, SystemExit), "every existing caller catches SystemExit"
+        # Asserted against the real downstream consumer rather than a copy of its pattern: `grid sync`
+        # classifies an expired session by matching this rendering, so the message is a contract.
+        # 503 must still NOT match — that is the misclassification its anchoring exists to prevent.
+        assert bool(_SESSION_EXPIRED_RE.match(str(exc.value))) is (status in (401, 403)), str(exc.value)
+
+
+def test_control_plane_transport_failure_carries_no_status(monkeypatch, tmp_path):
+    """A request that never got an answer has no status to report, and ``None`` is the honest value —
+    the caller distinguishes "the control plane said no" from "the control plane said nothing", which
+    ADR 0029 keys a refuse-vs-warn decision on."""
+    from remote import control_plane
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+
+    def boom(request):
+        raise httpx.ConnectError("connection refused")
+
+    _mock_control_plane(monkeypatch, boom)
+    with pytest.raises(control_plane.ControlPlaneError) as exc:
+        control_plane.refresh_network_token(network_id="n1", refresh_token="RT1")
+    assert exc.value.status is None
+    assert "control plane" in str(exc.value).lower()
+
+
 # ---------------------------------------------------------------------------
 # Remote relay client (remote/relay.py)
 # ---------------------------------------------------------------------------
@@ -11178,6 +11235,66 @@ def test_relay_register_node_raises_typed_errors(monkeypatch, tmp_path):
     _mock_relay(monkeypatch, lambda r: httpx.Response(500, text="boom"))
     with pytest.raises(relay.RelayError):
         relay.register_node("https://r", "AT", "n", models=["m"])
+
+
+def test_relay_check_credential_asks_the_authenticated_models_route(monkeypatch, tmp_path):
+    """The probe behind `grid launch`'s credential gate (issue 07, ADR 0029).
+
+    The route is load-bearing, not incidental: ``GET /relay/v1/models`` requires ``inference:models``,
+    and the control plane only ever grants the inference scopes as one bundle — so a token passes this
+    exactly when it holds the ``inference:create`` that ``/messages`` needs. Probing anything cheaper
+    would prove less than the app needs; probing ``/messages`` itself would create a billable job.
+    """
+    from remote import relay
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    seen = {}
+
+    def handler(request):
+        seen["method"], seen["path"] = request.method, request.url.path
+        seen["auth"] = request.headers.get("authorization")
+        return httpx.Response(200, json={"object": "list", "data": []})
+
+    _mock_relay(monkeypatch, handler)
+    assert relay.check_credential("https://relay.example", "AT") is None
+    assert (seen["method"], seen["path"]) == ("GET", "/relay/v1/models")
+    assert seen["auth"] == "Bearer AT"
+
+
+def test_relay_check_credential_raises_typed_errors_carrying_the_status(monkeypatch, tmp_path):
+    """The caller branches on *which* rejection this was — 401 is repairable by a refresh, 403 is not,
+    and 429/5xx/transport are not verdicts about the credential at all (ADR 0029's fail-open rule). So
+    unlike the one-shot pricing calls in this module, a failure here is typed rather than a
+    ``SystemExit``: only the caller knows which of those three answers to give a user."""
+    from remote import relay
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    _mock_relay(monkeypatch, lambda r: httpx.Response(401, text="Invalid Grid token"))
+    with pytest.raises(relay.RelayUnauthorized):
+        relay.check_credential("https://relay.example", "AT")
+
+    for status in (403, 429, 500):
+        _mock_relay(monkeypatch, lambda r, s=status: httpx.Response(s, text="detail here"))
+        with pytest.raises(relay.RelayError) as exc:
+            relay.check_credential("https://relay.example", "AT")
+        assert exc.value.status == status, status
+        assert "detail here" in str(exc.value), "the relay's own reason reaches the caller"
+
+
+def test_relay_check_credential_reports_a_transport_failure_without_a_status(monkeypatch, tmp_path):
+    """A probe that never got an answer must be distinguishable from one that was refused: the first
+    warns and launches anyway, the second refuses. ``status is None`` is what carries that."""
+    from remote import relay
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+
+    def boom(request):
+        raise httpx.ConnectError("connection refused")
+
+    _mock_relay(monkeypatch, boom)
+    with pytest.raises(relay.RelayError) as exc:
+        relay.check_credential("https://relay.example", "AT")
+    assert exc.value.status is None
 
 
 def test_relay_poll_maps_status_to_job_none_or_signal(monkeypatch, tmp_path):
@@ -12436,6 +12553,58 @@ def test_serve_node_id_comes_from_access_token_jwt():
     assert credentials.node_id_from_token(_jwt({"node_id": "node-abc", "sub": "u1"})) == "node-abc"
     assert credentials.node_id_from_token(_jwt({"sub": "u1"})) == ""   # JWT without a node_id claim
     assert credentials.node_id_from_token("opaque-not-a-jwt") == ""    # not a JWT at all
+
+
+# ---------------------------------------------------------------------------
+# The unverified claim decoder behind `node_id_from_token` and the launch
+# credential gate — issue 07, ADR 0029. (The gate's own tests live in the
+# `grid launch` credential section at the end of this file.)
+# ---------------------------------------------------------------------------
+
+def test_claims_from_token_is_total_and_never_raises():
+    """Every caller decides its own behaviour from these claims, so the decoder must have no failure
+    mode of its own: anything unusable is an empty mapping, never an exception.
+
+    The guards are the ones ``codex_auth._payload`` documents, and the four-segment case is the one a
+    naive ``split(".")[1]`` passes **silently** — segment 1 of a four-segment string decodes perfectly
+    well, so without a count check a token of the wrong shape yields real-looking claims.
+    """
+    from remote import credentials
+
+    assert credentials.claims_from_token(_jwt({"sub": "u1"})) == {"sub": "u1"}
+    assert credentials.claims_from_token(None) == {}                    # a half-written store is str|None
+    assert credentials.claims_from_token("opaque-not-a-jwt") == {}
+    assert credentials.claims_from_token(f"{_jwt({'sub': 'u1'})}.extra") == {}, "4 segments is not a JWT"
+    assert credentials.claims_from_token("header..sig") == {}           # empty payload segment
+    assert credentials.claims_from_token(_jwt_payload("[1, 2]")) == {}, "valid JSON, but not an object"
+    assert credentials.claims_from_token(_jwt_payload("not json at all")) == {}
+
+
+def test_token_expiry_reports_exp_verbatim_and_never_reads_the_clock():
+    """Whether a token is expired is the *caller's* decision — this only reports what the token says.
+
+    The split matters for the same reason ``codex_auth.decode_seat`` records: the refresh path has to
+    read claims back OUT of an already-expired token, so a decoder that rejected expired tokens would
+    brick precisely the case the refresh exists for.
+    """
+    from remote import credentials
+
+    past, future = 1_000_000_000, 2_000_000_000
+    assert credentials.token_expiry(_jwt({"exp": future})) == future
+    assert credentials.token_expiry(_jwt({"exp": past})) == past, "an expired token still decodes"
+    assert credentials.token_expiry(_jwt({"sub": "u1"})) is None, "no exp claim"
+    assert credentials.token_expiry("opaque-not-a-jwt") is None
+
+
+def test_token_expiry_refuses_a_boolean_exp():
+    """`isinstance(True, int)` is True in Python, so an unguarded check turns `exp: true` into
+    expires_at=1 — epoch 1970 — and the caller refreshes eagerly, forever. The same trap
+    `codex_auth.decode_seat` already guards."""
+    from remote import credentials
+
+    assert credentials.token_expiry(_jwt({"exp": True})) is None
+    assert credentials.token_expiry(_jwt({"exp": "soon"})) is None
+    assert credentials.token_expiry(_jwt({"exp": None})) is None
 
 
 def test_stamp_own_pid_overwrites_a_stale_spawner_value(monkeypatch, tmp_path):
@@ -22705,8 +22874,16 @@ def test_launch_claude_spawns_the_binary_and_returns_the_childs_exit_code(monkey
 
 
 def _grid_home_tree(root):
-    """Every path under a temp GRID_HOME — a snapshot to prove a launch writes nothing."""
-    return sorted(str(path.relative_to(root)) for path in root.rglob("*"))
+    """Every path under a temp GRID_HOME **and its bytes** — a snapshot to prove a launch writes nothing.
+
+    Contents, not just names: since issue 07 a launch may rewrite `credentials.toml` in place to store
+    a refreshed token (ADR 0029), and a paths-only snapshot cannot see that — it would go on claiming
+    "nothing was written" through the one write this command is now capable of.
+    """
+    return sorted(
+        (str(path.relative_to(root)), path.read_bytes() if path.is_file() else None)
+        for path in root.rglob("*")
+    )
 
 
 def test_launch_claude_hands_the_child_exactly_the_ten_documented_keys(monkeypatch, tmp_path):
@@ -23941,3 +24118,481 @@ def test_launch_print_env_records_why_it_is_allowed_to_print_a_token():
     body = source.split("def print_env", 1)[1].split("\n    def ", 1)[0]
     assert "0003" in body, "the token-printing site must name the ADR it is an exception to"
     assert "info --env" in body, "...and the carve-out it shares its justification with"
+
+
+# ---------------------------------------------------------------------------
+# `grid launch` checks the credential before it hands it over — issue 07, ADR 0029
+# (The pure claim decoder behind layer 1 is tested beside `node_id_from_token`.)
+# ---------------------------------------------------------------------------
+
+# FastAPI's shape for the relay's own rejections, so a test asserts on what a real refusal renders.
+_PROBE_DETAIL = {
+    401: "Invalid Grid token: Signature has expired",
+    403: "Missing required scope: inference:models",
+    429: "Too many failed authentication attempts",
+    500: "internal error",
+}
+
+
+def _mock_launch_relay(monkeypatch, *, probe=200, probe_sequence=None, models=None, detail=None):
+    """Answer both relay reads a launch makes, **by path**.
+
+    The suite's `_mock_relay` is path-blind, which is exactly why every pre-issue-07 launch test kept
+    passing when the credential probe was added — it answered 200 to a request it had never heard of.
+    That is fine for tests about the models; it is useless for tests about the credential, which need
+    `/relay/v1/models` and `/relay/v1/grid/overview` to disagree.
+
+    `probe_sequence` gives one answer per probe, so a refresh-and-retry can be driven; an entry may be
+    a status or an exception to raise. Returns the record of every probe's `Authorization` header,
+    which is how "exactly one refresh happened" is asserted.
+    """
+    seen = {"probes": []}
+    remaining = list(probe_sequence) if probe_sequence is not None else None
+
+    def handler(request):
+        if request.url.path == "/relay/v1/models":
+            seen["probes"].append(request.headers.get("authorization"))
+            answer = remaining.pop(0) if remaining else probe
+            if isinstance(answer, Exception):
+                raise answer
+            if answer == 200:
+                return httpx.Response(200, json={"object": "list", "data": []})
+            body = detail if detail is not None else _PROBE_DETAIL.get(answer, "refused")
+            return httpx.Response(answer, json={"detail": body})
+        return httpx.Response(200, json={"nodes": [{
+            "name": "seat", "engine": "claude", "online": True,
+            "models": list(_LAUNCH_TIER_MODELS if models is None else models),
+        }]})
+
+    _mock_relay(monkeypatch, handler)
+    return seen
+
+
+def _mock_token_refresh(monkeypatch, *, access="AT2", refresh="RT2", error=None):
+    """Substitute the control-plane refresh exchange and record every call.
+
+    Patched at the function rather than the transport, so a test can assert **how many** exchanges ran
+    — "exactly one refresh per launch" is a contract (ADR 0029), and a second one would quietly rotate
+    the credential twice.
+    """
+    from remote import control_plane
+
+    seen = {"calls": []}
+
+    def _refresh(*, network_id, refresh_token, api_url=None):
+        seen["calls"].append({"network_id": network_id, "refresh_token": refresh_token})
+        if error is not None:
+            raise error
+        bundle = {}
+        if access is not None:
+            bundle["access_token"] = access
+        if refresh is not None:
+            bundle["refresh_token"] = refresh
+        return bundle
+
+    monkeypatch.setattr(control_plane, "refresh_network_token", _refresh)
+    return seen
+
+
+def _forbid_token_refresh(monkeypatch):
+    """Fail the test if a refresh is attempted at all — how "this path costs no round-trip" is proved."""
+    from remote import control_plane
+
+    def _never(**kwargs):
+        raise AssertionError(f"the control plane must not be called here (got {kwargs!r})")
+
+    monkeypatch.setattr(control_plane, "refresh_network_token", _never)
+
+
+def _seed_launch_with_token(monkeypatch, tmp_path, token, **relay):
+    """`_seed_launchable_grid`, but with a chosen access token and the path-aware relay above."""
+    _seed_running_remote_grid(monkeypatch, tmp_path, access_token=token)
+    seen = _mock_launch_relay(monkeypatch, **relay)
+    _isolate_claude_settings(monkeypatch, tmp_path)
+    return seen
+
+
+def _in(seconds):
+    """A POSIX `exp` that many seconds from now (negative for the past)."""
+    return int(time.time()) + seconds
+
+
+def _stored(tmp_path, field, network_id="n1"):
+    from remote import credentials
+
+    for net in credentials.load_credentials().get("networks") or []:
+        if net.get("network_id") == network_id:
+            return net.get(field)
+    return None
+
+
+_YEAR = 365 * 86400
+
+
+# --- layer 1: what the token says about itself ------------------------------
+
+def test_launch_with_a_healthy_token_makes_no_control_plane_call(monkeypatch, tmp_path):
+    """The offline check has to be free, or it is a tax on every launch to catch a once-a-year event.
+
+    Asserted by making a refresh *fail the test* rather than by counting calls, so this cannot rot into
+    passing because some other mock happened to absorb the request.
+    """
+    _seed_launch_with_token(monkeypatch, tmp_path, _jwt({"exp": _in(_YEAR)}))
+    _forbid_token_refresh(monkeypatch)
+    seen = _capture_launch(monkeypatch)
+
+    assert cli.main(["launch", "claude"]) == 0
+    assert seen["argv"] == ["/usr/local/bin/claude"]
+
+
+def test_launch_refreshes_an_expired_token_and_hands_over_the_new_one(monkeypatch, tmp_path, capsys):
+    """The whole point of the feature: the user never sees a problem.
+
+    The child must get the *refreshed* token — the stored record is a snapshot taken before the
+    exchange, so a caller that re-read it would hand over the dead one and the launch would fail inside
+    the app exactly as it does today.
+    """
+    _seed_launch_with_token(monkeypatch, tmp_path, _jwt({"exp": _in(-3 * 86400)}))
+    refreshes = _mock_token_refresh(monkeypatch)
+    seen = _capture_launch(monkeypatch)
+
+    assert cli.main(["launch", "claude"]) == 0
+    assert seen["env"]["ANTHROPIC_AUTH_TOKEN"] == "AT2"
+    assert seen["env"]["ANTHROPIC_API_KEY"] == "AT2"
+    assert len(refreshes["calls"]) == 1
+    assert refreshes["calls"][0]["refresh_token"] == "RT"
+    err = capsys.readouterr().err
+    assert "Refreshed" in err and "3 days ago" in err, err
+
+
+def test_launch_refreshes_a_token_that_is_still_valid_but_inside_the_margin(monkeypatch, tmp_path,
+                                                                            capsys):
+    """The case only the offline check can see: the relay answers **200** for this token, so a probe
+    alone would hand it over and let it die at the user's third prompt."""
+    _seed_launch_with_token(monkeypatch, tmp_path, _jwt({"exp": _in(600)}))
+    refreshes = _mock_token_refresh(monkeypatch)
+    seen = _capture_launch(monkeypatch)
+
+    assert cli.main(["launch", "claude"]) == 0
+    assert seen["env"]["ANTHROPIC_AUTH_TOKEN"] == "AT2"
+    assert len(refreshes["calls"]) == 1
+    # The exact wording is pinned by the unit test below; here only that the user is told which way
+    # the deadline runs — a clock read a tick after the token was minted makes the count itself racy.
+    assert "expires in" in capsys.readouterr().err
+
+
+def test_expiry_phrase_says_which_side_of_the_deadline_and_how_far(monkeypatch):
+    """Without the distance the user is told a token is stale but not whether it went stale a year ago
+    (a machine left alone) or is about to (a session they should not start yet) — different problems
+    with different answers. Pinned as a pure function, so no clock race can make it flaky."""
+    from cli.grid_credential import _expiry_phrase
+
+    now = 1_000_000_000
+    assert _expiry_phrase(now - 3 * 86400, now) == "expired 3 days ago"
+    assert _expiry_phrase(now - 86400, now) == "expired 1 day ago"
+    assert _expiry_phrase(now - 7200, now) == "expired 2 hours ago"
+    assert _expiry_phrase(now - 30, now) == "expired less than a minute ago"
+    assert _expiry_phrase(now, now) == "expired less than a minute ago", "the boundary is expired"
+    assert _expiry_phrase(now + 600, now) == "expires in 10 minutes"
+    assert _expiry_phrase(now + 6 * 3600, now) == "expires in 6 hours"
+
+
+def test_launch_leaves_a_token_well_clear_of_the_margin_alone(monkeypatch, tmp_path):
+    """The margin is a day, not a week: a token good for a month must not be rotated on every launch."""
+    token = _jwt({"exp": _in(30 * 86400)})
+    _seed_launch_with_token(monkeypatch, tmp_path, token)
+    _forbid_token_refresh(monkeypatch)
+    seen = _capture_launch(monkeypatch)
+
+    assert cli.main(["launch", "claude"]) == 0
+    assert seen["env"]["ANTHROPIC_AUTH_TOKEN"] == token, "handed over untouched"
+
+
+def test_launch_treats_an_unreadable_token_as_unknown_not_as_expired(monkeypatch, tmp_path):
+    """"We cannot tell" and "it is dead" are different answers, and only one of them may cost a launch.
+
+    An opaque token is what a future credential format looks like from here. Guessing expired would
+    rotate a working credential on every launch; the probe is one round-trip away and knows better.
+    """
+    _seed_launch_with_token(monkeypatch, tmp_path, "opaque-not-a-jwt")
+    _forbid_token_refresh(monkeypatch)
+    seen = _capture_launch(monkeypatch)
+
+    assert cli.main(["launch", "claude"]) == 0
+    assert seen["env"]["ANTHROPIC_AUTH_TOKEN"] == "opaque-not-a-jwt"
+
+
+# --- layer 2: the repair ----------------------------------------------------
+
+def test_launch_persists_the_rotated_refresh_token_not_just_the_access_token(monkeypatch, tmp_path):
+    """The credential-destroying bug this feature could most easily have shipped.
+
+    The control plane rotates the refresh credential on **every** exchange and the old one stops
+    matching at once, while `update_network_tokens` takes `refresh_token` as an *optional* argument.
+    Persisting only the access token therefore kills this machine's refresh credential permanently —
+    silently, and while passing every assertion written about the access token, which is why this is
+    its own test.
+    """
+    _seed_launch_with_token(monkeypatch, tmp_path, _jwt({"exp": _in(-60)}))
+    _mock_token_refresh(monkeypatch, access="AT2", refresh="RT2")
+    _capture_launch(monkeypatch)
+
+    assert cli.main(["launch", "claude"]) == 0
+    assert _stored(tmp_path, "access_token") == "AT2"
+    assert _stored(tmp_path, "refresh_token") == "RT2", "the rotated refresh token must be stored"
+
+
+def test_launch_keeps_the_old_refresh_token_when_the_exchange_returns_none(monkeypatch, tmp_path):
+    """A control plane that chose not to rotate must not leave us storing an empty credential — which
+    is indistinguishable from having none at all, and would send the next launch to `grid login`."""
+    _seed_launch_with_token(monkeypatch, tmp_path, _jwt({"exp": _in(-60)}))
+    _mock_token_refresh(monkeypatch, access="AT2", refresh=None)
+    _capture_launch(monkeypatch)
+
+    assert cli.main(["launch", "claude"]) == 0
+    assert _stored(tmp_path, "refresh_token") == "RT"
+
+
+def test_print_env_prints_the_refreshed_token_and_keeps_the_note_off_stdout(monkeypatch, tmp_path,
+                                                                            capsys):
+    """`--print-env` exists so a user can drive their own shell; printing a dead token would reproduce
+    the exact trap this feature closes. The note goes to stderr so `eval "$(…)"` stays safe."""
+    _seed_launch_with_token(monkeypatch, tmp_path, _jwt({"exp": _in(-86400)}))
+    _mock_token_refresh(monkeypatch)
+    seen = _capture_launch(monkeypatch)
+
+    assert cli.main(["launch", "claude", "--print-env"]) == 0
+    out = capsys.readouterr()
+    assert "export ANTHROPIC_AUTH_TOKEN='AT2'" in out.out
+    assert "Refreshed" in out.err and "Refreshed" not in out.out
+    assert seen["spawns"] == [], "--print-env still starts nothing"
+
+
+def test_launch_refusals_distinguish_a_dead_credential_from_a_broken_control_plane(monkeypatch,
+                                                                                   tmp_path):
+    """Three failures, three different things to do — which is the whole reason the status rides the
+    exception. Telling a user to `grid login` during a control-plane outage sends them to a browser to
+    fix something that is not broken; not telling them when their credential is dead strands them."""
+    from remote import control_plane
+
+    # "Run `grid login`" is the *recommendation* marker. The 403 message names `grid login` too — to
+    # say it will not help — so a bare substring check would call that a recommendation.
+    cases = {
+        401: ("Run `grid login`", "membership"),
+        403: ("not your sign-in", "Run `grid login`"),
+        503: ("Try again shortly", "Run `grid login`"),
+    }
+    for status, (expected, forbidden) in cases.items():
+        _seed_launch_with_token(monkeypatch, tmp_path, _jwt({"exp": _in(-86400)}))
+        _mock_token_refresh(monkeypatch, error=control_plane.ControlPlaneError(
+            f"POST https://api.example/v1/grid/tokens/n1 failed ({status}): "
+            '{"detail": "the reason"}', status=status))
+        seen = _capture_launch(monkeypatch)
+
+        with pytest.raises(SystemExit) as exc:
+            cli.main(["launch", "claude"])
+        message = str(exc.value)
+        assert expected in message, (status, message)
+        assert forbidden not in message, (status, message)
+        assert "the reason" in message, "the control plane's own words reach the user"
+        assert seen["spawns"] == [], "nothing is started on a refusal"
+
+
+def test_launch_warns_and_launches_when_a_still_valid_token_cannot_be_renewed(monkeypatch, tmp_path,
+                                                                              capsys):
+    """The clause that bounds failing open: never cost the user a launch **that would have worked**.
+
+    Inside the margin the token still works, so a control-plane outage is not a reason to refuse. Past
+    `exp` it does not, which is why the sibling test above expects a refusal for the same failure.
+    """
+    from remote import control_plane
+
+    _seed_launch_with_token(monkeypatch, tmp_path, _jwt({"exp": _in(3600)}))
+    _mock_token_refresh(monkeypatch, error=control_plane.ControlPlaneError(
+        "Cannot reach the control plane (POST /v1/grid/tokens/n1): connection refused"))
+    seen = _capture_launch(monkeypatch)
+
+    assert cli.main(["launch", "claude"]) == 0
+    assert seen["argv"] == ["/usr/local/bin/claude"]
+    err = capsys.readouterr().err
+    assert "Warning" in err and "launching anyway" in err, err
+
+
+def test_launch_says_so_when_a_near_expiry_token_has_no_refresh_credential(monkeypatch, tmp_path,
+                                                                           capsys):
+    """Nothing to exchange, so nothing to repair — but silence would leave a user to discover on their
+    own that this grid stops working soon. The grid still decides whether it works *now*."""
+    _seed_remote(monkeypatch, tmp_path, networks=[
+        {"network_id": "n1", "name": "team", "access_token": _jwt({"exp": _in(3600)})}], active="team")
+    _mock_lifecycle(monkeypatch, status={"state": "running", "signaling_url": "https://relay.example"})
+    _mock_launch_relay(monkeypatch)
+    _isolate_claude_settings(monkeypatch, tmp_path)
+    _forbid_token_refresh(monkeypatch)
+    _capture_launch(monkeypatch)
+
+    assert cli.main(["launch", "claude"]) == 0
+    err = capsys.readouterr().err
+    assert "no refresh credential" in err and "grid login" in err, err
+
+
+# --- layer 3: what the grid says --------------------------------------------
+
+def test_launch_probes_the_authenticated_models_route_with_the_bearer(monkeypatch, tmp_path):
+    """Only an authenticated read can see an epoch bump, a revoked membership or a missing scope —
+    none of which a token can be asked about offline, and all of which the public overview ignores."""
+    token = _jwt({"exp": _in(_YEAR)})
+    seen_relay = _seed_launch_with_token(monkeypatch, tmp_path, token)
+    _forbid_token_refresh(monkeypatch)
+    _capture_launch(monkeypatch)
+
+    assert cli.main(["launch", "claude"]) == 0
+    assert seen_relay["probes"] == [f"Bearer {token}"], "one probe, carrying the token in question"
+
+
+def test_launch_refreshes_once_when_the_grid_rejects_a_token_that_looks_fine(monkeypatch, tmp_path,
+                                                                             capsys):
+    """A stale `member_epoch` — the likeliest rejection on an active grid, and completely invisible to
+    the offline check: the token's own `exp` is a year out and says nothing is wrong."""
+    token = _jwt({"exp": _in(_YEAR)})
+    seen_relay = _seed_launch_with_token(monkeypatch, tmp_path, token, probe_sequence=[401, 200])
+    refreshes = _mock_token_refresh(monkeypatch)
+    seen = _capture_launch(monkeypatch)
+
+    assert cli.main(["launch", "claude"]) == 0
+    assert seen["env"]["ANTHROPIC_AUTH_TOKEN"] == "AT2"
+    assert len(refreshes["calls"]) == 1
+    assert seen_relay["probes"] == [f"Bearer {token}", "Bearer AT2"], "re-probed with the new token"
+    assert "Refreshed" in capsys.readouterr().err
+
+
+def test_launch_refuses_when_even_a_renewed_token_is_rejected(monkeypatch, tmp_path):
+    """One refresh per run, total. A second exchange would mint another token carrying the same
+    rejected membership — a slower way to fail, and one more rotation of a credential that is already
+    in trouble."""
+    _seed_launch_with_token(
+        monkeypatch, tmp_path, _jwt({"exp": _in(_YEAR)}), probe_sequence=[401, 401])
+    refreshes = _mock_token_refresh(monkeypatch)
+    seen = _capture_launch(monkeypatch)
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["launch", "claude"])
+    assert "grid login" in str(exc.value)
+    assert len(refreshes["calls"]) == 1, "exactly one refresh, however many layers asked"
+    assert seen["spawns"] == []
+
+
+def test_launch_403_names_the_roles_when_the_token_carries_no_inference_scope(monkeypatch, tmp_path):
+    """Which 403 this is comes from the **token**, not from the relay's wording — keying user-facing
+    advice on a response body is the failure this feature exists to remove.
+
+    And the advice names roles rather than "ask the owner": the control plane's owner fallback
+    synthesises `roles=["admin"]`, whose scopes carry no inference at all, so this refusal can land in
+    front of the very person that advice would point at.
+    """
+    token = _jwt({"exp": _in(_YEAR), "scopes": ["provider:poll", "provider:heartbeat"]})
+    _seed_launch_with_token(monkeypatch, tmp_path, token, probe=403)
+    _forbid_token_refresh(monkeypatch)
+    seen = _capture_launch(monkeypatch)
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["launch", "claude"])
+    message = str(exc.value)
+    assert "`consumer` and `both` roles" in message, message
+    assert "Missing required scope" in message, "the relay's own reason survives"
+    assert seen["spawns"] == []
+
+
+def test_launch_403_names_membership_when_the_token_does_carry_the_scope(monkeypatch, tmp_path):
+    """The other 403: the scope is there, so the refusal is about who you are on this grid — and
+    `grid login` re-mints from the same membership, so recommending it would be a loop."""
+    token = _jwt({"exp": _in(_YEAR), "scopes": ["inference:create", "inference:models"]})
+    _seed_launch_with_token(monkeypatch, tmp_path, token, probe=403,
+                            detail="Grid member is not in local allowlist snapshot")
+    _forbid_token_refresh(monkeypatch)
+    _capture_launch(monkeypatch)
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["launch", "claude"])
+    message = str(exc.value)
+    assert "not as a member who may use this grid" in message, message
+    assert "roles" not in message, "this one is not about scope"
+
+
+def test_launch_warns_and_launches_when_the_probe_is_throttled(monkeypatch, tmp_path, capsys):
+    """429 is the most likely status for the exact user this feature is for — someone re-running a
+    launch against a credential that keeps failing. It is not a verdict about the token, so it must not
+    become one."""
+    _seed_launch_with_token(monkeypatch, tmp_path, _jwt({"exp": _in(_YEAR)}), probe=429)
+    _forbid_token_refresh(monkeypatch)
+    seen = _capture_launch(monkeypatch)
+
+    assert cli.main(["launch", "claude"]) == 0
+    assert seen["argv"] == ["/usr/local/bin/claude"]
+    err = capsys.readouterr().err
+    assert "Too many failed authentication attempts" in err and "launching anyway" in err, err
+
+
+def test_launch_warns_and_launches_when_the_probe_cannot_reach_the_relay(monkeypatch, tmp_path,
+                                                                         capsys):
+    """A check that could not run says so, and never costs a launch that would have worked — the same
+    disposition `claude_install._warn_unchecked` already has for the binary search."""
+    _seed_launch_with_token(monkeypatch, tmp_path, _jwt({"exp": _in(_YEAR)}),
+                            probe_sequence=[httpx.ConnectError("connection refused")])
+    _forbid_token_refresh(monkeypatch)
+    seen = _capture_launch(monkeypatch)
+
+    assert cli.main(["launch", "claude"]) == 0
+    assert seen["argv"] == ["/usr/local/bin/claude"]
+    assert "launching anyway" in capsys.readouterr().err
+
+
+def test_launch_reports_the_dead_credential_before_the_missing_models(monkeypatch, tmp_path):
+    """Preflight's two halves swap order, and this is why: a dead credential invalidates the model
+    advice — `grid join` cannot help while the token is rejected — whereas a missing model says nothing
+    about the credential. Both are wrong here; only one of them is worth acting on first."""
+    _seed_launch_with_token(monkeypatch, tmp_path, _jwt({"exp": _in(_YEAR)}),
+                            probe_sequence=[401, 401], models=["glm-5.2"])
+    _mock_token_refresh(monkeypatch)
+    _capture_launch(monkeypatch)
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["launch", "claude"])
+    message = str(exc.value)
+    assert "rejected" in message, message
+    assert "doesn't serve" not in message, "the model refusal must not pre-empt the credential one"
+
+
+# --- the write contract -----------------------------------------------------
+
+def test_launch_writes_nothing_when_the_credential_is_healthy(monkeypatch, tmp_path):
+    """`grid launch` can now write `credentials.toml` (ADR 0029), which makes "and only when it had
+    to" a claim worth pinning — including the file's *bytes*, since a refresh rewrites in place and
+    adds no path."""
+    _seed_launch_with_token(monkeypatch, tmp_path, _jwt({"exp": _in(_YEAR)}))
+    _forbid_token_refresh(monkeypatch)
+    _capture_launch(monkeypatch)
+    before = _grid_home_tree(tmp_path)
+
+    assert cli.main(["launch", "claude"]) == 0
+    assert _grid_home_tree(tmp_path) == before
+
+
+def test_launch_that_refreshes_writes_only_the_two_token_fields(monkeypatch, tmp_path):
+    """The write is maintenance of our own credential cache, not a side effect on the user's setup:
+    the session, the api_url, the user and every other grid come through untouched."""
+    from remote import credentials
+
+    _seed_launch_with_token(monkeypatch, tmp_path, _jwt({"exp": _in(-60)}))
+    _mock_token_refresh(monkeypatch)
+    _capture_launch(monkeypatch)
+    before = credentials.load_credentials()
+
+    assert cli.main(["launch", "claude"]) == 0
+    after = credentials.load_credentials()
+    assert {k: v for k, v in after.items() if k != "networks"} == \
+           {k: v for k, v in before.items() if k != "networks"}
+    changed = {
+        key for key in set(before["networks"][0]) | set(after["networks"][0])
+        if before["networks"][0].get(key) != after["networks"][0].get(key)
+    }
+    assert changed == {"access_token", "refresh_token"}

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -22547,8 +22547,9 @@ def _capture_launch(monkeypatch, *, binary="/usr/local/bin/claude", exit_code=0,
     return seen
 
 
-# Every tier `shared/launch/claude.MODEL_TIERS` names, so the default grid below passes preflight.
-_LAUNCH_TIER_MODELS = ["claude:opus", "claude:sonnet", "claude:haiku", "claude:fable"]
+# A grid that is serving something, which is all preflight asks for now that the tier table is gone.
+# The names are arbitrary — no launch code reads them; only "the list is non-empty" is load-bearing.
+_LAUNCH_MODELS = ["claude:opus", "claude:sonnet", "claude:haiku", "claude:fable"]
 
 
 def _isolate_claude_settings(monkeypatch, tmp_path):
@@ -22566,12 +22567,12 @@ def _isolate_claude_settings(monkeypatch, tmp_path):
     return config, project
 
 
-def _mock_tier_overview(monkeypatch, *, models=None, overview=None, seen=None):
+def _mock_launch_overview(monkeypatch, *, models=None, overview=None, seen=None):
     """Serve an overview whose grid serves every Claude Code tier — or exactly `models`, or a
     hand-built `overview` payload for the malformed cases."""
     _mock_overview(monkeypatch, overview if overview is not None else {
         "nodes": [{"name": "seat", "engine": "claude", "online": True,
-                   "models": list(_LAUNCH_TIER_MODELS if models is None else models)}]
+                   "models": list(_LAUNCH_MODELS if models is None else models)}]
     }, seen)
 
 
@@ -22580,44 +22581,26 @@ def _seed_launchable_grid(monkeypatch, tmp_path, *, models=None, overview=None, 
     """A signed-in remote user with one running grid whose overview serves every Claude Code tier,
     and isolated Claude Code settings. What a launch needs to get all the way to the spawn."""
     _seed_running_remote_grid(monkeypatch, tmp_path, access_token=access_token)
-    _mock_tier_overview(monkeypatch, models=models, overview=overview, seen=seen)
+    _mock_launch_overview(monkeypatch, models=models, overview=overview, seen=seen)
     return _isolate_claude_settings(monkeypatch, tmp_path)
 
 
-def test_launch_preflight_refuses_a_grid_that_does_not_serve_the_main_tier(monkeypatch, tmp_path):
-    """The whole risk of a hardcoded tier table lands here: a grid that does not serve it.
+def test_launch_does_not_judge_which_models_a_grid_serves(monkeypatch, tmp_path):
+    """The positive statement of the change that removed the tier table.
 
-    Unchecked, the failure surfaces *inside* Claude Code at the first prompt as an API error naming a
-    model — which a user reads as "Claude Code is broken", not "my grid has no such model". So it is a
-    refusal before any spawn, and the message has to be actionable on its own: what is missing, and
-    what the grid does serve.
+    `grid launch` used to inject a model per Claude Code tier from a hardcoded table, and refuse any
+    grid that did not serve those exact names — which put this command in charge of a choice it has no
+    standing to make. It sets no model now, so it has no basis for an opinion about which models are
+    there: a grid serving nothing but an unrelated model launches, and the app asks for whatever its
+    own configuration resolves to.
     """
-    _seed_launchable_grid(monkeypatch, tmp_path, models=["claude:haiku", "glm-5.2"])
+    _seed_launchable_grid(monkeypatch, tmp_path, models=["glm-5.2"])
     seen = _capture_launch(monkeypatch)
 
-    with pytest.raises(SystemExit) as exc:
-        cli.main(["launch", "claude"])
-
-    message = str(exc.value)
-    assert "claude:opus" in message, f"the missing model must be named: {message}"
-    assert "glm-5.2" in message, f"what the grid does serve must be listed: {message}"
-    assert "argv" not in seen, "refused before the spawn, never launched into a model error"
-
-
-def test_launch_preflight_refuses_a_grid_that_does_not_serve_the_small_fast_tier(monkeypatch,
-                                                                                tmp_path):
-    """The small/fast tier is required too — the subagent tier mirrors it, so every session uses it.
-
-    Its own test because a check that stopped at the first required tier would still pass the one
-    above, and the grid that serves only the main model is the likelier real-world half-configuration.
-    """
-    _seed_launchable_grid(monkeypatch, tmp_path, models=["claude:opus"])
-    seen = _capture_launch(monkeypatch)
-
-    with pytest.raises(SystemExit) as exc:
-        cli.main(["launch", "claude"])
-    assert "claude:haiku" in str(exc.value), str(exc.value)
-    assert "argv" not in seen
+    assert cli.main(["launch", "claude"]) == 0
+    assert seen["argv"] == ["/usr/local/bin/claude"]
+    assert [key for key in seen["env"] if key.endswith("_MODEL")] == [], \
+        "no model variable is injected, so none can be judged"
 
 
 def test_launch_preflight_refuses_a_grid_with_no_live_models_cleanly(monkeypatch, tmp_path):
@@ -22646,7 +22629,7 @@ def test_launch_preflight_degrades_cleanly_on_a_malformed_overview(monkeypatch, 
         seen = _capture_launch(monkeypatch)
         with pytest.raises(SystemExit) as exc:
             cli.main(["launch", "claude"])
-        assert "claude:opus" in str(exc.value), f"{payload} -> {exc.value}"
+        assert "no models" in str(exc.value).lower(), f"{payload} -> {exc.value}"
         assert "argv" not in seen, payload
 
 
@@ -22661,35 +22644,19 @@ def test_launch_preflight_reads_the_same_public_overview_as_models_and_engines(m
     assert (seen_request["method"], seen_request["path"]) == ("GET", "/relay/v1/grid/overview")
 
 
-def test_launch_preflight_remaps_an_unserved_optional_tier_to_the_main_model(monkeypatch, tmp_path,
-                                                                            capsys):
-    """A tier nobody in the session would have picked must not block a launch — but it must not be
-    left unset either.
+def test_launch_leaves_the_users_own_model_configuration_alone(monkeypatch, tmp_path):
+    """The reason the tier table went: a model already chosen in the environment must survive.
 
-    Unset is the trap: Claude Code then falls back to a *real Anthropic* model name that no grid
-    serves, so `/model sonnet` breaks in a way that looks like a Grid bug. Pointing it at the main
-    tier's model keeps every tier switch landing on something the grid actually serves.
+    While `grid launch` injected seven model variables, whatever the user had set was overwritten for
+    that session — their `settings.json`, their `/model` default, an `ANTHROPIC_MODEL` exported in
+    their shell. Setting none of them is what puts that choice back where it belongs.
     """
-    _seed_launchable_grid(monkeypatch, tmp_path, models=["claude:opus", "claude:haiku"])
+    monkeypatch.setenv("ANTHROPIC_MODEL", "a-model-the-user-picked")
+    _seed_launchable_grid(monkeypatch, tmp_path)
     seen = _capture_launch(monkeypatch)
 
-    assert cli.main(["launch", "claude"]) == 0, "an optional tier cannot block the launch"
-
-    assert seen["env"]["ANTHROPIC_DEFAULT_SONNET_MODEL"] == "claude:opus"
-    assert seen["env"]["ANTHROPIC_DEFAULT_FABLE_MODEL"] == "claude:opus"
-    # The tiers the grid *does* serve are untouched — a remap is per tier, not a flattening.
-    assert seen["env"]["ANTHROPIC_DEFAULT_HAIKU_MODEL"] == "claude:haiku"
-    assert seen["env"]["ANTHROPIC_MODEL"] == "claude:opus"
-    # Every documented variable still carries a value: "remapped" must never mean "omitted".
-    for key in [k for k in seen["env"] if k.endswith("_MODEL")]:
-        assert seen["env"][key], f"{key} was left empty by a remap"
-
-    # One line, and it names which *tiers* moved — the user thinks in `/model sonnet`, not in models.
-    lines = [ln for ln in capsys.readouterr().err.splitlines() if ln.strip()]
-    remap = [ln for ln in lines if "sonnet" in ln]
-    assert len(remap) == 1, f"the remap is reported once, not per tier: {lines}"
-    assert "fable" in remap[0], f"every moved tier is named in that one line: {remap[0]}"
-    assert "claude:opus" in remap[0], f"...and what they now resolve to: {remap[0]}"
+    assert cli.main(["launch", "claude"]) == 0
+    assert seen["env"]["ANTHROPIC_MODEL"] == "a-model-the-user-picked", "inherited, never overwritten"
 
 
 def test_launch_warns_when_claude_code_user_settings_override_the_injected_env(monkeypatch, tmp_path,
@@ -22742,16 +22709,19 @@ def test_launch_warns_when_project_settings_override_the_injected_env(monkeypatc
     _config, project = _seed_launchable_grid(monkeypatch, tmp_path)
     (project / ".claude").mkdir(parents=True)
     (project / ".claude" / "settings.local.json").write_text(
-        json.dumps({"env": {"CLAUDE_CODE_SUBAGENT_MODEL": "claude-haiku-4-5"}}), encoding="utf-8")
+        # Two keys: one this command injects, one it stopped injecting when the tier table went.
+        json.dumps({"env": {"ANTHROPIC_BASE_URL": "https://elsewhere.example",
+                            "ANTHROPIC_MODEL": "a-model-the-user-picked"}}), encoding="utf-8")
     _capture_launch(monkeypatch)
 
     assert cli.main(["launch", "claude"]) == 0
-    warnings = [ln for ln in capsys.readouterr().err.splitlines()
-                if "CLAUDE_CODE_SUBAGENT_MODEL" in ln]
-    # Not an `ANTHROPIC_*` name, but it overrides a variable this command sets just the same, so the
-    # check is "a key we inject", not a prefix.
+    err = capsys.readouterr().err
+    warnings = [ln for ln in err.splitlines() if "ANTHROPIC_BASE_URL" in ln]
     assert len(warnings) == 1, f"a project-level override must warn too: {warnings}"
     assert "settings.local.json" in warnings[0]
+    # The check is "a key we inject", not a prefix — and `ANTHROPIC_MODEL` is no longer one of ours,
+    # so warning about it would be telling the user their own model choice is a problem.
+    assert "ANTHROPIC_MODEL" not in err, f"a key we do not set is not a collision: {err}"
 
 
 @pytest.mark.skipif(not os.path.exists("/dev/zero"), reason="needs a character device")
@@ -22837,14 +22807,14 @@ def test_launch_survives_a_process_with_no_resolvable_home_directory(monkeypatch
         lambda: (_ for _ in ()).throw(RuntimeError("Could not determine home directory."))))
     (project / ".claude").mkdir(parents=True)
     (project / ".claude" / "settings.json").write_text(
-        json.dumps({"env": {"ANTHROPIC_MODEL": "claude-opus-4-6"}}), encoding="utf-8")
+        json.dumps({"env": {"ANTHROPIC_API_KEY": "sk-the-users-own"}}), encoding="utf-8")
     seen = _capture_launch(monkeypatch)
 
     assert cli.main(["launch", "claude"]) == 0
     assert seen["argv"], "no home directory is not a reason to refuse to launch"
     err = capsys.readouterr().err
     assert "home directory" in err, f"say which location could not be checked: {err}"
-    assert "ANTHROPIC_MODEL" in err, f"the project's settings are still checked: {err}"
+    assert "ANTHROPIC_API_KEY" in err, f"the project's settings are still checked: {err}"
 
 
 def test_launch_says_so_when_a_settings_file_cannot_be_read(monkeypatch, tmp_path, capsys):
@@ -22886,11 +22856,15 @@ def _grid_home_tree(root):
     )
 
 
-def test_launch_claude_hands_the_child_exactly_the_ten_documented_keys(monkeypatch, tmp_path):
+def test_launch_claude_hands_the_child_exactly_the_three_documented_keys(monkeypatch, tmp_path):
     """The env the child is given IS this feature's contract, so it is asserted key by key.
 
-    A one-character change to any variable name or model value must not be able to ship green: the
-    dictionary below is spelled out rather than derived from the constant it is testing.
+    A one-character change to any variable name must not be able to ship green: the dictionary below
+    is spelled out rather than derived from the code it is testing.
+
+    Three keys, not the ten ADR 0028 specified. The seven `*_MODEL` variables are gone: choosing which
+    model a session runs on is the user's, not this command's, and the exact-equality assertion below
+    is what keeps one from creeping back.
     """
     _seed_launchable_grid(monkeypatch, tmp_path)  # relay https://relay.example, access token AT
     monkeypatch.delenv("GRID_TOKEN", raising=False)  # so its absence below is the command's doing
@@ -22905,20 +22879,14 @@ def test_launch_claude_hands_the_child_exactly_the_ten_documented_keys(monkeypat
         "ANTHROPIC_BASE_URL": "https://relay.example/relay",
         "ANTHROPIC_AUTH_TOKEN": "AT",
         "ANTHROPIC_API_KEY": "AT",
-        "ANTHROPIC_MODEL": "claude:opus",
-        "ANTHROPIC_SMALL_FAST_MODEL": "claude:haiku",
-        "CLAUDE_CODE_SUBAGENT_MODEL": "claude:haiku",
-        "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude:opus",
-        "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude:sonnet",
-        "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude:haiku",
-        "ANTHROPIC_DEFAULT_FABLE_MODEL": "claude:fable",
     }
-    assert len(expected) == 10, "the documented block is ten keys; this list drifted"
+    assert len(expected) == 3, "the documented block is three keys; this list drifted"
     # Inherited environment, with those keys layered over it — the child keeps the user's PATH,
     # HOME and everything else, or Claude Code would launch into a stripped shell.
     assert seen["env"] == {**os.environ, **expected}
-    # ... and *only* those: any variable this command added or changed is one of the ten. This is
-    # what keeps a telemetry variable (deliberately not set, ADR 0028) from creeping in unnoticed.
+    # ... and *only* those: any variable this command added or changed is one of the three. This is
+    # what keeps a telemetry variable (deliberately not set, ADR 0028) — or a model variable — from
+    # creeping in unnoticed.
     assert {k: v for k, v in seen["env"].items() if os.environ.get(k) != v} == expected
     # `/v1` on the base is the single most likely mistake: Claude Code appends `/v1/messages` itself.
     assert "/v1" not in seen["env"]["ANTHROPIC_BASE_URL"]
@@ -22936,7 +22904,7 @@ def test_launch_claude_base_url_never_doubles_a_slash(monkeypatch, tmp_path):
     _seed_remote(monkeypatch, tmp_path,
                  networks=[{"network_id": "n1", "name": "team", "access_token": "AT"}], active="team")
     _mock_lifecycle(monkeypatch, status={"state": "running", "signaling_url": "https://relay.example/"})
-    _mock_tier_overview(monkeypatch)
+    _mock_launch_overview(monkeypatch)
     _isolate_claude_settings(monkeypatch, tmp_path)
     seen = _capture_launch(monkeypatch)
 
@@ -22954,7 +22922,7 @@ def test_launch_claude_targets_a_named_grid_and_defaults_to_the_active_one(monke
         {"network_id": "n1", "name": "team", "access_token": "AT-TEAM"},
         {"network_id": "n2", "name": "lab", "access_token": "AT-LAB"}], active="team")
     _mock_lifecycle(monkeypatch, status={"state": "running", "signaling_url": "https://relay.example"})
-    _mock_tier_overview(monkeypatch)
+    _mock_launch_overview(monkeypatch)
     _isolate_claude_settings(monkeypatch, tmp_path)
     seen = _capture_launch(monkeypatch)
 
@@ -23018,24 +22986,6 @@ def test_launch_is_wired_in_the_parser_and_classified_remote_only():
         with pytest.raises(SystemExit) as exc:
             parser.parse_args(["launch", "claude", flag])
         assert exc.value.code == 2, flag
-
-
-def test_launch_tier_models_are_named_in_exactly_one_module():
-    """The tier values are the single site a later discovery slice replaces, so a second copy anywhere
-    would make that a multi-site change — and one copy would then silently go stale."""
-    from shared.launch import claude
-
-    assert set(claude.MODEL_TIERS) == {"main", "small_fast", "opus", "sonnet", "haiku", "fable"}
-    home = Path(claude.__file__).resolve()
-    root = home.parents[2]
-    for value in sorted(set(claude.MODEL_TIERS.values())):
-        hits = {
-            path.resolve()
-            for package in ("cli", "shared", "local", "remote")
-            for path in (root / package).rglob("*.py")
-            if value in path.read_text(encoding="utf-8")
-        }
-        assert hits == {home}, f"{value!r} is named outside the one constant: {sorted(hits)}"
 
 
 def test_launch_adding_a_second_target_needs_no_change_to_the_claude_target(monkeypatch, tmp_path, capsys):
@@ -23383,14 +23333,14 @@ def test_launch_never_offers_an_install_for_a_grid_that_could_not_run_the_app(mo
     models were already read before the target was called, so checking them first costs nothing;
     installing first costs everything it takes to undo.
     """
-    _seed_launchable_grid(monkeypatch, tmp_path, models=["glm-5.2"])
+    _seed_launchable_grid(monkeypatch, tmp_path, overview={"nodes": []})
     _install_locations(monkeypatch, tmp_path)
     seen = _capture_launch(monkeypatch, binary=None, interactive=True, confirm=True)
 
     with pytest.raises(SystemExit) as exc:
         cli.main(["launch", "claude"])
 
-    assert "claude:opus" in str(exc.value), f"the grid is what failed, so name it: {exc.value}"
+    assert "no models" in str(exc.value).lower(), f"the grid is what failed, so name it: {exc.value}"
     assert seen["asked"] == [], "nobody may be offered an app their grid cannot run"
     assert seen["spawns"] == []
 
@@ -23623,7 +23573,10 @@ def test_launch_claude_prints_one_line_naming_the_grid_and_model_before_spawning
     assert seen["before_spawn"].out == "", "stdout belongs to the app, not to the launcher"
     lines = [line for line in seen["before_spawn"].err.splitlines() if line.strip()]
     assert len(lines) == 1, f"one line before the app starts, not {len(lines)}: {lines}"
-    assert "team" in lines[0] and "claude:opus" in lines[0]
+    # The grid, and only the grid. This command no longer chooses a model, so naming one here would
+    # be a claim it cannot keep — the app resolves that from its own configuration.
+    assert "team" in lines[0], lines[0]
+    assert "model" not in lines[0].lower(), f"nothing is claimed about the model: {lines[0]}"
 
 
 def _stub_binary(monkeypatch, path="/usr/local/bin/claude"):
@@ -23833,7 +23786,7 @@ def test_launch_does_not_read_a_forwarded_word_as_its_grid_argument(monkeypatch,
         {"network_id": "n1", "name": "team", "access_token": "AT-TEAM"},
         {"network_id": "n2", "name": "lab", "access_token": "AT-LAB"}], active="team")
     _mock_lifecycle(monkeypatch, status={"state": "running", "signaling_url": "https://relay.example"})
-    _mock_tier_overview(monkeypatch)
+    _mock_launch_overview(monkeypatch)
     _isolate_claude_settings(monkeypatch, tmp_path)
     seen = _capture_launch(monkeypatch)
 
@@ -24058,16 +24011,16 @@ def test_launch_print_env_prints_exactly_what_a_launch_would_inject(monkeypatch,
 def test_launch_print_env_runs_preflight_and_refuses_what_a_launch_refuses(monkeypatch, tmp_path,
                                                                            capsys):
     """Printing exports for a grid that cannot serve them would reproduce exactly the trap preflight
-    exists to close — the user evaluates the block, starts the app themselves, and meets a model
-    error that names nothing about their grid."""
-    _seed_launchable_grid(monkeypatch, tmp_path, models=["claude:haiku", "glm-5.2"])
+    exists to close — the user evaluates the block, starts the app themselves, and meets an error
+    that names nothing about their grid."""
+    _seed_launchable_grid(monkeypatch, tmp_path, overview={"nodes": []})
     _capture_launch(monkeypatch)
 
     with pytest.raises(SystemExit) as exc:
         cli.main(["launch", "claude", "--print-env"])
 
     message = str(exc.value)
-    assert "claude:opus" in message and "glm-5.2" in message, message
+    assert "no models" in message.lower() and "grid join" in message, message
     assert capsys.readouterr().out == "", "refused before a single export was printed"
 
 
@@ -24161,7 +24114,7 @@ def _mock_launch_relay(monkeypatch, *, probe=200, probe_sequence=None, models=No
             return httpx.Response(answer, json={"detail": body})
         return httpx.Response(200, json={"nodes": [{
             "name": "seat", "engine": "claude", "online": True,
-            "models": list(_LAUNCH_TIER_MODELS if models is None else models),
+            "models": list(_LAUNCH_MODELS if models is None else models),
         }]})
 
     _mock_relay(monkeypatch, handler)

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -22245,3 +22245,713 @@ def test_a_plain_stderr_is_still_quoted_verbatim_and_bounded():
     assert orphan_sweep._first_line("ps: illegal option -- w") == " (ps: illegal option -- w)"
     assert orphan_sweep._first_line("\n\n  access is denied  \n") == " (access is denied)"
     assert len(orphan_sweep._first_line("z" * 5000)) == 200 + len(" ()")
+
+
+# ---------------------------------------------------------------------------
+# `grid launch` (cli/launch.py + shared/launch/*) — issue 02, ADR 0028
+# ---------------------------------------------------------------------------
+
+def test_launch_with_no_target_lists_the_targets_and_exits_zero(monkeypatch, tmp_path, capsys):
+    """Bare `grid launch` is discovery, not an error: it names what can be launched and exits 0.
+
+    Deliberately NOT signed in — finding out what exists must not require an account, so the listing
+    is answered before the session gate every other launch path goes through.
+    """
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    state.set_mode("remote")
+
+    assert cli.main(["launch"]) == 0
+    assert "claude" in capsys.readouterr().out
+
+
+def _capture_launch(monkeypatch, *, binary="/usr/local/bin/claude", exit_code=0):
+    """Substitute the one OS-facing seam a launch acts through.
+
+    Returns a dict filled with the child's ``argv`` and ``env`` — the pair that *is* this feature's
+    contract — plus ``looked_for``, the executable names resolution was asked about. Patching the
+    module attributes (not a `subprocess` global) keeps every other subprocess in the suite real.
+    """
+    from shared.launch import system
+
+    seen = {"looked_for": []}
+
+    def fake_find(name):
+        seen["looked_for"].append(name)
+        return binary
+
+    def fake_spawn(argv, env):
+        seen["argv"], seen["env"] = list(argv), dict(env)
+        return exit_code
+
+    monkeypatch.setattr(system, "find_executable", fake_find)
+    monkeypatch.setattr(system, "spawn", fake_spawn)
+    return seen
+
+
+# Every tier `shared/launch/claude.MODEL_TIERS` names, so the default grid below passes preflight.
+_LAUNCH_TIER_MODELS = ["claude:opus", "claude:sonnet", "claude:haiku", "claude:fable"]
+
+
+def _isolate_claude_settings(monkeypatch, tmp_path):
+    """Point the two settings sources a launch reads at empty temp directories.
+
+    Both this repo's own `.claude/settings.json` and a typical `~/.claude/settings.json` carry an
+    `env` block, so without this the collision warning fires from the configuration of whoever is
+    running the suite — deciding tests that are about the grid. Returns (user config dir, project dir)
+    so a settings test can write into either.
+    """
+    config, project = tmp_path / "claude-config", tmp_path / "project"
+    project.mkdir(exist_ok=True)
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config))
+    monkeypatch.chdir(project)
+    return config, project
+
+
+def _mock_tier_overview(monkeypatch, *, models=None, overview=None, seen=None):
+    """Serve an overview whose grid serves every Claude Code tier — or exactly `models`, or a
+    hand-built `overview` payload for the malformed cases."""
+    _mock_overview(monkeypatch, overview if overview is not None else {
+        "nodes": [{"name": "seat", "engine": "claude", "online": True,
+                   "models": list(_LAUNCH_TIER_MODELS if models is None else models)}]
+    }, seen)
+
+
+def _seed_launchable_grid(monkeypatch, tmp_path, *, models=None, overview=None, seen=None,
+                          access_token="AT"):
+    """A signed-in remote user with one running grid whose overview serves every Claude Code tier,
+    and isolated Claude Code settings. What a launch needs to get all the way to the spawn."""
+    _seed_running_remote_grid(monkeypatch, tmp_path, access_token=access_token)
+    _mock_tier_overview(monkeypatch, models=models, overview=overview, seen=seen)
+    return _isolate_claude_settings(monkeypatch, tmp_path)
+
+
+def test_launch_preflight_refuses_a_grid_that_does_not_serve_the_main_tier(monkeypatch, tmp_path):
+    """The whole risk of a hardcoded tier table lands here: a grid that does not serve it.
+
+    Unchecked, the failure surfaces *inside* Claude Code at the first prompt as an API error naming a
+    model — which a user reads as "Claude Code is broken", not "my grid has no such model". So it is a
+    refusal before any spawn, and the message has to be actionable on its own: what is missing, and
+    what the grid does serve.
+    """
+    _seed_launchable_grid(monkeypatch, tmp_path, models=["claude:haiku", "glm-5.2"])
+    seen = _capture_launch(monkeypatch)
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["launch", "claude"])
+
+    message = str(exc.value)
+    assert "claude:opus" in message, f"the missing model must be named: {message}"
+    assert "glm-5.2" in message, f"what the grid does serve must be listed: {message}"
+    assert "argv" not in seen, "refused before the spawn, never launched into a model error"
+
+
+def test_launch_preflight_refuses_a_grid_that_does_not_serve_the_small_fast_tier(monkeypatch,
+                                                                                tmp_path):
+    """The small/fast tier is required too — the subagent tier mirrors it, so every session uses it.
+
+    Its own test because a check that stopped at the first required tier would still pass the one
+    above, and the grid that serves only the main model is the likelier real-world half-configuration.
+    """
+    _seed_launchable_grid(monkeypatch, tmp_path, models=["claude:opus"])
+    seen = _capture_launch(monkeypatch)
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["launch", "claude"])
+    assert "claude:haiku" in str(exc.value), str(exc.value)
+    assert "argv" not in seen
+
+
+def test_launch_preflight_refuses_a_grid_with_no_live_models_cleanly(monkeypatch, tmp_path):
+    """A grid with nothing joined is the most likely first-run state of all, so it must read as a
+    grid problem with a next step — not as an empty list, and never as a traceback."""
+    _seed_launchable_grid(monkeypatch, tmp_path, overview={"nodes": []})
+    seen = _capture_launch(monkeypatch)
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["launch", "claude"])
+    message = str(exc.value)
+    assert "no models" in message.lower(), f"say the grid is empty, don't print an empty list: {message}"
+    assert "grid join" in message, f"the way out must be named: {message}"
+    assert "argv" not in seen
+
+
+def test_launch_preflight_degrades_cleanly_on_a_malformed_overview(monkeypatch, tmp_path):
+    """The overview body crosses a trust boundary, so preflight defends exactly as the `models` /
+    `engines` renderers do — by reading it through the same helpers.
+
+    A non-list `nodes`, a scalar in it, and a node whose `models` is not a list all read as "serves
+    nothing", which is a refusal. The failure this rules out is a TypeError escaping as a traceback.
+    """
+    for payload in ({"nodes": "nope"}, {"nodes": [7, None]}, {"nodes": [{"models": 7}]}, {}):
+        _seed_launchable_grid(monkeypatch, tmp_path, overview=payload)
+        seen = _capture_launch(monkeypatch)
+        with pytest.raises(SystemExit) as exc:
+            cli.main(["launch", "claude"])
+        assert "claude:opus" in str(exc.value), f"{payload} -> {exc.value}"
+        assert "argv" not in seen, payload
+
+
+def test_launch_preflight_reads_the_same_public_overview_as_models_and_engines(monkeypatch, tmp_path):
+    """One read model for what a grid serves. A second source could disagree with `grid models`, and
+    then the refusal above would be arguing with the command the user ran to check it."""
+    seen_request = {}
+    _seed_launchable_grid(monkeypatch, tmp_path, seen=seen_request)
+    _capture_launch(monkeypatch)
+
+    assert cli.main(["launch", "claude"]) == 0
+    assert (seen_request["method"], seen_request["path"]) == ("GET", "/relay/v1/grid/overview")
+
+
+def test_launch_preflight_remaps_an_unserved_optional_tier_to_the_main_model(monkeypatch, tmp_path,
+                                                                            capsys):
+    """A tier nobody in the session would have picked must not block a launch — but it must not be
+    left unset either.
+
+    Unset is the trap: Claude Code then falls back to a *real Anthropic* model name that no grid
+    serves, so `/model sonnet` breaks in a way that looks like a Grid bug. Pointing it at the main
+    tier's model keeps every tier switch landing on something the grid actually serves.
+    """
+    _seed_launchable_grid(monkeypatch, tmp_path, models=["claude:opus", "claude:haiku"])
+    seen = _capture_launch(monkeypatch)
+
+    assert cli.main(["launch", "claude"]) == 0, "an optional tier cannot block the launch"
+
+    assert seen["env"]["ANTHROPIC_DEFAULT_SONNET_MODEL"] == "claude:opus"
+    assert seen["env"]["ANTHROPIC_DEFAULT_FABLE_MODEL"] == "claude:opus"
+    # The tiers the grid *does* serve are untouched — a remap is per tier, not a flattening.
+    assert seen["env"]["ANTHROPIC_DEFAULT_HAIKU_MODEL"] == "claude:haiku"
+    assert seen["env"]["ANTHROPIC_MODEL"] == "claude:opus"
+    # Every documented variable still carries a value: "remapped" must never mean "omitted".
+    for key in [k for k in seen["env"] if k.endswith("_MODEL")]:
+        assert seen["env"][key], f"{key} was left empty by a remap"
+
+    # One line, and it names which *tiers* moved — the user thinks in `/model sonnet`, not in models.
+    lines = [ln for ln in capsys.readouterr().err.splitlines() if ln.strip()]
+    remap = [ln for ln in lines if "sonnet" in ln]
+    assert len(remap) == 1, f"the remap is reported once, not per tier: {lines}"
+    assert "fable" in remap[0], f"every moved tier is named in that one line: {remap[0]}"
+    assert "claude:opus" in remap[0], f"...and what they now resolve to: {remap[0]}"
+
+
+def test_launch_warns_when_claude_code_user_settings_override_the_injected_env(monkeypatch, tmp_path,
+                                                                              capsys):
+    """Claude Code's own settings carry an `env` block that outranks the environment we hand the child.
+
+    A user with an Anthropic base URL there silently defeats this command — the app starts, talks to
+    Anthropic, and the grid looks broken. So it is warned about, in one line, naming the variable and
+    the file. Never edited: the file is the user's, and guessing which value they meant is not ours
+    to do.
+    """
+    config, _project = _seed_launchable_grid(monkeypatch, tmp_path)
+    config.mkdir(parents=True)
+    settings = config / "settings.json"
+    settings.write_text(json.dumps({"env": {"ANTHROPIC_BASE_URL": "https://api.anthropic.com"}}),
+                        encoding="utf-8")
+    before = settings.read_bytes()
+    seen = _capture_launch(monkeypatch)
+
+    assert cli.main(["launch", "claude"]) == 0, "a warning informs, it does not block"
+
+    warnings = [ln for ln in capsys.readouterr().err.splitlines()
+                if "ANTHROPIC_BASE_URL" in ln]
+    assert len(warnings) == 1, f"warned once, not once per key or per file: {warnings}"
+    assert str(settings) in warnings[0], f"the file to edit must be named: {warnings[0]}"
+    assert settings.read_bytes() == before, "the user's settings file is never modified"
+    # The env we hand the child is unchanged — we report the conflict, we do not try to win it.
+    assert seen["env"]["ANTHROPIC_BASE_URL"] == "https://relay.example/relay"
+
+
+def test_launch_is_silent_when_claude_code_settings_carry_no_overriding_value(monkeypatch, tmp_path,
+                                                                             capsys):
+    """A settings file that sets something we do not is not a conflict, and must not be mentioned —
+    a warning that fires on every launch is one users learn to scroll past."""
+    config, _project = _seed_launchable_grid(monkeypatch, tmp_path)
+    config.mkdir(parents=True)
+    (config / "settings.json").write_text(
+        json.dumps({"env": {"FOO": "bar"}, "model": "sonnet"}), encoding="utf-8")
+    _capture_launch(monkeypatch)
+
+    assert cli.main(["launch", "claude"]) == 0
+    lines = [ln for ln in capsys.readouterr().err.splitlines() if ln.strip()]
+    assert len(lines) == 1, f"only the status line, nothing about settings: {lines}"
+
+
+def test_launch_warns_when_project_settings_override_the_injected_env(monkeypatch, tmp_path, capsys):
+    """`grid launch claude` is typed inside a project, and a project's `.claude/settings.local.json`
+    overrides us exactly as the user-level file does. From inside the app the two are
+    indistinguishable, so checking only one would make the warning a half-truth."""
+    _config, project = _seed_launchable_grid(monkeypatch, tmp_path)
+    (project / ".claude").mkdir(parents=True)
+    (project / ".claude" / "settings.local.json").write_text(
+        json.dumps({"env": {"CLAUDE_CODE_SUBAGENT_MODEL": "claude-haiku-4-5"}}), encoding="utf-8")
+    _capture_launch(monkeypatch)
+
+    assert cli.main(["launch", "claude"]) == 0
+    warnings = [ln for ln in capsys.readouterr().err.splitlines()
+                if "CLAUDE_CODE_SUBAGENT_MODEL" in ln]
+    # Not an `ANTHROPIC_*` name, but it overrides a variable this command sets just the same, so the
+    # check is "a key we inject", not a prefix.
+    assert len(warnings) == 1, f"a project-level override must warn too: {warnings}"
+    assert "settings.local.json" in warnings[0]
+
+
+@pytest.mark.skipif(not os.path.exists("/dev/zero"), reason="needs a character device")
+def test_launch_refuses_to_read_a_settings_path_that_is_not_a_regular_file(monkeypatch, tmp_path,
+                                                                          capsys):
+    """A settings path is attacker-influenced: `grid launch` is run from inside a checkout, and git
+    stores a symlink in four bytes — so a hostile repo can ship `.claude/settings.json` pointing at
+    `/dev/zero`, which never reaches EOF, or at a FIFO, whose `open()` never returns.
+
+    Reading it would hang the launch before preflight ever ran. So the *target* must be a regular
+    file. Symlinks themselves stay allowed: dotfile managers legitimately symlink these files, and
+    rejecting the link rather than its target would break them for no security gain.
+    """
+    config, _project = _seed_launchable_grid(monkeypatch, tmp_path)
+    config.mkdir(parents=True)
+    (config / "settings.json").symlink_to("/dev/zero")
+    _capture_launch(monkeypatch)
+
+    assert cli.main(["launch", "claude"]) == 0, "it must neither hang nor block the launch"
+    err = capsys.readouterr().err
+    # The reason names *why* it was skipped. Asserting the specific reason is what keeps this test
+    # from passing on the size cap alone, which would report a JSON error instead.
+    assert "regular file" in err, err
+    assert "settings.json" in err, err
+
+
+def test_launch_skips_an_absurdly_large_settings_file(monkeypatch, tmp_path, capsys):
+    """The regular-file check rules out devices and FIFOs; this bounds the case it leaves — a merely
+    enormous regular file, which would otherwise be read into memory whole before being parsed.
+
+    The file is deliberately *valid* JSON carrying a real collision, so the two outcomes are
+    distinguishable: uncapped, this warns about `ANTHROPIC_BASE_URL`; capped, it says it was skipped.
+    """
+    from shared.launch import claude as claude_target
+
+    config, _project = _seed_launchable_grid(monkeypatch, tmp_path)
+    config.mkdir(parents=True)
+    padding = b" " * claude_target._MAX_SETTINGS_BYTES  # pushes it one byte past the cap
+    (config / "settings.json").write_bytes(
+        b'{"env": {"ANTHROPIC_BASE_URL": "https://api.anthropic.com"}}' + padding)
+    _capture_launch(monkeypatch)
+
+    assert cli.main(["launch", "claude"]) == 0, "an oversized settings file cannot block a launch"
+    err = capsys.readouterr().err
+    assert "larger than" in err, err
+    assert "ANTHROPIC_BASE_URL" not in err, "the cap fired, so the body was never parsed"
+
+
+def test_launch_survives_a_working_directory_that_no_longer_exists(monkeypatch, tmp_path, capsys):
+    """The settings check is a nicety; it must never be what stops a launch that would have worked.
+
+    A shell sitting in a directory that has since been removed — a deleted worktree, a cleaned temp
+    dir — makes `Path.cwd()` raise. That happens *after* both refusal points have passed, so without a
+    guard a launch the code has already decided would succeed dies instead on a `pathlib` traceback
+    that names neither the grid, nor Claude Code, nor `cd`.
+
+    The user-level settings are still checked: only the location that could not be resolved is
+    skipped.
+    """
+    config, project = _seed_launchable_grid(monkeypatch, tmp_path)
+    config.mkdir(parents=True)
+    (config / "settings.json").write_text(
+        json.dumps({"env": {"ANTHROPIC_BASE_URL": "https://api.anthropic.com"}}), encoding="utf-8")
+    seen = _capture_launch(monkeypatch)
+    os.rmdir(project)  # the cwd is pulled out from under the process
+
+    assert cli.main(["launch", "claude"]) == 0, "a dead cwd cannot stop a launch"
+    assert seen["argv"], "the app must still have been started"
+    err = capsys.readouterr().err
+    assert "ANTHROPIC_BASE_URL" in err, f"the location that DID resolve is still checked: {err}"
+
+
+def test_launch_survives_a_process_with_no_resolvable_home_directory(monkeypatch, tmp_path, capsys):
+    """The sibling of the dead-cwd case, and the reason the two locations resolve independently.
+
+    A container running as a UID with no passwd entry and no `HOME` makes `Path.home()` raise. Only
+    the user-level settings become uncheckable; the project's are still read, and the launch still
+    happens. Simulated rather than staged, because a UID with no home cannot be created from a test.
+    """
+    _config, project = _seed_launchable_grid(monkeypatch, tmp_path)
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR")  # so the home directory is what has to be resolved
+    monkeypatch.setattr(Path, "home", staticmethod(
+        lambda: (_ for _ in ()).throw(RuntimeError("Could not determine home directory."))))
+    (project / ".claude").mkdir(parents=True)
+    (project / ".claude" / "settings.json").write_text(
+        json.dumps({"env": {"ANTHROPIC_MODEL": "claude-opus-4-6"}}), encoding="utf-8")
+    seen = _capture_launch(monkeypatch)
+
+    assert cli.main(["launch", "claude"]) == 0
+    assert seen["argv"], "no home directory is not a reason to refuse to launch"
+    err = capsys.readouterr().err
+    assert "home directory" in err, f"say which location could not be checked: {err}"
+    assert "ANTHROPIC_MODEL" in err, f"the project's settings are still checked: {err}"
+
+
+def test_launch_says_so_when_a_settings_file_cannot_be_read(monkeypatch, tmp_path, capsys):
+    """A settings file that exists but will not parse is neither "no conflict" nor a reason to refuse.
+
+    Treating it as empty would be a swallowed read: the one check standing between the user and a
+    launch that looks like a broken grid would quietly not have run. So it says so and launches.
+    """
+    config, _project = _seed_launchable_grid(monkeypatch, tmp_path)
+    config.mkdir(parents=True)
+    (config / "settings.json").write_text("{ not json", encoding="utf-8")
+    _capture_launch(monkeypatch)
+
+    assert cli.main(["launch", "claude"]) == 0, "an unreadable settings file cannot block a launch"
+    err = capsys.readouterr().err
+    assert "settings.json" in err and "couldn't read" in err.lower(), err
+
+
+def test_launch_claude_spawns_the_binary_and_returns_the_childs_exit_code(monkeypatch, tmp_path):
+    """The app's exit code is the command's exit code, so `grid launch claude` composes in a script."""
+    _seed_launchable_grid(monkeypatch, tmp_path)
+    seen = _capture_launch(monkeypatch, exit_code=3)
+
+    assert cli.main(["launch", "claude"]) == 3  # non-zero survives, not flattened to 0 or 1
+    assert seen["argv"] == ["/usr/local/bin/claude"]
+    assert seen["looked_for"] == ["claude"]
+
+
+def _grid_home_tree(root):
+    """Every path under a temp GRID_HOME — a snapshot to prove a launch writes nothing."""
+    return sorted(str(path.relative_to(root)) for path in root.rglob("*"))
+
+
+def test_launch_claude_hands_the_child_exactly_the_ten_documented_keys(monkeypatch, tmp_path):
+    """The env the child is given IS this feature's contract, so it is asserted key by key.
+
+    A one-character change to any variable name or model value must not be able to ship green: the
+    dictionary below is spelled out rather than derived from the constant it is testing.
+    """
+    _seed_launchable_grid(monkeypatch, tmp_path)  # relay https://relay.example, access token AT
+    monkeypatch.delenv("GRID_TOKEN", raising=False)  # so its absence below is the command's doing
+    for key in [k for k in os.environ if k.startswith(("ANTHROPIC_", "CLAUDE_CODE_"))]:
+        monkeypatch.delenv(key, raising=False)  # a dev's own Anthropic env must not mask the assert
+    seen = _capture_launch(monkeypatch)
+    before = _grid_home_tree(tmp_path)
+
+    assert cli.main(["launch", "claude"]) == 0
+
+    expected = {
+        "ANTHROPIC_BASE_URL": "https://relay.example/relay",
+        "ANTHROPIC_AUTH_TOKEN": "AT",
+        "ANTHROPIC_API_KEY": "AT",
+        "ANTHROPIC_MODEL": "claude:opus",
+        "ANTHROPIC_SMALL_FAST_MODEL": "claude:haiku",
+        "CLAUDE_CODE_SUBAGENT_MODEL": "claude:haiku",
+        "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude:opus",
+        "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude:sonnet",
+        "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude:haiku",
+        "ANTHROPIC_DEFAULT_FABLE_MODEL": "claude:fable",
+    }
+    assert len(expected) == 10, "the documented block is ten keys; this list drifted"
+    # Inherited environment, with those keys layered over it — the child keeps the user's PATH,
+    # HOME and everything else, or Claude Code would launch into a stripped shell.
+    assert seen["env"] == {**os.environ, **expected}
+    # ... and *only* those: any variable this command added or changed is one of the ten. This is
+    # what keeps a telemetry variable (deliberately not set, ADR 0028) from creeping in unnoticed.
+    assert {k: v for k, v in seen["env"].items() if os.environ.get(k) != v} == expected
+    # `/v1` on the base is the single most likely mistake: Claude Code appends `/v1/messages` itself.
+    assert "/v1" not in seen["env"]["ANTHROPIC_BASE_URL"]
+    # A shell convenience variable from the hand-rolled recipe that the app never reads.
+    assert "GRID_TOKEN" not in seen["env"]
+
+    # The child only: the CLI's own environment is unchanged, and nothing was written to disk.
+    assert [k for k in os.environ if k.startswith(("ANTHROPIC_", "CLAUDE_CODE_"))] == []
+    assert _grid_home_tree(tmp_path) == before
+
+
+def test_launch_claude_base_url_never_doubles_a_slash(monkeypatch, tmp_path):
+    """A stored relay address with a trailing slash must not produce `…//relay`, which the client
+    would send verbatim."""
+    _seed_remote(monkeypatch, tmp_path,
+                 networks=[{"network_id": "n1", "name": "team", "access_token": "AT"}], active="team")
+    _mock_lifecycle(monkeypatch, status={"state": "running", "signaling_url": "https://relay.example/"})
+    _mock_tier_overview(monkeypatch)
+    _isolate_claude_settings(monkeypatch, tmp_path)
+    seen = _capture_launch(monkeypatch)
+
+    assert cli.main(["launch", "claude"]) == 0
+    assert seen["env"]["ANTHROPIC_BASE_URL"] == "https://relay.example/relay"
+
+
+def test_launch_claude_targets_a_named_grid_and_defaults_to_the_active_one(monkeypatch, tmp_path):
+    """`grid launch claude <grid>` reaches another grid without `grid use` and back again.
+
+    The two grids are told apart by their per-grid access token: `_mock_lifecycle` answers every
+    network id with the same status, so the relay base cannot distinguish them.
+    """
+    _seed_remote(monkeypatch, tmp_path, networks=[
+        {"network_id": "n1", "name": "team", "access_token": "AT-TEAM"},
+        {"network_id": "n2", "name": "lab", "access_token": "AT-LAB"}], active="team")
+    _mock_lifecycle(monkeypatch, status={"state": "running", "signaling_url": "https://relay.example"})
+    _mock_tier_overview(monkeypatch)
+    _isolate_claude_settings(monkeypatch, tmp_path)
+    seen = _capture_launch(monkeypatch)
+
+    assert cli.main(["launch", "claude", "lab"]) == 0
+    assert seen["env"]["ANTHROPIC_AUTH_TOKEN"] == "AT-LAB"  # the named grid, not the active one
+
+    assert cli.main(["launch", "claude"]) == 0
+    assert seen["env"]["ANTHROPIC_AUTH_TOKEN"] == "AT-TEAM"  # omitted → the active grid
+
+
+def test_launch_in_local_mode_refuses_naming_the_dialect_and_the_mode_switch(monkeypatch, tmp_path):
+    """A local grid serves chat/completions, never Anthropic Messages — so the refusal must name the
+    dialect (or the user files a bug) *and* the command that moves them (or it is a dead end)."""
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))  # default mode is local
+    _capture_launch(monkeypatch)  # if the gate leaked, the spawn below would be reached
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["launch", "claude"])
+
+    message = str(exc.value)
+    assert "Anthropic Messages" in message, f"the dialect is the reason and must be named: {message}"
+    assert "grid mode remote" in message, f"the way out must be named: {message}"
+    assert "`grid launch`" in message  # the gate names the command the user typed
+
+
+def test_launch_claude_without_a_stored_token_gives_the_login_guidance(monkeypatch, tmp_path):
+    """No token locally is the *familiar* failure, not a novel one: byte for byte what `info --env`
+    says. Launching with an empty bearer would fail inside Claude Code as an auth error instead."""
+    _seed_running_remote_grid(monkeypatch, tmp_path, access_token=None)
+    seen = _capture_launch(monkeypatch)
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["launch", "claude"])
+    assert str(exc.value) == (
+        "Grid team has no access token locally. Run `grid login` to refresh your grids."
+    )
+    assert "argv" not in seen, "refused before the spawn, never launched with an empty bearer"
+
+    with pytest.raises(SystemExit) as info_exc:
+        cli.main(["info", "--env"])
+    assert str(info_exc.value) == str(exc.value)  # one sentence, one source
+
+
+def test_launch_is_wired_in_the_parser_and_classified_remote_only():
+    """The two wiring hazards ADR 0028 names, asserted directly.
+
+    A handler imported only in `cli/__init__` makes `build_parser()` raise `NameError`; a command
+    missing from the dispatch tables would silently run the wrong mode's code.
+    """
+    parser = cli.build_parser()  # would raise NameError if the handler were not imported here
+    sub = next(a for a in parser._actions if isinstance(a, argparse._SubParsersAction))
+    assert "launch" in sub.choices
+
+    assert dispatch.REMOTE_ONLY["launch"], "launch must carry its own gate reason, not the default"
+    assert "launch" not in dispatch.AGNOSTIC
+    assert "launch" not in dispatch.REMOTE_HANDLERS
+
+    # Preflight always runs (ADR 0028): there is no opt-out, so any spelling of one is a parse error.
+    # A user who could skip the check would be back to diagnosing a model error inside Claude Code.
+    for flag in ("--no-preflight", "--skip-preflight", "--force"):
+        with pytest.raises(SystemExit) as exc:
+            parser.parse_args(["launch", "claude", flag])
+        assert exc.value.code == 2, flag
+
+
+def test_launch_tier_models_are_named_in_exactly_one_module():
+    """The tier values are the single site a later discovery slice replaces, so a second copy anywhere
+    would make that a multi-site change — and one copy would then silently go stale."""
+    from shared.launch import claude
+
+    assert set(claude.MODEL_TIERS) == {"main", "small_fast", "opus", "sonnet", "haiku", "fable"}
+    home = Path(claude.__file__).resolve()
+    root = home.parents[2]
+    for value in sorted(set(claude.MODEL_TIERS.values())):
+        hits = {
+            path.resolve()
+            for package in ("cli", "shared", "local", "remote")
+            for path in (root / package).rglob("*.py")
+            if value in path.read_text(encoding="utf-8")
+        }
+        assert hits == {home}, f"{value!r} is named outside the one constant: {sorted(hits)}"
+
+
+def test_launch_adding_a_second_target_needs_no_change_to_the_claude_target(monkeypatch, tmp_path, capsys):
+    """The protocol boundary, exercised: a target registered in the table is listed and runs, with
+    nothing in the Claude target touched — which is what makes Codex a new file and a registry line."""
+    from shared.launch import registry
+
+    ran = {}
+
+    class _FakeTarget:
+        name = "fake"
+        label = "Fake App"
+
+        def run(self, session):
+            ran["session"] = session
+            return 7
+
+    monkeypatch.setattr(registry, "TARGETS", {**registry.TARGETS, "fake": _FakeTarget()})
+    _seed_launchable_grid(monkeypatch, tmp_path)
+    seen = _capture_launch(monkeypatch)
+
+    assert cli.main(["launch"]) == 0
+    listing = capsys.readouterr().out
+    assert "claude" in listing and "fake" in listing  # the listing is the registry, not a literal
+
+    assert cli.main(["launch", "fake"]) == 7  # the new target's own exit code, unmodified
+    assert ran["session"].relay_base == "https://relay.example"
+    assert ran["session"].access_token == "AT"
+    assert ran["session"].label == "team"
+    assert "argv" not in seen, "the Claude target must not be involved in another target's launch"
+
+
+def test_launch_unknown_target_names_it_and_lists_the_available_ones(monkeypatch, tmp_path):
+    """A typo must be a clean error that names both what was rejected and what is valid, so the fix is
+    one edit away — and it must land before any network call or auth gate."""
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    state.set_mode("remote")  # deliberately signed out: an unknown target is not an auth problem
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["launch", "vscode"])
+    message = str(exc.value)
+    assert "vscode" in message  # the name that was rejected
+    assert "claude" in message  # ... and every name that would have worked
+    assert "login" not in message.lower(), f"a typo must not be reported as a sign-in problem: {message}"
+
+
+def test_launch_claude_when_the_binary_is_absent_is_a_clean_actionable_error(monkeypatch, tmp_path):
+    """No Claude Code on this machine is a clean error naming the app and where to get it — not a
+    traceback, and not a spawn of nothing. (Issue 04 turns this into an offer to install it.)"""
+    _seed_launchable_grid(monkeypatch, tmp_path)
+    seen = _capture_launch(monkeypatch, binary=None)
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["launch", "claude"])
+    message = str(exc.value)
+    assert "Claude Code" in message
+    assert "claude.com" in message, f"the message must say where to get it: {message}"
+    assert "argv" not in seen, "nothing may be spawned when the app was never found"
+
+
+def test_launch_claude_prints_one_line_naming_the_grid_and_model_before_spawning(monkeypatch, tmp_path, capsys):
+    """Once Claude Code's own UI owns the terminal the user can no longer tell which grid they are on,
+    so exactly one line says it first — one, because more would scroll away under the app's banner.
+
+    Read at spawn time, not afterwards: "before" is the whole point, and output collected at the end
+    would pass just as happily if the line were printed as the app exited.
+
+    On **stderr**, because stdout belongs to the launched app — a script capturing the app's output
+    must not receive the launcher's status line mixed into it.
+    """
+    _seed_launchable_grid(monkeypatch, tmp_path)
+    seen = _capture_launch(monkeypatch)
+
+    from shared.launch import system
+
+    spawn = system.spawn
+
+    def spy(argv, env):
+        seen["before_spawn"] = capsys.readouterr()
+        return spawn(argv, env)
+
+    monkeypatch.setattr(system, "spawn", spy)
+
+    assert cli.main(["launch", "claude"]) == 0
+    assert seen["before_spawn"].out == "", "stdout belongs to the app, not to the launcher"
+    lines = [line for line in seen["before_spawn"].err.splitlines() if line.strip()]
+    assert len(lines) == 1, f"one line before the app starts, not {len(lines)}: {lines}"
+    assert "team" in lines[0] and "claude:opus" in lines[0]
+
+
+def _stub_binary(monkeypatch, path="/usr/local/bin/claude"):
+    """Resolve the app, but leave the real ``spawn`` in place so its exit-code handling is exercised."""
+    from shared.launch import system
+
+    monkeypatch.setattr(system, "find_executable", lambda name: path)
+    return system
+
+
+def test_launch_reports_a_signal_killed_app_the_way_a_shell_does(monkeypatch, tmp_path, capsys):
+    """A child killed by a signal has no exit code — the OS reports ``-N``. Handing that straight to
+    the shell shows 256-N (SIGKILL → 247), which matches nothing a script author expects.
+
+    (There is no companion test for "one Ctrl-C returns 130": that was the old rule, and it was wrong —
+    a single interrupt now waits for the app's own exit. See
+    `test_launch_lets_the_app_finish_its_own_shutdown_on_ctrl_c`.)
+    """
+    _seed_launchable_grid(monkeypatch, tmp_path)
+    system = _stub_binary(monkeypatch)
+    monkeypatch.setattr(system.subprocess, "Popen",
+                        lambda *a, **k: SimpleNamespace(wait=lambda: -9))
+
+    assert cli.main(["launch", "claude"]) == 137  # 128 + SIGKILL, what `$?` would say
+    capsys.readouterr()
+
+
+def test_launch_when_the_app_cannot_be_executed_is_a_clean_error(monkeypatch, tmp_path, capsys):
+    """A path that resolved but cannot run (deleted between resolution and exec, or not executable)
+    is a clean error naming it — never a traceback out of subprocess."""
+    _seed_launchable_grid(monkeypatch, tmp_path)
+    system = _stub_binary(monkeypatch)
+
+    def denied(*a, **k):
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr(system.subprocess, "Popen", denied)
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["launch", "claude"])
+    assert "/usr/local/bin/claude" in str(exc.value) and "Permission denied" in str(exc.value)
+    capsys.readouterr()
+
+
+class _FakeChild:
+    """A child process that handles its own SIGINT: the first ``wait`` is interrupted (the terminal's
+    Ctrl-C reaches the parent too), and the app then finishes and exits on its own terms."""
+
+    def __init__(self, *args, exit_code=42, interrupts=1, **kwargs):
+        self.events = []
+        self._exit_code = exit_code
+        self._interrupts = interrupts
+
+    def __call__(self, *args, **kwargs):  # stands in for `subprocess.Popen(...)`
+        return self
+
+    def wait(self):
+        self.events.append("wait")
+        if self.events.count("wait") <= self._interrupts:
+            raise KeyboardInterrupt
+        return self._exit_code
+
+    def kill(self):
+        self.events.append("kill")
+
+
+def test_launch_lets_the_app_finish_its_own_shutdown_on_ctrl_c(monkeypatch, tmp_path, capsys):
+    """Ctrl-C must reach Claude Code the way it does when the user runs the binary themselves.
+
+    `subprocess.run` cannot be used for this: its stdlib implementation wraps the wait in a bare
+    `except:` that calls `process.kill()`, so the parent's own KeyboardInterrupt SIGKILLs the app while
+    it is still shutting down — losing whatever it does on exit, terminal restore included. Verified
+    against a real child that traps SIGINT: its "cleanup done" line never printed.
+
+    Asserting on wait/kill is asserting on the seam itself, which is the only place "we did not kill
+    the app" is observable at all.
+    """
+    _seed_launchable_grid(monkeypatch, tmp_path)
+    system = _stub_binary(monkeypatch)
+    child = _FakeChild()
+    monkeypatch.setattr(system.subprocess, "Popen", child)
+
+    assert cli.main(["launch", "claude"]) == 42  # the app's own exit code, not the interrupt's
+    assert child.events == ["wait", "wait"], f"the app must be waited for, never killed: {child.events}"
+    capsys.readouterr()
+
+
+def test_launch_gives_up_on_a_second_ctrl_c(monkeypatch, tmp_path, capsys):
+    """A user hammering Ctrl-C because the app is not going down must get their shell back, with the
+    conventional code rather than a traceback."""
+    _seed_launchable_grid(monkeypatch, tmp_path)
+    system = _stub_binary(monkeypatch)
+    child = _FakeChild(interrupts=2)
+    monkeypatch.setattr(system.subprocess, "Popen", child)
+
+    assert cli.main(["launch", "claude"]) == 130
+    assert "kill" not in child.events  # still ours to wait for, not to kill
+    capsys.readouterr()

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -365,8 +365,9 @@ def test_info_env_prints_openai_compat_without_real_secret(monkeypatch, tmp_path
     assert cli.cmd_info(args) == 0
 
     out = capsys.readouterr().out
-    assert 'OPENAI_BASE_URL="http://192.168.1.25:8090/v1"' in out
-    assert 'OPENAI_API_KEY="local-grid"' in out
+    # Single-quoted, matching the remote form — one quoting for both, or one of them stays wrong.
+    assert "OPENAI_BASE_URL='http://192.168.1.25:8090/v1'" in out
+    assert "OPENAI_API_KEY='local-grid'" in out
 
 
 def test_device_info_command_emits_the_contract(capsys):
@@ -19825,8 +19826,39 @@ def test_remote_info_env_prints_relay_base_and_token(monkeypatch, tmp_path, caps
     _mock_lifecycle(monkeypatch, status={"state": "running", "signaling_url": "https://relay.example"})
     assert cli.main(["info", "--env"]) == 0
     out = capsys.readouterr().out
-    assert 'export OPENAI_BASE_URL="https://relay.example/relay/v1"' in out
-    assert 'export OPENAI_API_KEY="AT"' in out  # the one deliberate token-printing carve-out
+    # Single-quoted, and quoted even though neither value needs it: the block is meant to be
+    # evaluated, so it is quoted uniformly by `shared.shell.quote` (see the injection test below).
+    assert "export OPENAI_BASE_URL='https://relay.example/relay/v1'" in out
+    assert "export OPENAI_API_KEY='AT'" in out  # the one deliberate token-printing carve-out
+
+
+@pytest.mark.skipif(shutil.which("sh") is None, reason="POSIX shell required")
+def test_remote_info_env_block_cannot_be_broken_out_of(monkeypatch, tmp_path, capsys):
+    """`info --env` exists to be evaluated — `eval "$(grid info --env)"` is the documented recipe —
+    so its own quoting has to hold whatever the values contain.
+
+    The token is an opaque credential this repo neither mints nor validates, and the relay base
+    arrives from the control plane; assuming which characters either can hold is the assumption that
+    turns a printed block into an executed one. The value below closes the quote and appends a
+    command, which is what a double-quoted, unescaped block would run.
+    """
+    canary = tmp_path / "executed"
+    hostile = f'ab"; touch {canary}; x="cd'
+    _seed_remote(monkeypatch, tmp_path,
+                 networks=[{"network_id": "n1", "name": "team", "access_token": hostile}],
+                 active="team")
+    _mock_lifecycle(monkeypatch, status={"state": "running", "signaling_url": "https://relay.example"})
+
+    assert cli.main(["info", "--env"]) == 0
+    block = capsys.readouterr().out
+
+    proof = subprocess.run(
+        ["sh", "-c", 'eval "$1"; printf %s "$OPENAI_API_KEY"', "sh", block],
+        capture_output=True, text=True, timeout=30,
+    )
+    assert proof.returncode == 0, proof.stderr
+    assert proof.stdout == hostile, f"the shell recovered {proof.stdout!r}, not the token"
+    assert not canary.exists(), "the printed block executed an injected command"
 
 
 def test_remote_info_env_requires_access_token(monkeypatch, tmp_path):
@@ -23577,6 +23609,39 @@ def test_launch_forwarding_the_mode_override_fails_the_way_the_help_says(monkeyp
     with pytest.raises(SystemExit) as exc:
         cli.main(["launch", "claude", "--", "--local"])
     assert "remote-mode command" in str(exc.value), str(exc.value)
+
+
+def test_a_mode_override_taken_out_of_a_passthrough_says_so(monkeypatch, tmp_path, capsys):
+    """A forwarded `--local`/`--remote` is removed from the command line, and that has to be said.
+
+    This is the one substitution in the feature that a user cannot see happening. `--local` flips the
+    run's mode, so a remote-only command then refuses — reporting a *mode* problem for a flag the
+    user aimed at the app, and pointing at a fix ("switch modes") that has nothing to do with their
+    actual mistake. `--remote` is the quieter half: it changes nothing and simply disappears.
+
+    So the warning is issued where the token is taken, covering both directions and any command,
+    rather than only being reachable through the local-mode gate.
+    """
+    _seed_launchable_grid(monkeypatch, tmp_path)
+    seen = _capture_launch(monkeypatch)
+
+    # The harmless direction: the launch still succeeds, but the vanishing is no longer silent.
+    assert cli.main(["launch", "claude", "--", "--remote"]) == 0
+    warning = capsys.readouterr().err
+    assert "--remote" in warning and "--" in warning, warning
+    assert "mode" in warning.lower(), warning
+    assert seen["argv"] == ["/usr/local/bin/claude"]
+
+    # The misleading direction: the refusal is now preceded by its real cause.
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["launch", "claude", "--", "--local"])
+    err = capsys.readouterr().err
+    assert "--local" in err, err
+    assert "remote-mode command" in str(exc.value)
+
+    # A mode override used the ordinary way is not a substitution and must stay silent.
+    assert cli.main(["--remote", "launch", "claude"]) == 0
+    assert capsys.readouterr().err.count("--remote") == 0
 
 
 def test_launch_does_not_read_a_forwarded_word_as_its_grid_argument(monkeypatch, tmp_path):


### PR DESCRIPTION
`grid launch <target>` starts a third-party app already pointed at the active grid. The endpoint and
the credential go into that app's own process environment and nowhere else — never exported to the
user's shell, never written to a config file. Closing the app is the entire cleanup, so there is no
`--restore`. One launch target ships: `claude` (Claude Code).

Driving Claude Code against a grid was already possible and people did it, but only by reconstructing
an undocumented recipe: start at `grid info --env`, then know that Claude Code speaks the Anthropic
Messages dialect so the endpoint is the same base **without** `/v1`, that the token goes into both
`ANTHROPIC_AUTH_TOKEN` and `ANTHROPIC_API_KEY`, and that all of it must be exported before the binary
starts. Every step is a place to get one string wrong and receive an error naming none of the causes.

Decisions live in [ADR 0028](docs/adr/0028-launch-hands-an-app-the-grid.md) and
[ADR 0029](docs/adr/0029-the-credential-is-checked-before-it-is-handed-over.md).

## What lands

**The command.** `grid launch` (bare) lists what can be launched and exits 0 — discovery, not an
error. `grid launch <target> [grid]` starts one; the grid positional matches `info`/`models`/`engines`
verbatim. Everything after the first `--` is the app's own command line, forwarded in order and
unread. `--print-env` prints the block as shell exports and starts nothing.

**Remote-only, and the refusal names the dialect.** A local grid serves `chat/completions`,
`completions`, `models` and media — there is no `/v1/messages` on it — so this is a design boundary,
not a missing flag. The local-mode gate learned to carry a per-command reason to say so.

**The credential is checked before it is handed over.** ADR 0028 knowingly used the public overview
for preflight, which ignores the bearer token; a rejected token then surfaced at the app's first
prompt, dressed by the relay as Anthropic's own `authentication_error`, with nothing in it naming
`grid`. Now the token's `exp` is read offline (24 h margin) and the grid is asked whether it will
accept it (`GET /relay/v1/models`). Anything stale — a passed expiry, a `member_epoch` or
`network_epoch` bumped by a membership change — is **refreshed in place** and the launch continues.
What cannot be repaired is refused before the app starts, saying which of "sign in again", "ask about
your membership" or "try again shortly" applies. A check that could not run warns and launches anyway.

**No model is chosen for you.** An earlier revision injected seven `*_MODEL` variables from a
hardcoded tier table. They are gone: that put this command in charge of which model a user's session
runs on, silently overriding their own `settings.json`, their `/model` default and any
`ANTHROPIC_MODEL` in their shell. The cost is stated in ADR 0028's amendment — a model the grid does
not serve now fails at the first prompt rather than at launch, because the launcher no longer knows
what will be asked for. Preflight keeps only the fact that holds regardless: an empty grid is refused.

## Two commits that are not about launch

- `fix(cli): quote every printed shell block` — found reviewing this feature. `grid info --env`
  emitted `export OPENAI_API_KEY="{token}"` with **no escaping**, and that block exists to be
  `eval`'d. A token containing `"` breaks out and everything after it executes — reproduced with a
  token that appended a `touch`, which ran. Quoting is now one function, `shared.shell.quote`, used by
  all three printers.
- `docs(adr): 0017 amendment` — a cherry-pick that was on `main` before it was reset to
  `public/main`; it rides along rather than needing a PR of its own.

## Test plan

- [x] `uv run --extra dev pytest` — 1621 passed / 7 skipped on the branch; **1713 passed / 7 skipped /
      7 deselected on the merge result with `public/main`**
- [x] `uv run --extra dev ruff check .` — clean, on the branch and on the merge result
- [x] Merge with `public/main` verified in a throwaway worktree: no conflicts, four files touched by
      both sides (`cli/_main.py`, `cli/parser.py`, `remote/relay.py`, `tests/test_local_cli.py`)
- [x] Credential paths exercised live against a closed port: an expired token refuses blaming the
      control plane, the same failure inside the margin warns and continues, and a healthy token makes
      no control-plane call at all
- [ ] End-to-end `grid launch claude` against a live remote grid serving a chat model
