### PR TITLE
feat(codex-cli): serve the Responses API dialect alongside chat

### DIFF
--- a/local/cli_seat_server.py
+++ b/local/cli_seat_server.py
@@ -84,6 +84,11 @@ def create_app(
     async def chat_completions(request: Request):
         return await _handle(app, request, wire="openai")
 
+    @app.post("/responses")
+    @app.post("/v1/responses")
+    async def responses(request: Request):
+        return await _handle(app, request, wire="responses")
+
     @app.post("/messages")
     @app.post("/v1/messages")
     async def messages(request: Request):
@@ -121,7 +126,12 @@ async def _handle(app: FastAPI, request: Request, *, wire: str = "openai"):
     if body.get("stream") and cli_seat.can_stream(spec):
         return StreamingResponse(_stream(app, prepared, wire=wire), media_type="text/event-stream")
 
-    answer_fn = cli_seat.answer_anthropic if wire == "anthropic" else cli_seat.answer
+    if wire == "responses":
+        answer_fn = cli_seat.answer_response
+    elif wire == "anthropic":
+        answer_fn = cli_seat.answer_anthropic
+    else:
+        answer_fn = cli_seat.answer
     async with app.state.slots:
         try:
             # A CLI run is a blocking subprocess of minutes. Off the event loop, or one request
@@ -135,7 +145,12 @@ async def _handle(app: FastAPI, request: Request, *, wire: str = "openai"):
             return _error(502, str(exc))
 
     if body.get("stream"):
-        sse = _as_anthropic_sse(completion) if wire == "anthropic" else _as_sse(completion)
+        if wire == "responses":
+            sse = _as_responses_sse(completion)
+        elif wire == "anthropic":
+            sse = _as_anthropic_sse(completion)
+        else:
+            sse = _as_sse(completion)
         return StreamingResponse(sse, media_type="text/event-stream")
     return JSONResponse(completion)
 
@@ -148,6 +163,10 @@ async def _stream(app: FastAPI, prepared, *, wire: str = "openai"):
     """
     if wire == "anthropic":
         async for frame in _stream_anthropic(app, prepared):
+            yield frame
+        return
+    if wire == "responses":
+        async for frame in _stream_responses(app, prepared):
             yield frame
         return
     spec, options = app.state.spec, app.state.options
@@ -277,6 +296,115 @@ async def _stream_anthropic(app: FastAPI, prepared):
     yield _anthropic_frame({"type": "message_stop"})
 
 
+async def _stream_responses(app, prepared):
+    """OpenAI Responses SSE: ``response.created``, ``output_text`` delta(s), ``response.completed``.
+
+    Same buffering rule as the OpenAI/Anthropic streams: with a tool protocol in play nothing goes
+    out until the CLI stops writing, because only the parse knows which bytes were the call —
+    emitting text deltas early is what let a client print the raw tool JSON as prose AND run the
+    tool. Tool-call items ride the terminal ``response.completed`` event's ``output[]``, never a
+    delta (they cannot be known until the answer is whole).
+
+    Reuses ``_anthropic_frame`` — the SSE framing (``event: <type>\\ndata: <json>``) is identical
+    across the Anthropic and Responses dialects; only the event names differ.
+    """
+    spec, options = app.state.spec, app.state.options
+    stream = cli_seat.answer_stream_response(spec, prepared, app.state.binary, options.timeout)
+    buffered = bool(prepared.tool_protocol)
+    resp_id = f"resp_{uuid.uuid4().hex}"
+    msg_id = f"msg_{uuid.uuid4().hex}"
+
+    yield _anthropic_frame({"type": "response.created", "response": {
+        "id": resp_id, "object": "response", "status": "in_progress",
+        "model": prepared.model, "output": []}})
+
+    def _open_text():
+        return (
+            _anthropic_frame({"type": "response.output_item.added", "output_index": 0,
+                "item": {"id": msg_id, "type": "message", "status": "in_progress",
+                         "role": "assistant", "content": []}}),
+            _anthropic_frame({"type": "response.content_part.added",
+                "output_index": 0, "content_index": 0,
+                "part": {"type": "output_text", "text": "", "annotations": []}}),
+        )
+
+    text_open = False
+    full_text = ""
+    response_obj = None
+    async with app.state.slots:
+        try:
+            while True:
+                # next() blocks on the child's stdout, so it runs off the event loop like the
+                # non-streaming call does.
+                kind, payload = await run_in_threadpool(_next_or_none, stream)
+                if kind is None:
+                    break
+                if kind == "delta":
+                    if buffered:
+                        continue
+                    if not text_open:
+                        for frame in _open_text():
+                            yield frame
+                        text_open = True
+                    full_text += payload
+                    yield _anthropic_frame({"type": "response.output_text.delta",
+                        "output_index": 0, "content_index": 0, "delta": payload})
+                else:
+                    response_obj, quota = payload
+                    if quota is not None:
+                        # A free reading the answer carried; refresh the cache so the next
+                        # request's ceiling check costs nothing.
+                        app.state.quota_cache = (time.monotonic(), quota)
+                    if buffered:
+                        # Nothing went out above — the whole answer, text included, is only known
+                        # now that the parse has run. Emit the text-item lifecycle and one delta
+                        # carrying the complete prose the parse left behind.
+                        text = _responses_output_text(response_obj)
+                        if text:
+                            for frame in _open_text():
+                                yield frame
+                            text_open = True
+                            full_text = text
+                            yield _anthropic_frame({"type": "response.output_text.delta",
+                                "output_index": 0, "content_index": 0, "delta": text})
+                    elif not text_open:
+                        full_text = _responses_output_text(response_obj)
+        except Exception as exc:  # noqa: BLE001 — mirrors the OpenAI stream's terminal-error contract
+            yield _anthropic_frame({"type": "response.failed", "response": {
+                "id": resp_id, "object": "response", "status": "failed",
+                "model": prepared.model, "output": [],
+                "error": {"message": str(exc) or type(exc).__name__,
+                          "code": "cli_seat_error"}}})
+            return
+
+    if text_open:
+        yield _anthropic_frame({"type": "response.output_text.done",
+            "output_index": 0, "content_index": 0, "text": full_text})
+        yield _anthropic_frame({"type": "response.content_part.done",
+            "output_index": 0, "content_index": 0,
+            "part": {"type": "output_text", "text": full_text, "annotations": []}})
+        yield _anthropic_frame({"type": "response.output_item.done",
+            "output_index": 0,
+            "item": {"id": msg_id, "type": "message", "status": "completed",
+                     "role": "assistant",
+                     "content": [{"type": "output_text", "text": full_text, "annotations": []}]}})
+
+    completed = response_obj or {"id": resp_id, "object": "response", "status": "completed",
+                                  "model": prepared.model, "output": [], "usage": {}}
+    yield _anthropic_frame({"type": "response.completed", "response": completed})
+
+
+def _responses_output_text(response_obj):
+    """The assistant's text from a ``to_response`` object — the first ``output_text`` part on the
+    message item, or "" when there is none (a tool-call-only answer)."""
+    for item in (response_obj.get("output") or []) if isinstance(response_obj, dict) else []:
+        if isinstance(item, dict) and item.get("type") == "message":
+            for part in item.get("content") or []:
+                if isinstance(part, dict) and part.get("type") == "output_text":
+                    return part.get("text") or ""
+    return ""
+
+
 def _anthropic_block_frames(blocks, start_index):
     """`content_block_start`/`delta`/`stop` for each text or tool_use block in `blocks`, indexed
     from `start_index`. Shared by the buffered live-stream path above and the no-stream fallback
@@ -369,9 +497,20 @@ def _as_anthropic_sse(message: dict):
     for frame in frames:
         yield frame
     yield _anthropic_frame({"type": "message_delta",
-                  "delta": {"stop_reason": message.get("stop_reason"), "stop_sequence": None},
-                  "usage": message.get("usage")})
+                   "delta": {"stop_reason": message.get("stop_reason"), "stop_sequence": None},
+                   "usage": message.get("usage")})
     yield _anthropic_frame({"type": "message_stop"})
+
+
+def _as_responses_sse(response_obj):
+    """SSE-wrap a finished Responses object, for a seat that cannot stream incrementally.
+    Sends ``response.created`` then ``response.completed`` — the minimum a Responses SSE consumer
+    needs, the complete output (text and any function-call items) riding the terminal event."""
+    resp_id = response_obj.get("id") or f"resp_{uuid.uuid4().hex}"
+    yield _anthropic_frame({"type": "response.created", "response": {
+        "id": resp_id, "object": "response", "status": "in_progress",
+        "model": response_obj.get("model"), "output": []}})
+    yield _anthropic_frame({"type": "response.completed", "response": response_obj})
 
 
 def _frame(payload: dict) -> str:

--- a/local/server.py
+++ b/local/server.py
@@ -170,6 +170,10 @@ def create_app(*, grid_id: str, grid_name: str) -> FastAPI:
     async def completions(request: Request):
         return await _proxy_openai(app, "completions", request)
 
+    @app.post("/v1/responses")
+    async def responses(request: Request):
+        return await _proxy_openai(app, "responses", request)
+
     @app.post("/v1/feedback")
     async def feedback(request: Request):
         """What the human did with an answer — the one signal that makes unattended training honest.

--- a/shared/agent/cli_seat.py
+++ b/shared/agent/cli_seat.py
@@ -585,6 +585,76 @@ def build_prompt(messages):
     return "\n\n".join(line for line in lines if line)
 
 
+def _responses_content_parts(content):
+    """Normalise Responses-API content parts so the existing flattener reads them.
+
+    The Responses dialect spells text parts ``input_text`` / ``output_text`` where the chat wire
+    uses plain ``text``. This rewrites just those type tags and leaves everything else (including
+    a bare string) untouched, so ``_flatten_content`` — shared across all three wires — needs no
+    dialect branch of its own.
+    """
+    if not isinstance(content, list):
+        return content
+    normalised = []
+    for part in content:
+        if isinstance(part, dict) and part.get("type") in ("input_text", "output_text"):
+            normalised.append({"type": "text", "text": part.get("text", "")})
+        else:
+            normalised.append(part)
+    return normalised
+
+
+def _messages_from_responses_input(body):
+    """Responses API ``input`` -> chat ``messages[]`` the shared prompt builder consumes.
+
+    The ``input`` field is the Responses analogue of ``messages``: a plain string (a lone user
+    turn) or an array of items. Message items use the flat ``{role, content}`` shape; output items
+    wrap it under ``{type: "message", message: {…}}``. Function-call items (``function_call`` /
+    ``function_call_output``) are mapped to the assistant-tool-call / tool-result shapes the
+    ``build_prompt`` replayer already reads, so a multi-turn tool conversation round-trips through
+    the Responses wire exactly as it does through chat.
+    """
+    raw = body.get("input")
+    if isinstance(raw, str):
+        return [{"role": "user", "content": raw}]
+    if not isinstance(raw, list):
+        return []
+    messages = []
+    for item in raw:
+        if isinstance(item, str):
+            messages.append({"role": "user", "content": item})
+            continue
+        if not isinstance(item, dict):
+            continue
+        itype = item.get("type")
+        if itype == "message":
+            inner = item.get("message") if isinstance(item.get("message"), dict) else item
+            messages.append({
+                "role": inner.get("role") or "assistant",
+                "content": _responses_content_parts(inner.get("content")),
+            })
+        elif itype == "function_call":
+            messages.append({
+                "role": "assistant",
+                "tool_calls": [{
+                    "id": item.get("call_id") or item.get("id") or f"call_{uuid.uuid4().hex[:24]}",
+                    "type": "function",
+                    "function": {
+                        "name": item.get("name") or "",
+                        "arguments": item.get("arguments") or "{}",
+                    },
+                }],
+            })
+        elif itype == "function_call_output":
+            messages.append({"role": "tool", "content": str(item.get("output") or "")})
+        elif "role" in item:
+            messages.append({
+                "role": item.get("role") or "user",
+                "content": _responses_content_parts(item.get("content")),
+            })
+    return messages
+
+
 @dataclass(frozen=True)
 class PreparedRequest:
     """Built once per request — the server logs it too, and recomputing would re-serialise the
@@ -598,12 +668,13 @@ class PreparedRequest:
     # None when the caller sent no `tools[]`, which is what keeps a client that brought its own
     # convention (Hermes' own `<tools>` system message) getting its text back verbatim.
     tool_protocol: object = None
-    # Which wire the caller spoke — "openai" or "anthropic". Carried on the request so the server
-    # answers in the SAME wire it was asked in without re-deriving it from the body a second time.
+    # Which wire the caller spoke — "openai", "anthropic", or "responses". Carried on the request
+    # so the server answers in the SAME wire it was asked in without re-deriving it from the body
+    # a second time.
     wire: str = "openai"
-    # The seat's own effort level, derived from the request's `thinking` field or, failing that,
-    # its `reasoning_effort` field — "" when the caller asked for neither, so today's argv/turn
-    # params are unaffected.
+    # The seat's own effort level, derived from the request's `thinking` field, the Responses
+    # `reasoning.effort` field, or the chat `reasoning_effort` field — "" when the caller asked for
+    # none, so today's argv/turn params are unaffected.
     effort: str = ""
 
 
@@ -677,18 +748,23 @@ def _effort_for_reasoning_effort(value):
 def _resolve_effort(body):
     """The request body's reasoning-effort signal -> a CLI effort level, or "" for none.
 
-    Two fields can carry this, never both meaningfully at once in practice since they belong to
+    Three fields can carry this, never more than one meaningfully at once since they belong to
     different wires: Anthropic's own `thinking` (a token budget) reaches the seat when a client
-    speaks `/messages` natively; the OpenAI standard `reasoning_effort` reaches it once an engine
-    that does not speak Anthropic has translated the request to the OpenAI wire first. `thinking`
-    wins whenever it actually resolves to an effort — it is the richer signal, carrying a real
-    budget rather than one of three words. A request naming neither, or naming only a disabled
-    `thinking`, falls through to `reasoning_effort`; a request with neither returns "", so an
-    ordinary body's resulting argv/turn params are unaffected.
+    speaks `/messages` natively; the Responses API's `reasoning.effort` reaches it when a client
+    speaks `/responses` natively; the OpenAI Chat standard `reasoning_effort` reaches it once an
+    engine that speaks neither has translated the request to the chat wire first. `thinking` wins
+    whenever it actually resolves to an effort — it is the richer signal, carrying a real budget
+    rather than one of three words. A request naming none of the three returns "", so an ordinary
+    body's resulting argv/turn params are unaffected.
     """
     thinking_effort = _effort_for_thinking(body.get("thinking"))
     if thinking_effort:
         return thinking_effort
+    reasoning = body.get("reasoning")
+    if isinstance(reasoning, dict):
+        effort = _effort_for_reasoning_effort(reasoning.get("effort"))
+        if effort:
+            return effort
     return _effort_for_reasoning_effort(body.get("reasoning_effort"))
 
 
@@ -706,9 +782,14 @@ def _reject_server_tools(tools):
 
 
 def prepare(body, kind, protocol=None, wire="openai"):
-    messages = body.get("messages")
-    if not isinstance(messages, list) or not messages:
-        raise SeatBadRequest("messages[] is required.")
+    if wire == "responses":
+        messages = _messages_from_responses_input(body)
+        if not messages:
+            raise SeatBadRequest("input is required.")
+    else:
+        messages = body.get("messages")
+        if not isinstance(messages, list) or not messages:
+            raise SeatBadRequest("messages[] is required.")
     requested = str(body.get("model") or "")
     model_alias = alias_for(kind, requested)
     if model_alias is None:
@@ -730,6 +811,14 @@ def prepare(body, kind, protocol=None, wire="openai"):
         # `_flatten_content` already reads both.
         system_prompt = _flatten_content(body.get("system"))
         system_prompt = system_prompt if system_prompt.strip() else DEFAULT_SYSTEM_PROMPT
+    elif wire == "responses":
+        # `instructions` is the TOP-LEVEL developer/system prompt on this wire — the analogue of
+        # Anthropic's `system`, not a message. A `role: "system"` item in `input` is also honoured
+        # (build_system_prompt extracts those), but `instructions` wins when both are present
+        # because it is the canonical Responses spelling and the one a native caller sets.
+        system_prompt = _flatten_content(body.get("instructions"))
+        if not system_prompt.strip():
+            system_prompt = build_system_prompt(messages)
     else:
         system_prompt = build_system_prompt(messages)
     return PreparedRequest(
@@ -979,4 +1068,77 @@ def answer_stream_anthropic(spec, prepared, binary, timeout):
             message = to_anthropic_message(
                 result, spec.kind, prepared.model, prepared.tool_protocol)
             yield "done", (message, quota)
+            return
+
+
+# answer -> OpenAI Responses API object
+
+def to_response(result, kind, model, protocol=None):
+    """A Responses API ``response`` object, built directly rather than via a chat.completion.
+
+    Tool calls become ``function_call`` output items (the Responses dialect's native shape), not
+    ``tool_calls`` on a message — the same parse that extracts them for chat feeds this instead, so
+    a tool conversation round-trips identically on every wire the seat speaks.
+    """
+    text, tool_calls = result.text, []
+    if protocol is not None and getattr(protocol, "parse", None):
+        text, tool_calls = protocol.parse(result.text)
+    output = [{
+        "id": f"msg_{uuid.uuid4().hex}",
+        "type": "message",
+        "status": "completed",
+        "role": "assistant",
+        "content": [{"type": "output_text", "text": text, "annotations": []}] if text else [],
+    }]
+    for call in tool_calls:
+        function = call.get("function") or {}
+        output.append({
+            "id": f"fc_{uuid.uuid4().hex[:24]}",
+            "type": "function_call",
+            "status": "completed",
+            "call_id": call.get("id") or f"call_{uuid.uuid4().hex[:24]}",
+            "name": function.get("name") or "",
+            "arguments": function.get("arguments") or "{}",
+        })
+    return {
+        "id": f"resp_{uuid.uuid4().hex}",
+        "object": "response",
+        "created_at": int(time.time()),
+        "status": "completed",
+        "model": model,
+        "output": output,
+        "usage": {
+            "input_tokens": result.input_tokens,
+            "output_tokens": result.output_tokens,
+            "total_tokens": result.input_tokens + result.output_tokens,
+        },
+        "grid_cli_seat": {
+            "kind": kind,
+            "total_cost_usd": result.cost_usd,
+            "duration_ms": result.duration_ms,
+            "num_turns": result.num_turns,
+            "session_id": result.session_id,
+        },
+    }
+
+
+def answer_response(spec, prepared, binary, timeout):
+    """`answer`'s Responses twin: the same one CLI run, decoded into the ``response`` object
+    ``/responses`` promises rather than a chat.completion."""
+    result = run_seat(spec, prepared, binary, timeout)
+    return to_response(result, spec.kind, prepared.model, prepared.tool_protocol)
+
+
+def answer_stream_response(spec, prepared, binary, timeout):
+    """`answer_stream`'s Responses twin: identical deltas, the final event built by
+    `to_response` instead of `to_chat_completion`."""
+    stream = stream_seat(spec, prepared, binary, timeout)
+    while True:
+        try:
+            yield "delta", next(stream)
+        except StopIteration as stop:
+            result, quota = stop.value
+            response = to_response(
+                result, spec.kind, prepared.model, prepared.tool_protocol)
+            yield "done", (response, quota)
             return

--- a/shared/models/api_catalog.py
+++ b/shared/models/api_catalog.py
@@ -344,7 +344,12 @@ CLAUDE_TIER_ALIASES: tuple[ApiModelEntry, ...] = tuple(
 # The Codex CLI seat — the `codex` binary driven locally, distinct from the `codex` kind above
 # (which is the OAuth HTTP seat, ADR 0015). Different kind key because a grid may serve both.
 # UNVERIFIED: no signed-in codex seat was available; slugs are the ones the OAuth seat reports.
-CODEX_CLI_LAST_VERIFIED = "2026-07-29"
+# The seat translates BOTH dialects (`chat/completions` and `responses`) through the CLI's own
+# subprocess, so a grid-src caller that speaks the Responses API natively is served without the
+# relay needing to convert — the seat server (`local/cli_seat_server.py`) answers `/responses`
+# directly. Unlike the OAuth `codex` kind (responses-only, stream-only), this seat serves chat too
+# and honours a non-streaming responses request, because the subprocess is not an SSE-only pipe.
+CODEX_CLI_LAST_VERIFIED = "2026-07-31"
 
 CODEX_CLI_KIND = "codex-cli"
 
@@ -423,7 +428,7 @@ WHITELISTS: dict[str, ApiWhitelist] = {
         env_var=None,
         entries=CODEX_CLI_WHITELIST,
         supports_model_listing=False,
-        endpoints=("chat/completions",),
+        endpoints=("chat/completions", "responses"),
         credential="none",
         flat_rate=True,
         local_seat_port=8098,

--- a/tests/test_cli_seat.py
+++ b/tests/test_cli_seat.py
@@ -945,3 +945,158 @@ def test_the_openai_stream_stays_data_only():
 
     assert "event:" not in body
     assert "data: [DONE]" in body
+
+
+# the seat serves /responses (OpenAI Responses API dialect)
+
+def test_the_codex_cli_catalog_row_declares_responses():
+    assert "responses" in api_catalog.WHITELISTS["codex-cli"].endpoints
+    assert "chat/completions" in api_catalog.WHITELISTS["codex-cli"].endpoints
+
+
+def test_a_responses_request_reads_string_input_as_a_user_message():
+    body = {"model": "codex-cli:gpt-5.5", "input": "hello"}
+    prepared = cli_seat.prepare(body, "codex-cli", wire="responses")
+    assert prepared.prompt == "hello"
+
+
+def test_a_responses_request_reads_message_array_input():
+    body = {"model": "codex-cli:gpt-5.5", "input": [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "second"},
+        {"role": "user", "content": "third"},
+    ]}
+    prepared = cli_seat.prepare(body, "codex-cli", wire="responses")
+    assert "User: first" in prepared.prompt
+    assert "Assistant: second" in prepared.prompt
+    assert "User: third" in prepared.prompt
+
+
+def test_a_responses_request_reads_instructions_as_the_system_prompt():
+    body = {"model": "codex-cli:gpt-5.5", "instructions": "Be brief.",
+            "input": [{"role": "user", "content": "hi"}]}
+    prepared = cli_seat.prepare(body, "codex-cli", wire="responses")
+    assert prepared.system_prompt == "Be brief."
+
+
+def test_a_responses_request_without_instructions_falls_back_to_system_role_items():
+    body = {"model": "codex-cli:gpt-5.5", "input": [
+        {"role": "system", "content": "You are a helper."},
+        {"role": "user", "content": "hi"},
+    ]}
+    prepared = cli_seat.prepare(body, "codex-cli", wire="responses")
+    assert prepared.system_prompt == "You are a helper."
+
+
+def test_responses_input_text_content_parts_are_normalised():
+    """The Responses dialect spells text parts ``input_text``/``output_text``; the shared flattener
+    reads ``text``. The normaliser rewrites just those type tags so no dialect branch leaks in."""
+    body = {"model": "codex-cli:gpt-5.5", "input": [
+        {"role": "user", "content": [{"type": "input_text", "text": "a plain question"}]},
+    ]}
+    prepared = cli_seat.prepare(body, "codex-cli", wire="responses")
+    assert prepared.prompt == "a plain question"
+
+
+def test_a_responses_function_call_output_item_is_replayed_as_a_tool_result():
+    body = {"model": "codex-cli:gpt-5.5", "input": [
+        {"role": "user", "content": "what is the weather?"},
+        {"type": "function_call", "call_id": "call_1", "name": "get_weather",
+         "arguments": '{"city": "Hanoi"}'},
+        {"type": "function_call_output", "call_id": "call_1", "output": "Sunny, 32C"},
+        {"role": "user", "content": "thanks"},
+    ]}
+    prompt = cli_seat.prepare(body, "codex-cli", wire="responses").prompt
+    assert '"name": "get_weather"' in prompt
+    assert "Tool result: Sunny, 32C" in prompt
+    assert "User: thanks" in prompt
+
+
+def test_to_response_builds_a_responses_object():
+    result = cli_seat.SeatResult(text="hello world", input_tokens=3, output_tokens=2)
+    resp = cli_seat.to_response(result, "codex-cli", "codex-cli:gpt-5.5")
+    assert resp["object"] == "response"
+    assert resp["status"] == "completed"
+    assert resp["model"] == "codex-cli:gpt-5.5"
+    msg = resp["output"][0]
+    assert msg["type"] == "message" and msg["role"] == "assistant"
+    assert msg["content"][0]["type"] == "output_text"
+    assert msg["content"][0]["text"] == "hello world"
+    assert resp["usage"] == {"input_tokens": 3, "output_tokens": 2, "total_tokens": 5}
+
+
+def test_to_response_maps_tool_calls_to_function_call_items():
+    text = ('{"tool_calls": [{"type": "function", "function": '
+            '{"name": "get_weather", "arguments": {"city": "Hanoi"}}}]}')
+    result = cli_seat.SeatResult(text=text, input_tokens=1, output_tokens=1)
+    resp = cli_seat.to_response(result, "codex-cli", "codex-cli:gpt-5.5", cli_seat.OPENAI)
+    items = resp["output"]
+    assert items[0]["type"] == "message"
+    fc = items[1]
+    assert fc["type"] == "function_call"
+    assert fc["name"] == "get_weather"
+    assert json.loads(fc["arguments"]) == {"city": "Hanoi"}
+    assert fc["call_id"].startswith("call_")
+
+
+def test_the_responses_stream_uses_event_data_pairs():
+    """The Responses SSE pairs ``event:`` + ``data:`` (like Anthropic, unlike OpenAI chat's
+    bare ``data:``) and emits the canonical lifecycle: created → delta(s) → completed."""
+    from fastapi.testclient import TestClient
+
+    from local.cli_seat_server import create_app
+    from shared.agent.seats import seat_for
+
+    def run(binary, prepared, timeout, on_delta):
+        on_delta("hi there")
+        return cli_seat.SeatResult(text="hi there", output_tokens=2)
+
+    base = seat_for("codex-cli")
+    spec = base.__class__(**{**base.__dict__, "run": run})
+    app = create_app(spec=spec, binary="/fake/bin", options=cli_seat.SeatOptions())
+    client = TestClient(app)
+
+    resp = client.post("/responses", json={
+        "model": "codex-cli:gpt-5.6-terra", "stream": True, "input": "hi"})
+    body = resp.text
+
+    assert 'event: response.created\n' in body
+    assert 'event: response.output_text.delta\n' in body
+    assert 'event: response.completed\n' in body
+    # every frame is an event: line immediately followed by its data: line
+    for pair in body.split("\n\n"):
+        if not pair.strip():
+            continue
+        lines = pair.split("\n")
+        assert lines[0].startswith("event: "), f"frame missing event: line: {pair!r}"
+        assert lines[1].startswith("data: "), f"event not paired with data: {pair!r}"
+
+
+def test_the_responses_non_stream_endpoint_returns_a_json_object():
+    from fastapi.testclient import TestClient
+
+    from local.cli_seat_server import create_app
+    from shared.agent.seats import seat_for
+
+    def run(binary, prepared, timeout, on_delta):
+        return cli_seat.SeatResult(text="plain answer", input_tokens=1, output_tokens=2)
+
+    base = seat_for("codex-cli")
+    spec = base.__class__(**{**base.__dict__, "run": run})
+    app = create_app(spec=spec, binary="/fake/bin", options=cli_seat.SeatOptions())
+    client = TestClient(app)
+
+    resp = client.post("/responses", json={
+        "model": "codex-cli:gpt-5.6-terra", "input": "hello"})
+    obj = resp.json()
+    assert obj["object"] == "response"
+    assert obj["output"][0]["content"][0]["text"] == "plain answer"
+
+
+def test_responses_reasoning_effort_is_read_from_the_nested_field():
+    """The Responses API carries effort under ``reasoning.effort``, not the flat
+    ``reasoning_effort`` the chat wire uses."""
+    body = {"model": "codex-cli:gpt-5.5", "input": "hi",
+            "reasoning": {"effort": "high"}}
+    prepared = cli_seat.prepare(body, "codex-cli", wire="responses")
+    assert prepared.effort == "high"


### PR DESCRIPTION
## What

The `codex-cli` seat drove the `codex` binary via subprocess but advertised only `chat/completions`, so a caller speaking the Responses API natively could not route to it — even though the relay, caps envelope, and SSE block alignment for the responses dialect were all already in place for the `codex` (OAuth) and `openai` kinds.

This adds the two pieces `codex-cli` was missing so it now serves **both** `chat/completions` and `responses` (the same pair `openai` serves).

## Changes

| File | What |
|---|---|
| `shared/models/api_catalog.py` | `endpoints=(chat/completions, responses)` for `codex-cli` |
| `shared/agent/cli_seat.py` | `prepare()` handles `wire=responses` (`input`→messages, `instructions`→system); `to_response()` / `answer_response()` / `answer_stream_response()`; `_resolve_effort()` reads `reasoning.effort` |
| `local/cli_seat_server.py` | `/responses` route + `_stream_responses()` (SSE lifecycle events) + `_as_responses_sse()` |
| `local/server.py` | `/v1/responses` proxy route (local mode) |
| `tests/test_cli_seat.py` | 11 new tests |

## Why additive

Existing `/chat/completions` and `/messages` paths are **unchanged**. The only behavioral difference is that `codex-cli` engines now advertise `responses` capability, so the grid routes responses requests to them — which is the goal.

## Test plan

- [x] 90/90 `test_cli_seat.py` pass (incl. 11 new)
- [x] 323/323 serve/catalog/proxy/join `test_local_cli.py` pass
- [x] `ruff check` clean
- [ ] CI