### PR TITLE
feat(claude-seat): serve concrete model ids discovered from the installed CLI

### DIFF
--- a/cli/models.py
+++ b/cli/models.py
@@ -90,12 +90,12 @@ def _catalog_api(args: argparse.Namespace) -> int:
                     "supports_structured_outputs": entry.supports_structured_outputs,
                     "notes": entry.notes,
                 }
-                for entry in whitelist.entries
+                for entry in api_catalog.entries_for(kind)
             ],
         }, indent=2))
         return 0
 
-    if not whitelist.entries:
+    if not api_catalog.entries_for(kind):
         # A known kind with no models listed yet — not an error, and emphatically not "unknown".
         # `grid catalog` answered the question it was asked (ADR 0012 D-a: no credential, no network);
         # the answer happens to be "none". Exit 0, like `--json`'s `models: []`.
@@ -110,7 +110,7 @@ def _catalog_api(args: argparse.Namespace) -> int:
         f"Models a `grid join --api {kind}` would serve "
         f"(verified {whitelist.last_verified}):"
     )
-    for entry in whitelist.entries:
+    for entry in api_catalog.entries_for(kind):
         print(api_catalog.format_api_entry(kind, entry, whitelist.endpoints))
     print()
     print(f"No key needed to view. Requests to {kind}:* models leave the grid for the vendor.")

--- a/cli/provider.py
+++ b/cli/provider.py
@@ -333,7 +333,7 @@ def _spawn_api_media_engine(cfg: dict[str, Any], args: argparse.Namespace) -> in
     # With no -m, serve the whole whitelist for this kind — same default as the remote join.
     advertised = _narrow_advertised(
         kind,
-        [api_catalog.advertised_name(kind, entry) for entry in whitelist.entries],
+        [api_catalog.advertised_name(kind, entry) for entry in api_catalog.entries_for(kind)],
         list(getattr(args, "models", None) or []),
     )
 

--- a/cli/remote_provider.py
+++ b/cli/remote_provider.py
@@ -341,7 +341,7 @@ def _resolve_api_targets(
     if getattr(args, "advertise_as", None):
         # Defence in depth: inline `-m real=alias` desugars into advertise_as after the early guard.
         raise SystemExit("--advertise-as aliasing doesn't apply with --api.")
-    valid = {api_catalog.advertised_name(kind, entry): entry for entry in whitelist.entries}
+    valid = {api_catalog.advertised_name(kind, entry): entry for entry in api_catalog.entries_for(kind)}
     # No -m = the whole whitelist (zero-config default); `valid` preserves whitelist order.
     requested = list(dict.fromkeys(args.models or []))  # dedupe so errors don't repeat
     chosen = requested or list(valid)
@@ -645,7 +645,7 @@ def _resolve_key_api_targets(
     else:
         # Media APIs (e.g. Doggi) don't expose GET /models — probe the endpoint to validate the key.
         _probe_media_api(kind, endpoint_url, key)
-        visible = {entry.vendor_name for entry in whitelist.entries}
+        visible = {entry.vendor_name for entry in api_catalog.entries_for(kind)}
         served = list(chosen)
     # The validation call above proved the key valid — only now persist it to the machine-local key
     # store, so a mistyped/revoked key is never stored for later joins (and the detached serve

--- a/shared/agent/claude_models.py
+++ b/shared/agent/claude_models.py
@@ -1,0 +1,186 @@
+"""Which concrete Claude models the installed `claude` binary serves.
+
+Two local sources, neither of which calls a vendor API:
+
+  `/model`  a local slash command (measured: 7ms, 0 tokens, $0, `num_turns: 0`) whose output
+            names the tier aliases this CLI accepts.
+  the executable  carries every concrete model id as a plain string in its bundle string pool.
+
+The first says which tiers exist, the second turns a tier into a dated id. Neither list is written
+down here, so a new Claude Code release brings its new models along without an edit.
+
+Design and the measurements behind each rule:
+docs/superpowers/specs/2026-07-31-claude-seat-dynamic-models-design.md
+"""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from pathlib import Path
+
+from shared.paths import grid_home
+
+# Same shape as the seat's QUOTA_ARGV: a local slash command, no model turn, no cost.
+MODELS_ARGV = ("-p", "/model", "--output-format", "json",
+               "--safe-mode", "--tools", "", "--no-session-persistence")
+
+_AVAILABLE = re.compile(r"Available:\s*([^\n]+)")
+_BRACKET = re.compile(r"\[[^\]]*\]$")   # opus[1m] -> opus
+
+
+def available_tiers(text):
+    """The alias names `/model` lists, in the order printed.
+
+    `[1m]`-style suffixes are stripped and NOT recorded: `--model opus[1m]` is known to work, but
+    the full id carrying the suffix has never been measured, so claiming a 1M window while
+    invoking the bare id could advertise a window the request does not get.
+
+    The trailing "or a full model ID" is prose, not an alias — it is dropped by the space test,
+    which is also why no alias containing a space can ever be served.
+    """
+    found = _AVAILABLE.search(text or "")
+    if found is None:
+        return []
+    tiers = []
+    for raw in found.group(1).split(","):
+        name = _BRACKET.sub("", raw.strip().rstrip("."))
+        if name and " " not in name and name not in tiers:
+            tiers.append(name)
+    return tiers
+
+
+def _version(raw):
+    """`4-1-20250805` -> `(4, 1)`.
+
+    A trailing segment of exactly eight digits is a release date, not a version component. Left
+    in, `claude-opus-4-1-20250805` would read `(4, 1, 20250805)` and outrank `claude-opus-5`.
+    """
+    parts = [int(part) for part in raw.split("-")]
+    if len(parts) > 1 and len(str(parts[-1])) == 8:
+        parts = parts[:-1]
+    return tuple(parts)
+
+
+def newest_ids(blob, tiers):
+    """`{tier: newest id}` for whichever of `tiers` the blob carries.
+
+    One pass over the whole blob, with the tiers alternated inside a single pattern. Scanning
+    per-tier instead costs a full 266MB pass each — measured 6.5s a pass, 47s for four.
+
+    Both anchors are load-bearing. The leading `[^a-z0-9.-]` rejects the Bedrock and Vertex
+    spellings (`us.anthropic.claude-opus-5`, `anthropic.claude-opus-5`); the trailing
+    `[^a-z0-9-]` rejects the `-fast` and `-v1` builds. A tier with no id at all — `best`,
+    `opusplan`, `default` — simply never matches and is absent from the result, which is why none
+    of those three is named anywhere in this file.
+
+    Ties go to the undated spelling: `claude-haiku-4-5` and `claude-haiku-4-5-20251001` both read
+    `(4, 5)`, and the undated one is the alias that follows its tier forward.
+    """
+    if not tiers:
+        return {}
+    alternation = b"|".join(re.escape(tier.encode()) for tier in tiers)
+    pattern = re.compile(
+        rb"[^a-z0-9.-](claude-(" + alternation + rb")-(\d+(?:-\d+)*))[^a-z0-9-]"
+    )
+    found = {}
+    for match in pattern.finditer(blob):
+        tier = match.group(2).decode()
+        found.setdefault(tier, {})[match.group(1).decode()] = _version(match.group(3).decode())
+    return {
+        tier: max(ids, key=lambda ident: (ids[ident], -len(ident)))
+        for tier, ids in found.items()
+    }
+
+
+def executable(binary):
+    """The file to scan, or None.
+
+    `binary` is whatever resolved on PATH, which is not necessarily the executable: a
+    cmux-managed entry is a twenty-line bash shim and scanning it finds nothing. Ask the CLI which
+    version is running and index the native install by it — deliberately the RUNNING version and
+    not the newest installed one, since several sit side by side under `versions/` and scanning
+    the wrong one would advertise models the serving binary may not have.
+    """
+    try:
+        proc = subprocess.run([binary, "--version"], capture_output=True, text=True, timeout=30)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    version = (proc.stdout or "").strip().split(" ")[0]
+    if not version:
+        return None
+    path = Path.home() / ".local" / "share" / "claude" / "versions" / version
+    return path if path.is_file() else None
+
+
+def _cache_file():
+    return grid_home() / "claude-models.json"
+
+
+def _cache_key(path):
+    stat = path.stat()
+    return f"{path}:{stat.st_size}:{int(stat.st_mtime)}"
+
+
+def _read_cache(key):
+    try:
+        stored = json.loads(_cache_file().read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(stored, dict) or stored.get("key") != key:
+        return None
+    models = stored.get("models")
+    return models if isinstance(models, list) else None
+
+
+def _write_cache(key, models):
+    cache = _cache_file()
+    try:
+        cache.parent.mkdir(parents=True, exist_ok=True)
+        cache.write_text(json.dumps({"key": key, "models": models}), encoding="utf-8")
+    except OSError:
+        pass   # an unwritable home costs a rescan, never an answer
+
+
+def _ask_tiers(binary):
+    try:
+        proc = subprocess.run([binary, *MODELS_ARGV], capture_output=True, text=True, timeout=60)
+        envelope = json.loads(proc.stdout or "")
+    except (OSError, subprocess.SubprocessError, ValueError):
+        return []
+    if not isinstance(envelope, dict):
+        return []
+    return available_tiers(str(envelope.get("result") or ""))
+
+
+def discover(binary):
+    """The concrete model ids this `claude` serves, newest per tier, in `/model` order.
+
+    Returns `[]` when anything is unavailable — no binary, no native install, unparseable output.
+    A caller that gets `[]` keeps its static list, so this can never block a join.
+
+    The cache is keyed on the executable's identity, and the `/model` probe sits INSIDE the miss
+    path: a cache hit costs the one `claude --version` needed to find the executable, and no
+    second spawn. Each spawn of a 266MB binary is ~1s, so which side of the cache they fall on is
+    the difference between a join that waits and one that does not.
+    """
+    path = executable(binary)
+    if path is None:
+        return []
+    try:
+        key = _cache_key(path)
+    except OSError:
+        return []
+    cached = _read_cache(key)
+    if cached is not None:
+        return cached
+    tiers = _ask_tiers(binary)
+    if not tiers:
+        return []
+    try:
+        resolved = newest_ids(path.read_bytes(), tiers)
+    except OSError:
+        return []
+    models = [resolved[tier] for tier in tiers if tier in resolved]
+    _write_cache(key, models)
+    return models

--- a/shared/agent/cli_seat.py
+++ b/shared/agent/cli_seat.py
@@ -232,10 +232,7 @@ def assert_available(spec):
 
 def advertised_models(kind):
     """What this seat serves, from the ONE catalog row the join also validates against."""
-    whitelist = api_catalog.WHITELISTS.get(kind)
-    if whitelist is None:
-        return []
-    return [api_catalog.advertised_name(kind, entry) for entry in whitelist.entries]
+    return [api_catalog.advertised_name(kind, entry) for entry in api_catalog.entries_for(kind)]
 
 
 def alias_for(kind, advertised):
@@ -245,8 +242,7 @@ def alias_for(kind, advertised):
     entry = api_catalog.find_advertised(kind, name)
     if entry is not None:
         return entry.vendor_name
-    whitelist = api_catalog.WHITELISTS.get(kind)
-    if whitelist and any(e.vendor_name == name for e in whitelist.entries):
+    if any(e.vendor_name == name for e in api_catalog.resolvable_entries(kind)):
         return name
     return None
 

--- a/shared/models/api_catalog.py
+++ b/shared/models/api_catalog.py
@@ -271,6 +271,11 @@ CLAUDE_LAST_VERIFIED = "2026-07-28"
 # The service-kind key, named here (not in remote/) for the same reason CODEX_KIND is.
 CLAUDE_KIND = "claude"
 
+# The FALLBACK row. `entries_for("claude")` normally answers with concrete ids read from the
+# installed binary (`shared/agent/claude_models.py`); this list is what a box with no readable
+# `claude` falls back to, and it is also the pre-discovery behaviour verbatim, so the worst case
+# here is exactly what shipped before.
+#
 # `--model` ALIASES, not dated ids: an alias always resolves to the current model of its tier, so
 # the row cannot go stale between releases.
 #
@@ -402,6 +407,69 @@ def advertised_name(kind: str, entry: ApiModelEntry) -> str:
     return f"{kind}:{entry.vendor_name}"
 
 
+_claude_entries: tuple[ApiModelEntry, ...] | None = None
+
+
+def entries_for(kind: str) -> tuple[ApiModelEntry, ...]:
+    """The models ``kind`` serves right now — the ONE reader every surface goes through.
+
+    Every kind but ``claude`` answers from its static row, unchanged. The Claude seat is not a
+    vendor endpoint but the operator's own CLI, so the honest answer is whatever ids that binary
+    carries; they are discovered once per process (see ``shared/agent/claude_models.py``) and fall
+    back to ``CLAUDE_WHITELIST`` whenever the binary cannot be read.
+    """
+    whitelist = WHITELISTS.get(kind)
+    if whitelist is None:
+        return ()
+    if kind != CLAUDE_KIND:
+        return whitelist.entries
+    global _claude_entries
+    if _claude_entries is None:
+        _claude_entries = _discovered_claude_entries() or whitelist.entries
+    return _claude_entries
+
+
+def _discovered_claude_entries() -> tuple[ApiModelEntry, ...]:
+    """Imported inside the call, not at module scope: the seat modules import this one, so a
+    top-level import would close the cycle. By the time anybody asks, both are loaded."""
+    from shared.agent import cli_seat, claude_models
+    from shared.agent.seats import claude as claude_seat
+
+    binary = cli_seat.seat_bin(claude_seat.SPEC)
+    if binary is None:
+        return ()
+    return tuple(
+        ApiModelEntry(
+            vendor_name=model_id,
+            # Still the `0` unknown sentinel: the seat has no /models endpoint to probe, and the
+            # `[1m]` alias form that would justify a real number is not verified for full ids.
+            context_window=0,
+            supports_tools=True,
+            supports_vision=False,
+            supports_json_mode=False,
+            supports_structured_outputs=False,
+            notes="Claude Code CLI seat — id read from the installed binary.",
+        )
+        for model_id in claude_models.discover(binary)
+    )
+
+
+def resolvable_entries(kind: str) -> tuple[ApiModelEntry, ...]:
+    """Every name ``kind`` will ANSWER to — what it currently advertises, plus the static row.
+
+    The two differ only for ``claude``, where discovery replaces the tier aliases with concrete
+    ids. Advertising the ids while still answering to `claude:sonnet` is deliberate: a relay
+    holding a capability envelope from before the upgrade keeps working, and the `claude` CLI
+    takes either spelling for ``--model``. Advertisement narrows; resolution does not.
+    """
+    current = entries_for(kind)
+    whitelist = WHITELISTS.get(kind)
+    if whitelist is None:
+        return current
+    seen = {entry.vendor_name for entry in current}
+    return current + tuple(e for e in whitelist.entries if e.vendor_name not in seen)
+
+
 def find_advertised(kind: str, advertised: str) -> ApiModelEntry | None:
     """The whitelist entry advertised under ``advertised`` (e.g. ``openai:gpt-5.5``), or None.
 
@@ -410,7 +478,7 @@ def find_advertised(kind: str, advertised: str) -> ApiModelEntry | None:
     whitelist = WHITELISTS.get(kind)
     if whitelist is None:
         return None
-    for entry in whitelist.entries:
+    for entry in resolvable_entries(kind):
         if advertised_name(kind, entry) == advertised:
             return entry
     return None

--- a/tests/test_cli_seat.py
+++ b/tests/test_cli_seat.py
@@ -48,7 +48,7 @@ def test_seat_for_names_what_is_available():
 
 def test_advertised_models_come_from_the_catalog():
     assert cli_seat.advertised_models("claude") == [
-        api_catalog.advertised_name("claude", e) for e in api_catalog.WHITELISTS["claude"].entries
+        api_catalog.advertised_name("claude", e) for e in api_catalog.entries_for("claude")
     ]
 
 


### PR DESCRIPTION
## What

`grid join --api claude` advertised four hand-written tier aliases (`claude:opus`, `claude:sonnet`,
`claude:haiku`, `claude:fable`). It now advertises the concrete model ids the installed CLI
actually serves:

```
claude:claude-sonnet-5    claude:claude-haiku-4-5
claude:claude-opus-5      claude:claude-fable-5
```

## Why

An alias tells a consumer nothing about which model answers, so a router cannot compare a Claude
seat against any other kind. The old list was also hand-maintained: a new Claude Code release left
it silently wrong until someone noticed.

## How

Two local sources, no network call to any vendor.

- **Which tiers exist** — `claude -p "/model"`, a local slash command. Measured `duration_ms: 7`,
  `num_turns: 0`, `total_cost_usd: 0`, empty `modelUsage`: no model turn, no cost.
- **Which concrete ids the binary carries** — a regex over the executable's string pool.

The tier names come from the CLI, so no list of tiers is written down. A tier with no matching id
is dropped, which is how `best`, `opusplan` and `default` disappear without any rule naming them.
The newest id per tier wins; a trailing eight-digit segment is treated as a release date, not a
version component, and a version tie goes to the undated spelling.

Anchors do the rest of the filtering: a leading `[^a-z0-9.-]` rejects the Bedrock and Vertex
spellings (`us.anthropic.claude-opus-5`), a trailing `[^a-z0-9-]` rejects `-fast` and `-v1` builds.

## Cost of the scan

The regex reads a 266MB executable. All tiers are alternated into one pattern so the file is
scanned once, not once per tier — 47s became 8.6s. The result is cached under `grid_home()`, keyed
on the executable's size and mtime, and the `/model` probe sits inside the cache-miss path. A warm
join costs 0.24s and a single `claude --version`.

The executable is located by asking the CLI its running version and indexing the native install by
it, rather than by scanning whatever `PATH` resolved — that is frequently a shim, and several
versions sit side by side.

## Compatibility

- `resolvable_entries()` keeps the old tier aliases resolvable while only the concrete ids are
  advertised, so a caller holding a capability envelope from before this change keeps working.
- Every failure path — no binary, no native install, unparseable output, unwritable cache — falls
  back to the previous four-alias list. A join is never blocked by this.
- `entries_for()` is the single reader every surface now goes through; other kinds answer from
  their static row exactly as before.

## Verification

Full suite: 1582 passed, 7 skipped (`test_train_adapters` and `test_doggi_handler` are excluded —
they fail on this machine for missing optional deps `numpy` / `requests`, unrelated).

Live matrix through the seat server, real subprocesses:

```
GET /models  -> claude:claude-sonnet-5, claude:claude-opus-5, claude:claude-haiku-4-5, claude:claude-fable-5
openai     claude:claude-sonnet-5   200  'ok'
openai     claude:claude-opus-5     200  'ok'
openai     claude:claude-haiku-4-5  200  'ok'
openai     claude:claude-fable-5    200  'ok'
anthropic  claude:claude-sonnet-5   200  'ok'
```

Each of the four ids was also confirmed accepted by `claude --model <id>`, resolving to
Sonnet 5 / Opus 5 / Haiku 4.5 / Fable 5 respectively.

## Known limitation

The newest id in the binary is assumed to be one the account can call. The binary is a proven
superset of what is served — it carries ids the models endpoint does not list. If a future build
ships an id before subscriptions can call it, this would advertise that id and the tier's requests
would fail, while the bare alias would have worked. The fallback does not cover that case, since
parsing would have succeeded. The fix, if it ever shows up, is to confirm each surviving tier with
`claude --model <tier> -p "/model"` (~8ms per tier) and prefer the CLI's answer.

`context_window` deliberately stays the `0` unknown sentinel. `--model opus[1m]` works, but the
full id carrying that suffix has not been measured, so claiming a 1M window while invoking the bare
id could advertise a window the request does not get.
