### PR TITLE
fix: claude seat decode, launch auth header, and a drain that waits on real work

### DIFF
--- a/docs/adr/0028-launch-hands-an-app-the-grid.md
+++ b/docs/adr/0028-launch-hands-an-app-the-grid.md
@@ -34,7 +34,7 @@ closing the app is the whole cleanup.
 | variable | value |
 |---|---|
 | `ANTHROPIC_BASE_URL` | `resolve_relay_base(...)` + `/relay` — **no** `/v1` |
-| `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_API_KEY` | the grid's `access_token` |
+| `ANTHROPIC_AUTH_TOKEN` (~~`ANTHROPIC_API_KEY`~~ — see below) | the grid's `access_token` |
 | ~~`ANTHROPIC_MODEL`, `ANTHROPIC_SMALL_FAST_MODEL`, `CLAUDE_CODE_SUBAGENT_MODEL`~~ | ~~the tier table~~ |
 | ~~`ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU,FABLE}_MODEL`~~ | ~~the tier table~~ |
 
@@ -59,8 +59,25 @@ single place a later slice replaces with discovery, and it is the reason the pre
 >
 > Preflight survives only as the one model fact that holds whatever the app asks: a grid serving
 > nothing can serve nothing, so an empty grid is still refused before the app starts. Everything else
-> in this ADR — the child-process-only environment, the base URL with no `/v1`, both token variables,
-> the rejected alternatives, `--print-env`'s carve-out — stands unchanged.
+> in this ADR — the child-process-only environment, the base URL with no `/v1`, the rejected
+> alternatives, `--print-env`'s carve-out — stands unchanged.
+>
+> ### Amended again — only `ANTHROPIC_AUTH_TOKEN`, never both
+>
+> The premise above ("both, because which one Claude Code reads depends on the path it takes to
+> authenticate") is **false**, and the app is the one that says so. With both set it opens with
+>
+> > `Both ANTHROPIC_AUTH_TOKEN and ANTHROPIC_API_KEY set · auth may not work as expected`
+>
+> and instructs the user to unset one. Observed on Claude Code 2.1.220, on the first real
+> `grid launch claude` after v0.3.11 shipped.
+>
+> Nothing was bought for that warning. grid-src's `_bearer_or_api_key` accepts either header but
+> **prefers `Authorization: Bearer` whenever both arrive** — which is precisely what
+> `ANTHROPIC_AUTH_TOKEN` produces — so `ANTHROPIC_API_KEY` never decided a single request. Its own
+> comment names the reason to prefer Bearer: when both are present, `x-api-key` *"likely holds the
+> caller's real Anthropic key, not the grid token"*. So this ADR was setting a variable the server
+> deliberately ignores, into the slot a user's own credential occupies. The env block is two keys.
 
 ## Considered options
 

--- a/docs/claude-code-quickstart.md
+++ b/docs/claude-code-quickstart.md
@@ -160,7 +160,6 @@ grid launch claude --print-env
 ```bash
 export ANTHROPIC_BASE_URL='https://relay.example/relay'
 export ANTHROPIC_AUTH_TOKEN='<your access token>'
-export ANTHROPIC_API_KEY='<your access token>'
 ```
 
 Note the base URL carries **no** `/v1` — Claude Code appends `/v1/messages` itself, so the `/v1` that

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -612,10 +612,9 @@ grid launch claude --print-env
 ```bash
 export ANTHROPIC_BASE_URL='https://relay.example/relay'
 export ANTHROPIC_AUTH_TOKEN='<your access token>'
-export ANTHROPIC_API_KEY='<your access token>'
 ```
 
-Three keys — an endpoint and a credential, and nothing else.
+Two keys — an endpoint and a credential, and nothing else. **Only the bearer variable**: setting `ANTHROPIC_API_KEY` beside it makes Claude Code warn that auth may not work, and buys nothing — the relay prefers `Authorization: Bearer` whenever both arrive.
 
 The base carries the relay prefix and **no** `/v1`: Claude Code appends `/v1/messages` itself, so the
 `/v1` that `grid info --env` prints for OpenAI clients would 404 every request here. This is the

--- a/remote/serve.py
+++ b/remote/serve.py
@@ -1415,6 +1415,7 @@ class _ServeState:
         self._access_token = access_token
         self._refresh_token = refresh_token
         self._inflight = 0
+        self._jobs_held = 0   # claimed-but-unfinished jobs; the drain's signal (see `jobs_held`)
         # The codex seat's credential holder — OUTSIDE the snapshot (ADR 0015 D-d): a token
         # rotation must not rebuild routing. Unconditional; primed only when the record has a
         # codex spec (startup + reload), unprimed otherwise and inert.
@@ -1613,6 +1614,28 @@ class _ServeState:
     def exit_inference(self) -> None:
         with self._lock:
             self._inflight = max(0, self._inflight - 1)
+
+    def enter_job(self) -> None:
+        with self._lock:
+            self._jobs_held += 1
+
+    def exit_job(self) -> None:
+        with self._lock:
+            self._jobs_held = max(0, self._jobs_held - 1)
+
+    def jobs_held(self) -> int:
+        """Claimed jobs a worker has not finished with — what the teardown drain waits on.
+
+        Deliberately NOT ``_inflight``. That one brackets the forward only and is published as
+        ``active_tasks`` for the relay's busy accounting, so widening it would change routing. This
+        brackets the whole of ``handle_job``, which is the real answer-owing window: routing, the
+        endpoint gate and every ``_try_submit_error`` run BEFORE the forward, and each of those
+        still owes the consumer a terminal response.
+
+        And not the worker threads either: one parked in a long-poll holds no job and cannot be
+        woken by ``stop``, so joining it only burns the shared budget."""
+        with self._lock:
+            return self._jobs_held
 
     def refresh(self, stale_token: str | None = None) -> bool:
         """Get a fresh access token after a 401: adopt one another worker already stored, else
@@ -2519,6 +2542,10 @@ def _poll_loop(state: _ServeState) -> None:
             _debug("poll: no job (204), re-polling")
             continue
         started = time.monotonic()
+        # Mark the job held for the WHOLE of handle_job, not just its forward: everything before the
+        # forward — routing, the endpoint gate, each `_try_submit_error` — still owes this consumer a
+        # terminal response, and the teardown drain waits on this counter (see `_ServeState.jobs_held`).
+        state.enter_job()
         try:
             handle_job(state, job)
         except Exception as exc:  # defence in depth: handle_job already guards, but never die here
@@ -2528,6 +2555,10 @@ def _poll_loop(state: _ServeState) -> None:
                 txn = job.get("transaction_id")
                 model = (job.get("body") or {}).get("model")
                 _debug(f"poll: job txn={txn} model={model!r} handled in {time.monotonic() - started:.2f}s")
+        finally:
+            # `finally`, not the `else`: a job that raised is finished with too, and leaking the
+            # count would make every later drain spend its whole budget waiting on a ghost.
+            state.exit_job()
 
 
 def _maybe_refresh_codex(state: _ServeState) -> None:
@@ -2696,8 +2727,14 @@ def _serve_loop(state: _ServeState, reload_thread: threading.Thread | None = Non
     finally:
         state.stop.set()
         deadline = time.monotonic() + _DRAIN_TIMEOUT
-        for worker in workers:
-            worker.join(timeout=max(0.0, deadline - time.monotonic()))
+        # Wait on in-flight JOBS, never on the worker threads. A worker parked in a long-poll cannot
+        # be woken by `state.stop` and does not return for up to `relay.POLL_TIMEOUT` (35s) — far past
+        # this whole budget — so joining workers in list order let the first parked one (workers are
+        # idle almost always) spend the entire deadline, leaving `join(timeout=0.0)` for a worker
+        # genuinely mid-`handle_job` and for the heartbeat/reload joins below. The counter is the
+        # honest signal: it covers exactly the window from claim to submit.
+        while state.jobs_held() and time.monotonic() < deadline:
+            time.sleep(0.02)
         heartbeat.join(timeout=max(0.0, deadline - time.monotonic()))
         # Join the reload daemon too, against the SAME deadline — like the heartbeat, it can `register_once`
         # (re-advertise), so it must finish before the caller's `unregister_node`, or a reload's PUT could
@@ -2720,11 +2757,25 @@ def _serve_loop(state: _ServeState, reload_thread: threading.Thread | None = Non
             if state.codex_seat.exchange_in_flight():
                 _warn("codex token exchange still unfinished at exit — if the next refresh "
                       "fails, re-run `grid join --api codex` to sign in again")
-        stragglers = [worker.name for worker in workers if worker.is_alive()]
-        if stragglers:
+        # Two different facts, deliberately two different lines. An abandoned PARKED poller costs
+        # nobody an answer; only a job still unsubmitted does. Reporting every live thread as the
+        # latter (what this used to do) reads as fleet-wide data loss on every ordinary restart and
+        # sends an operator hunting a bug that isn't there.
+        unfinished = state.jobs_held()
+        if unfinished:
             print(
-                f"\n{len(stragglers)} poll worker(s) still in flight after {_DRAIN_TIMEOUT}s drain — "
-                f"abandoning ({', '.join(stragglers)}); their consumers may see no terminal response.",
+                f"\n{unfinished} job(s) still in flight after {_DRAIN_TIMEOUT}s drain — "
+                f"abandoning; their consumers may see no terminal response.",
+                file=sys.stderr,
+            )
+        # Subtract the job holders: they are alive too, and calling them "parked, holding no job"
+        # would be the same overstatement in miniature. Counted, not named — pollers are
+        # interchangeable, so twenty thread names are a wall of text with no diagnostic value
+        # (unlike the heartbeat/reload lines below, where the name IS the finding).
+        parked = max(0, sum(1 for worker in workers if worker.is_alive()) - unfinished)
+        if parked:
+            print(
+                f"\n{parked} poll worker(s) abandoned while parked in a long-poll — they hold no job.",
                 file=sys.stderr,
             )
         if heartbeat.is_alive():

--- a/shared/agent/seats/claude.py
+++ b/shared/agent/seats/claude.py
@@ -45,26 +45,50 @@ def invoke(binary, prepared, tmpdir, stream=False):
     return argv, prepared.prompt
 
 
-def decode(proc, tmpdir):
-    """The final `result` envelope, from either output format.
+def _json_lines(raw):
+    """Every line of `raw` that parses as JSON. Non-JSON lines are skipped, not errors — the CLI
+    prints plain-text notices alongside its events."""
+    for line in raw.splitlines():
+        try:
+            yield json.loads(line)
+        except ValueError:
+            continue
 
-    `--output-format json` prints that object alone; `stream-json` prints it as the last of many
-    lines. Handling both here is what lets the streaming path reuse this function, so the two
-    modes cannot produce different answers.
+
+def _last_result(events):
+    """The final `result` element of an event sequence, or None. Last, not first: a retried turn
+    emits more than one, and the last is the answer actually delivered."""
+    found = None
+    for event in events:
+        if isinstance(event, dict) and event.get("type") == "result":
+            found = event
+    return found
+
+
+def decode(proc, tmpdir):
+    """The final `result` envelope, from any of the three output shapes.
+
+    `--output-format json` prints EITHER the bare result object (older builds) or a JSON array of
+    the whole event sequence (2.1.220); `stream-json` prints those events one per line. Handling
+    all three here is what lets the streaming path reuse this function, so the modes cannot
+    produce different answers.
+
+    The array shape is why the parse and the fallback are no longer try/except partners: an array
+    parses *successfully*, so keying the event scan off a JSONDecodeError meant a valid array
+    yielded no envelope and every non-streaming request failed with the message below — while the
+    answer sat in the array unread.
     """
     raw = (proc.stdout or "").strip()
-    envelope = None
     try:
         parsed = json.loads(raw)
-        envelope = parsed if isinstance(parsed, dict) else None
     except (TypeError, ValueError):
-        for line in raw.splitlines():          # stream-json: find the terminal result line
-            try:
-                event = json.loads(line)
-            except ValueError:
-                continue
-            if isinstance(event, dict) and event.get("type") == "result":
-                envelope = event
+        parsed = None
+    if isinstance(parsed, dict):
+        envelope = parsed
+    elif isinstance(parsed, list):
+        envelope = _last_result(parsed)
+    else:
+        envelope = _last_result(_json_lines(raw))   # stream-json: one event per line
     if envelope is None:
         detail = raw or (proc.stderr or "").strip() or f"exit code {proc.returncode}"
         raise SeatError(f"`claude` returned no result envelope: {detail[:400]}")

--- a/shared/launch/claude.py
+++ b/shared/launch/claude.py
@@ -59,6 +59,18 @@ def _environment(session: GridSession) -> dict[str, str]:
     cost is recorded where the decision is: a grid that does not serve what the app asks for now
     fails at the first prompt rather than at launch.
 
+    **Only one credential variable, and it is the bearer one.** ADR 0028 set `ANTHROPIC_API_KEY`
+    alongside it, reasoning that which one the app reads depends on how it authenticates. The app
+    itself says otherwise: with both set it prints
+
+        Both ANTHROPIC_AUTH_TOKEN and ANTHROPIC_API_KEY set · auth may not work as expected
+
+    and tells the user to unset one. Nothing was bought for that — the relay takes either header but
+    **prefers `Authorization: Bearer` when both arrive** (`_bearer_or_api_key` in grid-src), which is
+    exactly what `ANTHROPIC_AUTH_TOKEN` produces, so `ANTHROPIC_API_KEY` never decided a request.
+    Worse, it collides with the variable a user's own Anthropic key lives in — the same collision
+    that relay function guards against by ignoring `x-api-key` whenever a Bearer is present.
+
     `GRID_TOKEN` is absent for a different reason: it appears in the hand-rolled recipe, but it is a
     shell convenience variable this app never reads. Telemetry variables are absent too — whether
     Grid should disable Claude Code's error reporting is an open product question (ADR 0028), and
@@ -68,9 +80,7 @@ def _environment(session: GridSession) -> dict[str, str]:
         # `rstrip` before the suffix: a stored relay address with a trailing slash would otherwise
         # produce a doubled slash the client sends verbatim.
         "ANTHROPIC_BASE_URL": session.relay_base.rstrip("/") + _RELAY_SUFFIX,
-        # Both, because which one Claude Code reads depends on the path it takes to authenticate.
         "ANTHROPIC_AUTH_TOKEN": session.access_token,
-        "ANTHROPIC_API_KEY": session.access_token,
     }
 
 

--- a/tests/test_cli_seat.py
+++ b/tests/test_cli_seat.py
@@ -480,6 +480,64 @@ def test_claude_decode_reads_the_result_line_out_of_a_jsonl_stream():
     assert result.text == "done" and result.cost_usd == 0.25 and result.input_tokens == 3
 
 
+# `--output-format json` is not one shape. Claude Code 2.1.220 prints a JSON ARRAY of events on a
+# single line, where older builds printed the bare result object. The array parses fine, so the
+# JSONL fallback below never runs and the answer — sitting right there in the array — was dropped:
+# every non-streaming request 502'd with "no result envelope".
+def _array_stdout(*events):
+    return json.dumps(list(events))
+
+
+def test_claude_decode_reads_the_result_out_of_a_json_array():
+    raw = _array_stdout(
+        {"type": "system", "subtype": "init", "cwd": "/tmp/grid-claude-seat-x"},
+        {"type": "assistant", "message": {"content": [{"type": "text", "text": "ok"}]}},
+        {"type": "rate_limit_event", "rate_limit": {"status": "allowed"}},
+        {"type": "result", "result": "ok", "is_error": False, "total_cost_usd": 0.5,
+         "duration_ms": 7, "num_turns": 1, "session_id": "s",
+         "usage": {"input_tokens": 10, "cache_read_input_tokens": 5,
+                   "cache_creation_input_tokens": 2, "output_tokens": 3}},
+    )
+    result = claude.decode(SimpleNamespace(stdout=raw, stderr="", returncode=0), Path("/tmp"))
+    assert result.text == "ok"
+    assert result.input_tokens == 17 and result.output_tokens == 3
+    assert result.cost_usd == 0.5 and result.session_id == "s"
+
+
+def test_claude_decode_ignores_non_result_elements_of_an_array():
+    """`system`/`assistant`/`rate_limit_event` carry no answer — only the `result` element does, and
+    picking any other one would return a fragment as if it were the reply."""
+    raw = _array_stdout(
+        {"type": "system", "subtype": "init"},
+        {"type": "assistant", "message": {"content": [{"type": "text", "text": "partial"}]}},
+        {"type": "result", "result": "final", "is_error": False},
+    )
+    result = claude.decode(SimpleNamespace(stdout=raw, stderr="", returncode=0), Path("/tmp"))
+    assert result.text == "final"
+
+
+def test_claude_decode_surfaces_an_error_carried_by_an_array_result():
+    """The array shape must not become a hole the `is_error` check falls through: a failed turn has
+    to raise here, or the seat would answer 200 with the error text as the model's reply."""
+    raw = _array_stdout(
+        {"type": "system", "subtype": "init"},
+        {"type": "result", "is_error": True, "result": "Not logged in"},
+    )
+    with pytest.raises(cli_seat.SeatError) as caught:
+        claude.decode(SimpleNamespace(stdout=raw, stderr="", returncode=0), Path("/tmp"))
+    # Not just "it raised": the undecoded path ALSO raises, and its message quotes the raw stdout —
+    # which contains "Not logged in" verbatim. Pin the reason, or this passes without the fix.
+    assert "Not logged in" == str(caught.value)
+
+
+def test_claude_decode_still_refuses_an_array_with_no_result():
+    """An array that never carries a `result` is a genuine failure — it must keep raising rather
+    than silently decoding to an empty answer."""
+    raw = _array_stdout({"type": "system", "subtype": "init"})
+    with pytest.raises(cli_seat.SeatError, match="no result envelope"):
+        claude.decode(SimpleNamespace(stdout=raw, stderr="", returncode=0), Path("/tmp"))
+
+
 def test_both_seats_declare_streaming():
     for kind, spec in SEATS.items():
         assert cli_seat.can_stream(spec), f"{kind} should stream"

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -22808,14 +22808,14 @@ def test_launch_survives_a_process_with_no_resolvable_home_directory(monkeypatch
         lambda: (_ for _ in ()).throw(RuntimeError("Could not determine home directory."))))
     (project / ".claude").mkdir(parents=True)
     (project / ".claude" / "settings.json").write_text(
-        json.dumps({"env": {"ANTHROPIC_API_KEY": "sk-the-users-own"}}), encoding="utf-8")
+        json.dumps({"env": {"ANTHROPIC_AUTH_TOKEN": "the-users-own"}}), encoding="utf-8")
     seen = _capture_launch(monkeypatch)
 
     assert cli.main(["launch", "claude"]) == 0
     assert seen["argv"], "no home directory is not a reason to refuse to launch"
     err = capsys.readouterr().err
     assert "home directory" in err, f"say which location could not be checked: {err}"
-    assert "ANTHROPIC_API_KEY" in err, f"the project's settings are still checked: {err}"
+    assert "ANTHROPIC_AUTH_TOKEN" in err, f"the project's settings are still checked: {err}"
 
 
 def test_launch_says_so_when_a_settings_file_cannot_be_read(monkeypatch, tmp_path, capsys):
@@ -22857,15 +22857,16 @@ def _grid_home_tree(root):
     )
 
 
-def test_launch_claude_hands_the_child_exactly_the_three_documented_keys(monkeypatch, tmp_path):
+def test_launch_claude_hands_the_child_exactly_the_two_documented_keys(monkeypatch, tmp_path):
     """The env the child is given IS this feature's contract, so it is asserted key by key.
 
     A one-character change to any variable name must not be able to ship green: the dictionary below
     is spelled out rather than derived from the code it is testing.
 
-    Three keys, not the ten ADR 0028 specified. The seven `*_MODEL` variables are gone: choosing which
-    model a session runs on is the user's, not this command's, and the exact-equality assertion below
-    is what keeps one from creeping back.
+    Two keys, not the ten ADR 0028 specified. The seven `*_MODEL` variables are gone because choosing
+    a session's model is the user's call, and `ANTHROPIC_API_KEY` is gone because setting it *next to*
+    `ANTHROPIC_AUTH_TOKEN` makes Claude Code warn that auth may not work — see the sibling below. The
+    exact-equality assertion is what keeps either from creeping back.
     """
     _seed_launchable_grid(monkeypatch, tmp_path)  # relay https://relay.example, access token AT
     monkeypatch.delenv("GRID_TOKEN", raising=False)  # so its absence below is the command's doing
@@ -22879,16 +22880,18 @@ def test_launch_claude_hands_the_child_exactly_the_three_documented_keys(monkeyp
     expected = {
         "ANTHROPIC_BASE_URL": "https://relay.example/relay",
         "ANTHROPIC_AUTH_TOKEN": "AT",
-        "ANTHROPIC_API_KEY": "AT",
     }
-    assert len(expected) == 3, "the documented block is three keys; this list drifted"
+    assert len(expected) == 2, "the documented block is two keys; this list drifted"
     # Inherited environment, with those keys layered over it — the child keeps the user's PATH,
     # HOME and everything else, or Claude Code would launch into a stripped shell.
     assert seen["env"] == {**os.environ, **expected}
-    # ... and *only* those: any variable this command added or changed is one of the three. This is
+    # ... and *only* those: any variable this command added or changed is one of the two. This is
     # what keeps a telemetry variable (deliberately not set, ADR 0028) — or a model variable — from
     # creeping in unnoticed.
     assert {k: v for k, v in seen["env"].items() if os.environ.get(k) != v} == expected
+    # Named rather than left to the equality above, because this one is a *user-visible* regression:
+    # with both set, Claude Code prints "auth may not work as expected" at every start-up.
+    assert "ANTHROPIC_API_KEY" not in expected, "never alongside ANTHROPIC_AUTH_TOKEN"
     # `/v1` on the base is the single most likely mistake: Claude Code appends `/v1/messages` itself.
     assert "/v1" not in seen["env"]["ANTHROPIC_BASE_URL"]
     # A shell convenience variable from the hand-rolled recipe that the app never reads.
@@ -22897,6 +22900,32 @@ def test_launch_claude_hands_the_child_exactly_the_three_documented_keys(monkeyp
     # The child only: the CLI's own environment is unchanged, and nothing was written to disk.
     assert [k for k in os.environ if k.startswith(("ANTHROPIC_", "CLAUDE_CODE_"))] == []
     assert _grid_home_tree(tmp_path) == before
+
+
+def test_launch_sets_one_credential_variable_not_two(monkeypatch, tmp_path):
+    """Setting both credential variables is worse than useless, and the app says so out loud.
+
+    ADR 0028 set `ANTHROPIC_API_KEY` beside `ANTHROPIC_AUTH_TOKEN`, reasoning that which one Claude
+    Code reads depends on how it authenticates. Claude Code disagrees — with both set it opens with
+
+        Both ANTHROPIC_AUTH_TOKEN and ANTHROPIC_API_KEY set · auth may not work as expected
+
+    and tells the user to unset one. Nothing was bought for that warning: the relay accepts either
+    header but **prefers `Authorization: Bearer` when both arrive**, which is the one
+    `ANTHROPIC_AUTH_TOKEN` produces — so `ANTHROPIC_API_KEY` never decided a single request. It only
+    collided with the variable a user's own Anthropic key lives in.
+
+    Its own test rather than a line in the exact-keys assertion, because "these two must never both
+    be set" is a different claim from "the block is these keys", and it is the one a future tier of
+    credential handling is most likely to break.
+    """
+    _seed_launchable_grid(monkeypatch, tmp_path)
+    seen = _capture_launch(monkeypatch)
+
+    assert cli.main(["launch", "claude"]) == 0
+    injected = {k for k, v in seen["env"].items() if os.environ.get(k) != v}
+    assert "ANTHROPIC_AUTH_TOKEN" in injected, "the bearer variable is the one the relay prefers"
+    assert "ANTHROPIC_API_KEY" not in injected, "setting both is what makes Claude Code warn"
 
 
 def test_launch_claude_base_url_never_doubles_a_slash(monkeypatch, tmp_path):
@@ -24212,7 +24241,6 @@ def test_launch_refreshes_an_expired_token_and_hands_over_the_new_one(monkeypatc
 
     assert cli.main(["launch", "claude"]) == 0
     assert seen["env"]["ANTHROPIC_AUTH_TOKEN"] == "AT2"
-    assert seen["env"]["ANTHROPIC_API_KEY"] == "AT2"
     assert len(refreshes["calls"]) == 1
     assert refreshes["calls"][0]["refresh_token"] == "RT"
     err = capsys.readouterr().err

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -12469,8 +12469,11 @@ def test_serve_loop_teardown_bounded_by_drain_timeout(monkeypatch, tmp_path, cap
     # One shared 0.2s deadline → ~0.2s total; a per-worker join would be ~8 × 0.2 = 1.6s.
     assert elapsed < 1.0
     err = capsys.readouterr().err
-    # Workers still in flight at the deadline are logged, not dropped silently.
-    assert "still in flight after" in err
+    # Workers abandoned at the deadline are logged, not dropped silently. They were parked in a
+    # long-poll holding no job, so the line says exactly that — the consumer-facing "no terminal
+    # response" warning belongs to unfinished JOBS and would be a false alarm here.
+    assert "8 poll worker(s) abandoned while parked" in err
+    assert "may see no terminal response" not in err
     # So is the heartbeat, which is joined BEFORE the reload thread against the same deadline — so a
     # heartbeat that overruns (e.g. a slow engine-health sweep) is also what ate the reload thread's
     # turn. Without this line an operator sees the consequence and never the cause.
@@ -12524,8 +12527,15 @@ def test_serve_loop_drain_lets_inflight_job_finish(monkeypatch, tmp_path):
 
     def fake_poll(state):
         state.stop.set()          # shutdown begins while this 'job' is mid-flight
-        time.sleep(0.05)          # in-flight work, well within _DRAIN_TIMEOUT
-        submitted.append("done")  # result submitted before the worker returns
+        # `enter_job`/`exit_job` is what the real `_poll_loop` brackets `handle_job` with, and what
+        # the drain waits on. This fake replaces `_poll_loop` wholesale, so it has to declare the
+        # job itself — a bare sleeping thread holds nothing the teardown could owe anyone.
+        state.enter_job()
+        try:
+            time.sleep(0.05)          # in-flight work, well within _DRAIN_TIMEOUT
+            submitted.append("done")  # result submitted before the worker returns
+        finally:
+            state.exit_job()
 
     monkeypatch.setattr(serve, "_poll_loop", fake_poll)
     monkeypatch.setattr(serve, "_heartbeat_loop", lambda state: None)
@@ -12534,6 +12544,74 @@ def test_serve_loop_drain_lets_inflight_job_finish(monkeypatch, tmp_path):
     serve._serve_loop(state)
 
     assert submitted == ["done"]
+
+
+def test_serve_loop_drain_is_not_eaten_by_workers_parked_in_a_long_poll(monkeypatch, tmp_path):
+    """The drain budget belongs to real work, not to idle threads.
+
+    The sibling above passes with ONE worker, which is exactly why the starvation hid: joining
+    workers in list order against a shared deadline means the FIRST parked poller — unwakeable, a
+    long-poll runs to `relay.POLL_TIMEOUT` (35s) — consumes the whole budget, and every worker
+    after it gets `join(timeout=0.0)`. Workers are idle almost always, so the busy one is almost
+    never first. Here worker 1 parks and worker 2 holds a job: the job must still submit.
+    """
+    from remote import serve
+
+    monkeypatch.setattr(serve, "_DRAIN_TIMEOUT", 1.0)
+    parked = threading.Event()          # never set during drain → a real long-poll
+    submitted: list[str] = []
+
+    def fake_poll(state):
+        if threading.current_thread().name == "poll-worker-1":   # joined FIRST today
+            state.stop.set()            # shutdown begins
+            parked.wait(30)
+            return
+        state.enter_job()               # poll-worker-2: genuinely holding a job
+        try:
+            time.sleep(0.1)             # work well inside _DRAIN_TIMEOUT
+            submitted.append("done")
+        finally:
+            state.exit_job()
+
+    monkeypatch.setattr(serve, "_poll_loop", fake_poll)
+    monkeypatch.setattr(serve, "_heartbeat_loop", lambda state: None)
+    state = _serve_state(monkeypatch, tmp_path, max_concurrency=2)
+
+    try:
+        serve._serve_loop(state)
+    finally:
+        parked.set()
+
+    assert submitted == ["done"], "the parked worker ate the whole drain budget"
+    assert state.jobs_held() == 0
+
+
+def test_serve_loop_teardown_reports_jobs_not_idle_threads(monkeypatch, tmp_path, capsys):
+    """Parked pollers hold no job, so abandoning them costs no consumer a response — saying they do
+    sends an operator hunting a data-loss bug that isn't there (it did, once). Report the two
+    separately: idle threads as an abandonment note, in-flight JOBS as the warning that matters."""
+    from remote import serve
+
+    monkeypatch.setattr(serve, "_DRAIN_TIMEOUT", 0.2)
+    parked = threading.Event()
+
+    def stuck_poll(state):
+        state.stop.set()
+        parked.wait(30)
+
+    monkeypatch.setattr(serve, "_poll_loop", stuck_poll)
+    monkeypatch.setattr(serve, "_heartbeat_loop", lambda state: None)
+    state = _serve_state(monkeypatch, tmp_path, max_concurrency=4)
+
+    try:
+        serve._serve_loop(state)
+    finally:
+        parked.set()
+
+    err = capsys.readouterr().err
+    assert "4 poll worker(s) abandoned while parked" in err
+    # No job was ever in flight, so the consumer-facing warning must NOT appear.
+    assert "may see no terminal response" not in err
 
 
 def test_relay_poll_malformed_body_raises_relay_error(monkeypatch):
@@ -21290,7 +21368,15 @@ def _poll_loop_state_and_poll(job_then_none):
     """A minimal serve state + a poll_once double that yields `job_then_none` then stops the loop."""
     from remote import serve
 
-    state = SimpleNamespace(stop=threading.Event())
+    # `enter_job`/`exit_job` bracket each claimed job so the teardown drain can wait on real work
+    # rather than on idle poll threads; this stub only has to accept the calls.
+    held: list[int] = []
+    state = SimpleNamespace(
+        stop=threading.Event(),
+        enter_job=lambda: held.append(1),
+        exit_job=lambda: held.pop(),
+        jobs_held=lambda: len(held),
+    )
     queue = list(job_then_none)
 
     def fake_poll(_state, **_kwargs):

--- a/uv.lock
+++ b/uv.lock
@@ -814,7 +814,7 @@ wheels = [
 
 [[package]]
 name = "grid"
-version = "0.3.11"
+version = "0.3.13"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Four commits, all provider-side fixes found while tracing 503s and slow responses on the prod `gmail.com` grid.

## `fix(claude-seat)`: decode the JSON array claude 2.1.220 prints

`--output-format json` no longer prints a bare result object — it prints a JSON array of the whole
event sequence. `decode` only accepted a dict, and its line-scanning fallback lived in the
`except (TypeError, ValueError)` of the same `json.loads`. **An array parses successfully**, so the
fallback never ran and the envelope stayed `None`: **every non-streaming request 502'd** with
"no result envelope" while the answer sat unread in the array.

Streaming was unaffected — its multi-line output fails `json.loads`, which is what let the fallback
run and hid this. That is why the seat was only ever tested with `"stream": true`.

Now handles all three shapes: bare object, array, one-event-per-line. `codex`'s decode is line-based
and reads its answer from a file, so it was never affected.

## `fix(serve)`: drain on held jobs, not on parked poll workers

Teardown joined the N poll workers in list order against one shared 5s deadline. A worker parked in a
long-poll cannot be woken by `stop` and does not return for up to `POLL_TIMEOUT` (35s), and workers
are idle almost always — so the first consumed the whole budget and the heartbeat/reload joins below
it got `join(timeout=0.0)`, making their `is_alive()` checks and the ADR 0010 C5 late-re-register
warning nominal rather than real.

Waits on a new `_jobs_held` counter instead, bracketing the whole of `handle_job`. Deliberately not
`_inflight` — that brackets the forward only and is published as `active_tasks` for the relay's busy
accounting, so widening it would change routing.

Measured (20 workers, all parked):

| | teardown | heartbeat budget | reload budget |
|---|---|---|---|
| before | always 5.00s | 0.00s | 0.00s |
| after | 0.00s idle / job duration | 5.00s | 4.00s |

**Not a data-loss fix.** Workers run concurrently, so the old joins were a wait, not a starvation —
the consumer-visible bound was already ≤5s and still is. The win is teardown latency (which shortens
the window where the node is registered-but-dying and the master still hands it jobs) plus honest
reporting. The `provider_offline` failures come from the master failing queued/streaming txns on
`PUT role=consumer`, which is by design and untouched.

The straggler line is also split in two: reporting every live thread as "still in flight … consumers
may see no terminal response" claimed data loss on every ordinary restart when the threads were
parked holding nothing — that line sent this investigation down a wrong root cause.

## Also included (earlier on this branch)

- `fix(launch)`: set only `ANTHROPIC_AUTH_TOKEN`, never both credential variables (+ ADR 0028 / docs)
- `chore`: re-lock so `uv.lock`'s grid entry tracks `pyproject` again

## Test plan

- [x] `pytest tests/` — 1746 passed, 7 skipped, 0 failed (after merging `main` in)
- [x] `ruff check .` — clean
- [x] `main` merged into the branch; no conflicts; test count 1627 vs main's 1620 (no tests lost)
- [x] Seat decode verified against the **real** `claude 2.1.220` binary: the exact stdout that produced
      the 502 now decodes to text/usage/cost
- [x] Live seat run from this branch on a spare port: non-streaming `/messages` → **200** (was 502),
      streaming → 200 (no regression). Prod was not touched.
- [x] Drain behaviour measured in both scenarios (table above)