### PR TITLE
fix(cli-seat): stream text again when a request carries tools

### DIFF
--- a/local/cli_seat_server.py
+++ b/local/cli_seat_server.py
@@ -155,11 +155,9 @@ async def _stream(app: FastAPI, prepared, *, wire: str = "openai"):
     base = {"id": f"chatcmpl-{uuid.uuid4().hex}", "object": "chat.completion.chunk",
             "created": int(time.time()), "model": prepared.model}
     first = True
-    # With a tool protocol in play, nothing is streamed as it arrives: the raw `{"tool_calls": …}`
-    # would go out as prose AND come back as a parsed call, so the client printed the JSON and ran
-    # the tool. Only the parse knows which bytes were the call, and it cannot run until the answer
-    # ends — so the whole thing waits, and `content` is sent once, below.
-    buffered = bool(prepared.tool_protocol)
+    # Text before the first `{` cannot be part of a call, so it streams; the rest waits for the
+    # parse. See `_SafeText` — this used to hold the WHOLE answer whenever tools were present.
+    safe = _SafeText(bool(prepared.tool_protocol))
     async with app.state.slots:
         try:
             while True:
@@ -169,7 +167,8 @@ async def _stream(app: FastAPI, prepared, *, wire: str = "openai"):
                 if kind is None:
                     break
                 if kind == "delta":
-                    if buffered:
+                    payload = safe.feed(payload)
+                    if not payload:
                         continue
                     delta = {"content": payload}
                     if first:
@@ -184,9 +183,10 @@ async def _stream(app: FastAPI, prepared, *, wire: str = "openai"):
                         app.state.quota_cache = (time.monotonic(), quota)
                     choice = (payload.get("choices") or [{}])[0]
                     message = choice.get("message") or {}
-                    text = message.get("content") or ""
-                    if buffered and text:
-                        # The prose the parse left behind — the whole answer minus any call.
+                    # Only what the stream did not already send — the prose the parse left behind,
+                    # minus the span emitted before the first `{`.
+                    text = safe.remainder(message.get("content") or "")
+                    if text:
                         delta = {"content": text}
                         if first:
                             delta["role"], first = "assistant", False
@@ -219,13 +219,14 @@ async def _stream_anthropic(app: FastAPI, prepared):
     """Anthropic SSE: `message_start`, one block per text/tool_use in the answer, `message_delta`,
     `message_stop`.
 
-    Same buffering rule as the OpenAI stream above: with a tool protocol in play nothing goes out
-    until the CLI stops writing, because only the parse knows which bytes were the call — emitting
-    text deltas early is what let a client print the raw tool JSON as prose AND run the tool.
+    Same streaming rule as the OpenAI stream above, via the same `_SafeText`: text before the first
+    `{` goes out as it arrives, the rest waits for the parse — because only the parse knows which
+    bytes were the call, and emitting those early is what let a client print raw tool JSON as prose
+    AND run the tool.
     """
     spec, options = app.state.spec, app.state.options
     stream = cli_seat.answer_stream_anthropic(spec, prepared, app.state.binary, options.timeout)
-    buffered = bool(prepared.tool_protocol)
+    safe = _SafeText(bool(prepared.tool_protocol))
     msg_id = f"msg_{uuid.uuid4().hex}"
 
     yield _anthropic_frame({"type": "message_start", "message": {
@@ -244,7 +245,8 @@ async def _stream_anthropic(app: FastAPI, prepared):
                 if kind is None:
                     break
                 if kind == "delta":
-                    if buffered:
+                    payload = safe.feed(payload)
+                    if not payload:
                         continue
                     if not text_open:
                         yield _anthropic_frame({"type": "content_block_start", "index": index,
@@ -260,14 +262,27 @@ async def _stream_anthropic(app: FastAPI, prepared):
                         app.state.quota_cache = (time.monotonic(), quota)
                     usage = message.get("usage") or usage
                     stop_reason = message.get("stop_reason") or "end_turn"
-                    if buffered:
-                        # Nothing went out above — the whole answer, text and any tool_use block
-                        # alike, is only known now that the parse has run on the complete text.
-                        frames, index = _anthropic_block_frames(message.get("content") or [], index)
-                        for frame in frames:
-                            yield frame
-                    elif text_open:
+                    # One path, whatever was streamed. Finish the text the stream started (nothing,
+                    # a prefix, or all of it), close it, then render the tool_use blocks — which
+                    # only exist now that the parse has run on the complete answer. With nothing
+                    # streamed this emits exactly the frames the fully-buffered path used to.
+                    content = message.get("content") or []
+                    tail = safe.remainder("".join(
+                        b.get("text") or "" for b in content if b.get("type") == "text"))
+                    if tail:
+                        if not text_open:
+                            yield _anthropic_frame({"type": "content_block_start", "index": index,
+                                         "content_block": {"type": "text", "text": ""}})
+                            text_open = True
+                        yield _anthropic_frame({"type": "content_block_delta", "index": index,
+                                     "delta": {"type": "text_delta", "text": tail}})
+                    if text_open:
                         yield _anthropic_frame({"type": "content_block_stop", "index": index})
+                        index, text_open = index + 1, False
+                    frames, index = _anthropic_block_frames(
+                        [b for b in content if b.get("type") == "tool_use"], index)
+                    for frame in frames:
+                        yield frame
         except Exception as exc:  # noqa: BLE001 — mirrors the OpenAI stream's terminal-error contract
             yield _anthropic_frame({"type": "error", "error": {
                 "type": "cli_seat_error", "message": str(exc) or type(exc).__name__}})
@@ -277,10 +292,60 @@ async def _stream_anthropic(app: FastAPI, prepared):
     yield _anthropic_frame({"type": "message_stop"})
 
 
+class _SafeText:
+    """Answer text provably outside any tool call, so it can go out as it arrives.
+
+    Both protocols ask the model to reply with a JSON object "and nothing else", and the parse
+    (`cli_seat._json_objects`) finds a call ANYWHERE in the text — so from the first `{` on, nothing
+    can be called prose until the answer ends and the parse has run. Everything before it can: no
+    byte there can end up inside a call. That is the whole rule, and it is what lets a turn stream
+    while still never printing raw tool JSON as prose.
+
+    What this replaced keyed on the mere PRESENCE of tools, so a client that always sends a tool
+    roster — Claude Code does — never saw a token until the turn was over. Measured on the prod
+    grid: the gap to the second chunk equalled the whole request, 344s on an opus turn.
+
+    Prose that legitimately contains `{` (a code block) stops streaming there and finishes in one
+    burst. That is the old behaviour for that turn, never worse — safety before coverage.
+
+    One class, both wires, because the rule must not drift between them (the same reason
+    `_anthropic_block_frames` is shared).
+    """
+
+    def __init__(self, guarded: bool) -> None:
+        self._guarded = guarded
+        self._sent = ""
+        self._stopped = False
+
+    def feed(self, delta: str) -> str:
+        """The part of `delta` safe to emit now — `""` once the rest must be held."""
+        if self._stopped:
+            return ""
+        safe = delta
+        if self._guarded:
+            brace = delta.find("{")
+            if brace >= 0:
+                safe, self._stopped = delta[:brace], True
+        self._sent += safe
+        return safe
+
+    def remainder(self, text: str) -> str:
+        """What still needs emitting once the parse has run.
+
+        The `startswith` guard is what keeps the client's total byte-for-byte equal to the final
+        answer: it holds whenever the parse returned the text unchanged (the no-call case, which
+        `parse_openai_tool_calls` returns UNSTRIPPED), and fails only on the whitespace `.strip()`
+        removes when a call WAS found — where what already went out covers the prose and re-sending
+        a recomputed span would double it.
+        """
+        return text[len(self._sent):] if text.startswith(self._sent) else ""
+
+
 def _anthropic_block_frames(blocks, start_index):
     """`content_block_start`/`delta`/`stop` for each text or tool_use block in `blocks`, indexed
-    from `start_index`. Shared by the buffered live-stream path above and the no-stream fallback
-    below, so a block is never rendered two different ways."""
+    from `start_index`. Shared by the live-stream path above — which passes only the `tool_use`
+    blocks, having already streamed the text — and the no-stream fallback below, which passes the
+    whole answer, so a block is never rendered two different ways."""
     frames, index = [], start_index
     for block in blocks:
         kind = block.get("type")

--- a/tests/test_cli_seat.py
+++ b/tests/test_cli_seat.py
@@ -945,3 +945,152 @@ def test_the_openai_stream_stays_data_only():
 
     assert "event:" not in body
     assert "data: [DONE]" in body
+
+
+# Streaming with tools attached.
+#
+# `buffered = bool(prepared.tool_protocol)` dropped EVERY delta whenever the request carried tools,
+# so the whole answer landed in one burst at the end. Claude Code always sends its tool roster, so
+# every one of its turns was silent — measured on the prod grid as a gap-to-second-chunk equal to
+# the entire request (344s of nothing on an opus turn). The guard itself is real: the parse decides
+# which bytes were the call, so a delta emitted early once let a client print raw tool JSON as prose
+# AND run the tool. The rule that satisfies both: stream up to the first `{`, hold from there.
+
+_ANTHROPIC_TOOL = {"name": "get_weather", "description": "Get weather",
+                   "input_schema": {"type": "object", "properties": {"loc": {"type": "string"}}}}
+_OPENAI_TOOL = {"type": "function", "function": {"name": "get_weather", "description": "Get weather",
+                "parameters": {"type": "object", "properties": {"loc": {"type": "string"}}}}}
+_TOOL_JSON = '{"type": "tool_use", "name": "get_weather", "input": {"loc": "Hanoi"}}'
+_OPENAI_CALL_JSON = ('{"tool_calls": [{"type": "function", "function": '
+                     '{"name": "get_weather", "arguments": {"loc": "Hanoi"}}}]}')
+
+
+def _seat_app(pieces):
+    """An app whose seat emits `pieces` as separate deltas, then returns their concatenation."""
+    from local.cli_seat_server import create_app
+    from shared.agent.seats import seat_for
+
+    def run(binary, prepared, timeout, on_delta):
+        # `run_seat` passes on_delta=None on the non-streaming path — the same spec has to serve both.
+        for piece in pieces:
+            if on_delta is not None:
+                on_delta(piece)
+        return cli_seat.SeatResult(text="".join(pieces), output_tokens=len(pieces))
+
+    base = seat_for("claude")
+    spec = base.__class__(**{**base.__dict__, "run": run})
+    return create_app(spec=spec, binary="/fake/bin", options=cli_seat.SeatOptions())
+
+
+def _sse_frames(body):
+    """Every `data:` payload in an SSE body, decoded."""
+    out = []
+    for line in body.splitlines():
+        if line.startswith("data: ") and line[6:].strip() != "[DONE]":
+            try:
+                out.append(json.loads(line[6:]))
+            except ValueError:
+                pass
+    return out
+
+
+def _streamed_text(body):
+    return "".join(f["delta"]["text"] for f in _sse_frames(body)
+                   if f.get("type") == "content_block_delta"
+                   and (f.get("delta") or {}).get("type") == "text_delta")
+
+
+def _post_messages(app, body):
+    from fastapi.testclient import TestClient
+    return TestClient(app).post("/messages", json=body).text
+
+
+def test_a_prose_answer_streams_even_when_the_request_carries_tools():
+    """The regression this whole change is about: a turn that calls no tool must not be held back
+    just because tools were offered."""
+    pieces = ["The sea ", "is wide ", "and deep."]
+    body = _post_messages(_seat_app(pieces), {
+        "model": "claude:sonnet", "stream": True, "tools": [_ANTHROPIC_TOOL],
+        "messages": [{"role": "user", "content": "describe the sea"}]})
+
+    deltas = [f for f in _sse_frames(body) if f.get("type") == "content_block_delta"]
+    assert len(deltas) > 1, "the answer arrived in one burst — still buffered"
+    assert _streamed_text(body) == "".join(pieces)
+
+
+def test_a_tool_call_is_never_streamed_as_prose():
+    """The property the buffering existed to protect. The model was told to reply with the JSON
+    object and nothing else, so this streams no text at all — and the raw call must never reach the
+    client as text, or it prints the JSON and runs the tool."""
+    body = _post_messages(_seat_app([_TOOL_JSON]), {
+        "model": "claude:sonnet", "stream": True, "tools": [_ANTHROPIC_TOOL],
+        "messages": [{"role": "user", "content": "weather in Hanoi?"}]})
+
+    assert _streamed_text(body) == ""
+    assert "get_weather" not in _streamed_text(body)
+    kinds = [(f.get("content_block") or {}).get("type") for f in _sse_frames(body)
+             if f.get("type") == "content_block_start"]
+    assert "tool_use" in kinds, "the call must still be delivered as a tool_use block"
+
+
+def test_prose_before_a_call_streams_but_the_call_does_not():
+    pieces = ["Let me check. ", _TOOL_JSON]
+    body = _post_messages(_seat_app(pieces), {
+        "model": "claude:sonnet", "stream": True, "tools": [_ANTHROPIC_TOOL],
+        "messages": [{"role": "user", "content": "weather in Hanoi?"}]})
+
+    streamed = _streamed_text(body)
+    assert "Let me check." in streamed
+    assert "tool_use" not in streamed and "get_weather" not in streamed
+    kinds = [(f.get("content_block") or {}).get("type") for f in _sse_frames(body)
+             if f.get("type") == "content_block_start"]
+    assert "tool_use" in kinds
+
+
+def test_the_streamed_text_equals_what_the_non_streaming_answer_returns():
+    """The client must end up with exactly the same bytes either way — the streamed prefix plus
+    whatever the final frames add, never a doubled or a missing span."""
+    from fastapi.testclient import TestClient
+
+    pieces = ["The sea ", "is wide."]
+    request = {"model": "claude:sonnet", "tools": [_ANTHROPIC_TOOL],
+               "messages": [{"role": "user", "content": "describe the sea"}]}
+
+    streamed = _streamed_text(_post_messages(_seat_app(pieces), {**request, "stream": True}))
+    whole = TestClient(_seat_app(pieces)).post("/messages", json=request).json()
+    assert streamed == "".join(b.get("text", "") for b in whole["content"] if b.get("type") == "text")
+
+
+def test_the_openai_stream_shares_the_rule():
+    """One rule, both wires — `/chat/completions` buffered on the same flag and must not drift."""
+    from fastapi.testclient import TestClient
+    from local.cli_seat_server import create_app
+    from shared.agent.seats import seat_for
+
+    def app_for(pieces):
+        def run(binary, prepared, timeout, on_delta):
+            for piece in pieces:
+                on_delta(piece)
+            return cli_seat.SeatResult(text="".join(pieces), output_tokens=1)
+        base = seat_for("codex-cli")
+        spec = base.__class__(**{**base.__dict__, "run": run})
+        return create_app(spec=spec, binary="/fake/bin", options=cli_seat.SeatOptions())
+
+    def post(pieces):
+        return TestClient(app_for(pieces)).post("/chat/completions", json={
+            "model": "codex-cli:gpt-5.6-terra", "stream": True, "tools": [_OPENAI_TOOL],
+            "messages": [{"role": "user", "content": "hi"}]}).text
+
+    def content(body):
+        return "".join((f.get("choices") or [{}])[0].get("delta", {}).get("content") or ""
+                       for f in _sse_frames(body))
+
+    prose = post(["The sea ", "is wide."])
+    prose_deltas = [f for f in _sse_frames(prose)
+                    if ((f.get("choices") or [{}])[0].get("delta") or {}).get("content")]
+    assert len(prose_deltas) > 1, "prose still arrives in one burst on the OpenAI wire"
+    assert content(prose) == "The sea is wide."
+
+    call = post([_OPENAI_CALL_JSON])
+    assert content(call) == "", "the raw call leaked into the stream as prose"
+    assert any(((f.get("choices") or [{}])[0].get("delta") or {}).get("tool_calls") for f in _sse_frames(call))


### PR DESCRIPTION
## The bug

`buffered = bool(prepared.tool_protocol)` dropped **every** delta whenever a request offered tools,
and emitted the whole answer at the end. Claude Code always sends its tool roster, so every one of
its turns was silent — even a pure prose answer with no call in it.

Measured on the prod `gmail.com` grid: one chunk at 0.4–0.6s, then a gap to the second chunk equal to
essentially the entire request, then 6–9 chunks at once.

| model | total | chunks | first chunk | gap to next |
|---|---|---|---|---|
| opus-5 | 344.8s | 9 | 0.6s | **344.2s** |
| opus-5 | 284.6s | 9 | 0.5s | **284.0s** |
| sonnet-5 | 28.2s | 6 | 0.4s | 27.8s |

The guard it protected is real: the parse decides which bytes were the call, so a delta emitted early
once let a client print raw tool JSON as prose **and** run the tool. But it keyed on the *presence* of
tools, not on whether the answer contained a call.

## The rule

Both protocols ask the model to reply with a JSON object "and nothing else", and the parse finds a
call anywhere in the text. So text before the first `{` can never end up inside a call and is safe to
stream; from that brace on it waits for the parse.

`_SafeText` holds that rule once for **all three wires** — the file already shares
`_anthropic_block_frames` for the same reason. Its `remainder()` keeps the client's total
byte-for-byte equal to the final answer.

Prose that legitimately contains `{` (a code block) stops streaming there and finishes in one burst:
the old behaviour for that turn, never worse.

## Merge note — the third wire

`main`'s `/responses` stream (PR #42) landed while this was in flight carrying the **same**
`buffered = bool(prepared.tool_protocol)`. Merged as-is it would have kept the frozen stream for every
codex-cli turn offering tools, and the rule this PR unifies would have drifted immediately. It now
uses the same `_SafeText`, with its own test.

## Test plan

- [x] `pytest tests/` — 1764 passed, 7 skipped, 0 failed (after merging `main`)
- [x] `ruff check .` — clean
- [x] Live A/B against the real `claude 2.1.220`, same request with and without one tool attached:
      first text delta **16.71s → 2.90s**, **6 → 23** frames
- [x] Forced tool call still streams no text and arrives as a `tool_use` block; no raw JSON as prose
- [x] No-tools path unchanged (24 deltas, streams from ~3s)
- [x] 6 new tests cover both directions — prose-with-tools *must* stream, a call *must not* leak as
      text — on all three wires, plus an invariant that streamed text equals the non-streaming answer
- [x] Verified against a seat run from this branch on a spare port; prod untouched

## Scope

Fixes the stream going **silent**. Does not shorten a turn: the ~3.3s per-request floor (a fresh
`claude -p` per request), the 0% prompt-cache rate, and the tool roster being re-sent every request
are all untouched and measured separately.