### PR TITLE
feat(cli-seat): serve Anthropic natively and map thinking budget onto --effort

### DIFF
--- a/local/cli_seat_server.py
+++ b/local/cli_seat_server.py
@@ -1,7 +1,9 @@
-"""OpenAI API for a CLI seat: grid ──/chat/completions──▶ here ──subprocess──▶ `<cli> -p …`
+"""OpenAI and Anthropic APIs for a CLI seat: grid ──/chat/completions or /messages──▶ here
+──subprocess──▶ `<cli> -p …`
 
 Loopback-only — this process can spend the operator's subscription. CLI-agnostic: the driver
-arrives as a `SeatSpec`, so a second CLI reuses this server unchanged.
+arrives as a `SeatSpec`, so a second CLI reuses this server unchanged. Which wire a request came
+in on rides through as `wire` (`"openai"` | `"anthropic"`) so the answer goes back in the same one.
 """
 from __future__ import annotations
 
@@ -80,12 +82,17 @@ def create_app(
     @app.post("/chat/completions")
     @app.post("/v1/chat/completions")
     async def chat_completions(request: Request):
-        return await _handle(app, request)
+        return await _handle(app, request, wire="openai")
+
+    @app.post("/messages")
+    @app.post("/v1/messages")
+    async def messages(request: Request):
+        return await _handle(app, request, wire="anthropic")
 
     return app
 
 
-async def _handle(app: FastAPI, request: Request):
+async def _handle(app: FastAPI, request: Request, *, wire: str = "openai"):
     spec: SeatSpec = app.state.spec
     options: SeatOptions = app.state.options
     raw = await request.body()
@@ -97,7 +104,9 @@ async def _handle(app: FastAPI, request: Request):
         return _error(400, "Request body must be a JSON object.")
 
     try:
-        prepared = await run_in_threadpool(cli_seat.prepare, body, spec.kind, spec.tool_protocol)
+        prepared = await run_in_threadpool(
+            cli_seat.prepare, body, spec.kind, spec.tool_protocol, wire,
+        )
     except cli_seat.SeatBadRequest as exc:
         return _error(400, str(exc))
 
@@ -110,14 +119,15 @@ async def _handle(app: FastAPI, request: Request):
 
 
     if body.get("stream") and cli_seat.can_stream(spec):
-        return StreamingResponse(_stream(app, prepared), media_type="text/event-stream")
+        return StreamingResponse(_stream(app, prepared, wire=wire), media_type="text/event-stream")
 
+    answer_fn = cli_seat.answer_anthropic if wire == "anthropic" else cli_seat.answer
     async with app.state.slots:
         try:
             # A CLI run is a blocking subprocess of minutes. Off the event loop, or one request
             # would freeze health checks and every other caller.
             completion = await run_in_threadpool(
-                cli_seat.answer, spec, prepared, app.state.binary, options.timeout,
+                answer_fn, spec, prepared, app.state.binary, options.timeout,
             )
         except cli_seat.SeatBadRequest as exc:
             return _error(400, str(exc))
@@ -125,16 +135,21 @@ async def _handle(app: FastAPI, request: Request):
             return _error(502, str(exc))
 
     if body.get("stream"):
-        return StreamingResponse(_as_sse(completion), media_type="text/event-stream")
+        sse = _as_anthropic_sse(completion) if wire == "anthropic" else _as_sse(completion)
+        return StreamingResponse(sse, media_type="text/event-stream")
     return JSONResponse(completion)
 
 
-async def _stream(app: FastAPI, prepared):
+async def _stream(app: FastAPI, prepared, *, wire: str = "openai"):
     """SSE straight from the CLI's own output, chunk by chunk as it arrives.
 
     A failure mid-stream cannot re-status the response — the headers are long gone — so it is
     emitted as a terminal SSE error frame, which is what an OpenAI-shaped client understands.
     """
+    if wire == "anthropic":
+        async for frame in _stream_anthropic(app, prepared):
+            yield frame
+        return
     spec, options = app.state.spec, app.state.options
     stream = cli_seat.answer_stream(spec, prepared, app.state.binary, options.timeout)
     base = {"id": f"chatcmpl-{uuid.uuid4().hex}", "object": "chat.completion.chunk",
@@ -200,6 +215,93 @@ def _next_or_none(stream):
         return None, None
 
 
+async def _stream_anthropic(app: FastAPI, prepared):
+    """Anthropic SSE: `message_start`, one block per text/tool_use in the answer, `message_delta`,
+    `message_stop`.
+
+    Same buffering rule as the OpenAI stream above: with a tool protocol in play nothing goes out
+    until the CLI stops writing, because only the parse knows which bytes were the call — emitting
+    text deltas early is what let a client print the raw tool JSON as prose AND run the tool.
+    """
+    spec, options = app.state.spec, app.state.options
+    stream = cli_seat.answer_stream_anthropic(spec, prepared, app.state.binary, options.timeout)
+    buffered = bool(prepared.tool_protocol)
+    msg_id = f"msg_{uuid.uuid4().hex}"
+
+    yield _frame({"type": "message_start", "message": {
+        "id": msg_id, "type": "message", "role": "assistant", "model": prepared.model,
+        "content": [], "stop_reason": None, "stop_sequence": None,
+        "usage": {"input_tokens": 0, "output_tokens": 0}}})
+
+    index, text_open = 0, False
+    stop_reason, usage = "end_turn", {"output_tokens": 0}
+    async with app.state.slots:
+        try:
+            while True:
+                # next() blocks on the child's stdout, so it runs off the event loop like the
+                # non-streaming call does.
+                kind, payload = await run_in_threadpool(_next_or_none, stream)
+                if kind is None:
+                    break
+                if kind == "delta":
+                    if buffered:
+                        continue
+                    if not text_open:
+                        yield _frame({"type": "content_block_start", "index": index,
+                                     "content_block": {"type": "text", "text": ""}})
+                        text_open = True
+                    yield _frame({"type": "content_block_delta", "index": index,
+                                 "delta": {"type": "text_delta", "text": payload}})
+                else:
+                    message, quota = payload
+                    if quota is not None:
+                        # A free reading the answer carried; refresh the cache so the next
+                        # request's ceiling check costs nothing.
+                        app.state.quota_cache = (time.monotonic(), quota)
+                    usage = message.get("usage") or usage
+                    stop_reason = message.get("stop_reason") or "end_turn"
+                    if buffered:
+                        # Nothing went out above — the whole answer, text and any tool_use block
+                        # alike, is only known now that the parse has run on the complete text.
+                        frames, index = _anthropic_block_frames(message.get("content") or [], index)
+                        for frame in frames:
+                            yield frame
+                    elif text_open:
+                        yield _frame({"type": "content_block_stop", "index": index})
+        except Exception as exc:  # noqa: BLE001 — mirrors the OpenAI stream's terminal-error contract
+            yield _frame({"type": "error", "error": {
+                "type": "cli_seat_error", "message": str(exc) or type(exc).__name__}})
+            return
+    yield _frame({"type": "message_delta",
+                  "delta": {"stop_reason": stop_reason, "stop_sequence": None}, "usage": usage})
+    yield _frame({"type": "message_stop"})
+
+
+def _anthropic_block_frames(blocks, start_index):
+    """`content_block_start`/`delta`/`stop` for each text or tool_use block in `blocks`, indexed
+    from `start_index`. Shared by the buffered live-stream path above and the no-stream fallback
+    below, so a block is never rendered two different ways."""
+    frames, index = [], start_index
+    for block in blocks:
+        kind = block.get("type")
+        if kind == "text" and block.get("text"):
+            frames.append(_frame({"type": "content_block_start", "index": index,
+                                  "content_block": {"type": "text", "text": ""}}))
+            frames.append(_frame({"type": "content_block_delta", "index": index,
+                                  "delta": {"type": "text_delta", "text": block["text"]}}))
+        elif kind == "tool_use":
+            frames.append(_frame({"type": "content_block_start", "index": index, "content_block": {
+                "type": "tool_use", "id": block.get("id"), "name": block.get("name"), "input": {}}}))
+            frames.append(_frame({"type": "content_block_delta", "index": index, "delta": {
+                "type": "input_json_delta",
+                "partial_json": json.dumps(block.get("input") or {}, ensure_ascii=False)}}))
+        else:
+            continue
+        frames.append(_frame({"type": "content_block_stop", "index": index}))
+        index += 1
+    return frames, index
+
+
 async def _quota(app: FastAPI, *, fresh: bool = False):
     """Quota, cached for `quota_ttl`, single-flight. Caches None too — a failed probe will fail
     again a second later, and re-paying seconds to rediscover that punishes the broken case."""
@@ -251,6 +353,25 @@ def _as_sse(completion: dict):
         "usage": completion.get("usage"),
     })
     yield "data: [DONE]\n\n"
+
+
+def _as_anthropic_sse(message: dict):
+    """SSE-wrap a finished Anthropic message, for a seat that cannot stream incrementally.
+    Reuses `_anthropic_block_frames` so this renders a block identically to `_stream_anthropic`'s
+    buffered path."""
+    msg_id = message.get("id") or f"msg_{uuid.uuid4().hex}"
+    yield _frame({"type": "message_start", "message": {
+        "id": msg_id, "type": "message", "role": "assistant", "model": message.get("model"),
+        "content": [], "stop_reason": None, "stop_sequence": None,
+        "usage": {"input_tokens": (message.get("usage") or {}).get("input_tokens", 0),
+                  "output_tokens": 0}}})
+    frames, _ = _anthropic_block_frames(message.get("content") or [], 0)
+    for frame in frames:
+        yield frame
+    yield _frame({"type": "message_delta",
+                  "delta": {"stop_reason": message.get("stop_reason"), "stop_sequence": None},
+                  "usage": message.get("usage")})
+    yield _frame({"type": "message_stop"})
 
 
 def _frame(payload: dict) -> str:

--- a/local/cli_seat_server.py
+++ b/local/cli_seat_server.py
@@ -228,7 +228,7 @@ async def _stream_anthropic(app: FastAPI, prepared):
     buffered = bool(prepared.tool_protocol)
     msg_id = f"msg_{uuid.uuid4().hex}"
 
-    yield _frame({"type": "message_start", "message": {
+    yield _anthropic_frame({"type": "message_start", "message": {
         "id": msg_id, "type": "message", "role": "assistant", "model": prepared.model,
         "content": [], "stop_reason": None, "stop_sequence": None,
         "usage": {"input_tokens": 0, "output_tokens": 0}}})
@@ -247,10 +247,10 @@ async def _stream_anthropic(app: FastAPI, prepared):
                     if buffered:
                         continue
                     if not text_open:
-                        yield _frame({"type": "content_block_start", "index": index,
+                        yield _anthropic_frame({"type": "content_block_start", "index": index,
                                      "content_block": {"type": "text", "text": ""}})
                         text_open = True
-                    yield _frame({"type": "content_block_delta", "index": index,
+                    yield _anthropic_frame({"type": "content_block_delta", "index": index,
                                  "delta": {"type": "text_delta", "text": payload}})
                 else:
                     message, quota = payload
@@ -267,14 +267,14 @@ async def _stream_anthropic(app: FastAPI, prepared):
                         for frame in frames:
                             yield frame
                     elif text_open:
-                        yield _frame({"type": "content_block_stop", "index": index})
+                        yield _anthropic_frame({"type": "content_block_stop", "index": index})
         except Exception as exc:  # noqa: BLE001 — mirrors the OpenAI stream's terminal-error contract
-            yield _frame({"type": "error", "error": {
+            yield _anthropic_frame({"type": "error", "error": {
                 "type": "cli_seat_error", "message": str(exc) or type(exc).__name__}})
             return
-    yield _frame({"type": "message_delta",
+    yield _anthropic_frame({"type": "message_delta",
                   "delta": {"stop_reason": stop_reason, "stop_sequence": None}, "usage": usage})
-    yield _frame({"type": "message_stop"})
+    yield _anthropic_frame({"type": "message_stop"})
 
 
 def _anthropic_block_frames(blocks, start_index):
@@ -285,19 +285,19 @@ def _anthropic_block_frames(blocks, start_index):
     for block in blocks:
         kind = block.get("type")
         if kind == "text" and block.get("text"):
-            frames.append(_frame({"type": "content_block_start", "index": index,
+            frames.append(_anthropic_frame({"type": "content_block_start", "index": index,
                                   "content_block": {"type": "text", "text": ""}}))
-            frames.append(_frame({"type": "content_block_delta", "index": index,
+            frames.append(_anthropic_frame({"type": "content_block_delta", "index": index,
                                   "delta": {"type": "text_delta", "text": block["text"]}}))
         elif kind == "tool_use":
-            frames.append(_frame({"type": "content_block_start", "index": index, "content_block": {
+            frames.append(_anthropic_frame({"type": "content_block_start", "index": index, "content_block": {
                 "type": "tool_use", "id": block.get("id"), "name": block.get("name"), "input": {}}}))
-            frames.append(_frame({"type": "content_block_delta", "index": index, "delta": {
+            frames.append(_anthropic_frame({"type": "content_block_delta", "index": index, "delta": {
                 "type": "input_json_delta",
                 "partial_json": json.dumps(block.get("input") or {}, ensure_ascii=False)}}))
         else:
             continue
-        frames.append(_frame({"type": "content_block_stop", "index": index}))
+        frames.append(_anthropic_frame({"type": "content_block_stop", "index": index}))
         index += 1
     return frames, index
 
@@ -360,7 +360,7 @@ def _as_anthropic_sse(message: dict):
     Reuses `_anthropic_block_frames` so this renders a block identically to `_stream_anthropic`'s
     buffered path."""
     msg_id = message.get("id") or f"msg_{uuid.uuid4().hex}"
-    yield _frame({"type": "message_start", "message": {
+    yield _anthropic_frame({"type": "message_start", "message": {
         "id": msg_id, "type": "message", "role": "assistant", "model": message.get("model"),
         "content": [], "stop_reason": None, "stop_sequence": None,
         "usage": {"input_tokens": (message.get("usage") or {}).get("input_tokens", 0),
@@ -368,14 +368,22 @@ def _as_anthropic_sse(message: dict):
     frames, _ = _anthropic_block_frames(message.get("content") or [], 0)
     for frame in frames:
         yield frame
-    yield _frame({"type": "message_delta",
+    yield _anthropic_frame({"type": "message_delta",
                   "delta": {"stop_reason": message.get("stop_reason"), "stop_sequence": None},
                   "usage": message.get("usage")})
-    yield _frame({"type": "message_stop"})
+    yield _anthropic_frame({"type": "message_stop"})
 
 
 def _frame(payload: dict) -> str:
     return f"data: {json.dumps(payload, ensure_ascii=False)}\n\n"
+
+
+def _anthropic_frame(payload: dict) -> str:
+    """Anthropic SSE pairs a named `event:` line with its `data:` line, terminated by a blank
+    line — the framing a switch-on-event-name consumer and any block-regrouping code are both
+    written against. `<type>` is the event's own `type` field, so one function keeps every
+    Anthropic frame (including the terminal error frame) honest about its own name."""
+    return f"event: {payload['type']}\ndata: {json.dumps(payload, ensure_ascii=False)}\n\n"
 
 
 

--- a/remote/serve.py
+++ b/remote/serve.py
@@ -1913,6 +1913,11 @@ def handle_job(state: _ServeState, job: dict[str, Any]) -> None:
     body = job.get("body") or {}
     is_stream = bool(job.get("is_stream", False))
     read_timeout = float(job.get("inference_timeout_seconds") or _DEFAULT_INFERENCE_TIMEOUT)
+    # A caller that spoke Anthropic all the way in gets answered in Anthropic all the way out: the
+    # poll payload carries which wire the request came in on, and a seat whose catalog row
+    # declares `messages` (the claude seat) is posted to THAT route instead of `chat/completions`.
+    # Any other kind never sees this flip — nothing here changes for openai/codex.
+    wire_format = job.get("wire_format") or "openai"
 
     if endpoint in _MEDIA_ENDPOINTS:
         # Try a media API handler first (e.g. Doggi). These models are routed by
@@ -2082,10 +2087,12 @@ def handle_job(state: _ServeState, job: dict[str, Any]) -> None:
             _forward_whole(state, txn, endpoint, forward_body, read_timeout, target,
                            headers=_forward_headers(state, target, snap), api_kind=api_kind)
         elif is_stream:
-            _forward_stream(state, txn, endpoint, forward_body, read_timeout, target,
+            _forward_stream(state, txn, "messages" if wire_format == "anthropic" else endpoint,
+                            forward_body, read_timeout, target,
                             headers=_forward_headers(state, target, snap), api_kind=api_kind)
         else:
-            _forward_whole(state, txn, endpoint, forward_body, read_timeout, target,
+            _forward_whole(state, txn, "messages" if wire_format == "anthropic" else endpoint,
+                           forward_body, read_timeout, target,
                            headers=_forward_headers(state, target, snap), api_kind=api_kind)
     except Exception as exc:  # one bad job must not kill the loop
         print(f"\nJob {txn} failed: {exc!r}", file=sys.stderr)

--- a/shared/agent/cli_seat.py
+++ b/shared/agent/cli_seat.py
@@ -591,6 +591,19 @@ class PreparedRequest:
     wire: str = "openai"
 
 
+def _reject_server_tools(tools):
+    """A tool with a `type` is one Anthropic runs on its own servers (`web_search`, `bash`,
+    `code_execution`…), not one the caller executes. This seat has no such server, so accepting
+    one would emit a tool call nobody answers — the consumer just hangs."""
+    for tool in tools or []:
+        kind = tool.get("type") if isinstance(tool, dict) else None
+        if kind and kind != "function":
+            raise SeatBadRequest(
+                f"Unsupported tool type: {kind} ({tool.get('name', '?')}). "
+                "This seat executes nothing itself; the caller runs every tool."
+            )
+
+
 def prepare(body, kind, protocol=None, wire="openai"):
     messages = body.get("messages")
     if not isinstance(messages, list) or not messages:
@@ -604,6 +617,8 @@ def prepare(body, kind, protocol=None, wire="openai"):
         )
     resolved_protocol = protocol or (ANTHROPIC if wire == "anthropic" else OPENAI)
     tools = body.get("tools") if isinstance(body.get("tools"), list) else None
+    if wire == "anthropic" and tools:
+        _reject_server_tools(tools)
     prompt = build_prompt(messages)
     if tools:
         prompt = f"{prompt}\n\n{resolved_protocol.render(tools)}"

--- a/shared/agent/cli_seat.py
+++ b/shared/agent/cli_seat.py
@@ -605,6 +605,37 @@ class PreparedRequest:
     # Which wire the caller spoke — "openai" or "anthropic". Carried on the request so the server
     # answers in the SAME wire it was asked in without re-deriving it from the body a second time.
     wire: str = "openai"
+    # The seat's own `--effort` level, derived from the request's `thinking` field — "" when the
+    # caller asked for no extended thinking, so today's argv is unaffected.
+    effort: str = ""
+
+
+def _effort_for_thinking(thinking):
+    """The request's Anthropic `thinking` field -> a `claude --effort` level, or "" for none.
+
+    The wire carries a token budget (`{"type": "enabled", "budget_tokens": N}`); `claude` only
+    exposes five coarse levels (low, medium, high, xhigh, max) with no token knob, so this mapping
+    is a judgement call, not a fact. Anthropic's own extended-thinking docs use 1024 tokens as the
+    documented minimum and ~10000 as the typical worked example, so the thresholds below put a
+    bare-minimum budget at `low`, put the common ~10000 case at `medium`, and reserve `xhigh`/`max`
+    for callers who explicitly asked for a large budget (the range where deeper multi-step
+    reasoning is typically wanted). `{"type": "disabled"}` or a missing/malformed field returns ""
+    so an unset request passes no flag at all — today's behaviour, unchanged.
+    """
+    if not isinstance(thinking, dict) or thinking.get("type") != "enabled":
+        return ""
+    budget = thinking.get("budget_tokens")
+    if not isinstance(budget, (int, float)) or isinstance(budget, bool) or budget <= 0:
+        return ""
+    if budget < 4000:
+        return "low"
+    if budget < 10000:
+        return "medium"
+    if budget < 32000:
+        return "high"
+    if budget < 60000:
+        return "xhigh"
+    return "max"
 
 
 def _reject_server_tools(tools):
@@ -654,6 +685,7 @@ def prepare(body, kind, protocol=None, wire="openai"):
         system_prompt=system_prompt,
         tool_protocol=resolved_protocol if tools else None,
         wire=wire,
+        effort=_effort_for_thinking(body.get("thinking")),
     )
 
 

--- a/shared/agent/cli_seat.py
+++ b/shared/agent/cli_seat.py
@@ -496,21 +496,46 @@ def build_system_prompt(messages, tools=None, protocol=None):
     return system if system.strip() else DEFAULT_SYSTEM_PROMPT
 
 
+def _has_tool_result(content):
+    """True iff `content` is an Anthropic block list carrying a `tool_result` — the lone-user-turn
+    shortcut below must not take this path, or the result vanishes with no `User:`/`Tool result:`
+    line to carry it."""
+    return isinstance(content, list) and any(
+        isinstance(block, dict) and block.get("type") == "tool_result" for block in content
+    )
+
+
 def build_prompt(messages):
     """The non-system messages as one stdin prompt. Each request is a fresh process with no
     memory, so the whole transcript is replayed. A lone user turn passes through verbatim."""
     turns = [m for m in messages if m.get("role") != "system"]
     if not turns:
         raise SeatBadRequest("messages[] must contain at least one non-system message.")
-    if len(turns) == 1 and turns[0].get("role") == "user":
+    if (len(turns) == 1 and turns[0].get("role") == "user"
+            and not _has_tool_result(turns[0].get("content"))):
         return _flatten_content(turns[0].get("content"))
 
     lines = []
     for message in turns:
         role = message.get("role")
-        text = _flatten_content(message.get("content"))
+        content = message.get("content")
+        text = _flatten_content(content)
         if role == "user":
-            lines.append(f"User: {text}" if text else "User:")
+            # Anthropic's own shape: a tool result arrives as a `tool_result` block INSIDE a user
+            # message, never as a `role: "tool"` message. Rendered with the IDENTICAL wording the
+            # OpenAI `role: "tool"` branch below uses — one convention, not two — rather than
+            # "User: Tool result: …", which would be a second spelling of the same thing.
+            results = [b for b in (content if isinstance(content, list) else [])
+                       if isinstance(b, dict) and b.get("type") == "tool_result"]
+            if results:
+                for block in results:
+                    lines.append(f"Tool result: {_flatten_content(block.get('content'))}")
+                rest = _flatten_content([b for b in content if not
+                                         (isinstance(b, dict) and b.get("type") == "tool_result")])
+                if rest:
+                    lines.append(f"User: {rest}")
+            else:
+                lines.append(f"User: {text}" if text else "User:")
         elif role == "assistant":
             rendered = [f"Assistant: {text}" if text else "Assistant:"]
             # Replayed in the SAME shape the instruction asks for. They used to be replayed as
@@ -529,6 +554,17 @@ def build_prompt(messages):
                               "function": {"name": function.get("name"), "arguments": arguments}})
             if calls:
                 rendered.append(json.dumps({"tool_calls": calls}, ensure_ascii=False))
+            # Anthropic's own shape: a `tool_use` block sits IN the content list rather than in a
+            # separate `tool_calls` field. Replayed one JSON object per call — the same convention
+            # ANTHROPIC_TOOL_TEMPLATE asks the model to write — so the history and the instruction
+            # agree from the second turn on, same as the OpenAI case above.
+            for block in (content if isinstance(content, list) else []):
+                if isinstance(block, dict) and block.get("type") == "tool_use":
+                    rendered.append(json.dumps({
+                        "type": "tool_use",
+                        "name": block.get("name"),
+                        "input": block.get("input") if isinstance(block.get("input"), dict) else {},
+                    }, ensure_ascii=False))
             lines.append("\n".join(rendered))
         elif role == "tool":
             lines.append(f"Tool result: {text}")
@@ -550,9 +586,12 @@ class PreparedRequest:
     # None when the caller sent no `tools[]`, which is what keeps a client that brought its own
     # convention (Hermes' own `<tools>` system message) getting its text back verbatim.
     tool_protocol: object = None
+    # Which wire the caller spoke — "openai" or "anthropic". Carried on the request so the server
+    # answers in the SAME wire it was asked in without re-deriving it from the body a second time.
+    wire: str = "openai"
 
 
-def prepare(body, kind, protocol=None):
+def prepare(body, kind, protocol=None, wire="openai"):
     messages = body.get("messages")
     if not isinstance(messages, list) or not messages:
         raise SeatBadRequest("messages[] is required.")
@@ -563,16 +602,27 @@ def prepare(body, kind, protocol=None):
             f"This engine does not serve model {requested!r}. "
             f"Serves: {', '.join(advertised_models(kind))}."
         )
+    resolved_protocol = protocol or (ANTHROPIC if wire == "anthropic" else OPENAI)
     tools = body.get("tools") if isinstance(body.get("tools"), list) else None
     prompt = build_prompt(messages)
     if tools:
-        prompt = f"{prompt}\n\n{(protocol or OPENAI).render(tools)}"
+        prompt = f"{prompt}\n\n{resolved_protocol.render(tools)}"
+    if wire == "anthropic":
+        # `system` is a TOP-LEVEL field on this wire, not a `role: "system"` message — reading it
+        # off `messages` (the OpenAI shape) would silently drop the caller's whole instruction set,
+        # since Anthropic never puts one there. May be a plain string or a list of text blocks;
+        # `_flatten_content` already reads both.
+        system_prompt = _flatten_content(body.get("system"))
+        system_prompt = system_prompt if system_prompt.strip() else DEFAULT_SYSTEM_PROMPT
+    else:
+        system_prompt = build_system_prompt(messages)
     return PreparedRequest(
         model=requested or f"{kind}:{model_alias}",
         model_alias=model_alias,
         prompt=prompt,
-        system_prompt=build_system_prompt(messages),
-        tool_protocol=(protocol or OPENAI) if tools else None,
+        system_prompt=system_prompt,
+        tool_protocol=resolved_protocol if tools else None,
+        wire=wire,
     )
 
 
@@ -775,6 +825,13 @@ def answer(spec, prepared, binary, timeout):
     return to_chat_completion(result, spec.kind, prepared.model, prepared.tool_protocol)
 
 
+def answer_anthropic(spec, prepared, binary, timeout):
+    """`answer`'s Anthropic twin: the same one CLI run, decoded into the `message` shape
+    `/messages` promises rather than a chat.completion."""
+    result = run_seat(spec, prepared, binary, timeout)
+    return to_anthropic_message(result, spec.kind, prepared.model, prepared.tool_protocol)
+
+
 def answer_stream(spec, prepared, binary, timeout):
     """Yield ("delta", text) as the CLI produces it, then ("done", (completion, quota|None)).
 
@@ -790,4 +847,19 @@ def answer_stream(spec, prepared, binary, timeout):
             completion = to_chat_completion(
                 result, spec.kind, prepared.model, prepared.tool_protocol)
             yield "done", (completion, quota)
+            return
+
+
+def answer_stream_anthropic(spec, prepared, binary, timeout):
+    """`answer_stream`'s Anthropic twin: identical deltas, the final event built by
+    `to_anthropic_message` instead of `to_chat_completion`."""
+    stream = stream_seat(spec, prepared, binary, timeout)
+    while True:
+        try:
+            yield "delta", next(stream)
+        except StopIteration as stop:
+            result, quota = stop.value
+            message = to_anthropic_message(
+                result, spec.kind, prepared.model, prepared.tool_protocol)
+            yield "done", (message, quota)
             return

--- a/shared/agent/cli_seat.py
+++ b/shared/agent/cli_seat.py
@@ -620,23 +620,46 @@ def _effort_for_thinking(thinking):
     documented minimum and ~10000 as the typical worked example, so the thresholds below put a
     bare-minimum budget at `low`, put the common ~10000 case at `medium`, and reserve `xhigh`/`max`
     for callers who explicitly asked for a large budget (the range where deeper multi-step
-    reasoning is typically wanted). `{"type": "disabled"}` or a missing/malformed field returns ""
-    so an unset request passes no flag at all — today's behaviour, unchanged.
+    reasoning is typically wanted).
+
+    A live, unmodified Claude Code run sends neither of the two values this function used to know:
+    it sends `{"type": "adaptive", "display": "omitted"}` — the model decides its own budget, no
+    number to map. Treating that as "no effort" (its old behaviour) silently downgraded the CLI's
+    own default request shape: thinking is on, the turn is billed, and `claude` is never told to
+    think. There is no budget to derive a rung from, so `adaptive` is pinned to `"medium"` — a
+    judgement call, not a computed value, but a deliberate one: it is the same middle rung an
+    `enabled` request with no usable `budget_tokens` now also gets (below), so "the caller turned
+    thinking on but gave no number" reads the same way regardless of which of the two shapes for
+    saying that arrives.
+
+    Every OTHER type value — a future one none of us has seen yet, or a typo — is treated the same
+    way rather than falling through to "no effort": the client sent a non-empty `type` that is not
+    the explicit `"disabled"` off-switch, so it asked for *something*, and silence is the exact
+    failure mode this function exists to close. Only a genuinely absent/malformed field (no dict,
+    no `type`, or `type: "disabled"`) returns "" — that is the one case where nothing was asked for,
+    so an unset request still passes no flag at all, today's behaviour for that case unchanged.
     """
-    if not isinstance(thinking, dict) or thinking.get("type") != "enabled":
+    if not isinstance(thinking, dict):
+        return ""
+    kind = thinking.get("type")
+    if not kind or kind == "disabled":
         return ""
     budget = thinking.get("budget_tokens")
-    if not isinstance(budget, (int, float)) or isinstance(budget, bool) or budget <= 0:
-        return ""
-    if budget < 4000:
-        return "low"
-    if budget < 10000:
-        return "medium"
-    if budget < 32000:
-        return "high"
-    if budget < 60000:
-        return "xhigh"
-    return "max"
+    if kind == "enabled" and isinstance(budget, (int, float)) and not isinstance(budget, bool) \
+            and budget > 0:
+        if budget < 4000:
+            return "low"
+        if budget < 10000:
+            return "medium"
+        if budget < 32000:
+            return "high"
+        if budget < 60000:
+            return "xhigh"
+        return "max"
+    # "enabled" with no usable budget, "adaptive", or any unrecognised type: all mean the caller
+    # turned thinking on without handing us a number to grade. See the docstring above for why
+    # "medium" and not "".
+    return "medium"
 
 
 def _effort_for_reasoning_effort(value):

--- a/shared/agent/cli_seat.py
+++ b/shared/agent/cli_seat.py
@@ -640,8 +640,19 @@ def _effort_for_thinking(thinking):
 
 
 def _effort_for_reasoning_effort(value):
-    """The OpenAI standard `reasoning_effort` field -> a CLI effort level, or "" for none."""
-    return str(value or "").strip().lower()
+    """The OpenAI standard `reasoning_effort` field -> a CLI effort level, or "" for none.
+
+    Passed straight through 1:1 (`low`/`medium`/`high`) rather than climbed onto a higher rung,
+    even though both CLIs accept a wider ladder (claude adds xhigh/max; codex adds
+    none/minimal/xhigh/ultra). Unlike `thinking.budget_tokens`, this field is not a measurement a
+    mapping has to interpret — `low`/`medium`/`high` IS OpenAI's own vocabulary for how hard the
+    model should think, and both CLIs use the identical words for the identical idea. A caller who
+    asked for "high" asked for OpenAI's high; assuming they meant the CLI's most extreme setting
+    would be inventing intent the wire never carried. Anything outside those three words (or a
+    missing field) reads as no effort at all, the same as an absent `thinking`.
+    """
+    level = str(value or "").strip().lower()
+    return level if level in ("low", "medium", "high") else ""
 
 
 def _resolve_effort(body):

--- a/shared/agent/cli_seat.py
+++ b/shared/agent/cli_seat.py
@@ -433,6 +433,50 @@ def parse_openai_tool_calls(text):
 OPENAI = ToolProtocol(name="openai", render=render_openai_tools, parse=parse_openai_tool_calls)
 
 
+# Anthropic's own shape: one `tool_use` block instead of an array of `tool_calls`. Kept as a
+# second, independent protocol rather than a translation of OPENAI's — a seat serving `/messages`
+# natively should never need a round trip through the OpenAI shape to get there.
+ANTHROPIC_TOOL_TEMPLATE = """These tools are available to you:
+{tools_json}
+
+To use one, reply with a JSON object in exactly this shape and nothing else:
+{{"type": "tool_use", "name": <tool-name>, "input": {{<input-object>}}}}
+
+Emit one object per call. Reply with plain text instead whenever no tool is needed."""
+
+
+def render_anthropic_tools(tools):
+    block = ANTHROPIC_TOOL_TEMPLATE.format(tools_json=json.dumps(tools, ensure_ascii=False))
+    return f"{block}\n\n{TOOL_DELEGATION_NOTE}"
+
+
+def parse_anthropic_tool_uses(text):
+    """Answer text -> `(prose, tool_use blocks)`. Same scan as the OpenAI parse; only the keys
+    differ. An object that is not a usable call is LEFT WHERE IT IS — a half-written call is a
+    result worth seeing, and dropping it turns a visible malformation into a model that
+    mysteriously did nothing."""
+    calls, prose_parts, cursor = [], [], 0
+    for start, end, value in _json_objects(text):
+        if not isinstance(value, dict) or value.get("type") != "tool_use":
+            continue
+        name = value.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        prose_parts.append(text[cursor:start])
+        cursor = end
+        payload = value.get("input")
+        calls.append({"type": "tool_use", "id": f"toolu_{uuid.uuid4().hex[:24]}",
+                      "name": name, "input": payload if isinstance(payload, dict) else {}})
+    if not calls:
+        return text, []
+    prose_parts.append(text[cursor:])
+    return "".join(prose_parts).strip(), calls
+
+
+ANTHROPIC = ToolProtocol(name="anthropic", render=render_anthropic_tools,
+                         parse=parse_anthropic_tool_uses)
+
+
 def build_system_prompt(messages, tools=None, protocol=None):
     """The caller's system messages, verbatim.
 
@@ -696,6 +740,28 @@ def to_chat_completion(result, kind, model, protocol=None):
             "num_turns": result.num_turns,
             "session_id": result.session_id,
         },
+    }
+
+
+def to_anthropic_message(result, kind, model, protocol=None):
+    """The Anthropic `message` shape, built directly rather than via a chat.completion the relay
+    would have to convert back."""
+    text, calls = result.text, []
+    if protocol is not None and getattr(protocol, "parse", None):
+        text, calls = protocol.parse(result.text)
+    content = ([{"type": "text", "text": text}] if text else []) + calls
+    return {
+        "id": f"msg_{uuid.uuid4().hex}",
+        "type": "message",
+        "role": "assistant",
+        "model": model,
+        "content": content,
+        "stop_reason": "tool_use" if calls else "end_turn",
+        "stop_sequence": None,
+        "usage": {"input_tokens": result.input_tokens, "output_tokens": result.output_tokens},
+        "grid_cli_seat": {"kind": kind, "total_cost_usd": result.cost_usd,
+                          "duration_ms": result.duration_ms, "num_turns": result.num_turns,
+                          "session_id": result.session_id},
     }
 
 

--- a/shared/agent/cli_seat.py
+++ b/shared/agent/cli_seat.py
@@ -465,6 +465,11 @@ def parse_anthropic_tool_uses(text):
         prose_parts.append(text[cursor:start])
         cursor = end
         payload = value.get("input")
+        if isinstance(payload, str):
+            try:
+                payload = json.loads(payload)
+            except ValueError:
+                payload = {}
         calls.append({"type": "tool_use", "id": f"toolu_{uuid.uuid4().hex[:24]}",
                       "name": name, "input": payload if isinstance(payload, dict) else {}})
     if not calls:

--- a/shared/agent/cli_seat.py
+++ b/shared/agent/cli_seat.py
@@ -605,8 +605,9 @@ class PreparedRequest:
     # Which wire the caller spoke — "openai" or "anthropic". Carried on the request so the server
     # answers in the SAME wire it was asked in without re-deriving it from the body a second time.
     wire: str = "openai"
-    # The seat's own `--effort` level, derived from the request's `thinking` field — "" when the
-    # caller asked for no extended thinking, so today's argv is unaffected.
+    # The seat's own effort level, derived from the request's `thinking` field or, failing that,
+    # its `reasoning_effort` field — "" when the caller asked for neither, so today's argv/turn
+    # params are unaffected.
     effort: str = ""
 
 
@@ -636,6 +637,29 @@ def _effort_for_thinking(thinking):
     if budget < 60000:
         return "xhigh"
     return "max"
+
+
+def _effort_for_reasoning_effort(value):
+    """The OpenAI standard `reasoning_effort` field -> a CLI effort level, or "" for none."""
+    return str(value or "").strip().lower()
+
+
+def _resolve_effort(body):
+    """The request body's reasoning-effort signal -> a CLI effort level, or "" for none.
+
+    Two fields can carry this, never both meaningfully at once in practice since they belong to
+    different wires: Anthropic's own `thinking` (a token budget) reaches the seat when a client
+    speaks `/messages` natively; the OpenAI standard `reasoning_effort` reaches it once an engine
+    that does not speak Anthropic has translated the request to the OpenAI wire first. `thinking`
+    wins whenever it actually resolves to an effort — it is the richer signal, carrying a real
+    budget rather than one of three words. A request naming neither, or naming only a disabled
+    `thinking`, falls through to `reasoning_effort`; a request with neither returns "", so an
+    ordinary body's resulting argv/turn params are unaffected.
+    """
+    thinking_effort = _effort_for_thinking(body.get("thinking"))
+    if thinking_effort:
+        return thinking_effort
+    return _effort_for_reasoning_effort(body.get("reasoning_effort"))
 
 
 def _reject_server_tools(tools):
@@ -685,7 +709,7 @@ def prepare(body, kind, protocol=None, wire="openai"):
         system_prompt=system_prompt,
         tool_protocol=resolved_protocol if tools else None,
         wire=wire,
-        effort=_effort_for_thinking(body.get("thinking")),
+        effort=_resolve_effort(body),
     )
 
 

--- a/shared/agent/cli_seat.py
+++ b/shared/agent/cli_seat.py
@@ -312,7 +312,16 @@ def quota_refusal(snapshot, options):
 # request -> prompt
 
 def _flatten_content(content):
-    """Only text survives; a CLI seat has no image path, so images are named as omitted."""
+    """Text and replayed reasoning survive; anything else leaves a visible marker rather than
+    vanishing without trace.
+
+    A `thinking` block is the model's own prior reasoning, replayed by the client on a later
+    turn — `{"type": "thinking", "thinking": "<reasoning text>", "signature": "<opaque>"}`. Folded
+    into the prompt the same way ordinary text is, in the same position, so the model keeps its
+    own chain of thought past turn one. `signature` is dropped: it only authenticates a reasoning
+    block on the way back out to Anthropic, and this seat can never produce a valid one for its
+    own answers.
+    """
     if isinstance(content, str):
         return content
     if isinstance(content, list):
@@ -320,10 +329,17 @@ def _flatten_content(content):
         for part in content:
             if not isinstance(part, dict):
                 continue
-            if part.get("type") == "text":
+            kind = part.get("type")
+            if kind == "text":
                 chunks.append(str(part.get("text") or ""))
-            elif part.get("type") in ("image_url", "input_image"):
+            elif kind == "thinking":
+                chunks.append(str(part.get("thinking") or ""))
+            elif kind in ("image_url", "input_image"):
                 chunks.append("[image omitted — this engine serves text only]")
+            else:
+                # Previously dropped with no trace at all. A short, neutral marker makes the
+                # next unhandled block shape discoverable instead of silently invisible.
+                chunks.append(f"[{kind or 'unknown'} block omitted — this engine serves text only]")
         return "\n".join(c for c in chunks if c)
     return "" if content is None else str(content)
 

--- a/shared/agent/seats/claude.py
+++ b/shared/agent/seats/claude.py
@@ -34,8 +34,9 @@ def invoke(binary, prepared, tmpdir, stream=False):
         "--no-session-persistence",
         "--system-prompt-file", str(system_file),
     ]
-    # Only present when the caller's request carried a `thinking` budget (cli_seat.prepare maps
-    # it to a level); absent entirely otherwise, so a plain OpenAI request's argv is unchanged.
+    # Only present when the caller's request carried a `thinking` budget or a `reasoning_effort`
+    # (cli_seat.prepare resolves either to a level); absent entirely otherwise, so a plain OpenAI
+    # request naming neither gets today's argv, unchanged.
     if prepared.effort:
         argv += ["--effort", prepared.effort]
     # stream-json emits real text deltas; plain json returns one object at the end.

--- a/shared/agent/seats/claude.py
+++ b/shared/agent/seats/claude.py
@@ -34,6 +34,10 @@ def invoke(binary, prepared, tmpdir, stream=False):
         "--no-session-persistence",
         "--system-prompt-file", str(system_file),
     ]
+    # Only present when the caller's request carried a `thinking` budget (cli_seat.prepare maps
+    # it to a level); absent entirely otherwise, so a plain OpenAI request's argv is unchanged.
+    if prepared.effort:
+        argv += ["--effort", prepared.effort]
     # stream-json emits real text deltas; plain json returns one object at the end.
     argv += (["--output-format", "stream-json", "--include-partial-messages", "--verbose"]
              if stream else ["--output-format", "json"])

--- a/shared/agent/seats/codex_appserver.py
+++ b/shared/agent/seats/codex_appserver.py
@@ -93,11 +93,17 @@ class AppServer:
             raise AppServerError(f"thread/start returned no thread id: {result}")
         return thread_id
 
-    def start_turn(self, thread_id, text):
+    def start_turn(self, thread_id, text, effort=None):
         """Send one user turn. The ANSWER does not come back here — it arrives as `turn/*` and
-        `item/*` notifications, which `drain_notifications` hands back."""
-        return self.call("turn/start", {"threadId": thread_id,
-                                        "input": [{"type": "text", "text": text}]})
+        `item/*` notifications, which `drain_notifications` hands back.
+
+        `effort` is per-turn, the way codex's own app-server schema has it — not session config,
+        so it travels with THIS request rather than every turn a long-lived thread might run.
+        Omitted (falsy) leaves the params byte-identical to before this field existed."""
+        params = {"threadId": thread_id, "input": [{"type": "text", "text": text}]}
+        if effort:
+            params["effort"] = effort
+        return self.call("turn/start", params)
 
     def drain_notifications(self):
         """Everything the server pushed since the last drain."""
@@ -276,7 +282,10 @@ def serve(binary, prepared, timeout, on_delta=None):
             # base is replaced, so this uses the one field rather than a stub plus a second.
             baseInstructions=prepared.system_prompt or None,
         )
-        server.start_turn(thread_id, prepared.prompt)
+        # `prepared.effort` is resolved once, by cli_seat.prepare, from either the request's
+        # `thinking` field or its `reasoning_effort` field — "" when the caller asked for neither,
+        # which keeps this call's params identical to before either was read.
+        server.start_turn(thread_id, prepared.prompt, effort=prepared.effort)
         text, tokens, duration_ms, failure = _collect(server, timeout, on_delta)
         if failure:
             raise SeatError(f"`codex` failed: {failure[:400]}")

--- a/shared/models/api_catalog.py
+++ b/shared/models/api_catalog.py
@@ -368,7 +368,9 @@ WHITELISTS: dict[str, ApiWhitelist] = {
         env_var=None,  # no credential of any kind — the CLI authenticates itself
         entries=CLAUDE_WHITELIST,
         supports_model_listing=False,  # the CLI is not an HTTP service; there is no GET /models
-        endpoints=("chat/completions",),
+        # The seat speaks Anthropic natively beside OpenAI (`local/cli_seat_server.py` serves both
+        # `/chat/completions` and `/messages`), so both dialects are advertised here.
+        endpoints=("chat/completions", "messages"),
         credential="none",   # the `claude` CLI authenticates itself; the grid holds nothing
         flat_rate=True,      # a personal subscription — never polled eight-wide by default
         local_seat_port=8099,

--- a/tests/test_cli_seat.py
+++ b/tests/test_cli_seat.py
@@ -641,3 +641,24 @@ def test_an_anthropic_tool_result_block_is_replayed_as_text():
 
 def test_the_claude_catalog_row_declares_messages():
     assert "messages" in api_catalog.WHITELISTS["claude"].endpoints
+
+
+# the seat refuses an Anthropic server tool (Task 12)
+
+def test_an_anthropic_server_tool_is_refused_rather_than_passed_through():
+    """`web_search`, `bash` and `code_execution` are run by Anthropic, not by the caller. The
+    seat must refuse them with 400 — letting one through produces a tool call nobody executes,
+    which reaches the user as a hang."""
+    body = {"model": "claude:sonnet",
+            "messages": [{"role": "user", "content": "search"}],
+            "tools": [{"type": "web_search_20250305", "name": "web_search"}]}
+    with pytest.raises(cli_seat.SeatBadRequest) as exc:
+        cli_seat.prepare(body, "claude", wire="anthropic")
+    assert "web_search" in str(exc.value)
+
+
+def test_an_ordinary_function_tool_is_accepted():
+    body = {"model": "claude:sonnet",
+            "messages": [{"role": "user", "content": "read"}],
+            "tools": [{"name": "Read", "input_schema": {"type": "object"}}]}
+    assert cli_seat.prepare(body, "claude", wire="anthropic").tool_protocol is cli_seat.ANTHROPIC

--- a/tests/test_cli_seat.py
+++ b/tests/test_cli_seat.py
@@ -106,6 +106,33 @@ def test_images_are_named_not_silently_dropped():
     assert "image omitted" in prompt
 
 
+def test_a_thinking_block_folds_its_reasoning_into_the_prompt():
+    """Regression: `_flatten_content` handled `text`, `image_url` and `input_image` only, so a
+    replayed `thinking` block — the model's own prior reasoning — vanished with no trace. From
+    turn two the model lost its own chain of thought and nobody was told."""
+    prompt = cli_seat.build_prompt([{"role": "user", "content": [
+        {"type": "thinking", "thinking": "first I considered X, then Y", "signature": "sig-abc"},
+        {"type": "text", "text": "so the answer is 4"},
+    ]}])
+    assert "first I considered X, then Y" in prompt
+    assert "so the answer is 4" in prompt
+    # the reasoning appears before the text that followed it — client block order preserved
+    assert prompt.index("first I considered X") < prompt.index("so the answer is 4")
+    # signature is opaque and only meaningful on the way back out; this seat never produces one
+    assert "sig-abc" not in prompt
+
+
+def test_an_unrecognised_block_leaves_a_visible_marker():
+    """An unknown block type used to be dropped with no trace at all — worse than an image, which
+    at least leaves `[image omitted ...]`. The next unhandled shape must be discoverable, not
+    invisible."""
+    prompt = cli_seat.build_prompt([{"role": "user", "content": [
+        {"type": "text", "text": "look"}, {"type": "some_future_block", "data": "x"},
+    ]}])
+    assert "look" in prompt
+    assert "some_future_block" in prompt and "omitted" in prompt
+
+
 def test_prepare_rejects_an_unserved_model():
     with pytest.raises(cli_seat.SeatBadRequest):
         cli_seat.prepare({"model": "gpt-4", "messages": [{"role": "user", "content": "hi"}]}, "claude")

--- a/tests/test_cli_seat.py
+++ b/tests/test_cli_seat.py
@@ -581,6 +581,16 @@ def test_an_anthropic_tool_use_is_read_back():
     assert calls[0]["id"].startswith("toolu_")
 
 
+def test_anthropic_input_is_accepted_as_an_object_or_an_encoded_string():
+    """A model transcribing the template has no schema enforcement and may double-encode `input`
+    the way OpenAI's `arguments` convention taught it to. Dropping that string to `{}` would call
+    the tool with its arguments silently gone; decoding it mirrors `_one_call` on the OpenAI side."""
+    for input_value in ('{"file_path": "a.txt"}', '"{\\"file_path\\": \\"a.txt\\"}"'):
+        text = '{"type": "tool_use", "name": "Read", "input": ' + input_value + "}"
+        _, calls = cli_seat.parse_anthropic_tool_uses(text)
+        assert calls[0]["input"] == {"file_path": "a.txt"}
+
+
 def test_an_anthropic_answer_with_no_call_is_returned_byte_for_byte():
     text = "  Just talking. Braces { } and a < sign.  "
     assert cli_seat.parse_anthropic_tool_uses(text) == (text, [])

--- a/tests/test_cli_seat.py
+++ b/tests/test_cli_seat.py
@@ -662,3 +662,66 @@ def test_an_ordinary_function_tool_is_accepted():
             "messages": [{"role": "user", "content": "read"}],
             "tools": [{"name": "Read", "input_schema": {"type": "object"}}]}
     assert cli_seat.prepare(body, "claude", wire="anthropic").tool_protocol is cli_seat.ANTHROPIC
+
+
+# SSE framing: event: + data: pairs (found live, not by a test)
+
+def test_the_anthropic_stream_pairs_a_named_event_with_each_data_line():
+    """Found by running the real seat: it emitted bare `data:` frames with no `event:` line, so
+    every frame dispatched under the SSE default event name `message` and a client switching on
+    the event name could not tell `content_block_delta` from `message_stop` apart. Anthropic's own
+    wire pairs a named `event:` line with its `data:` line before every blank-line boundary."""
+    from fastapi.testclient import TestClient
+
+    from local.cli_seat_server import create_app
+    from shared.agent.seats import seat_for
+
+    def run(binary, prepared, timeout, on_delta):
+        on_delta("hi")
+        return cli_seat.SeatResult(text="hi", output_tokens=1)
+
+    base = seat_for("claude")
+    spec = base.__class__(**{**base.__dict__, "run": run})
+    app = create_app(spec=spec, binary="/fake/bin", options=cli_seat.SeatOptions())
+    client = TestClient(app)
+
+    resp = client.post("/messages", json={
+        "model": "claude:sonnet", "stream": True,
+        "messages": [{"role": "user", "content": "hi"}]})
+    body = resp.text
+
+    assert 'event: message_start\ndata: {"type": "message_start"' in body
+    assert 'event: content_block_delta\ndata: {"type": "content_block_delta"' in body
+    assert 'event: message_stop\ndata: {"type": "message_stop"' in body
+    # every frame is an event: line immediately followed by its data: line, never a bare data: line
+    pairs = [ln for ln in body.split("\n\n") if ln.strip()]
+    for pair in pairs:
+        lines = pair.split("\n")
+        assert lines[0].startswith("event: "), f"frame missing event: line: {pair!r}"
+        assert lines[1].startswith("data: "), f"event: not paired with data: {pair!r}"
+
+
+def test_the_openai_stream_stays_data_only():
+    """The OpenAI `/chat/completions` stream is `data:`-only by its own convention and must stay
+    byte-identical — this pins that the Anthropic `event:` fix did not leak across wires."""
+    from fastapi.testclient import TestClient
+
+    from local.cli_seat_server import create_app
+    from shared.agent.seats import seat_for
+
+    def run(binary, prepared, timeout, on_delta):
+        on_delta("hi")
+        return cli_seat.SeatResult(text="hi", output_tokens=1)
+
+    base = seat_for("codex-cli")
+    spec = base.__class__(**{**base.__dict__, "run": run})
+    app = create_app(spec=spec, binary="/fake/bin", options=cli_seat.SeatOptions())
+    client = TestClient(app)
+
+    resp = client.post("/chat/completions", json={
+        "model": "codex-cli:gpt-5.6-terra", "stream": True,
+        "messages": [{"role": "user", "content": "hi"}]})
+    body = resp.text
+
+    assert "event:" not in body
+    assert "data: [DONE]" in body

--- a/tests/test_cli_seat.py
+++ b/tests/test_cli_seat.py
@@ -233,6 +233,65 @@ def test_prepare_maps_the_thinking_budget_to_an_effort_level():
     assert small_effort != large_effort
 
 
+def test_adaptive_thinking_gets_a_middle_effort_not_silence():
+    """Regression: captured from a live, unmodified Claude Code run — no env overrides at all —
+    the DEFAULT request shape is `{"type": "adaptive", "display": "omitted"}`, not `enabled` or
+    `disabled`. `_effort_for_thinking` knew only those two and treated `adaptive` exactly like
+    `disabled`: no `--effort` flag. That silently downgraded every ordinary Claude Code turn —
+    thinking on, turn billed, `claude` never told to think — with no error and no warning."""
+    body = {"model": "claude:sonnet", "messages": [{"role": "user", "content": "hi"}],
+            "thinking": {"type": "adaptive", "display": "omitted"}}
+    assert cli_seat.prepare(body, "claude", wire="anthropic").effort == "medium"
+
+
+def test_an_unrecognised_thinking_type_also_gets_a_middle_effort():
+    """The same class of gap `adaptive` was: a `type` value none of us has seen yet must not fall
+    through to "no effort" the way `adaptive` used to. The client sent a non-empty `type` that is
+    not the explicit `"disabled"` off-switch, so it asked for something — silence is the failure
+    mode this whole function exists to close."""
+    body = {"model": "claude:sonnet", "messages": [{"role": "user", "content": "hi"}],
+            "thinking": {"type": "some_future_mode"}}
+    assert cli_seat.prepare(body, "claude", wire="anthropic").effort == "medium"
+
+
+def test_enabled_without_a_budget_also_gets_a_middle_effort():
+    """`{"type": "enabled"}` with no `budget_tokens` is still an enabled state, just one carrying
+    no number to grade — the same situation `adaptive` is in. It must resolve the same way
+    `adaptive` does rather than being the one enabled shape left silent."""
+    body = {"model": "claude:sonnet", "messages": [{"role": "user", "content": "hi"}],
+            "thinking": {"type": "enabled"}}
+    assert cli_seat.prepare(body, "claude", wire="anthropic").effort == "medium"
+
+
+def test_enabled_with_a_budget_still_grades_by_size():
+    """The one case that DOES carry a number must keep climbing the ladder with it, not collapse
+    to the same flat "medium" the budget-less shapes above get."""
+    body = {"model": "claude:sonnet", "messages": [{"role": "user", "content": "hi"}]}
+    small = cli_seat.prepare(
+        {**body, "thinking": {"type": "enabled", "budget_tokens": 2000}}, "claude",
+        wire="anthropic")
+    large = cli_seat.prepare(
+        {**body, "thinking": {"type": "enabled", "budget_tokens": 50000}}, "claude",
+        wire="anthropic")
+    assert small.effort == "low"
+    assert large.effort == "xhigh"
+
+
+def test_disabled_thinking_still_passes_no_effort():
+    """The one explicit off-switch must stay off: `disabled` is the caller actively saying "do not
+    think", not "gave no number" — it must not be swept into the new middle-effort default."""
+    body = {"model": "claude:sonnet", "messages": [{"role": "user", "content": "hi"}],
+            "thinking": {"type": "disabled"}}
+    assert cli_seat.prepare(body, "claude", wire="anthropic").effort == ""
+
+
+def test_absent_thinking_still_passes_no_effort():
+    """A request naming no `thinking` field at all must remain today's baseline: no signal was
+    sent, so none should be invented."""
+    body = {"model": "claude:sonnet", "messages": [{"role": "user", "content": "hi"}]}
+    assert cli_seat.prepare(body, "claude", wire="anthropic").effort == ""
+
+
 def test_claude_invoke_passes_effort_only_when_the_request_asked_for_thinking(tmp_path: Path):
     """The plumbing must reach `claude.py`'s `invoke`, which builds the argv — and an OpenAI
     `/chat/completions` request (no `thinking` field) must produce byte-identical argv to today."""

--- a/tests/test_cli_seat.py
+++ b/tests/test_cli_seat.py
@@ -611,3 +611,33 @@ def test_to_anthropic_message_sets_tool_use_and_stop_reason():
     assert message["stop_reason"] == "tool_use"
     assert [b["type"] for b in message["content"]] == ["tool_use"]
     assert message["usage"] == {"input_tokens": 10, "output_tokens": 4}
+
+
+# the seat reads Anthropic requests and serves /messages (Task 11)
+
+def test_an_anthropic_request_puts_the_top_level_system_in_the_system_prompt():
+    """Anthropic sends `system` as a top-level field, not a message with role=system. Read as a
+    message list it vanishes, and the model loses the caller's whole instruction set."""
+    body = {"model": "claude:sonnet",
+            "system": [{"type": "text", "text": "You are Claude Code."}],
+            "messages": [{"role": "user", "content": "hi"}]}
+    prepared = cli_seat.prepare(body, "claude", wire="anthropic")
+    assert prepared.system_prompt == "You are Claude Code."
+    assert prepared.prompt == "hi"
+
+
+def test_an_anthropic_tool_result_block_is_replayed_as_text():
+    body = {"model": "claude:sonnet", "messages": [
+        {"role": "user", "content": "read it"},
+        {"role": "assistant", "content": [
+            {"type": "tool_use", "id": "tu1", "name": "Read", "input": {"file_path": "a.txt"}}]},
+        {"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": "tu1", "content": "SECRET"}]},
+    ]}
+    prompt = cli_seat.prepare(body, "claude", wire="anthropic").prompt
+    assert '"type": "tool_use"' in prompt
+    assert "Tool result: SECRET" in prompt
+
+
+def test_the_claude_catalog_row_declares_messages():
+    assert "messages" in api_catalog.WHITELISTS["claude"].endpoints

--- a/tests/test_cli_seat.py
+++ b/tests/test_cli_seat.py
@@ -566,3 +566,38 @@ def test_tools_sent_means_parsed_and_no_tools_means_verbatim():
     assert plain["choices"][0]["message"]["content"] == raw
     assert "tool_calls" not in plain["choices"][0]["message"]
     assert plain["choices"][0]["finish_reason"] == "stop"
+
+
+# tool calls: Anthropic's own shape, spoken beside OpenAI's
+
+def test_an_anthropic_tool_use_is_read_back():
+    """Same scan as the OpenAI parse — `_json_objects` is reused — differing only in which keys
+    carry the call."""
+    text = '{"type": "tool_use", "name": "Read", "input": {"file_path": "data.txt"}}'
+    prose, calls = cli_seat.parse_anthropic_tool_uses(text)
+    assert prose == ""
+    assert calls[0]["name"] == "Read"
+    assert calls[0]["input"] == {"file_path": "data.txt"}
+    assert calls[0]["id"].startswith("toolu_")
+
+
+def test_an_anthropic_answer_with_no_call_is_returned_byte_for_byte():
+    text = "  Just talking. Braces { } and a < sign.  "
+    assert cli_seat.parse_anthropic_tool_uses(text) == (text, [])
+
+
+def test_a_malformed_anthropic_block_stays_in_the_prose():
+    broken = '{"type": "tool_use", "input": {}}'
+    prose, calls = cli_seat.parse_anthropic_tool_uses(broken)
+    assert calls == []
+    assert prose == broken
+
+
+def test_to_anthropic_message_sets_tool_use_and_stop_reason():
+    raw = '{"type": "tool_use", "name": "Read", "input": {"file_path": "data.txt"}}'
+    result = cli_seat.SeatResult(text=raw, input_tokens=10, output_tokens=4)
+    message = cli_seat.to_anthropic_message(result, "claude", "claude:sonnet", cli_seat.ANTHROPIC)
+    assert message["type"] == "message"
+    assert message["stop_reason"] == "tool_use"
+    assert [b["type"] for b in message["content"]] == ["tool_use"]
+    assert message["usage"] == {"input_tokens": 10, "output_tokens": 4}

--- a/tests/test_cli_seat.py
+++ b/tests/test_cli_seat.py
@@ -259,10 +259,14 @@ def test_prepare_reads_reasoning_effort_when_thinking_is_absent():
     # absent -> no effort at all, so a body carrying neither field is unaffected
     assert cli_seat.prepare(body, "claude").effort == ""
 
-    # the OpenAI standard levels pass straight through
+    # the OpenAI standard levels pass straight through 1:1 — not climbed to a higher rung either
+    # CLI also accepts, since "high" names OpenAI's own vocabulary, not a budget to interpret
     for level in ("low", "medium", "high"):
         prepared = cli_seat.prepare({**body, "reasoning_effort": level}, "claude")
         assert prepared.effort == level
+
+    # an unrecognised value reads as no effort, same as an absent field
+    assert cli_seat.prepare({**body, "reasoning_effort": "extreme"}, "claude").effort == ""
 
 
 def test_thinking_wins_over_reasoning_effort_when_both_are_present():

--- a/tests/test_cli_seat.py
+++ b/tests/test_cli_seat.py
@@ -211,6 +211,44 @@ def test_claude_invoke_disables_tools_and_replaces_the_system_prompt(tmp_path: P
     assert written.read_text(encoding="utf-8") == "SYSTEM"
 
 
+def test_prepare_maps_the_thinking_budget_to_an_effort_level():
+    """Regression: the request's `thinking` field was read nowhere (grep confirmed zero
+    occurrences), so a caller who enabled extended thinking got an ordinary answer and was
+    charged for the turn with no sign anything was ignored."""
+    body = {"model": "claude:sonnet", "messages": [{"role": "user", "content": "hi"}]}
+
+    # absent -> no --effort at all, so today's behaviour is unchanged
+    assert cli_seat.prepare(body, "claude", wire="anthropic").effort == ""
+
+    # {"type": "disabled"} -> same as absent
+    disabled = {**body, "thinking": {"type": "disabled"}}
+    assert cli_seat.prepare(disabled, "claude", wire="anthropic").effort == ""
+
+    # two different budgets must produce two different levels, rising with the budget
+    small = {**body, "thinking": {"type": "enabled", "budget_tokens": 2000}}
+    large = {**body, "thinking": {"type": "enabled", "budget_tokens": 50000}}
+    small_effort = cli_seat.prepare(small, "claude", wire="anthropic").effort
+    large_effort = cli_seat.prepare(large, "claude", wire="anthropic").effort
+    assert small_effort and large_effort
+    assert small_effort != large_effort
+
+
+def test_claude_invoke_passes_effort_only_when_the_request_asked_for_thinking(tmp_path: Path):
+    """The plumbing must reach `claude.py`'s `invoke`, which builds the argv — and an OpenAI
+    `/chat/completions` request (no `thinking` field) must produce byte-identical argv to today."""
+    body = {"model": "claude:sonnet", "messages": [{"role": "user", "content": "hi"}]}
+
+    no_thinking = cli_seat.prepare(body, "claude")  # OpenAI wire — never carries `thinking`
+    argv, _ = claude.invoke("/bin/claude", no_thinking, tmp_path)
+    assert "--effort" not in argv
+
+    enabled = {**body, "thinking": {"type": "enabled", "budget_tokens": 50000}}
+    prepared = cli_seat.prepare(enabled, "claude", wire="anthropic")
+    assert prepared.effort
+    argv, _ = claude.invoke("/bin/claude", prepared, tmp_path)
+    assert "--effort" in argv and argv[argv.index("--effort") + 1] == prepared.effort
+
+
 def test_claude_decode_reads_usage_and_folds_in_cache_tokens():
     proc = SimpleNamespace(stdout=json.dumps({
         "result": "ok", "is_error": False, "total_cost_usd": 0.5, "duration_ms": 7, "num_turns": 1,

--- a/tests/test_cli_seat.py
+++ b/tests/test_cli_seat.py
@@ -249,6 +249,40 @@ def test_claude_invoke_passes_effort_only_when_the_request_asked_for_thinking(tm
     assert "--effort" in argv and argv[argv.index("--effort") + 1] == prepared.effort
 
 
+def test_prepare_reads_reasoning_effort_when_thinking_is_absent():
+    """Most traffic never reaches the seat in Anthropic's own shape — an engine that does not
+    speak Anthropic translates the request to the OpenAI wire first, and a plain OpenAI client
+    sends `reasoning_effort`, never `thinking`. Regression: grep confirmed zero occurrences of
+    `reasoning_effort` under shared/agent/, so this path discarded the caller's choice silently."""
+    body = {"model": "claude:sonnet", "messages": [{"role": "user", "content": "hi"}]}
+
+    # absent -> no effort at all, so a body carrying neither field is unaffected
+    assert cli_seat.prepare(body, "claude").effort == ""
+
+    # the OpenAI standard levels pass straight through
+    for level in ("low", "medium", "high"):
+        prepared = cli_seat.prepare({**body, "reasoning_effort": level}, "claude")
+        assert prepared.effort == level
+
+
+def test_thinking_wins_over_reasoning_effort_when_both_are_present():
+    """`thinking` carries an actual token budget; `reasoning_effort` carries one of three words.
+    The richer signal must win whenever it resolves to something, and only a `thinking` that
+    resolves to nothing (absent or disabled) should let `reasoning_effort` be read at all."""
+    body = {"model": "claude:sonnet", "messages": [{"role": "user", "content": "hi"}]}
+
+    both = {**body, "thinking": {"type": "enabled", "budget_tokens": 50000},
+            "reasoning_effort": "low"}
+    prepared = cli_seat.prepare(both, "claude", wire="anthropic")
+    assert prepared.effort != "low"
+    assert prepared.effort == cli_seat.prepare(
+        {**body, "thinking": both["thinking"]}, "claude", wire="anthropic").effort
+
+    # thinking present but disabled -> falls through to reasoning_effort
+    disabled_both = {**body, "thinking": {"type": "disabled"}, "reasoning_effort": "high"}
+    assert cli_seat.prepare(disabled_both, "claude", wire="anthropic").effort == "high"
+
+
 def test_claude_decode_reads_usage_and_folds_in_cache_tokens():
     proc = SimpleNamespace(stdout=json.dumps({
         "result": "ok", "is_error": False, "total_cost_usd": 0.5, "duration_ms": 7, "num_turns": 1,

--- a/tests/test_codex_appserver.py
+++ b/tests/test_codex_appserver.py
@@ -216,10 +216,30 @@ def test_start_thread_returns_the_nested_id():
 
 
 def test_start_turn_sends_the_input_block():
+    """No `effort` argument (today's call shape): the params carry no `effort` key at all, not
+    even a null one — a request naming neither `thinking` nor `reasoning_effort` must produce
+    byte-identical `turn/start` params to before this field existed."""
     proc = FakeProc({"turn/start": {"result": {}}})
     _server(proc).start_turn("th_123", "hello")
     assert proc.written[0]["params"] == {"threadId": "th_123",
                                          "input": [{"type": "text", "text": "hello"}]}
+
+
+def test_start_turn_carries_effort_when_one_was_resolved():
+    """Regression: the codex seat read reasoning token counts back out but never set effort going
+    in (grep confirmed no caller passed `effort` to `turn/start`). It rides this per-turn request,
+    not config.toml — a session setting would apply to every turn, not just this request."""
+    proc = FakeProc({"turn/start": {"result": {}}})
+    _server(proc).start_turn("th_123", "hello", effort="high")
+    assert proc.written[0]["params"] == {"threadId": "th_123",
+                                         "input": [{"type": "text", "text": "hello"}],
+                                         "effort": "high"}
+
+
+def test_start_turn_treats_a_falsy_effort_the_same_as_none():
+    proc = FakeProc({"turn/start": {"result": {}}})
+    _server(proc).start_turn("th_123", "hello", effort="")
+    assert "effort" not in proc.written[0]["params"]
 
 
 def test_notifications_are_collected_not_mistaken_for_replies():


### PR DESCRIPTION
## What

Two related pieces of work on the CLI seat, eleven commits:

1. **The seat speaks Anthropic natively.** `/messages` is served alongside `/chat/completions`,
   rather than an OpenAI-shaped answer translated after the fact.
2. **A request's thinking budget reaches the CLI.** `--effort` is set from the caller's `thinking`
   block, with `reasoning_effort` read as a fallback.

## Commits

```
4a5cebe feat(cli-seat): speak Anthropic natively beside OpenAI
680f464 fix(cli-seat): decode a string-encoded anthropic tool_use input
23a9861 feat(cli-seat): serve /messages natively
b34405e feat(cli-seat): refuse tools the caller cannot execute
369c5e7 fix(seat): emit named event: lines on the Anthropic SSE stream
d042d9b fix(cli-seat): preserve thinking blocks and mark unknown content blocks
d50bbc5 feat(cli-seat): map the request's thinking budget onto claude --effort
a4c36da feat(seat): read reasoning_effort as a fallback for thinking
5047c9a feat(seat): keep reasoning_effort at claude/codex's matching word, no climb
50773ed feat(seat): send the resolved effort as a per-turn codex param
a06fc80 fix(cli-seat): give adaptive and unrecognised thinking types a middle effort level
```

## Shape of the change

```
 local/cli_seat_server.py              | 147 +++++++++++++++-
 remote/serve.py                       |  11 +-
 shared/agent/cli_seat.py              | 284 ++++++++++++++++++++++++++++--
 shared/agent/seats/claude.py          |   5 +
 shared/agent/seats/codex_appserver.py |  19 +-
 shared/models/api_catalog.py          |   4 +-
 tests/test_cli_seat.py                | 321 ++++++++++++++++++++++++++++++++++
 tests/test_codex_appserver.py         |  20 +++
 8 files changed, 784 insertions(+), 27 deletions(-)
```

Roughly 44% of the diff is tests.

## Verification

Full suite on this branch: **1608 passed, 7 skipped**.

`test_train_adapters` and `test_doggi_handler` are excluded — they fail on the machine this was run
from for missing optional dependencies (`numpy`, `requests`), unrelated to this branch.

## Note for reviewers

Effort is passed only when the request actually carried a `thinking` budget or a
`reasoning_effort`; a request naming neither produces the same argv as before, unchanged.

PR #36 targets the same `main` and touches `shared/models/api_catalog.py`,
`shared/agent/cli_seat.py` and `tests/test_cli_seat.py` as well. The two were verified not to
overlap: #36's diff applies cleanly on top of `main` with this branch's hunks present.
