### PR TITLE
feat(claude-seat): verify each discovered model id is callable before advertising it

### DIFF
--- a/shared/agent/claude_models.py
+++ b/shared/agent/claude_models.py
@@ -17,13 +17,17 @@ from __future__ import annotations
 import json
 import re
 import subprocess
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 from shared.paths import grid_home
 
-# Same shape as the seat's QUOTA_ARGV: a local slash command, no model turn, no cost.
-MODELS_ARGV = ("-p", "/model", "--output-format", "json",
-               "--safe-mode", "--tools", "", "--no-session-persistence")
+# Same shape as the seat's QUOTA_ARGV: a local slash command, no model turn, no cost. Shared by
+# both probes here so the two can never drift into asking under different conditions.
+_PROBE_ARGV = ("--output-format", "json", "--safe-mode", "--tools", "",
+               "--no-session-persistence")
+
+MODELS_ARGV = ("-p", "/model", *_PROBE_ARGV)
 
 _AVAILABLE = re.compile(r"Available:\s*([^\n]+)")
 _BRACKET = re.compile(r"\[[^\]]*\]$")   # opus[1m] -> opus
@@ -62,8 +66,8 @@ def _version(raw):
     return tuple(parts)
 
 
-def newest_ids(blob, tiers):
-    """`{tier: newest id}` for whichever of `tiers` the blob carries.
+def ranked_ids(blob, tiers):
+    """`{tier: [ids, newest first]}` for whichever of `tiers` the blob carries.
 
     One pass over the whole blob, with the tiers alternated inside a single pattern. Scanning
     per-tier instead costs a full 266MB pass each — measured 6.5s a pass, 47s for four.
@@ -76,6 +80,9 @@ def newest_ids(blob, tiers):
 
     Ties go to the undated spelling: `claude-haiku-4-5` and `claude-haiku-4-5-20251001` both read
     `(4, 5)`, and the undated one is the alias that follows its tier forward.
+
+    A whole ranked list rather than one winner, because the newest id a build carries is not
+    always one the account may call — see `accepts` and `discover`.
     """
     if not tiers:
         return {}
@@ -88,9 +95,39 @@ def newest_ids(blob, tiers):
         tier = match.group(2).decode()
         found.setdefault(tier, {})[match.group(1).decode()] = _version(match.group(3).decode())
     return {
-        tier: max(ids, key=lambda ident: (ids[ident], -len(ident)))
+        tier: sorted(ids, key=lambda ident: (ids[ident], -len(ident)), reverse=True)
         for tier, ids in found.items()
     }
+
+
+# `/model <name>` answers one of three ways, and only the first means "you may call this":
+#     Set model to Opus 5 for this session only
+#     Model 'claude-opus-6' not found                            -> no such model
+#     Mythos 5 isn't available for your account yet. Run /model  -> real, but not for this account
+# The third is the one no amount of reading the binary could have told us: entitlement is an
+# account fact, and the binary is a proven superset of what an account may call.
+_ACCEPTED = re.compile(r"^Set model to ", re.M)
+
+
+def accepts(binary, model_id):
+    """True iff this CLI will actually serve `model_id` for the signed-in account.
+
+    Costs one local slash command, measured at ~11ms and $0 — no model turn. `--no-session-persistence`
+    is what makes "for this session only" a no-op: nothing is written back.
+
+    Unreadable output reads as False. That direction matters: a seat that advertises a model it
+    cannot serve fails every request into that tier, while one that skips a model it could have
+    served merely offers less.
+    """
+    try:
+        proc = subprocess.run([binary, "-p", f"/model {model_id}", *_PROBE_ARGV],
+                              capture_output=True, text=True, timeout=60)
+        envelope = json.loads(proc.stdout or "")
+    except (OSError, subprocess.SubprocessError, ValueError):
+        return False
+    if not isinstance(envelope, dict):
+        return False
+    return bool(_ACCEPTED.search(str(envelope.get("result") or "")))
 
 
 def executable(binary):
@@ -178,9 +215,22 @@ def discover(binary):
     if not tiers:
         return []
     try:
-        resolved = newest_ids(path.read_bytes(), tiers)
+        ranked = ranked_ids(path.read_bytes(), tiers)
     except OSError:
         return []
-    models = [resolved[tier] for tier in tiers if tier in resolved]
+    def first_callable(tier):
+        """Walk DOWN the tier until one id is actually callable. Normally the first try wins and
+        this is a single probe; during a rollout that ships an id before enabling it, the walk
+        lands on the newest the account may really use instead of failing the whole tier."""
+        for model_id in ranked.get(tier, ()):
+            if accepts(binary, model_id):
+                return model_id
+        return None
+
+    # One thread per tier. Each probe is a separate `claude` process and spawning that binary
+    # costs ~1s of wall clock whatever the command does, so four sequential walks turned an 8.6s
+    # cold discovery into 23s. They share nothing, so running them together costs one spawn.
+    with ThreadPoolExecutor(max_workers=max(1, len(tiers))) as pool:
+        models = [found for found in pool.map(first_callable, tiers) if found is not None]
     _write_cache(key, models)
     return models


### PR DESCRIPTION
## What

Closes the known limitation recorded in #36: a discovered model id is now verified as callable
before it is advertised.

## The gap this closes

#36 read concrete ids out of the Claude Code executable and advertised the newest per tier. The
executable is a proven superset of what an account may actually call, so a build that ships an id
before enabling it would have made the whole tier fail — and the fallback could not help, because
parsing had succeeded. It just produced an id nobody could use.

## What made it fixable

`claude -p "/model <name>"` is a local slash command (~11ms, `$0`, no model turn) and it answers
in three distinguishable ways:

```
/model claude-opus-5         -> Set model to Opus 5 for this session only
/model claude-opus-6         -> Model 'claude-opus-6' not found
/model claude-mythos-5       -> Mythos 5 isn't available for your account yet. Run /model to pick another
/model claude-opus-4-6-fast  -> Model 'claude-opus-4-6-fast' not found
```

The `mythos` answer is the important one: the CLI knows **account entitlement**, not merely whether
an id exists. That is a fact no amount of reading the binary could have supplied, and it is exactly
the case #36 had to accept.

Only `Set model to …` counts as callable. Unreadable output reads as not-callable — a seat that
advertises what it cannot serve fails every request into that tier, while one that skips a model it
could have served merely offers less.

## How it works

`ranked_ids()` now returns every id per tier, newest first, instead of one winner. `discover()`
walks down a tier until an id verifies. Normally the newest wins on the first probe; during a
rollout the walk lands on the newest id the account may really use rather than failing the tier.

`--no-session-persistence` is what makes "for this session only" a no-op — nothing is written back.

## Cost

The probes are one `claude` process each, and spawning that binary costs ~1s of wall clock whatever
the command does. Four sequential walks took cold discovery from 8.6s to 23.1s, so the tiers are
walked in parallel — they share nothing.

| | before #36 | #36 | this PR |
|---|---|---|---|
| cold discovery | — | 8.6s | 13.3s |
| warm join | — | 0.24s | 0.25s |

Cold discovery happens once per Claude Code update; the warm path is unchanged.

## Verification

Full suite: **1708 passed, 7 skipped** (`test_train_adapters` / `test_doggi_handler` excluded for
missing optional deps `numpy` / `requests` on this machine, unrelated).

Direct checks:

```
accepts claude-opus-5    True
accepts claude-opus-6    False
accepts claude-mythos-5  False
```

Live matrix through the seat server, real subprocesses — 4 ids over `/chat/completions` and one
over `/messages`, all 200, all returning real text.

`grid catalog --api claude` output is unchanged, which is the point: the same four ids, now
verified rather than assumed.
