### PR TITLE
fix(claude-seat): stop advertising model names no client asks for

### DIFF
--- a/shared/agent/claude_models.py
+++ b/shared/agent/claude_models.py
@@ -160,6 +160,14 @@ def _cache_key(path):
 
 
 def _read_cache(key):
+    """The cached ids for this executable, or None to force a rescan.
+
+    An EMPTY stored list reads as a miss, not as "this binary serves nothing". Nothing writes one
+    any more (see `discover`), but machines that ran the version which did are still carrying one,
+    and a stored `[]` was a permanent cache HIT — discovery never re-probed, so the seat advertised
+    the static fallback for the life of that executable. Treating it as a miss heals those boxes on
+    their next join rather than requiring the file be deleted by hand.
+    """
     try:
         stored = json.loads(_cache_file().read_text(encoding="utf-8"))
     except (OSError, ValueError):
@@ -167,7 +175,7 @@ def _read_cache(key):
     if not isinstance(stored, dict) or stored.get("key") != key:
         return None
     models = stored.get("models")
-    return models if isinstance(models, list) else None
+    return models if isinstance(models, list) and models else None
 
 
 def _write_cache(key, models):
@@ -232,5 +240,12 @@ def discover(binary):
     # cold discovery into 23s. They share nothing, so running them together costs one spawn.
     with ThreadPoolExecutor(max_workers=max(1, len(tiers))) as pool:
         models = [found for found in pool.map(first_callable, tiers) if found is not None]
-    _write_cache(key, models)
+    # Only a NON-EMPTY result is worth remembering. Every way this list comes back empty is
+    # transient — `accepts` reads an unparseable envelope as False, so one expired login, one rate
+    # limit, one timeout on a 266MB spawn empties it — while the cache key is the executable's
+    # identity, which does not change when the transient condition clears. Caching `[]` therefore
+    # pinned the seat to the static fallback until the binary was next upgraded. Paying for a
+    # rescan on each join is the cheaper side of that trade by a wide margin.
+    if models:
+        _write_cache(key, models)
     return models

--- a/shared/models/api_catalog.py
+++ b/shared/models/api_catalog.py
@@ -271,28 +271,65 @@ CLAUDE_LAST_VERIFIED = "2026-07-28"
 # The service-kind key, named here (not in remote/) for the same reason CODEX_KIND is.
 CLAUDE_KIND = "claude"
 
-# The FALLBACK row. `entries_for("claude")` normally answers with concrete ids read from the
-# installed binary (`shared/agent/claude_models.py`); this list is what a box with no readable
-# `claude` falls back to, and it is also the pre-discovery behaviour verbatim, so the worst case
-# here is exactly what shipped before.
+# The FALLBACK row — what a box ADVERTISES when discovery cannot read its `claude`.
+# `entries_for("claude")` normally answers with concrete ids read from the installed binary
+# (`shared/agent/claude_models.py`); this list is the answer when that returns nothing.
 #
-# `--model` ALIASES, not dated ids: an alias always resolves to the current model of its tier, so
-# the row cannot go stale between releases.
+# CONCRETE IDS, not `--model` tier aliases, and the trade is deliberate. An alias can never go
+# stale, which is why this row held `opus`/`sonnet`/`haiku`/`fable` before — but a tier alias is a
+# name no client ever ASKS for. Claude Code sends `claude-opus-5`; the relay's bare-name matcher
+# compares suffixes exactly (`alias_targets_for_endpoint`, cli internal), so a grid whose only seat
+# fell back to aliases advertises four names and matches none of them. Measured on the `gmail.com`
+# grid 2026-07-31: 193 × 503 in one day, every one of them a bare concrete id against a
+# tier-alias-only node. A stale id is a bug we can see and fix; a name nobody requests is a seat
+# that silently serves nothing.
+#
+# Staleness is bounded by where this row is even reachable: discovery is the normal path, and it
+# only falls through here when the binary cannot be read at all. Keep these in step with the
+# newest tier ids when the seat is re-verified (`CLAUDE_LAST_VERIFIED`).
+#
+# The tier aliases are NOT dropped — they move to `CLAUDE_TIER_ALIASES` below and stay resolvable.
 #
 # `context_window` is the `0` unknown sentinel (rendered `—`) throughout. The seat has no /models
 # endpoint to probe and the repo's rule is that an un-probed number is not written down — the
 # alternative would be a fabricated figure that silently mis-sizes routing decisions.
 #
 # `supports_tools=True` describes the WIRE CONTRACT, which is what a consumer can rely on: send
-# OpenAI `tools[]`, get `tool_calls[]` back. Mechanically those are Hermes-style `<tool_call>` text
-# the adapter parses, NOT the vendor's native tool_use — see `shared/agent/cli_seat.py`.
+# OpenAI `tools[]`, get `tool_calls[]` back. Mechanically the seat teaches the CLI a JSON reply
+# shape in the prompt and parses it back out — NOT the vendor's native tool_use — see
+# `shared/agent/cli_seat.py`.
 CLAUDE_WHITELIST: tuple[ApiModelEntry, ...] = tuple(
     ApiModelEntry(
-        vendor_name=alias,
+        vendor_name=model_id,
         context_window=0,
         supports_tools=True,
         supports_vision=False,      # the adapter drops image parts; claiming vision would lie
         supports_json_mode=False,   # `--json-schema` is not wired into the seat yet
+        supports_structured_outputs=False,
+        notes=note,
+    )
+    for model_id, note in (
+        ("claude-opus-5", "Claude Code CLI seat — most capable tier."),
+        ("claude-sonnet-5", "Claude Code CLI seat — balanced tier."),
+        ("claude-haiku-4-5", "Claude Code CLI seat — fastest tier."),
+        ("claude-fable-5", "Claude Code CLI seat — Fable tier."),
+    )
+)
+
+# Resolvable-only: names the seat still ANSWERS to but no longer advertises.
+#
+# Load-bearing during the rollout, not politeness. A relay holding a capability envelope written
+# before this change routes `claude:sonnet` to a seat that has since upgraded; without this the
+# seat would reject a name it had itself advertised an hour earlier. The `claude` CLI takes either
+# spelling for `--model`, so answering to both costs nothing. Advertisement narrows; resolution
+# does not — the same rule `resolvable_entries` already states.
+CLAUDE_TIER_ALIASES: tuple[ApiModelEntry, ...] = tuple(
+    ApiModelEntry(
+        vendor_name=alias,
+        context_window=0,
+        supports_tools=True,
+        supports_vision=False,
+        supports_json_mode=False,
         supports_structured_outputs=False,
         notes=note,
     )
@@ -459,17 +496,29 @@ def _discovered_claude_entries() -> tuple[ApiModelEntry, ...]:
 def resolvable_entries(kind: str) -> tuple[ApiModelEntry, ...]:
     """Every name ``kind`` will ANSWER to — what it currently advertises, plus the static row.
 
-    The two differ only for ``claude``, where discovery replaces the tier aliases with concrete
-    ids. Advertising the ids while still answering to `claude:sonnet` is deliberate: a relay
-    holding a capability envelope from before the upgrade keeps working, and the `claude` CLI
-    takes either spelling for ``--model``. Advertisement narrows; resolution does not.
+    The two differ only for ``claude``, where the advertised set is concrete ids (discovered from
+    the binary, or `CLAUDE_WHITELIST`) while `claude:sonnet` and the other tier aliases must keep
+    resolving: a relay holding a capability envelope from before an upgrade routes the old name,
+    and the `claude` CLI takes either spelling for ``--model``. Advertisement narrows; resolution
+    does not.
+
+    The aliases come from `CLAUDE_TIER_ALIASES` rather than from the whitelist, because the
+    whitelist no longer holds them — it is the concrete-id fallback now, and on a box where that
+    fallback IS what got advertised, `current` and `whitelist.entries` are the same four names.
     """
     current = entries_for(kind)
     whitelist = WHITELISTS.get(kind)
     if whitelist is None:
         return current
+    extra = whitelist.entries + (CLAUDE_TIER_ALIASES if kind == CLAUDE_KIND else ())
     seen = {entry.vendor_name for entry in current}
-    return current + tuple(e for e in whitelist.entries if e.vendor_name not in seen)
+    out: list[ApiModelEntry] = list(current)
+    for entry in extra:
+        if entry.vendor_name in seen:
+            continue
+        seen.add(entry.vendor_name)   # `extra` may repeat a name across its two halves
+        out.append(entry)
+    return tuple(out)
 
 
 def find_advertised(kind: str, advertised: str) -> ApiModelEntry | None:


### PR DESCRIPTION
Two ways a Claude seat ends up advertising four model names that match nothing, both measured on a live grid on 2026-07-31: **193 × 503 in one day**, every one a bare concrete id (`claude-opus-5`) arriving at a node that advertised only tier aliases (`claude:opus`).

## 1. The fallback advertised tier aliases

`CLAUDE_WHITELIST` is what a box advertises when `claude_models.discover()` cannot read the installed binary. It held `opus`/`sonnet`/`haiku`/`fable` because an alias can never go stale — but a tier alias is a name **no client ever sends**. Claude Code sends `claude-opus-5`, and the relay matches bare names by exact suffix, so a seat on the fallback path advertises four names and matches none of them.

It now advertises the concrete ids. The aliases are not dropped: they move to `CLAUDE_TIER_ALIASES` and stay **resolvable but unadvertised**, so a relay holding a capability envelope written before an upgrade can still route `claude:sonnet` to a seat that has since upgraded.

Trade-off, stated plainly: the concrete ids **can** go stale where an alias could not. The blast radius is bounded — the fallback only runs on a box where discovery failed outright — and the row now says to update it alongside `CLAUDE_LAST_VERIFIED`.

## 2. An empty discovery result was cached forever

`discover()` wrote its result to `~/.grid/claude-models.json` even when that result was `[]`, and `_read_cache` returned `[]` as a **cache hit**. Every way the list comes back empty is transient — `accepts()` reads an unparseable envelope as `False`, so one expired login, one rate limit, or one timeout empties it — while the cache key is the executable identity, which does not change when the condition clears. A single transient failure pinned the seat to the static fallback until the binary was next upgraded.

Now: an empty result is never written, and an empty stored list reads as a miss, so boxes already carrying one heal on their next join instead of needing the file deleted by hand.

## Verification

Both branches of `entries_for` / `resolvable_entries`, and all four cache paths, exercised directly:

| case | result |
|---|---|
| discovery works | advertises 4 concrete ids; resolves 8 (ids + aliases) |
| discovery fails | advertises 4 concrete ids; resolves 8 |
| stored `models: []` | reads as a miss |
| discovery returns `[]` | no cache file written |
| probes recover | cache written again |

`1731 passed, 7 skipped`. `tests/test_train_adapters.py` fails collection on a missing `numpy` — pre-existing, unrelated.

A stale comment in the same block described tool calls as `Hermes-style <tool_call>` text; Hermes was removed, so it now describes what the seat actually does.