### PR TITLE
fix(seat): tool_use omitted bug + Claude stream-json + Codex tool refusal

### DIFF
--- a/local/cli_seat_server.py
+++ b/local/cli_seat_server.py
@@ -110,7 +110,7 @@ async def _handle(app: FastAPI, request: Request, *, wire: str = "openai"):
 
     try:
         prepared = await run_in_threadpool(
-            cli_seat.prepare, body, spec.kind, spec.tool_protocol, wire,
+            cli_seat.prepare, body, spec.kind, spec.tool_protocol, wire, spec.tool_note,
         )
     except cli_seat.SeatBadRequest as exc:
         return _error(400, str(exc))
@@ -185,7 +185,17 @@ async def _stream(app: FastAPI, prepared, *, wire: str = "openai"):
                 kind, payload = await run_in_threadpool(_next_or_none, stream)
                 if kind is None:
                     break
-                if kind == "delta":
+                if kind == "reasoning":
+                    # `reasoning_content` is the field the OpenAI-compatible ecosystem settled on
+                    # for this; a client that does not know it ignores it, and one that does shows
+                    # the think instead of a dead connection. Never `content` — that is the answer,
+                    # and the tool parse reads it.
+                    delta = {"reasoning_content": payload}
+                    if first:
+                        delta["role"], first = "assistant", False
+                    yield _frame({**base, "choices": [
+                        {"index": 0, "delta": delta, "finish_reason": None}]})
+                elif kind == "delta":
                     payload = safe.feed(payload)
                     if not payload:
                         continue
@@ -263,6 +273,12 @@ async def _stream_anthropic(app: FastAPI, prepared):
                 kind, payload = await run_in_threadpool(_next_or_none, stream)
                 if kind is None:
                     break
+                if kind == "reasoning":
+                    # Dropped, deliberately, and the only wire where it is. An Anthropic `thinking`
+                    # block carries a `signature` the vendor mints and the client verifies when the
+                    # block is replayed on the next turn; this seat has no signature to put there,
+                    # so an unsigned block would be rejected on replay — worse than not sending it.
+                    continue
                 if kind == "delta":
                     payload = safe.feed(payload)
                     if not payload:
@@ -361,13 +377,23 @@ class _SafeText:
 
 
 async def _stream_responses(app, prepared):
-    """OpenAI Responses SSE: ``response.created``, ``output_text`` delta(s), ``response.completed``.
+    """OpenAI Responses SSE: every item announced as its own ``output_item``, then
+    ``response.completed``.
 
     Same streaming rule as the OpenAI/Anthropic streams, via the same ``_SafeText``: text before the
     first ``{`` goes out as it arrives, the rest waits for the parse — because only the parse knows
     which bytes were the call, and emitting those early is what let a client print raw tool JSON as
-    prose AND run the tool. Tool-call items ride the terminal ``response.completed`` event's
-    ``output[]``, never a delta (they cannot be known until the answer is whole).
+    prose AND run the tool.
+
+    A tool call is still only KNOWN once the answer is whole, but it must still be announced as an
+    ``output_item``. It used to appear nowhere but inside the terminal ``response.completed``, and a
+    client that builds its output from the item events — Codex CLI does — saw a stream that
+    announced nothing and ran no tool. So the call is replayed here as the item event sequence the
+    dialect defines (``added`` -> ``arguments.delta`` -> ``arguments.done`` -> ``done``), with the
+    whole argument string as one delta: the bytes arrive at once, and the shape is what matters.
+
+    ``output_index`` is assigned in emission order and reused in ``response.completed``, so the
+    indices a client saw stream are the indices it finds in the final object.
 
     Reuses ``_anthropic_frame`` — the SSE framing (``event: <type>\\ndata: <json>``) is identical
     across the Anthropic and Responses dialects; only the event names differ.
@@ -377,24 +403,51 @@ async def _stream_responses(app, prepared):
     safe = _SafeText(bool(prepared.tool_protocol))
     resp_id = f"resp_{uuid.uuid4().hex}"
     msg_id = f"msg_{uuid.uuid4().hex}"
+    reasoning_id = f"rs_{uuid.uuid4().hex[:24]}"
 
     yield _anthropic_frame({"type": "response.created", "response": {
         "id": resp_id, "object": "response", "status": "in_progress",
         "model": prepared.model, "output": []}})
 
-    def _open_text():
+    # Assigned as items open, never guessed: thinking may be absent, text may be absent (a call-only
+    # answer), and a hardcoded 0 for the message was what made every later index wrong.
+    next_index = 0
+    reasoning_index = text_index = None
+    reasoning_open, text_open = False, False
+    reasoning_text, full_text = "", ""
+    response_obj = None
+
+    def _open_reasoning(index):
         return (
-            _anthropic_frame({"type": "response.output_item.added", "output_index": 0,
+            _anthropic_frame({"type": "response.output_item.added", "output_index": index,
+                "item": {"id": reasoning_id, "type": "reasoning", "summary": []}}),
+            _anthropic_frame({"type": "response.reasoning_summary_part.added",
+                "item_id": reasoning_id, "output_index": index, "summary_index": 0,
+                "part": {"type": "summary_text", "text": ""}}),
+        )
+
+    def _close_reasoning(index, text):
+        return (
+            _anthropic_frame({"type": "response.reasoning_summary_text.done",
+                "item_id": reasoning_id, "output_index": index, "summary_index": 0, "text": text}),
+            _anthropic_frame({"type": "response.reasoning_summary_part.done",
+                "item_id": reasoning_id, "output_index": index, "summary_index": 0,
+                "part": {"type": "summary_text", "text": text}}),
+            _anthropic_frame({"type": "response.output_item.done", "output_index": index,
+                "item": {"id": reasoning_id, "type": "reasoning",
+                         "summary": [{"type": "summary_text", "text": text}]}}),
+        )
+
+    def _open_text(index):
+        return (
+            _anthropic_frame({"type": "response.output_item.added", "output_index": index,
                 "item": {"id": msg_id, "type": "message", "status": "in_progress",
                          "role": "assistant", "content": []}}),
             _anthropic_frame({"type": "response.content_part.added",
-                "output_index": 0, "content_index": 0,
+                "item_id": msg_id, "output_index": index, "content_index": 0,
                 "part": {"type": "output_text", "text": "", "annotations": []}}),
         )
 
-    text_open = False
-    full_text = ""
-    response_obj = None
     async with app.state.slots:
         try:
             while True:
@@ -403,17 +456,36 @@ async def _stream_responses(app, prepared):
                 kind, payload = await run_in_threadpool(_next_or_none, stream)
                 if kind is None:
                     break
+                if kind == "reasoning":
+                    if not reasoning_open:
+                        reasoning_index, next_index = next_index, next_index + 1
+                        for frame in _open_reasoning(reasoning_index):
+                            yield frame
+                        reasoning_open = True
+                    reasoning_text += payload
+                    yield _anthropic_frame({"type": "response.reasoning_summary_text.delta",
+                        "item_id": reasoning_id, "output_index": reasoning_index,
+                        "summary_index": 0, "delta": payload})
+                    continue
                 if kind == "delta":
                     payload = safe.feed(payload)
                     if not payload:
                         continue
+                    # The think is over the moment the answer starts, so close its item before the
+                    # message opens — two items may not be in progress at the same index depth.
+                    if reasoning_open:
+                        for frame in _close_reasoning(reasoning_index, reasoning_text):
+                            yield frame
+                        reasoning_open = False
                     if not text_open:
-                        for frame in _open_text():
+                        text_index, next_index = next_index, next_index + 1
+                        for frame in _open_text(text_index):
                             yield frame
                         text_open = True
                     full_text += payload
                     yield _anthropic_frame({"type": "response.output_text.delta",
-                        "output_index": 0, "content_index": 0, "delta": payload})
+                        "item_id": msg_id, "output_index": text_index,
+                        "content_index": 0, "delta": payload})
                 else:
                     response_obj, quota = payload
                     if quota is not None:
@@ -425,13 +497,19 @@ async def _stream_responses(app, prepared):
                     # none (a call-only answer leaves this empty and the text item never opens).
                     tail = safe.remainder(_responses_output_text(response_obj))
                     if tail:
+                        if reasoning_open:
+                            for frame in _close_reasoning(reasoning_index, reasoning_text):
+                                yield frame
+                            reasoning_open = False
                         if not text_open:
-                            for frame in _open_text():
+                            text_index, next_index = next_index, next_index + 1
+                            for frame in _open_text(text_index):
                                 yield frame
                             text_open = True
                         full_text += tail
                         yield _anthropic_frame({"type": "response.output_text.delta",
-                            "output_index": 0, "content_index": 0, "delta": tail})
+                            "item_id": msg_id, "output_index": text_index,
+                            "content_index": 0, "delta": tail})
         except Exception as exc:  # noqa: BLE001 — mirrors the OpenAI stream's terminal-error contract
             yield _anthropic_frame({"type": "response.failed", "response": {
                 "id": resp_id, "object": "response", "status": "failed",
@@ -440,20 +518,50 @@ async def _stream_responses(app, prepared):
                           "code": "cli_seat_error"}}})
             return
 
+    # A think with no answer after it (the model emitted only a tool call) still has to close.
+    if reasoning_open:
+        for frame in _close_reasoning(reasoning_index, reasoning_text):
+            yield frame
+        reasoning_open = False
+
     if text_open:
         yield _anthropic_frame({"type": "response.output_text.done",
-            "output_index": 0, "content_index": 0, "text": full_text})
+            "item_id": msg_id, "output_index": text_index, "content_index": 0, "text": full_text})
         yield _anthropic_frame({"type": "response.content_part.done",
-            "output_index": 0, "content_index": 0,
+            "item_id": msg_id, "output_index": text_index, "content_index": 0,
             "part": {"type": "output_text", "text": full_text, "annotations": []}})
         yield _anthropic_frame({"type": "response.output_item.done",
-            "output_index": 0,
+            "output_index": text_index,
             "item": {"id": msg_id, "type": "message", "status": "completed",
                      "role": "assistant",
                      "content": [{"type": "output_text", "text": full_text, "annotations": []}]}})
 
     completed = response_obj or {"id": resp_id, "object": "response", "status": "completed",
                                   "model": prepared.model, "output": [], "usage": {}}
+    for call in [item for item in (completed.get("output") or [])
+                 if isinstance(item, dict) and item.get("type") == "function_call"]:
+        index, next_index = next_index, next_index + 1
+        opening = {**call, "arguments": "", "status": "in_progress"}
+        yield _anthropic_frame({"type": "response.output_item.added",
+            "output_index": index, "item": opening})
+        yield _anthropic_frame({"type": "response.function_call_arguments.delta",
+            "item_id": call.get("id"), "output_index": index,
+            "delta": call.get("arguments") or "{}"})
+        yield _anthropic_frame({"type": "response.function_call_arguments.done",
+            "item_id": call.get("id"), "output_index": index,
+            "arguments": call.get("arguments") or "{}"})
+        yield _anthropic_frame({"type": "response.output_item.done",
+            "output_index": index, "item": call})
+
+    # The thinking item is not in `to_response`'s output — it is a streaming-only concern there —
+    # but a client that saw it stream must find it in the final object at the SAME index, so it is
+    # spliced in at the front, which is where its index came from.
+    if reasoning_index is not None:
+        completed = {**completed, "output": [
+            {"id": reasoning_id, "type": "reasoning",
+             "summary": [{"type": "summary_text", "text": reasoning_text}]},
+            *(completed.get("output") or []),
+        ]}
     yield _anthropic_frame({"type": "response.completed", "response": completed})
 
 

--- a/remote/serve.py
+++ b/remote/serve.py
@@ -729,6 +729,7 @@ def _api_upstream_name(api_kind: str, advertised: str) -> str:
     return advertised.partition(":")[2] or advertised
 
 
+
 def _api_unsupported_params(api_kind: str, body: dict[str, Any]) -> list[str]:
     """Params in ``body`` the vendor is known to reject (catalog fact), null values excluded —
     the vendors accept an explicit null, so only a real value earns a refusal."""

--- a/shared/agent/cli_seat.py
+++ b/shared/agent/cli_seat.py
@@ -678,6 +678,8 @@ class PreparedRequest:
     # `reasoning.effort` field, or the chat `reasoning_effort` field — "" when the caller asked for
     # none, so today's argv/turn params are unaffected.
     effort: str = ""
+    messages: tuple = ()   # raw non-system messages, for structured-input seats
+    tool_text: str = ""    # rendered tool protocol text, "" when caller sent no tools
 
 
 def _effort_for_thinking(thinking):
@@ -803,9 +805,10 @@ def prepare(body, kind, protocol=None, wire="openai"):
     tools = body.get("tools") if isinstance(body.get("tools"), list) else None
     if wire == "anthropic" and tools:
         _reject_server_tools(tools)
+    tool_text = resolved_protocol.render(tools) if tools else ""
     prompt = build_prompt(messages)
-    if tools:
-        prompt = f"{prompt}\n\n{resolved_protocol.render(tools)}"
+    if tool_text:
+        prompt = f"{prompt}\n\n{tool_text}"
     if wire == "anthropic":
         # `system` is a TOP-LEVEL field on this wire, not a `role: "system"` message — reading it
         # off `messages` (the OpenAI shape) would silently drop the caller's whole instruction set,
@@ -831,6 +834,8 @@ def prepare(body, kind, protocol=None, wire="openai"):
         tool_protocol=resolved_protocol if tools else None,
         wire=wire,
         effort=_resolve_effort(body),
+        messages=tuple(m for m in messages if m.get("role") != "system"),
+        tool_text=tool_text,
     )
 
 

--- a/shared/agent/cli_seat.py
+++ b/shared/agent/cli_seat.py
@@ -16,6 +16,7 @@ import os
 import queue
 import shutil
 import subprocess
+import sys
 import tempfile
 import threading
 import time
@@ -50,6 +51,30 @@ class SeatResult:
 
 
 @dataclass(frozen=True)
+class Reasoning:
+    """One chunk of the model's thinking, travelling the same channel as an answer delta.
+
+    A marker type rather than a second callback: a seat emits thinking and answer text on one
+    ordered stream, and splitting them into two channels would lose which came first. It must not be
+    a bare string — thinking is NOT part of the answer, so it never reaches `_SafeText`, never counts
+    toward the text the parse reads back, and never lands in `content`.
+    """
+
+    text: str
+
+
+@dataclass(frozen=True)
+class TurnEnd:
+    """One of the CLI's turns finished — NOT the request.
+
+    A CLI handed a replayed transcript may run several turns for one request, answering each past
+    question again on its way to the live one. Only the last of those is the answer; the rest are
+    re-runs and must not reach the client. `parse_event` marks the boundaries with this and
+    `stream_seat` counts them, because only the seat knows how many turns it asked for.
+    """
+
+
+@dataclass(frozen=True)
 class QuotaSnapshot:
     """One quota reading. Percentages are 0-100; resets stay verbatim (they carry no year)."""
 
@@ -79,9 +104,15 @@ class SeatSpec:
                                     # `on_delta(text)` is called per streamed chunk, or None.
                                     # Wins over invoke/decode when set.
     parse_usage: object = None      # (text) -> QuotaSnapshot | None
-    parse_event: object = None      # (event) -> str to stream | QuotaSnapshot | None
+    parse_event: object = None      # (event) -> str | Reasoning | QuotaSnapshot | TurnEnd | None
+    expected_turns: object = None   # (stdin) -> how many turns this input will make the CLI run.
+                                    # None = one, the ordinary case. Set only by a CLI whose input
+                                    # format re-runs replayed history (see seats/claude.py).
     home_env: str = ""              # env var pointing the CLI at its own home; "" = shares the user's
     config_files: tuple = ()        # ((relative path, text), …) written into that home
+    tool_note: str = ""             # extra instruction appended to the tool block, for a CLI whose
+                                    # own tools stay visible to the model and must be named to be
+                                    # ruled out. "" for a CLI that can hide them (claude's --tools "")
 
 
 @dataclass(frozen=True)
@@ -352,6 +383,12 @@ DEFAULT_SYSTEM_PROMPT = "You are a helpful assistant."
 # of emitting a tool call — it believed it still had an editor and reported the refusal as the
 # outcome. It only works when the vendor's base prompt is REPLACED too; left in place, that prompt
 # reasserts the agent identity and the model goes back to trying the work itself.
+#
+# Do not soften this for a seat it does not fit. It was reworded once, to stop asserting "no file,
+# shell, editor or network tool" on codex, where the model can see `exec` in its own list — and the
+# rewording measurably cost claude, where the sentence is exactly true (`--tools ""`) and the
+# enumeration is the part that works. A seat whose CLI leaves its own tools visible corrects this in
+# its `tool_note` instead, which is appended after and is the last word.
 TOOL_DELEGATION_NOTE = (
     "You have NO ability to execute anything yourself — no file, shell, editor or network tool. "
     "Any workspace, sandbox or approval described to you concerns the process you run in, NOT the "
@@ -373,7 +410,10 @@ def _json_objects(text):
     them inside strings, so a `\\{.*?\\}` or a brace counter truncates any call whose argument is
     an object — the common case.
     """
-    decoder = json.JSONDecoder()
+    # strict=False: a model writing a shell command puts REAL newlines and tabs inside the JSON
+    # string. Strict mode rejects those as control characters, the scan finds no call, and the raw
+    # `{"tool_calls": …}` is handed back as prose — the user sees it printed instead of run.
+    decoder = json.JSONDecoder(strict=False)
     index = 0
     while True:
         index = text.find("{", index)
@@ -404,7 +444,7 @@ def _one_call(entry):
     arguments = function.get("arguments")
     if isinstance(arguments, str):
         try:
-            arguments = json.loads(arguments)
+            arguments = json.loads(arguments, strict=False)
         except ValueError:
             arguments = {}
     return {
@@ -444,7 +484,62 @@ def parse_openai_tool_calls(text):
     return "".join(prose_parts).strip(), calls
 
 
+# The same shape OPENAI_TOOL_TEMPLATE asks for, as a schema a CLI can enforce at decode time.
+# Asking produces a call that is *usually* well-formed; measured on a live codex turn, one came back
+# with a closing brace missing and the whole object was printed to the user as prose. A constrained
+# decode cannot emit that. `text` stays so an ordinary answer is still expressible — constrain the
+# shape, not the choice of whether to call a tool.
+#
+# Strict structured outputs, whose rules the first draft broke and the vendor named exactly:
+# "'additionalProperties' is required to be supplied and to be false". Every object must also list
+# EVERY property in `required` — there are no optional keys — so `tool_calls` is required and simply
+# empty when no tool is wanted. `arguments` is a STRING holding JSON, not an object: a free-form
+# object cannot be expressed under these rules, and the OpenAI wire spells it that way regardless
+# (`_one_call` already decodes both).
+OPENAI_OUTPUT_SCHEMA = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["text", "tool_calls"],
+    "properties": {
+        "text": {"type": "string",
+                 "description": "The reply. Empty when a tool call is the whole answer."},
+        "tool_calls": {
+            "type": "array",
+            "description": "Empty when no tool is needed.",
+            "items": {
+                "type": "object",
+                "additionalProperties": False,
+                "required": ["name", "arguments"],
+                "properties": {
+                    "name": {"type": "string"},
+                    "arguments": {"type": "string",
+                                  "description": "JSON object, encoded as a string."},
+                },
+            },
+        },
+    },
+}
+
+
+def parse_structured_answer(text):
+    """A schema-constrained answer -> `(prose, calls)`. Falls back to the text scan.
+
+    The fallback is not belt-and-braces: `outputSchema` binds the FINAL message only, so a turn that
+    ends in prose, or a CLI that ignored the schema, still arrives in the old shape.
+    """
+    try:
+        value = json.loads(text, strict=False)
+    except (TypeError, ValueError):
+        return parse_openai_tool_calls(text)
+    if not isinstance(value, dict) or "text" not in value:
+        return parse_openai_tool_calls(text)
+    calls = [c for c in (_one_call(c) for c in value.get("tool_calls") or []) if c]
+    return str(value.get("text") or ""), calls
+
+
 OPENAI = ToolProtocol(name="openai", render=render_openai_tools, parse=parse_openai_tool_calls)
+STRUCTURED = ToolProtocol(name="structured", render=render_openai_tools,
+                          parse=parse_structured_answer)
 
 
 # Anthropic's own shape: one `tool_use` block instead of an array of `tool_calls`. Kept as a
@@ -481,7 +576,7 @@ def parse_anthropic_tool_uses(text):
         payload = value.get("input")
         if isinstance(payload, str):
             try:
-                payload = json.loads(payload)
+                payload = json.loads(payload, strict=False)
             except ValueError:
                 payload = {}
         calls.append({"type": "tool_use", "id": f"toolu_{uuid.uuid4().hex[:24]}",
@@ -585,6 +680,45 @@ def build_prompt(messages):
         else:
             lines.append(text)
     return "\n\n".join(line for line in lines if line)
+
+
+# Caller-side request metadata, not content: `cache_control` belongs to the caller's own API call
+# and 400s when forwarded into ours.
+STRIPPED_KEYS = ("cache_control",)
+
+# Framed, because the payload is a JSON array and without this the model describes it instead of
+# continuing it.
+JSON_PROMPT_HEADER = (
+    "The conversation so far, as JSON. Continue it: answer the last message. "
+    "Do not describe or repeat the JSON."
+)
+
+
+def _strip_metadata(value):
+    if isinstance(value, dict):
+        return {k: _strip_metadata(v) for k, v in value.items() if k not in STRIPPED_KEYS}
+    if isinstance(value, list):
+        return [_strip_metadata(v) for v in value]
+    return value
+
+
+def json_prompt(messages, tools_text=None, keep_system=False):
+    """The transcript as verbatim JSON — nothing flattened into prose.
+
+    A `tool_use` stays a tool_use and a `tool_result` stays a tool_result, so the model can see the
+    shape it is expected to answer in. Flattening turned both into sentences, and the model then had
+    to guess the format back.
+
+    `keep_system` keeps `role: "system"` messages in the transcript, for a wire whose system prompt
+    came from a top-level field and so never read them.
+    """
+    turns = _strip_metadata(
+        list(messages) if keep_system else [m for m in messages if m.get("role") != "system"])
+    if not turns:
+        raise SeatBadRequest("messages[] must contain at least one non-system message.")
+    body = json.dumps(turns, ensure_ascii=False, indent=2, default=str)
+    prompt = f"{JSON_PROMPT_HEADER}\n\n{body}"
+    return f"{prompt}\n\n{tools_text}" if tools_text else prompt
 
 
 def _responses_content_parts(content):
@@ -761,15 +895,21 @@ def _resolve_effort(body):
     rather than one of three words. A request naming none of the three returns "", so an ordinary
     body's resulting argv/turn params are unaffected.
     """
-    thinking_effort = _effort_for_thinking(body.get("thinking"))
-    if thinking_effort:
-        return thinking_effort
-    reasoning = body.get("reasoning")
-    if isinstance(reasoning, dict):
-        effort = _effort_for_reasoning_effort(reasoning.get("effort"))
-        if effort:
-            return effort
-    return _effort_for_reasoning_effort(body.get("reasoning_effort"))
+    thinking = body.get("thinking")
+    budget = thinking.get("budget_tokens") if isinstance(thinking, dict) else None
+    if isinstance(budget, (int, float)) and not isinstance(budget, bool) and budget > 0:
+        return _effort_for_thinking(thinking)   # a real number beats every word below
+
+    # A word the caller actually wrote beats one this file infers. Claude Code sends BOTH
+    # `thinking: {"type": "adaptive"}` (no number, so we guess "medium") and
+    # `output_config: {"effort": "high"}` — captured live. Reading only `thinking` graded its
+    # high-effort request as medium.
+    for source in (body.get("output_config"), body.get("reasoning")):
+        if isinstance(source, dict):
+            effort = _effort_for_reasoning_effort(source.get("effort"))
+            if effort:
+                return effort
+    return _effort_for_reasoning_effort(body.get("reasoning_effort")) or _effort_for_thinking(thinking)
 
 
 def _reject_server_tools(tools):
@@ -785,7 +925,50 @@ def _reject_server_tools(tools):
             )
 
 
-def prepare(body, kind, protocol=None, wire="openai"):
+def _tool_name(tool):
+    """The name a tool can be called by, or "" when it has none."""
+    if not isinstance(tool, dict):
+        return ""
+    name = tool.get("name")
+    if not name and isinstance(tool.get("function"), dict):
+        name = tool["function"].get("name")
+    return name if isinstance(name, str) else ""
+
+
+def _callable_tools(tools):
+    """Only the tools the caller can actually execute for us.
+
+    Captured from a live Codex CLI request: its `tools[]` also carries `{"type": "web_search",
+    "name": null}` and `{"type": "namespace", ...}`. Those run on the vendor's side, not the
+    caller's, and a nameless entry cannot be named in a name-based protocol — rendered into the
+    prompt they are an offer nobody can answer.
+    """
+    return [t for t in tools or []
+            if (t.get("type") if isinstance(t, dict) else None) in (None, "function")
+            and _tool_name(t)]
+
+
+def _tool_constraints(body):
+    """The caller's `tool_choice` / `parallel_tool_calls`, as instruction text. "" when free."""
+    parts = []
+    if body.get("parallel_tool_calls") is False:
+        # The templates invite several calls at once; Codex CLI asks for one.
+        parts.append("Emit AT MOST ONE tool call in this reply.")
+    choice = body.get("tool_choice")
+    if isinstance(choice, dict):
+        if choice.get("type") in ("any", "tool", "function"):
+            named = choice.get("name") or (choice.get("function") or {}).get("name")
+            parts.append(f"You MUST call {named or 'one of the tools above'} in this reply.")
+    elif choice == "required":
+        parts.append("You MUST call one of the tools above in this reply.")
+    return " ".join(parts)
+
+
+def _tools_disabled(choice):
+    return choice == "none" or (isinstance(choice, dict) and choice.get("type") == "none")
+
+
+def prepare(body, kind, protocol=None, wire="openai", tool_note=""):
     if wire == "responses":
         messages = _messages_from_responses_input(body)
         if not messages:
@@ -805,10 +988,19 @@ def prepare(body, kind, protocol=None, wire="openai"):
     tools = body.get("tools") if isinstance(body.get("tools"), list) else None
     if wire == "anthropic" and tools:
         _reject_server_tools(tools)
+    tools = None if _tools_disabled(body.get("tool_choice")) else _callable_tools(tools)
     tool_text = resolved_protocol.render(tools) if tools else ""
-    prompt = build_prompt(messages)
+    # Constraints, then the seat's note — the caller's own rules outrank ours, and both come after
+    # the tool list so they are the last thing read about tools.
     if tool_text:
-        prompt = f"{prompt}\n\n{tool_text}"
+        for extra in (_tool_constraints(body), tool_note):
+            if extra:
+                tool_text = f"{tool_text}\n\n{extra}"
+    # `keep_system`: a system prompt taken from a TOP-LEVEL field leaves any `role: "system"`
+    # message in the transcript unread. Claude Code sends both — captured live, a 6379-character
+    # system message sat inside `messages[]` and was dropped.
+    prompt = json_prompt(messages, tool_text or None,
+                         keep_system=wire in ("anthropic", "responses"))
     if wire == "anthropic":
         # `system` is a TOP-LEVEL field on this wire, not a `role: "system"` message — reading it
         # off `messages` (the OpenAI shape) would silently drop the caller's whole instruction set,
@@ -883,6 +1075,10 @@ def stream_seat(spec, prepared, binary, timeout):
     with tempfile.TemporaryDirectory(prefix=f"grid-{spec.kind}-seat-") as tmp:
         tmpdir = Path(tmp)
         argv, stdin = spec.invoke(binary, prepared, tmpdir, stream=True)
+        # Turns to sit out before anything is forwarded. Counted from the stdin actually built, not
+        # recomputed from `messages`, so it cannot drift from what the CLI was really handed.
+        skip_turns = max(0, spec.expected_turns(stdin) - 1) if spec.expected_turns else 0
+        turns_done = 0
         try:
             proc = subprocess.Popen(
                 argv, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
@@ -911,7 +1107,12 @@ def stream_seat(spec, prepared, binary, timeout):
                     parsed = spec.parse_event(event)
                     if isinstance(parsed, QuotaSnapshot):
                         quota.append(parsed)   # free quota reading, carried by the answer itself
-                    elif parsed:
+                    elif isinstance(parsed, TurnEnd):
+                        turns_done += 1
+                    elif parsed and turns_done >= skip_turns:
+                        # Everything before the last turn is the CLI re-answering a question the
+                        # transcript had already settled. Forwarded, it arrived glued to the front
+                        # of the real answer with no separator — the "…work on?Mochi" shape.
                         yield parsed
         finally:
             writer.join(timeout=1)
@@ -969,6 +1170,25 @@ def _write_stdin(proc, text):
         pass  # the child exited early; its own output explains why
 
 
+
+def parse_calls(protocol, text):
+    """`(prose, calls)` from a protocol, shouting when a call was attempted and did not parse.
+
+    A malformed call still travels as text — it is the model's output and is not ours to repair or
+    delete. But it must not travel SILENTLY: unannounced it reads like an ordinary answer, and the
+    user is left staring at raw JSON with nothing saying a tool call failed. Measured on a live
+    codex turn: the model wrote `{"tool_calls": …}` with one closing brace missing, the scan found
+    nothing, and the whole object was printed as prose.
+    """
+    if protocol is None or not getattr(protocol, "parse", None):
+        return text, []
+    prose, calls = protocol.parse(text)
+    if not calls and ('"tool_calls"' in text or '"tool_use"' in text):
+        print(f"[cli-seat] a tool call did not parse ({len(text)}B); forwarded as text",
+              file=sys.stderr, flush=True)
+    return prose, calls
+
+
 # answer -> OpenAI chat.completion
 
 def to_chat_completion(result, kind, model, protocol=None):
@@ -980,9 +1200,7 @@ def to_chat_completion(result, kind, model, protocol=None):
     translates into an Anthropic `tool_use` block. Without it the text is returned verbatim, which
     is what a caller that brought its own convention wants.
     """
-    text, tool_calls = result.text, []
-    if protocol is not None and getattr(protocol, "parse", None):
-        text, tool_calls = protocol.parse(result.text)
+    text, tool_calls = parse_calls(protocol, result.text)
     message = {"role": "assistant", "content": text}
     if tool_calls:
         message["tool_calls"] = tool_calls
@@ -1011,13 +1229,33 @@ def to_chat_completion(result, kind, model, protocol=None):
     }
 
 
+def _to_tool_use(call):
+    """A parsed call in EITHER protocol's shape -> an Anthropic `tool_use` block.
+
+    The seat's protocol and the wire it answers on are chosen independently: codex parses with
+    STRUCTURED (OpenAI-shaped calls) but may be asked on `/messages`. Without this the OpenAI shape
+    was spliced into `content` verbatim and the client received a block of type "function".
+    """
+    if call.get("type") == "tool_use":
+        return call
+    function = call.get("function") or {}
+    arguments = function.get("arguments")
+    if isinstance(arguments, str):
+        try:
+            arguments = json.loads(arguments, strict=False)
+        except ValueError:
+            arguments = {}
+    return {"type": "tool_use",
+            "id": call.get("id") or f"toolu_{uuid.uuid4().hex[:24]}",
+            "name": function.get("name") or "",
+            "input": arguments if isinstance(arguments, dict) else {}}
+
+
 def to_anthropic_message(result, kind, model, protocol=None):
     """The Anthropic `message` shape, built directly rather than via a chat.completion the relay
     would have to convert back."""
-    text, calls = result.text, []
-    if protocol is not None and getattr(protocol, "parse", None):
-        text, calls = protocol.parse(result.text)
-    content = ([{"type": "text", "text": text}] if text else []) + calls
+    text, calls = parse_calls(protocol, result.text)
+    content = ([{"type": "text", "text": text}] if text else []) + [_to_tool_use(c) for c in calls]
     return {
         "id": f"msg_{uuid.uuid4().hex}",
         "type": "message",
@@ -1045,8 +1283,18 @@ def answer_anthropic(spec, prepared, binary, timeout):
     return to_anthropic_message(result, spec.kind, prepared.model, prepared.tool_protocol)
 
 
+def _kinded(chunk):
+    """One streamed chunk -> ("reasoning", text) or ("delta", text).
+
+    Shared by the three `answer_stream*` wrappers so a seat's thinking cannot be labelled the answer
+    on one wire and thinking on another.
+    """
+    return ("reasoning", chunk.text) if isinstance(chunk, Reasoning) else ("delta", chunk)
+
+
 def answer_stream(spec, prepared, binary, timeout):
-    """Yield ("delta", text) as the CLI produces it, then ("done", (completion, quota|None)).
+    """Yield ("delta", text) / ("reasoning", text) as the CLI produces it, then
+    ("done", (completion, quota|None)).
 
     Tool calls ride the final ("done") event, never a delta: only a whole answer can be parsed,
     so nothing about a call is known until the CLI has finished writing it.
@@ -1054,7 +1302,7 @@ def answer_stream(spec, prepared, binary, timeout):
     stream = stream_seat(spec, prepared, binary, timeout)
     while True:
         try:
-            yield "delta", next(stream)
+            yield _kinded(next(stream))
         except StopIteration as stop:
             result, quota = stop.value
             completion = to_chat_completion(
@@ -1069,7 +1317,7 @@ def answer_stream_anthropic(spec, prepared, binary, timeout):
     stream = stream_seat(spec, prepared, binary, timeout)
     while True:
         try:
-            yield "delta", next(stream)
+            yield _kinded(next(stream))
         except StopIteration as stop:
             result, quota = stop.value
             message = to_anthropic_message(
@@ -1087,16 +1335,20 @@ def to_response(result, kind, model, protocol=None):
     ``tool_calls`` on a message — the same parse that extracts them for chat feeds this instead, so
     a tool conversation round-trips identically on every wire the seat speaks.
     """
-    text, tool_calls = result.text, []
-    if protocol is not None and getattr(protocol, "parse", None):
-        text, tool_calls = protocol.parse(result.text)
-    output = [{
-        "id": f"msg_{uuid.uuid4().hex}",
-        "type": "message",
-        "status": "completed",
-        "role": "assistant",
-        "content": [{"type": "output_text", "text": text, "annotations": []}] if text else [],
-    }]
+    text, tool_calls = parse_calls(protocol, result.text)
+    # A call-only answer carries NO message item. It used to emit one with `content: []`, and a
+    # Responses client reading `output[]` in order then saw an assistant message that said nothing
+    # standing in front of the call. An empty message is only correct when there is nothing else to
+    # report — an answer with neither text nor calls — so that one case still gets it.
+    output = []
+    if text or not tool_calls:
+        output.append({
+            "id": f"msg_{uuid.uuid4().hex}",
+            "type": "message",
+            "status": "completed",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": text, "annotations": []}] if text else [],
+        })
     for call in tool_calls:
         function = call.get("function") or {}
         output.append({
@@ -1142,7 +1394,7 @@ def answer_stream_response(spec, prepared, binary, timeout):
     stream = stream_seat(spec, prepared, binary, timeout)
     while True:
         try:
-            yield "delta", next(stream)
+            yield _kinded(next(stream))
         except StopIteration as stop:
             result, quota = stop.value
             response = to_response(

--- a/shared/agent/cli_seat.py
+++ b/shared/agent/cli_seat.py
@@ -332,6 +332,8 @@ def _flatten_content(content):
                 chunks.append(str(part.get("thinking") or ""))
             elif kind in ("image_url", "input_image"):
                 chunks.append("[image omitted — this engine serves text only]")
+            elif kind in ("tool_use", "tool_result"):
+                continue  # build_prompt renders these separately — skip, don't mark "omitted"
             else:
                 # Previously dropped with no trace at all. A short, neutral marker makes the
                 # next unhandled block shape discoverable instead of silently invisible.

--- a/shared/agent/codex_models.py
+++ b/shared/agent/codex_models.py
@@ -1,0 +1,83 @@
+"""Which models the signed-in `codex` account can actually use.
+
+Asked, not hardcoded. The app-server answers `model/list` from the account itself, so a model added
+by the vendor arrives without an edit here — the static list had already fallen behind by two
+(`gpt-5.6-sol`, the one Codex CLI picks by DEFAULT, and `gpt-5.4`).
+
+Cached per account: the answer is the same for every seat on this machine and asking costs an
+app-server spawn. `hidden` models are dropped, which is what the static list was approximating by
+hand when it excluded `codex-auto-review`.
+"""
+from __future__ import annotations
+
+import json
+import time
+
+from shared.paths import grid_home
+
+CACHE_TTL = 24 * 3600
+
+
+def _cache_file():
+    return grid_home() / "codex-models.json"
+
+
+def _read_cache():
+    try:
+        stored = json.loads(_cache_file().read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    models = stored.get("models")
+    if not isinstance(models, list) or not models:
+        return None   # never treat an empty result as a hit; it would pin the seat at zero models
+    if time.time() - float(stored.get("fetched_at") or 0) > CACHE_TTL:
+        return None
+    return models
+
+
+def _write_cache(models):
+    try:
+        path = _cache_file()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"fetched_at": time.time(), "models": models}),
+                        encoding="utf-8")
+    except OSError:
+        pass   # a cache that cannot be written is a slow seat, not a broken one
+
+
+def usable(entries):
+    """`model/list` data -> the ids worth serving, in the order the vendor gave them."""
+    out = []
+    for entry in entries or []:
+        if not isinstance(entry, dict) or entry.get("hidden"):
+            continue
+        model_id = entry.get("id") or entry.get("model")
+        if isinstance(model_id, str) and model_id and model_id not in out:
+            out.append(model_id)
+    return out
+
+
+def discover(binary=None):
+    """The account's model ids, or `[]` when the CLI cannot be asked.
+
+    `[]` is the caller's cue to fall back to the static list — never a reason to serve nothing.
+    """
+    cached = _read_cache()
+    if cached is not None:
+        return cached
+
+    server = None
+    try:
+        from shared.agent.seats import codex_appserver
+
+        server = codex_appserver.start_app_server(binary=binary, timeout=60.0)
+        models = usable((server.call("model/list", {}) or {}).get("data"))
+    except Exception:  # noqa: BLE001 — discovery must never take the seat down with it
+        return []
+    finally:
+        if server is not None:
+            server.stop()
+
+    if models:
+        _write_cache(models)
+    return models

--- a/shared/agent/seats/claude.py
+++ b/shared/agent/seats/claude.py
@@ -12,17 +12,7 @@ LABEL = "Claude Code"
 # Exits 0 when signed in.
 SIGNIN_ARGV = ("auth", "status")
 
-# Three flags carry the whole isolation story, each verified on the real binary:
-#   --safe-mode         NOT --bare. --bare takes only ANTHROPIC_API_KEY and never reads OAuth or
-#                       the keychain, so a subscription seat under it answers "Not logged in".
-#   --tools ""          removes every built-in tool, so the model must WRITE a tool call as text.
-#   --system-prompt-file REPLACES Claude Code's own prompt with the caller's.
-#
-# Replacing, not appending, is a privacy decision. Claude Code's default prompt carries the
-# machine's cwd, OS and git status, so a seat that kept it answered a bare `pwd?` with the
-# provider's real path and username — no tool needed. Replacing also drops ~5000 prompt tokens
-# per request. The cost: this serves plain Claude, not Claude Code, so a benchmark measuring the
-# two combined must use a different seat.
+
 def to_stream_json(messages, tools_text=None):
     """Convert OpenAI/Anthropic messages to Claude --input-format stream-json lines.
 
@@ -82,6 +72,17 @@ def to_stream_json(messages, tools_text=None):
     return "\n".join(lines)
 
 
+# Three flags carry the whole isolation story, each verified on the real binary:
+#   --safe-mode         NOT --bare. --bare takes only ANTHROPIC_API_KEY and never reads OAuth or
+#                       the keychain, so a subscription seat under it answers "Not logged in".
+#   --tools ""          removes every built-in tool, so the model must WRITE a tool call as text.
+#   --system-prompt-file REPLACES Claude Code's own prompt with the caller's.
+#
+# Replacing, not appending, is a privacy decision. Claude Code's default prompt carries the
+# machine's cwd, OS and git status, so a seat that kept it answered a bare `pwd?` with the
+# provider's real path and username — no tool needed. Replacing also drops ~5000 prompt tokens
+# per request. The cost: this serves plain Claude, not Claude Code, so a benchmark measuring the
+# two combined must use a different seat.
 def invoke(binary, prepared, tmpdir, stream=False):
     system_file = tmpdir / "system.txt"
     system_file.write_text(prepared.system_prompt, encoding="utf-8")

--- a/shared/agent/seats/claude.py
+++ b/shared/agent/seats/claude.py
@@ -13,6 +13,59 @@ LABEL = "Claude Code"
 SIGNIN_ARGV = ("auth", "status")
 
 
+def _as_text(value):
+    """Anything unsendable, verbatim as text. Never dropped, never summarised."""
+    return {"type": "text", "text": json.dumps(value, ensure_ascii=False, default=str)}
+
+
+def _as_anthropic_image(block):
+    """OpenAI `image_url` / `input_image` -> Anthropic `image`. None if there is no url to carry."""
+    source = block.get("image_url") if isinstance(block.get("image_url"), dict) else {}
+    url = source.get("url") or block.get("url") or block.get("image_url")
+    if not isinstance(url, str) or not url:
+        return None
+    if not url.startswith("data:"):
+        return {"type": "image", "source": {"type": "url", "url": url}}
+    head, _, data = url.partition(",")
+    if not data:
+        return None
+    return {"type": "image", "source": {"type": "base64",
+                                        "media_type": head[5:].split(";")[0] or "image/png",
+                                        "data": data}}
+
+
+# Caller-side request metadata, not content. `cache_control` belongs to the caller's own API call —
+# forwarded into ours it 400s (`ttl='1h'` needs a beta header this seat does not send).
+STRIPPED_KEYS = ("cache_control",)
+
+
+def _passthrough_blocks(content):
+    """Blocks forwarded as-is, in their original order.
+
+    `claude` is Anthropic-native, so a block this file does not know is still one the CLI may.
+    Nothing is dropped or replaced with a marker: what cannot go as-is goes as text.
+    """
+    blocks = []
+    for block in content if isinstance(content, list) else []:
+        if not isinstance(block, dict):
+            blocks.append(_as_text(block))
+            continue
+        if any(key in block for key in STRIPPED_KEYS):
+            block = {k: v for k, v in block.items() if k not in STRIPPED_KEYS}
+        kind = block.get("type")
+        if kind == "text":
+            # An empty text block 400s, so it travels as its own JSON rather than being deleted.
+            blocks.append(block if block.get("text") else _as_text(block))
+        elif kind == "tool_result":
+            blocks.append(block if block.get("content")
+                          else {**block, "content": json.dumps(block, ensure_ascii=False)})
+        elif kind in ("image_url", "input_image"):
+            blocks.append(_as_anthropic_image(block) or _as_text(block))
+        else:
+            blocks.append(block)
+    return blocks
+
+
 def to_stream_json(messages, tools_text=None):
     """Convert OpenAI/Anthropic messages to Claude --input-format stream-json lines.
 
@@ -20,35 +73,47 @@ def to_stream_json(messages, tools_text=None):
     OpenAI tool_calls become Anthropic tool_use blocks; role:tool becomes user + tool_result.
     Consecutive tool results are merged into ONE user message (Claude requires alternating
     user/assistant turns). tools_text (if set) is appended to the last user message.
+
+    Empty content 400s (`text content blocks must be non-empty`), so a message with nothing in it
+    travels as its own JSON rather than being dropped or padded with invented text.
     """
-    from shared.agent import cli_seat
+    return "\n".join(
+        json.dumps({"type": m["role"], "message": m}, ensure_ascii=False)
+        for m in conversation(messages, tools_text)
+    )
 
-    lines, last_user = [], None
-    pending_tool_results = []
 
-    def flush_tool_results():
+def conversation(messages, tools_text=None):
+    """The transcript as Anthropic messages: `[{"role", "content"}, …]`.
+
+    OpenAI `tool_calls` become `tool_use`; `role: "tool"` becomes a user `tool_result`, consecutive
+    ones merged into one message. Blocks keep their type and order. `tools_text`, if set, is
+    appended to the last user message.
+    """
+    out, last_user = [], None
+    pending = []
+
+    def flush():
         nonlocal last_user
-        if pending_tool_results:
-            lines.append(json.dumps({"type": "user", "message": {"role": "user",
-                "content": pending_tool_results[:]}}, ensure_ascii=False))
-            last_user = len(lines) - 1
-            pending_tool_results.clear()
+        if pending:
+            out.append({"role": "user", "content": pending[:]})
+            last_user = len(out) - 1
+            pending.clear()
 
     for msg in messages:
         role, content = msg.get("role"), msg.get("content")
         if role == "system":
             continue
         if role == "tool":
-            pending_tool_results.append({"type": "tool_result",
+            pending.append(_passthrough_blocks([{
+                "type": "tool_result",
                 "tool_use_id": msg.get("tool_call_id", ""),
-                "content": cli_seat._flatten_content(content)})
+                "content": content,
+            }])[0])
             continue
-        flush_tool_results()
+        flush()
         if role == "assistant":
-            blocks = []
-            text = cli_seat._flatten_content(content)
-            if text:
-                blocks.append({"type": "text", "text": text})
+            blocks = _passthrough_blocks(content)
             for call in msg.get("tool_calls") or []:
                 fn = (call or {}).get("function") or {}
                 args = fn.get("arguments")
@@ -60,43 +125,24 @@ def to_stream_json(messages, tools_text=None):
                 blocks.append({"type": "tool_use", "id": call.get("id", ""),
                                "name": fn.get("name", ""),
                                "input": args if isinstance(args, dict) else {}})
-            for block in (content if isinstance(content, list) else []):
-                if isinstance(block, dict) and block.get("type") == "tool_use":
-                    blocks.append({"type": "tool_use", "id": block.get("id", ""),
-                                   "name": block.get("name", ""),
-                                   "input": block.get("input") if isinstance(block.get("input"), dict) else {}})
-            if not blocks:
-                blocks.append({"type": "text", "text": ""})
-            lines.append(json.dumps({"type": "assistant",
-                "message": {"role": "assistant", "content": blocks}}, ensure_ascii=False))
+            out.append({"role": "assistant", "content": blocks or [_as_text(msg)]})
             continue
-        if isinstance(content, list):
-            tool_results = [b for b in content if isinstance(b, dict) and b.get("type") == "tool_result"]
-            other = [b for b in content if not (isinstance(b, dict) and b.get("type") == "tool_result")]
-            text = cli_seat._flatten_content(other) if other else ""
-            content = ([{"type": "text", "text": text}] if text else []) + tool_results
-            if not content:
-                content = ""
-        lines.append(json.dumps({"type": "user",
-            "message": {"role": role or "user",
-                        "content": content if content is not None else ""}}, ensure_ascii=False))
-        last_user = len(lines) - 1
+        content = _passthrough_blocks(content) if isinstance(content, list) else content
+        out.append({"role": role or "user", "content": content or [_as_text(msg)]})
+        last_user = len(out) - 1
 
-    flush_tool_results()
+    flush()
 
     if tools_text:
-        if last_user is not None:
-            obj = json.loads(lines[last_user])
-            c = obj["message"]["content"]
-            c = [{"type": "text", "text": c}] if isinstance(c, str) else (c if isinstance(c, list) else [])
-            c.append({"type": "text", "text": tools_text})
-            obj["message"]["content"] = c
-            lines[last_user] = json.dumps(obj, ensure_ascii=False)
+        if last_user is None:
+            out.append({"role": "user", "content": [{"type": "text", "text": tools_text}]})
         else:
-            lines.append(json.dumps({"type": "user", "message": {"role": "user",
-                "content": [{"type": "text", "text": tools_text}]}}, ensure_ascii=False))
+            c = out[last_user]["content"]
+            c = [{"type": "text", "text": c}] if isinstance(c, str) else list(c)
+            out[last_user]["content"] = c + [{"type": "text", "text": tools_text}]
+    return out
 
-    return "\n".join(lines)
+
 
 
 # Three flags carry the whole isolation story, each verified on the real binary:
@@ -111,6 +157,22 @@ def to_stream_json(messages, tools_text=None):
 # per request. The cost: this serves plain Claude, not Claude Code, so a benchmark measuring the
 # two combined must use a different seat.
 def invoke(binary, prepared, tmpdir, stream=False):
+    """One turn, one prompt on stdin.
+
+    `--input-format stream-json` cannot replay a transcript: every `user` line is a live turn, and
+    claude's own answer to each is inserted into the history before the next runs. Measured — the
+    replay of [user, assistant(tool_use), user(tool_result)] produced:
+
+        result #1: ''                                              <- claude's own turn, empty
+        result #2: 'API Error: 400 messages: text content blocks must be non-empty'
+
+    That empty turn is claude's, not ours, so no amount of filtering on the way in removes it. The
+    same interleaving splits a `tool_use` from its `tool_result`, which is the `messages.N.content.M`
+    400 and the repeated identical tool call.
+
+    `to_stream_json` is kept and tested for the session-based path (`--session-id`/`--resume`),
+    which is the only way to replay structure without spawning turns.
+    """
     system_file = tmpdir / "system.txt"
     system_file.write_text(prepared.system_prompt, encoding="utf-8")
     argv = [
@@ -120,14 +182,12 @@ def invoke(binary, prepared, tmpdir, stream=False):
         "--model", prepared.model_alias,
         "--no-session-persistence",
         "--system-prompt-file", str(system_file),
-        "--input-format", "stream-json",
     ]
     if prepared.effort:
         argv += ["--effort", prepared.effort]
     argv += (["--output-format", "stream-json", "--include-partial-messages", "--verbose"]
              if stream else ["--output-format", "json"])
-    stdin = to_stream_json(prepared.messages, tools_text=prepared.tool_text or None)
-    return argv, stdin
+    return argv, prepared.prompt
 
 
 def _json_lines(raw):
@@ -235,6 +295,21 @@ def parse_usage(text):
     )
 
 
+def expected_turns(stdin):
+    """How many turns this stdin will make `claude` run — one per `user` line.
+
+    Counted off the built stdin rather than off `messages`, so it cannot disagree with what
+    `to_stream_json` actually emitted. At least one: a request always runs a turn.
+    """
+    turns = 0
+    for line in (stdin or "").splitlines():
+        try:
+            turns += json.loads(line).get("type") == "user"
+        except ValueError:
+            continue
+    return max(1, turns)
+
+
 def parse_event(event):
     """One streamed event -> the text to forward, a QuotaSnapshot, or None.
 
@@ -250,13 +325,29 @@ def parse_event(event):
             return QuotaSnapshot(session_pct=100, week_pct=100,
                                  session_reset=_reset_text(info), week_reset=_reset_text(info))
         return None
+    # End of ONE turn, not of the request: a replayed transcript runs one per `user` line, and
+    # `stream_seat` counts these to know when the live turn has finally started.
+    if event.get("type") == "result":
+        from shared.agent.cli_seat import TurnEnd
+
+        return TurnEnd()
     if event.get("type") != "stream_event":
         return None
     inner = event.get("event") or {}
     if inner.get("type") != "content_block_delta":
         return None
     delta = inner.get("delta") or {}
-    return delta.get("text") if delta.get("type") == "text_delta" else None
+    if delta.get("type") == "text_delta":
+        return delta.get("text")
+    # Extended thinking, when the caller asked for an effort. Returned as `Reasoning` rather than a
+    # bare string so it cannot be mistaken for the answer — the tool parse must never read it, and a
+    # `--effort` turn used to sit silent until the thinking finished.
+    if delta.get("type") == "thinking_delta":
+        from shared.agent.cli_seat import Reasoning
+
+        text = delta.get("thinking") or ""
+        return Reasoning(text) if text else None
+    return None
 
 
 SPEC = SeatSpec(
@@ -279,4 +370,5 @@ SPEC = SeatSpec(
     quota_argv=QUOTA_ARGV,
     parse_usage=parse_usage,
     parse_event=parse_event,
+    expected_turns=expected_turns,
 )

--- a/shared/agent/seats/claude.py
+++ b/shared/agent/seats/claude.py
@@ -51,8 +51,10 @@ def to_stream_json(messages, tools_text=None):
                 fn = (call or {}).get("function") or {}
                 args = fn.get("arguments")
                 if isinstance(args, str):
-                    try: args = json.loads(args)
-                    except ValueError: args = {}
+                    try:
+                        args = json.loads(args)
+                    except ValueError:
+                        args = {}
                 blocks.append({"type": "tool_use", "id": call.get("id", ""),
                                "name": fn.get("name", ""),
                                "input": args if isinstance(args, dict) else {}})
@@ -90,16 +92,14 @@ def invoke(binary, prepared, tmpdir, stream=False):
         "--model", prepared.model_alias,
         "--no-session-persistence",
         "--system-prompt-file", str(system_file),
+        "--input-format", "stream-json",
     ]
-    # Only present when the caller's request carried a `thinking` budget or a `reasoning_effort`
-    # (cli_seat.prepare resolves either to a level); absent entirely otherwise, so a plain OpenAI
-    # request naming neither gets today's argv, unchanged.
     if prepared.effort:
         argv += ["--effort", prepared.effort]
-    # stream-json emits real text deltas; plain json returns one object at the end.
     argv += (["--output-format", "stream-json", "--include-partial-messages", "--verbose"]
              if stream else ["--output-format", "json"])
-    return argv, prepared.prompt
+    stdin = to_stream_json(prepared.messages, tools_text=prepared.tool_text or None)
+    return argv, stdin
 
 
 def _json_lines(raw):

--- a/shared/agent/seats/claude.py
+++ b/shared/agent/seats/claude.py
@@ -23,6 +23,63 @@ SIGNIN_ARGV = ("auth", "status")
 # provider's real path and username — no tool needed. Replacing also drops ~5000 prompt tokens
 # per request. The cost: this serves plain Claude, not Claude Code, so a benchmark measuring the
 # two combined must use a different seat.
+def to_stream_json(messages, tools_text=None):
+    """Convert OpenAI/Anthropic messages to Claude --input-format stream-json lines.
+
+    System messages are skipped (system prompt goes via --system-prompt-file).
+    OpenAI tool_calls become Anthropic tool_use blocks; role:tool becomes user + tool_result.
+    tools_text (if set) is appended to the last user message.
+    """
+    from shared.agent import cli_seat
+
+    lines, last_user = [], None
+    for msg in messages:
+        role, content = msg.get("role"), msg.get("content")
+        if role == "system":
+            continue
+        if role == "tool":
+            lines.append(json.dumps({"type": "user", "message": {"role": "user", "content": [
+                {"type": "tool_result", "tool_use_id": msg.get("tool_call_id", ""),
+                 "content": cli_seat._flatten_content(content)}]}}, ensure_ascii=False))
+            continue
+        if role == "assistant":
+            blocks = []
+            text = cli_seat._flatten_content(content)
+            if text:
+                blocks.append({"type": "text", "text": text})
+            for call in msg.get("tool_calls") or []:
+                fn = (call or {}).get("function") or {}
+                args = fn.get("arguments")
+                if isinstance(args, str):
+                    try: args = json.loads(args)
+                    except ValueError: args = {}
+                blocks.append({"type": "tool_use", "id": call.get("id", ""),
+                               "name": fn.get("name", ""),
+                               "input": args if isinstance(args, dict) else {}})
+            for block in (content if isinstance(content, list) else []):
+                if isinstance(block, dict) and block.get("type") == "tool_use":
+                    blocks.append({"type": "tool_use", "id": block.get("id", ""),
+                                   "name": block.get("name", ""),
+                                   "input": block.get("input") if isinstance(block.get("input"), dict) else {}})
+            lines.append(json.dumps({"type": "assistant",
+                "message": {"role": "assistant", "content": blocks}}, ensure_ascii=False))
+            continue
+        lines.append(json.dumps({"type": "user",
+            "message": {"role": role or "user",
+                        "content": content if content is not None else ""}}, ensure_ascii=False))
+        last_user = len(lines) - 1
+
+    if tools_text and last_user is not None:
+        obj = json.loads(lines[last_user])
+        c = obj["message"]["content"]
+        c = [{"type": "text", "text": c}] if isinstance(c, str) else (c if isinstance(c, list) else [])
+        c.append({"type": "text", "text": tools_text})
+        obj["message"]["content"] = c
+        lines[last_user] = json.dumps(obj, ensure_ascii=False)
+
+    return "\n".join(lines)
+
+
 def invoke(binary, prepared, tmpdir, stream=False):
     system_file = tmpdir / "system.txt"
     system_file.write_text(prepared.system_prompt, encoding="utf-8")

--- a/shared/agent/seats/claude.py
+++ b/shared/agent/seats/claude.py
@@ -18,20 +18,32 @@ def to_stream_json(messages, tools_text=None):
 
     System messages are skipped (system prompt goes via --system-prompt-file).
     OpenAI tool_calls become Anthropic tool_use blocks; role:tool becomes user + tool_result.
-    tools_text (if set) is appended to the last user message.
+    Consecutive tool results are merged into ONE user message (Claude requires alternating
+    user/assistant turns). tools_text (if set) is appended to the last user message.
     """
     from shared.agent import cli_seat
 
     lines, last_user = [], None
+    pending_tool_results = []
+
+    def flush_tool_results():
+        nonlocal last_user
+        if pending_tool_results:
+            lines.append(json.dumps({"type": "user", "message": {"role": "user",
+                "content": pending_tool_results[:]}}, ensure_ascii=False))
+            last_user = len(lines) - 1
+            pending_tool_results.clear()
+
     for msg in messages:
         role, content = msg.get("role"), msg.get("content")
         if role == "system":
             continue
         if role == "tool":
-            lines.append(json.dumps({"type": "user", "message": {"role": "user", "content": [
-                {"type": "tool_result", "tool_use_id": msg.get("tool_call_id", ""),
-                 "content": cli_seat._flatten_content(content)}]}}, ensure_ascii=False))
+            pending_tool_results.append({"type": "tool_result",
+                "tool_use_id": msg.get("tool_call_id", ""),
+                "content": cli_seat._flatten_content(content)})
             continue
+        flush_tool_results()
         if role == "assistant":
             blocks = []
             text = cli_seat._flatten_content(content)
@@ -53,21 +65,36 @@ def to_stream_json(messages, tools_text=None):
                     blocks.append({"type": "tool_use", "id": block.get("id", ""),
                                    "name": block.get("name", ""),
                                    "input": block.get("input") if isinstance(block.get("input"), dict) else {}})
+            if not blocks:
+                blocks.append({"type": "text", "text": ""})
             lines.append(json.dumps({"type": "assistant",
                 "message": {"role": "assistant", "content": blocks}}, ensure_ascii=False))
             continue
+        if isinstance(content, list):
+            tool_results = [b for b in content if isinstance(b, dict) and b.get("type") == "tool_result"]
+            other = [b for b in content if not (isinstance(b, dict) and b.get("type") == "tool_result")]
+            text = cli_seat._flatten_content(other) if other else ""
+            content = ([{"type": "text", "text": text}] if text else []) + tool_results
+            if not content:
+                content = ""
         lines.append(json.dumps({"type": "user",
             "message": {"role": role or "user",
                         "content": content if content is not None else ""}}, ensure_ascii=False))
         last_user = len(lines) - 1
 
-    if tools_text and last_user is not None:
-        obj = json.loads(lines[last_user])
-        c = obj["message"]["content"]
-        c = [{"type": "text", "text": c}] if isinstance(c, str) else (c if isinstance(c, list) else [])
-        c.append({"type": "text", "text": tools_text})
-        obj["message"]["content"] = c
-        lines[last_user] = json.dumps(obj, ensure_ascii=False)
+    flush_tool_results()
+
+    if tools_text:
+        if last_user is not None:
+            obj = json.loads(lines[last_user])
+            c = obj["message"]["content"]
+            c = [{"type": "text", "text": c}] if isinstance(c, str) else (c if isinstance(c, list) else [])
+            c.append({"type": "text", "text": tools_text})
+            obj["message"]["content"] = c
+            lines[last_user] = json.dumps(obj, ensure_ascii=False)
+        else:
+            lines.append(json.dumps({"type": "user", "message": {"role": "user",
+                "content": [{"type": "text", "text": tools_text}]}}, ensure_ascii=False))
 
     return "\n".join(lines)
 

--- a/shared/agent/seats/codex.py
+++ b/shared/agent/seats/codex.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import json
 
-from shared.agent.cli_seat import SeatError, SeatResult, SeatSpec
+from shared.agent.cli_seat import STRUCTURED, SeatError, SeatResult, SeatSpec
 
 BINARY = "codex"
 LABEL = "Codex"
@@ -32,6 +32,12 @@ CONFIG_TOML = """# Written by grid at every seat start. Hand edits are overwritt
 approval_policy = "untrusted"
 sandbox_mode = "read-only"
 web_search = "disabled"
+
+# Reasoning summaries ON, so a thinking turn has something on the wire. Default is "none": codex
+# emits no `item/reasoning/summaryTextDelta` at all, and a request that thinks for 4s of a 5s turn
+# sends nothing until the answer starts. "auto" lets the model decide how much to summarise; the
+# seat forwards it as a reasoning item, never as answer text (`_REASONING` in codex_appserver).
+model_reasoning_summary = "auto"
 
 # Suppress the prompt blocks codex injects of its own accord. Verified with
 # `codex debug prompt-input`: without these the model is handed a sandbox description, an
@@ -87,15 +93,43 @@ skill_mcp_dependency_install = false
 goals = false
 sqlite = false
 code_mode_host = false
-
-# Block apply_patch at call time — the tool can't be hidden from the model (no feature
-# flag exists, unlike shell_tool), but "blocked by app configuration" is cleaner than
-# the generic JSON-RPC error _respond_to_server returns for unknown methods. The model
-# still SEES the tool in its function list, but when it calls it the app-server blocks
-# it internally without asking the client.
-[apps._default.tools.apply_patch]
-enabled = false
 """
+# Removed: `[apps._default.tools.apply_patch] enabled = false`. `codex --strict-config` rejects it —
+# "unknown configuration field `apps._default.tools`" on 0.146.0 — so it blocked nothing and only
+# looked like it did, since codex ignores unrecognised keys silently without that flag. Validate any
+# change to the config above with:
+#     CODEX_HOME=~/.grid/seats/codex-cli codex --strict-config exec --skip-git-repo-check -s read-only "hi"
+# apply_patch is ruled out by TOOL_NOTE instead, the same way `exec` and `wait` are.
+
+# Codex keeps `exec` and `wait` in the model's function list whatever the config says. Verified on
+# 0.146.0: `[features] shell_tool` is still a recognised key but no longer names this tool, and
+# nothing else removes it — `--disable exec_tool` / `exec` / `command_execution` answer "Unknown
+# feature flag", `--disable unified_exec` is accepted and changes nothing, and `tools.exec.enabled`
+# / `experimental_use_exec_command_tool` are unknown config fields. Asked to list its tools, a live
+# seat answers `functions.exec` / `functions.wait`.
+#
+# So the seat can only DECLINE the approval those calls raise, and the decline carries no
+# explanation: `ExecCommandApprovalResponse` has one field, `decision`. The model reads the bare
+# refusal as ground truth and answers "this environment exposes no shell/command-execution tool,
+# therefore the command was not run" — measured, verbatim — instead of emitting the caller's tool
+# call. This note is the only channel left to tell it otherwise.
+#
+# It says which tools are real by REFERENCE, never by name. Naming them was tried and backfired:
+# the note listed `exec` and `wait` as disabled, and those are the very names Codex CLI gives its
+# OWN tools when it is the client — so the note was telling the model the caller's tools did not
+# work. Measured against a caller offering `exec`/`wait`: 5 of 6 turns emitted the call, the sixth
+# answered "I can't inspect the repository from this environment." Phrased by reference the note
+# cannot collide, whatever the caller names its tools, and it still is not the generic "you have no
+# tools" line the model can disprove by reading its own function list.
+TOOL_NOTE = (
+    "Only the tools listed above are real. Any other tool in your function list — including any "
+    "built-in of your own, whatever it is called — is disabled here: calling it is refused, "
+    "returns nothing, and wastes the turn. A tool listed above is NOT disabled even when a "
+    "built-in of yours happens to share its name; reach it by emitting the JSON call, never by "
+    "invoking it directly. A refusal is a fact about this process, not about the user's request: "
+    "never mention it, and never conclude from it that the work cannot be done or that no way to "
+    "run commands is available."
+)
 
 # `--ignore-user-config` is deliberately ABSENT: the config above is ours and must be read.
 # `--ignore-rules` stays — a project `.rules` file lives outside CODEX_HOME and would still load.
@@ -218,6 +252,10 @@ SPEC = SeatSpec(
     binary=BINARY,
     home_env="CODEX_HOME",
     config_files=(("config.toml", CONFIG_TOML),),
+    tool_note=TOOL_NOTE,
+    # The turn is decoded against OPENAI_OUTPUT_SCHEMA, so the answer arrives as {text, tool_calls}.
+    # Falls back to the plain text scan when it does not — see `parse_structured_answer`.
+    tool_protocol=STRUCTURED,
     label=LABEL,
     signin_argv=SIGNIN_ARGV,
     login_argv=("login",),

--- a/shared/agent/seats/codex.py
+++ b/shared/agent/seats/codex.py
@@ -87,6 +87,14 @@ skill_mcp_dependency_install = false
 goals = false
 sqlite = false
 code_mode_host = false
+
+# Block apply_patch at call time — the tool can't be hidden from the model (no feature
+# flag exists, unlike shell_tool), but "blocked by app configuration" is cleaner than
+# the generic JSON-RPC error _respond_to_server returns for unknown methods. The model
+# still SEES the tool in its function list, but when it calls it the app-server blocks
+# it internally without asking the client.
+[apps._default.tools.apply_patch]
+enabled = false
 """
 
 # `--ignore-user-config` is deliberately ABSENT: the config above is ours and must be read.
@@ -187,9 +195,9 @@ def run(binary, prepared, timeout, on_delta=None):
     the client — unanswered, those hang the turn, which is the likeliest explanation for a 16-minute
     request observed on the exec path.
 
-    The caller's system prompt goes in `developerInstructions`, closer to the conversation than
-    base instructions, because the Hermes tool protocol is an instruction to obey rather than
-    background the model may drift from.
+    The caller's system prompt REPLACES codex's own base prompt via `baseInstructions`. Measured:
+    leaving the vendor prompt in place and using `developerInstructions` instead still had codex
+    answer "the workspace denied the file-edit request" — it kept believing it had an editor.
     """
     from shared.agent.seats import codex_appserver
 

--- a/shared/agent/seats/codex_appserver.py
+++ b/shared/agent/seats/codex_appserver.py
@@ -15,6 +15,7 @@ import json
 import os
 import signal
 import subprocess
+import sys
 import threading
 import time
 from collections import deque
@@ -29,6 +30,16 @@ CLIENT_NAME = "grid"
 # Sent back when the SERVER asks the client for something. -32601 is JSON-RPC "method not found".
 UNSUPPORTED_REQUEST = -32601
 
+# Why every refusal below happened, in the model's own turn. Carried in whichever field the method's
+# schema provides for it, so the model reads a reason and a way forward rather than a bare "no" —
+# a bare "no" is what it reported to the user as "this environment exposes no shell".
+REJECTION = (
+    "Nothing can be executed in this process — the request never reached the user's machine, and "
+    "retrying it will fail the same way. This is not a limit on what the user asked for. To act, "
+    "emit the tool call as JSON in the shape your instructions describe; the caller runs it and "
+    "returns the output to you."
+)
+
 
 class AppServerError(RuntimeError):
     """The app-server could not be started, died, or answered with an error."""
@@ -42,6 +53,7 @@ class AppServer:
         self.proc = proc
         self.timeout = timeout
         self.notifications = deque(maxlen=1000)  # bounded: a live thread pushes thousands
+        self.refusals = []   # every server request this client turned down, in order
         self._replies = {}
         self._state = threading.Condition()
         self._write_lock = threading.Lock()
@@ -93,16 +105,20 @@ class AppServer:
             raise AppServerError(f"thread/start returned no thread id: {result}")
         return thread_id
 
-    def start_turn(self, thread_id, text, effort=None):
+    def start_turn(self, thread_id, text, effort=None, output_schema=None):
         """Send one user turn. The ANSWER does not come back here — it arrives as `turn/*` and
         `item/*` notifications, which `drain_notifications` hands back.
 
         `effort` is per-turn, the way codex's own app-server schema has it — not session config,
         so it travels with THIS request rather than every turn a long-lived thread might run.
-        Omitted (falsy) leaves the params byte-identical to before this field existed."""
+        `output_schema` constrains the final assistant message — the one lever that makes a tool
+        call structurally valid instead of merely requested. Both are omitted when falsy, leaving
+        the params byte-identical to before either existed."""
         params = {"threadId": thread_id, "input": [{"type": "text", "text": text}]}
         if effort:
             params["effort"] = effort
+        if output_schema:
+            params["outputSchema"] = output_schema
         return self.call("turn/start", params)
 
     def drain_notifications(self):
@@ -167,27 +183,61 @@ class AppServer:
     def _respond_to_server(self, request_id, method, params=None):
         """Answer a server request with the proper response shape per method, or refuse.
 
-        A headless seat has nobody to approve or execute tools, but silence hangs the
-        turn. Returning the proper JSON-RPC result (not a generic error) gives the model
-        a clean denial it can understand and recover from, rather than a cryptic -32601.
+        A headless seat has nobody to approve or execute tools, but silence hangs the turn. Every
+        refusal here therefore says WHY, in the field the schema provides for it, so the model can
+        recover inside the same turn instead of stopping.
+
+        The two approval families use different vocabularies, and this had them crossed. A
+        `ReviewDecision` (command execution, apply-patch) has no `"decline"` member at all — its
+        options are `approved`, `approved_for_session`, `timed_out`, `abort`, and the object form
+        `{"denied": {"rejection": …}}`. Sending the string `"decline"` was sending a value that does
+        not exist, and the turn stopped there. `"decline"` is a `FileChangeApprovalDecision`, the
+        enum for the ONE method that was falling through to the generic error instead.
+
+        `denied` is also the only refusal that carries text and the only one documented to let the
+        agent "continue the session and try something else" — `abort` stops until the next user
+        message, which is the behaviour being complained about, not the one wanted.
         """
         try:
-            if method in ("item/commandExecution/requestApproval", "execCommandApproval"):
-                self._send({"id": request_id, "result": {"decision": "decline"}})
-            elif method in ("item/permissions/requestApproval", "applyPatchApproval"):
-                self._send({"id": request_id, "result": {"permissions": {}}})
+            if method in ("item/commandExecution/requestApproval", "execCommandApproval",
+                          "applyPatchApproval"):
+                self._refuse_with_reason(request_id, method,
+                                         {"decision": {"denied": {"rejection": REJECTION}}})
+            elif method == "item/fileChange/requestApproval":
+                # `decline` here means "denied, but keep going"; `cancel` is the one that interrupts.
+                self._refuse_with_reason(request_id, method, {"decision": "decline"})
+            elif method == "item/permissions/requestApproval":
+                # Grant nothing. Both members are optional, so `{}` IS the empty profile.
+                self._refuse_with_reason(request_id, method, {"permissions": {}})
+            elif method == "item/tool/requestUserInput":
+                # Nobody to ask. Answering with no answers beats the generic error, which this
+                # method used to get: it is a shape the server can read.
+                self._refuse_with_reason(request_id, method, {"answers": {}})
             elif method == "item/tool/call":
-                self._send({"id": request_id, "result": {
+                self._refuse_with_reason(request_id, method, {
                     "success": False,
-                    "contentItems": [{"type": "inputText", "text":
-                        "This tool is not available. Emit tool calls as text per your instructions."}],
-                }})
+                    "contentItems": [{"type": "inputText", "text": REJECTION}],
+                })
             else:
-                self._send({"id": request_id,
-                            "error": {"code": UNSUPPORTED_REQUEST,
-                                      "message": f"{method}: this client answers no requests"}})
+                self._refuse_with_reason(request_id, method, None)
         except AppServerError:
             pass  # broken pipe — the reader thread detects the exit naturally
+
+    def _refuse_with_reason(self, request_id, method, result):
+        """Send `result` (or a JSON-RPC error when None) and record that the refusal happened.
+
+        Recorded because a refusal used to be invisible from outside: the model quietly gave up mid
+        turn and the seat's log showed a plain 200. `refusals` is what makes "it just stopped"
+        answerable after the fact.
+        """
+        self.refusals.append(method)
+        print(f"[cli-seat] refused server request {method}", file=sys.stderr, flush=True)
+        if result is None:
+            self._send({"id": request_id,
+                        "error": {"code": UNSUPPORTED_REQUEST,
+                                  "message": f"{method}: this client answers no requests"}})
+            return
+        self._send({"id": request_id, "result": result})
 
     def _send(self, message):
         line = json.dumps(message) + "\n"
@@ -253,6 +303,11 @@ def read_quota(home=None, binary=None, timeout=60.0):
 # Notification methods, exactly as the server spells them (from its own ServerNotification schema —
 # these are compared literally, not guessed at by substring).
 _DELTA = "item/agentMessage/delta"          # params: {delta, itemId, threadId, turnId}
+# Thinking. Two separate items, never two spellings of one: `summaryTextDelta` is the short summary
+# codex shows a human, `textDelta` the raw chain when a caller asked for it. Both are forwarded and
+# neither is duplicated by the other. Ignoring them left the stream silent for the whole think —
+# measured 4.3s of a 5.2s turn with nothing on the wire.
+_REASONING = ("item/reasoning/summaryTextDelta", "item/reasoning/textDelta")
 _ITEM_DONE = "item/completed"               # params: {item, threadId, turnId, completedAtMs}
 _TURN_DONE = "turn/completed"               # params: {turn, threadId} — NOT usage; see below
 _TOKENS = "thread/tokenUsage/updated"       # params: {tokenUsage: {last, total}, threadId, turnId}
@@ -300,7 +355,10 @@ def serve(binary, prepared, timeout, on_delta=None):
         # `prepared.effort` is resolved once, by cli_seat.prepare, from either the request's
         # `thinking` field or its `reasoning_effort` field — "" when the caller asked for neither,
         # which keeps this call's params identical to before either was read.
-        server.start_turn(thread_id, prepared.prompt, effort=prepared.effort)
+        # Constrained only when the caller sent tools. With none, there is no call to shape and a
+        # schema would just force plain prose through a JSON wrapper.
+        schema = cli_seat.OPENAI_OUTPUT_SCHEMA if prepared.tool_text else None
+        server.start_turn(thread_id, prepared.prompt, effort=prepared.effort, output_schema=schema)
         text, tokens, duration_ms, failure = _collect(server, timeout, on_delta)
         if failure:
             raise SeatError(f"`codex` failed: {failure[:400]}")
@@ -344,6 +402,14 @@ def _collect(server, timeout, on_delta):
                     text += chunk
                     if on_delta:
                         on_delta(chunk)
+            elif method in _REASONING:
+                # Forwarded but NOT added to `text`: thinking is not the answer, and folding it in
+                # would put it through the tool parse and into `content`.
+                chunk = params.get("delta") or params.get("text") or ""
+                if chunk and on_delta:
+                    from shared.agent.cli_seat import Reasoning
+
+                    on_delta(Reasoning(chunk))
             elif method == _ITEM_DONE:
                 item = params.get("item") or {}
                 # The completed item is authoritative — deltas may be partial, or absent entirely.

--- a/shared/agent/seats/codex_appserver.py
+++ b/shared/agent/seats/codex_appserver.py
@@ -171,20 +171,23 @@ class AppServer:
         turn. Returning the proper JSON-RPC result (not a generic error) gives the model
         a clean denial it can understand and recover from, rather than a cryptic -32601.
         """
-        if method in ("item/commandExecution/requestApproval", "execCommandApproval"):
-            self._send({"id": request_id, "result": {"decision": "decline"}})
-        elif method in ("item/permissions/requestApproval", "applyPatchApproval"):
-            self._send({"id": request_id, "result": {"permissions": {}}})
-        elif method == "item/tool/call":
-            self._send({"id": request_id, "result": {
-                "success": False,
-                "contentItems": [{"type": "inputText", "text":
-                    "This tool is not available. Emit tool calls as text per your instructions."}],
-            }})
-        else:
-            self._send({"id": request_id,
-                        "error": {"code": UNSUPPORTED_REQUEST,
-                                  "message": f"{method}: this client answers no requests"}})
+        try:
+            if method in ("item/commandExecution/requestApproval", "execCommandApproval"):
+                self._send({"id": request_id, "result": {"decision": "decline"}})
+            elif method in ("item/permissions/requestApproval", "applyPatchApproval"):
+                self._send({"id": request_id, "result": {"permissions": {}}})
+            elif method == "item/tool/call":
+                self._send({"id": request_id, "result": {
+                    "success": False,
+                    "contentItems": [{"type": "inputText", "text":
+                        "This tool is not available. Emit tool calls as text per your instructions."}],
+                }})
+            else:
+                self._send({"id": request_id,
+                            "error": {"code": UNSUPPORTED_REQUEST,
+                                      "message": f"{method}: this client answers no requests"}})
+        except AppServerError:
+            pass  # broken pipe — the reader thread detects the exit naturally
 
     def _send(self, message):
         line = json.dumps(message) + "\n"

--- a/shared/agent/seats/codex_appserver.py
+++ b/shared/agent/seats/codex_appserver.py
@@ -171,9 +171,9 @@ class AppServer:
         turn. Returning the proper JSON-RPC result (not a generic error) gives the model
         a clean denial it can understand and recover from, rather than a cryptic -32601.
         """
-        if method == "item/commandExecution/requestApproval":
+        if method in ("item/commandExecution/requestApproval", "execCommandApproval"):
             self._send({"id": request_id, "result": {"decision": "decline"}})
-        elif method == "item/permissions/requestApproval":
+        elif method in ("item/permissions/requestApproval", "applyPatchApproval"):
             self._send({"id": request_id, "result": {"permissions": {}}})
         elif method == "item/tool/call":
             self._send({"id": request_id, "result": {

--- a/shared/agent/seats/codex_appserver.py
+++ b/shared/agent/seats/codex_appserver.py
@@ -150,7 +150,7 @@ class AppServer:
                     self._replies[message.get("id")] = message
                     self._state.notify_all()
             elif "id" in message:
-                self._refuse(message["id"], message.get("method"))
+                self._respond_to_server(message["id"], message.get("method"), message.get("params"))
             else:
                 with self._state:
                     self.notifications.append(message)
@@ -164,15 +164,27 @@ class AppServer:
         for line in self.proc.stderr:
             self._stderr_tail.append(line)
 
-    def _refuse(self, request_id, method):
-        """The server asked US for something — an approval, a tool call. A headless seat has
-        nobody to ask, and silence would hang the turn forever, so refuse out loud."""
-        try:
+    def _respond_to_server(self, request_id, method, params=None):
+        """Answer a server request with the proper response shape per method, or refuse.
+
+        A headless seat has nobody to approve or execute tools, but silence hangs the
+        turn. Returning the proper JSON-RPC result (not a generic error) gives the model
+        a clean denial it can understand and recover from, rather than a cryptic -32601.
+        """
+        if method == "item/commandExecution/requestApproval":
+            self._send({"id": request_id, "result": {"decision": "decline"}})
+        elif method == "item/permissions/requestApproval":
+            self._send({"id": request_id, "result": {"permissions": {}}})
+        elif method == "item/tool/call":
+            self._send({"id": request_id, "result": {
+                "success": False,
+                "contentItems": [{"type": "inputText", "text":
+                    "This tool is not available. Emit tool calls as text per your instructions."}],
+            }})
+        else:
             self._send({"id": request_id,
                         "error": {"code": UNSUPPORTED_REQUEST,
                                   "message": f"{method}: this client answers no requests"}})
-        except AppServerError:
-            pass
 
     def _send(self, message):
         line = json.dumps(message) + "\n"

--- a/shared/models/api_catalog.py
+++ b/shared/models/api_catalog.py
@@ -363,7 +363,10 @@ CODEX_CLI_WHITELIST: tuple[ApiModelEntry, ...] = tuple(
         supports_structured_outputs=False,
         notes="Codex CLI seat — verify against a signed-in seat.",
     )
-    for name in ("gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5", "gpt-5.4-mini")
+    # `gpt-5.6-sol` is what Codex CLI picks when the user takes its DEFAULT model. Captured live:
+    # 30 consecutive requests for it, every one answered "No providers available for this model",
+    # because the seat advertised the other four and not the one the client reaches for first.
+    for name in ("gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.5", "gpt-5.4-mini")
 )
 
 # One structure per kind: the verified-date and the entries can't drift apart.
@@ -448,10 +451,19 @@ def supported_kinds() -> tuple[str, ...]:
 
 
 def advertised_name(kind: str, entry: ApiModelEntry) -> str:
+    """`<kind>:<vendor>` — the prefix is load-bearing for the codex seat.
+
+    Bare vendor names were tried. Codex CLI recognises its own model slugs and, for the 5.6 family,
+    then sends `tools: []` through any non-built-in provider — measured 0 tools bare vs 10 with the
+    prefix. Nothing in its catalog changes that (`tool_mode`, `use_responses_lite` and
+    `multi_agent_version` were all patched in its own cache, still 0), so the prefix is the only
+    thing that keeps those models usable at all.
+    """
     return f"{kind}:{entry.vendor_name}"
 
 
 _claude_entries: tuple[ApiModelEntry, ...] | None = None
+_codex_cli_entries: tuple[ApiModelEntry, ...] | None = None
 
 
 def entries_for(kind: str) -> tuple[ApiModelEntry, ...]:
@@ -465,12 +477,17 @@ def entries_for(kind: str) -> tuple[ApiModelEntry, ...]:
     whitelist = WHITELISTS.get(kind)
     if whitelist is None:
         return ()
-    if kind != CLAUDE_KIND:
-        return whitelist.entries
-    global _claude_entries
-    if _claude_entries is None:
-        _claude_entries = _discovered_claude_entries() or whitelist.entries
-    return _claude_entries
+    if kind == CLAUDE_KIND:
+        global _claude_entries
+        if _claude_entries is None:
+            _claude_entries = _discovered_claude_entries() or whitelist.entries
+        return _claude_entries
+    if kind == CODEX_CLI_KIND:
+        global _codex_cli_entries
+        if _codex_cli_entries is None:
+            _codex_cli_entries = _discovered_codex_cli_entries() or whitelist.entries
+        return _codex_cli_entries
+    return whitelist.entries
 
 
 def _discovered_claude_entries() -> tuple[ApiModelEntry, ...]:
@@ -526,17 +543,46 @@ def resolvable_entries(kind: str) -> tuple[ApiModelEntry, ...]:
     return tuple(out)
 
 
-def find_advertised(kind: str, advertised: str) -> ApiModelEntry | None:
-    """The whitelist entry advertised under ``advertised`` (e.g. ``openai:gpt-5.5``), or None.
 
-    Only the namespaced form resolves — a bare vendor name is not an advertised name.
+def _discovered_codex_cli_entries() -> tuple[ApiModelEntry, ...]:
+    """The signed-in account's own list, via the app-server's `model/list`.
+
+    Imported inside the call for the same cycle reason as the Claude one. `()` on any failure, so
+    an unauthenticated or older CLI falls back to CODEX_CLI_WHITELIST rather than serving nothing.
+    """
+    from shared.agent import cli_seat, codex_models
+    from shared.agent.seats import codex as codex_seat
+
+    binary = cli_seat.seat_bin(codex_seat.SPEC)
+    if binary is None:
+        return ()
+    return tuple(
+        ApiModelEntry(
+            vendor_name=model_id,
+            # `model/list` carries no window or tool flag; both stay at the static row's values
+            # rather than being invented from a field that does not exist.
+            context_window=0,
+            supports_tools=True,
+            supports_vision=False,
+            supports_json_mode=False,
+            supports_structured_outputs=False,
+            notes="Codex CLI seat — id read from the signed-in account.",
+        )
+        for model_id in codex_models.discover(binary)
+    )
+
+def find_advertised(kind: str, advertised: str) -> ApiModelEntry | None:
+    """The whitelist entry advertised under ``advertised``, or None.
+
+    The bare vendor name is the advertised name now; the old `<kind>:<vendor>` spelling still
+    resolves so a record written before the change keeps working.
     """
     whitelist = WHITELISTS.get(kind)
     if whitelist is None:
         return None
     for entry in resolvable_entries(kind):
-        if advertised_name(kind, entry) == advertised:
-            return entry
+        if advertised in (advertised_name(kind, entry), entry.vendor_name):
+            return entry   # bare vendor name resolves too, so an older record still works
     return None
 
 

--- a/tests/test_cli_seat.py
+++ b/tests/test_cli_seat.py
@@ -1299,3 +1299,20 @@ def test_flatten_content_skips_tool_result_not_omitted():
     content = [{"type": "tool_result", "tool_use_id": "tu1", "content": "file contents"}]
     result = cli_seat._flatten_content(content)
     assert "omitted" not in result
+
+def test_prepare_carries_raw_messages_and_tool_text():
+    body = {
+        "model": "claude:sonnet",
+        "messages": [{"role": "user", "content": "hello"}],
+        "tools": [{"type": "function", "function": {"name": "read_file", "parameters": {}}}],
+    }
+    prepared = cli_seat.prepare(body, "claude")
+    assert len(prepared.messages) == 1
+    assert prepared.messages[0]["content"] == "hello"
+    assert prepared.tool_text
+
+def test_prepare_tool_text_empty_without_tools():
+    body = {"model": "claude:sonnet",
+            "messages": [{"role": "user", "content": "hello"}]}
+    prepared = cli_seat.prepare(body, "claude")
+    assert prepared.tool_text == ""

--- a/tests/test_cli_seat.py
+++ b/tests/test_cli_seat.py
@@ -1316,3 +1316,28 @@ def test_prepare_tool_text_empty_without_tools():
             "messages": [{"role": "user", "content": "hello"}]}
     prepared = cli_seat.prepare(body, "claude")
     assert prepared.tool_text == ""
+
+def test_to_stream_json_converts_openai_messages():
+    from shared.agent.seats.claude import to_stream_json
+    messages = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": None, "tool_calls": [
+            {"id": "c1", "type": "function",
+             "function": {"name": "read_file", "arguments": '{"path": "foo.txt"}'}}
+        ]},
+        {"role": "tool", "tool_call_id": "c1", "content": "file contents"},
+        {"role": "user", "content": "thanks"},
+    ]
+    objs = [json.loads(line) for line in to_stream_json(messages).splitlines()]
+    assert len(objs) == 4
+    assert objs[0]["message"]["content"] == "hello"
+    tu = next(b for b in objs[1]["message"]["content"] if b["type"] == "tool_use")
+    assert tu["name"] == "read_file" and tu["input"] == {"path": "foo.txt"}
+    assert any(b["type"] == "tool_result" for b in objs[2]["message"]["content"])
+
+def test_to_stream_json_appends_tool_instructions():
+    from shared.agent.seats.claude import to_stream_json
+    lines = to_stream_json([{"role": "user", "content": "hi"}], tools_text="TOOLS HERE")
+    content = json.loads(lines.splitlines()[-1])["message"]["content"]
+    assert isinstance(content, list)
+    assert any("TOOLS HERE" in b.get("text", "") for b in content)

--- a/tests/test_cli_seat.py
+++ b/tests/test_cli_seat.py
@@ -1284,3 +1284,18 @@ def test_the_responses_stream_shares_the_rule():
 
     call = deltas([_OPENAI_CALL_JSON])
     assert "".join(call) == "", "the raw call leaked into the stream as prose"
+
+
+def test_flatten_content_skips_tool_use_not_omitted():
+    content = [
+        {"type": "text", "text": "let me read that"},
+        {"type": "tool_use", "id": "tu1", "name": "read_file", "input": {"path": "foo.txt"}},
+    ]
+    result = cli_seat._flatten_content(content)
+    assert "omitted" not in result
+    assert "let me read that" in result
+
+def test_flatten_content_skips_tool_result_not_omitted():
+    content = [{"type": "tool_result", "tool_use_id": "tu1", "content": "file contents"}]
+    result = cli_seat._flatten_content(content)
+    assert "omitted" not in result

--- a/tests/test_cli_seat.py
+++ b/tests/test_cli_seat.py
@@ -199,9 +199,12 @@ def test_options_survive_flags_then_record_then_child_argv():
 # adapters
 
 def test_claude_invoke_disables_tools_and_replaces_the_system_prompt(tmp_path: Path):
-    prepared = cli_seat.PreparedRequest("claude:sonnet", "sonnet", "hi", "SYSTEM")
+    prepared = cli_seat.PreparedRequest("claude:sonnet", "sonnet", "hi", "SYSTEM",
+                                        messages=({"role": "user", "content": "hi"},))
     argv, stdin = claude.invoke("/bin/claude", prepared, tmp_path)
-    assert stdin == "hi"
+    assert "--input-format" in argv and argv[argv.index("--input-format") + 1] == "stream-json"
+    first = json.loads(stdin.splitlines()[0])
+    assert first["type"] == "user" and first["message"]["content"] == "hi"
     assert "--tools" in argv and argv[argv.index("--tools") + 1] == ""
     assert "--safe-mode" in argv and "--no-session-persistence" in argv
     # REPLACES the vendor prompt: keeping it leaked the provider's cwd, OS and git branch to a
@@ -1339,5 +1342,29 @@ def test_to_stream_json_appends_tool_instructions():
     from shared.agent.seats.claude import to_stream_json
     lines = to_stream_json([{"role": "user", "content": "hi"}], tools_text="TOOLS HERE")
     content = json.loads(lines.splitlines()[-1])["message"]["content"]
+    assert isinstance(content, list)
+    assert any("TOOLS HERE" in b.get("text", "") for b in content)
+
+def test_claude_invoke_uses_stream_json_input(tmp_path):
+    prepared = cli_seat.PreparedRequest(
+        model="claude:sonnet", model_alias="sonnet", prompt="unused",
+        system_prompt="You are helpful.",
+        messages=({"role": "user", "content": "hello"},))
+    from shared.agent.seats import claude
+    argv, stdin = claude.invoke("/fake/claude", prepared, tmp_path)
+    assert "--input-format" in argv
+    assert argv[argv.index("--input-format") + 1] == "stream-json"
+    first = json.loads(stdin.splitlines()[0])
+    assert first["type"] == "user" and first["message"]["content"] == "hello"
+
+def test_claude_invoke_appends_tool_text(tmp_path):
+    prepared = cli_seat.PreparedRequest(
+        model="claude:sonnet", model_alias="sonnet", prompt="unused",
+        system_prompt="You are helpful.", tool_protocol=cli_seat.OPENAI,
+        tool_text="TOOLS HERE",
+        messages=({"role": "user", "content": "hello"},))
+    from shared.agent.seats import claude
+    _, stdin = claude.invoke("/fake/claude", prepared, tmp_path)
+    content = json.loads(stdin.splitlines()[-1])["message"]["content"]
     assert isinstance(content, list)
     assert any("TOOLS HERE" in b.get("text", "") for b in content)

--- a/tests/test_cli_seat.py
+++ b/tests/test_cli_seat.py
@@ -1368,3 +1368,68 @@ def test_claude_invoke_appends_tool_text(tmp_path):
     content = json.loads(stdin.splitlines()[-1])["message"]["content"]
     assert isinstance(content, list)
     assert any("TOOLS HERE" in b.get("text", "") for b in content)
+
+
+# edge cases for to_stream_json (bugs found in code review)
+
+def test_to_stream_json_merges_consecutive_tool_results():
+    """B2: parallel tool calls produce consecutive role:tool messages. Claude requires
+    alternating user/assistant turns, so they must merge into ONE user message."""
+    from shared.agent.seats.claude import to_stream_json
+    messages = [
+        {"role": "user", "content": "check both files"},
+        {"role": "assistant", "content": None, "tool_calls": [
+            {"id": "c1", "type": "function", "function": {"name": "read", "arguments": "{}"}},
+            {"id": "c2", "type": "function", "function": {"name": "read", "arguments": "{}"}},
+        ]},
+        {"role": "tool", "tool_call_id": "c1", "content": "file A"},
+        {"role": "tool", "tool_call_id": "c2", "content": "file B"},
+        {"role": "user", "content": "thanks"},
+    ]
+    objs = [json.loads(line) for line in to_stream_json(messages).splitlines()]
+    types = [o["type"] for o in objs]
+    assert types == ["user", "assistant", "user", "user"]
+    merged = objs[2]["message"]["content"]
+    assert len(merged) == 2
+    assert all(b["type"] == "tool_result" for b in merged)
+    assert merged[0]["content"] == "file A"
+    assert merged[1]["content"] == "file B"
+
+
+def test_to_stream_json_empty_assistant_gets_placeholder():
+    """R4: an assistant message with no text and no tool_calls must not produce content: []
+    — Claude requires at least one block per message."""
+    from shared.agent.seats.claude import to_stream_json
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": None},
+        {"role": "user", "content": "hello?"},
+    ]
+    objs = [json.loads(line) for line in to_stream_json(messages).splitlines()]
+    assistant_blocks = objs[1]["message"]["content"]
+    assert len(assistant_blocks) >= 1
+
+
+def test_to_stream_json_image_in_user_content_is_omitted():
+    """R3: OpenAI image_url blocks in user content must not be passed raw to Claude —
+    flatten to text (images become 'omitted')."""
+    from shared.agent.seats.claude import to_stream_json
+    messages = [{"role": "user", "content": [
+        {"type": "text", "text": "describe this"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+    ]}]
+    obj = json.loads(to_stream_json(messages).splitlines()[0])
+    content = obj["message"]["content"]
+    assert isinstance(content, list)
+    assert any(b["type"] == "text" and "describe this" in b["text"] for b in content)
+    assert not any("image_url" in str(b) for b in content)
+
+
+def test_to_stream_json_tools_text_with_no_user_messages():
+    """R5: if there are no user messages, tools_text creates one rather than being dropped."""
+    from shared.agent.seats.claude import to_stream_json
+    messages = [{"role": "assistant", "content": "hi"}]
+    lines = to_stream_json(messages, tools_text="TOOLS")
+    last = json.loads(lines.splitlines()[-1])
+    assert last["type"] == "user"
+    assert any("TOOLS" in b.get("text", "") for b in last["message"]["content"])

--- a/tests/test_codex_appserver.py
+++ b/tests/test_codex_appserver.py
@@ -1,18 +1,368 @@
-"""Tests for the codex app-server client's server-request handling."""
-from unittest.mock import MagicMock
+"""The codex app-server client: payload -> QuotaSnapshot, and the never-raise contract.
 
+No real binary here — a scripted stdin/stdout stands in for the process, so the reader thread,
+the id demultiplexing and the refusal path are all exercised for real. The one test that needs
+the actual `codex` is marked `canary`.
+"""
+from __future__ import annotations
+
+import io
+import json
+import queue
+import re
+import time
+
+import pytest
+
+from shared.agent.cli_seat import QuotaSnapshot
+from shared.agent.seats import claude, codex_appserver
 from shared.agent.seats.codex_appserver import AppServer, UNSUPPORTED_REQUEST
 
+# The exact result the real binary returns, captured from `account/rateLimits/read`.
+REAL_PAYLOAD = {
+    "rateLimits": {
+        "limitId": "codex",
+        "planType": "plus",
+        "primary": {"usedPercent": 3, "windowDurationMins": 10080, "resetsAt": 1785913699},
+        "secondary": None,
+        "rateLimitReachedType": None,
+        "spendControlReached": False,
+    },
+    "rateLimitsByLimitId": {},
+    "rateLimitResetCredits": {},
+}
 
-def _make_server():
+
+class _Stdout:
+    """A blocking line source; the reader thread iterates it exactly as it iterates a real pipe."""
+
+    def __init__(self):
+        self.lines = queue.Queue()
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        line = self.lines.get()
+        if line is None:
+            raise StopIteration
+        return line
+
+
+class FakeProc:
+    """A scripted app-server: each request written gets whatever its method maps to."""
+
+    def __init__(self, replies=None, alive=False):
+        self.replies = replies or {}
+        self.stdout = _Stdout()
+        self.stderr = io.StringIO("")
+        self.stdin = self
+        self.written = []
+        self.alive = alive
+        self.pid = 424242
+        self.stdin_closed = False
+
+    def write(self, line):
+        self.written.append(json.loads(line))
+        message = json.loads(line)
+        reply = self.replies.get(message.get("method"))
+        if reply is not None and "id" in message:
+            self.push({"id": message["id"], **reply})
+
+    def push(self, message):
+        self.stdout.lines.put(json.dumps(message) + "\n")
+
+    def hang_up(self):
+        self.stdout.lines.put(None)
+
+    def flush(self):
+        pass
+
+    def close(self):
+        self.stdin_closed = True
+
+    def poll(self):
+        return None if self.alive else 0
+
+    def wait(self, timeout=None):
+        self.alive = False
+        return 0
+
+    def kill(self):
+        self.alive = False
+
+
+def _server(proc, timeout=2.0):
+    return codex_appserver.AppServer(proc, timeout=timeout)
+
+
+def _wait_for(predicate, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+# payload -> QuotaSnapshot
+
+def test_the_real_payload_maps_to_a_snapshot():
+    snapshot = codex_appserver.snapshot_from_rate_limits(REAL_PAYLOAD)
+    assert isinstance(snapshot, QuotaSnapshot)
+    assert snapshot.session_pct == 3
+    assert snapshot.week_pct == 0          # secondary is null on this plan
+    assert snapshot.session_reset != ""
+    assert snapshot.week_reset == ""
+
+
+def test_secondary_becomes_the_week_window():
+    payload = {"rateLimits": {"primary": {"usedPercent": 12, "resetsAt": 1785913699},
+                              "secondary": {"usedPercent": 47, "resetsAt": 1785999999}}}
+    snapshot = codex_appserver.snapshot_from_rate_limits(payload)
+    assert (snapshot.session_pct, snapshot.week_pct) == (12, 47)
+    assert snapshot.week_reset != ""
+
+
+def test_a_blocked_account_reports_full_windows():
+    """Mirrors claude's blocked branch: the percentages can read low while the account is barred."""
+    payload = {"rateLimits": {"primary": {"usedPercent": 3}, "secondary": None,
+                              "rateLimitReachedType": "rate_limit_reached"}}
+    snapshot = codex_appserver.snapshot_from_rate_limits(payload)
+    assert (snapshot.session_pct, snapshot.week_pct) == (100, 100)
+
+
+def test_spend_control_also_counts_as_blocked():
+    payload = {"rateLimits": {"primary": {"usedPercent": 1}, "spendControlReached": True}}
+    assert codex_appserver.snapshot_from_rate_limits(payload).session_pct == 100
+
+
+@pytest.mark.parametrize("payload", [
+    None, "", [], {}, {"rateLimits": None}, {"rateLimits": {}},
+    {"rateLimits": {"primary": None, "secondary": None}},
+])
+def test_a_payload_with_no_window_reads_as_none(payload):
+    assert codex_appserver.snapshot_from_rate_limits(payload) is None
+
+
+@pytest.mark.parametrize("value,expected", [(None, 0), ("", 0), ("nope", 0), (3, 3),
+                                            (3.6, 4), (-5, 0), (250, 100)])
+def test_percentages_are_clamped_whole_numbers(value, expected):
+    payload = {"rateLimits": {"primary": {"usedPercent": value}}}
+    assert codex_appserver.snapshot_from_rate_limits(payload).session_pct == expected
+
+
+# reset formatting
+
+def test_reset_text_matches_the_claude_seat_exactly():
+    """Both seats feed the same quota display, so a drift here shows up as two formats in one UI."""
+    window = {"resetsAt": 1785913699}
+    assert codex_appserver._reset_text(window) == claude._reset_text(window)
+    assert re.fullmatch(r"[a-z]{3} \d{1,2} at \d{1,2}:\d{2}(am|pm)",
+                        codex_appserver._reset_text(window))
+
+
+@pytest.mark.parametrize("stamp", [None, 0, "", "later", -(10 ** 18)])
+def test_an_unusable_reset_stamp_reads_as_empty(stamp):
+    assert codex_appserver._reset_text({"resetsAt": stamp}) == ""
+
+
+# the transport
+
+def test_call_returns_the_reply_for_its_own_id():
+    proc = FakeProc({"account/rateLimits/read": {"result": REAL_PAYLOAD}})
+    server = _server(proc)
+    assert server.call("account/rateLimits/read", {}) == REAL_PAYLOAD
+    assert proc.written[0]["id"] == 1
+
+
+def test_read_rate_limits_maps_a_live_reply():
+    server = _server(FakeProc({"account/rateLimits/read": {"result": REAL_PAYLOAD}}))
+    assert server.read_rate_limits() == QuotaSnapshot(
+        session_pct=3, week_pct=0,
+        session_reset=codex_appserver._reset_text({"resetsAt": 1785913699}), week_reset="",
+    )
+
+
+def test_read_rate_limits_returns_none_on_a_server_error():
+    server = _server(FakeProc({"account/rateLimits/read":
+                               {"error": {"code": -32603, "message": "not signed in"}}}))
+    assert server.read_rate_limits() is None
+
+
+def test_read_rate_limits_returns_none_when_the_server_dies():
+    proc = FakeProc()  # answers nothing
+    server = _server(proc, timeout=5.0)
+    proc.hang_up()
+    assert server.read_rate_limits() is None
+
+
+def test_read_rate_limits_returns_none_on_timeout():
+    server = _server(FakeProc(), timeout=0.05)
+    assert server.read_rate_limits() is None
+
+
+def test_call_raises_where_the_quota_read_swallows():
+    """The never-raise contract belongs to the quota read, not to the transport underneath it."""
+    server = _server(FakeProc({"thread/start": {"error": {"code": -1, "message": "nope"}}}))
+    with pytest.raises(codex_appserver.AppServerError):
+        server.start_thread(cwd="/tmp")
+
+
+def test_start_thread_returns_the_nested_id():
+    proc = FakeProc({"thread/start": {"result": {"thread": {"id": "th_123"}}}})
+    server = _server(proc)
+    assert server.start_thread(cwd="/tmp", model=None, ephemeral=True) == "th_123"
+    assert proc.written[0]["params"] == {"cwd": "/tmp", "ephemeral": True}  # None is dropped
+
+
+def test_start_turn_sends_the_input_block():
+    """No `effort` argument (today's call shape): the params carry no `effort` key at all, not
+    even a null one — a request naming neither `thinking` nor `reasoning_effort` must produce
+    byte-identical `turn/start` params to before this field existed."""
+    proc = FakeProc({"turn/start": {"result": {}}})
+    _server(proc).start_turn("th_123", "hello")
+    assert proc.written[0]["params"] == {"threadId": "th_123",
+                                         "input": [{"type": "text", "text": "hello"}]}
+
+
+def test_start_turn_carries_effort_when_one_was_resolved():
+    """Regression: the codex seat read reasoning token counts back out but never set effort going
+    in (grep confirmed no caller passed `effort` to `turn/start`). It rides this per-turn request,
+    not config.toml — a session setting would apply to every turn, not just this request."""
+    proc = FakeProc({"turn/start": {"result": {}}})
+    _server(proc).start_turn("th_123", "hello", effort="high")
+    assert proc.written[0]["params"] == {"threadId": "th_123",
+                                         "input": [{"type": "text", "text": "hello"}],
+                                         "effort": "high"}
+
+
+def test_start_turn_treats_a_falsy_effort_the_same_as_none():
+    proc = FakeProc({"turn/start": {"result": {}}})
+    _server(proc).start_turn("th_123", "hello", effort="")
+    assert "effort" not in proc.written[0]["params"]
+
+
+def test_notifications_are_collected_not_mistaken_for_replies():
+    proc = FakeProc({"account/rateLimits/read": {"result": REAL_PAYLOAD}})
+    server = _server(proc)
+    proc.push({"method": "account/rateLimits/updated", "params": {"rateLimits": {}}})
+    assert _wait_for(lambda: server.notifications)
+    assert server.read_rate_limits() is not None      # the notification did not consume the reply
+    assert [n["method"] for n in server.drain_notifications()] == ["account/rateLimits/updated"]
+    assert server.drain_notifications() == []
+
+
+def test_a_server_request_is_refused_rather_than_left_hanging():
+    """The server can ask the client for an approval. A headless seat has nobody to ask, and
+    silence would hang the turn — so it must answer with an error."""
+    proc = FakeProc()
+    _server(proc)
+    proc.push({"id": 77, "method": "execCommandApproval", "params": {}})
+    assert _wait_for(lambda: proc.written)
+    assert proc.written[0]["id"] == 77
+    assert proc.written[0]["error"]["code"] == codex_appserver.UNSUPPORTED_REQUEST
+
+
+def test_junk_lines_do_not_kill_the_reader():
+    proc = FakeProc({"account/rateLimits/read": {"result": REAL_PAYLOAD}})
+    server = _server(proc)
+    proc.stdout.lines.put("not json at all\n")
+    proc.stdout.lines.put("[1, 2, 3]\n")
+    assert server.read_rate_limits() is not None
+
+
+# start / stop
+
+def test_stop_kills_the_process_group(monkeypatch):
+    """Process group, not process: codex spawns children that a bare terminate would orphan."""
+    killed = []
+    monkeypatch.setattr(codex_appserver.os, "killpg", lambda pid, sig: killed.append((pid, sig)))
+    proc = FakeProc(alive=True)
+    _server(proc).stop()
+    assert killed == [(proc.pid, codex_appserver.signal.SIGTERM)]
+    assert proc.stdin_closed
+
+
+def test_stop_is_a_no_op_when_the_process_already_exited(monkeypatch):
+    monkeypatch.setattr(codex_appserver.os, "killpg",
+                        lambda pid, sig: pytest.fail("killed an already-dead pid"))
+    _server(FakeProc(alive=False)).stop()
+
+
+def _fake_popen(monkeypatch, proc, seen):
+    monkeypatch.setattr(codex_appserver.cli_seat, "seat_bin", lambda spec: "/fake/codex")
+    def popen(argv, **kwargs):
+        seen.append((argv, kwargs))
+        return proc
+    monkeypatch.setattr(codex_appserver.subprocess, "Popen", popen)
+
+
+def test_start_handshakes_before_anything_else(monkeypatch, tmp_path):
+    proc = FakeProc({"initialize": {"result": {}}})
+    seen = []
+    _fake_popen(monkeypatch, proc, seen)
+
+    server = codex_appserver.start_app_server(home=tmp_path)
+    argv, kwargs = seen[0]
+    assert argv == ["/fake/codex", "app-server", "--stdio"]
+    assert kwargs["env"]["CODEX_HOME"] == str(tmp_path)
+    assert kwargs["start_new_session"] is True
+    assert proc.written[0]["method"] == "initialize"
+    assert proc.written[0]["params"]["clientInfo"]["name"] == codex_appserver.CLIENT_NAME
+    assert proc.written[1]["method"] == "initialized"
+    assert "id" not in proc.written[1]              # a notification, never answered
+    server.stop()
+
+
+def test_a_failed_handshake_does_not_leave_a_process_behind(monkeypatch, tmp_path):
+    proc = FakeProc({"initialize": {"error": {"code": -1, "message": "bad client"}}})
+    _fake_popen(monkeypatch, proc, [])
+    with pytest.raises(codex_appserver.AppServerError):
+        codex_appserver.start_app_server(home=tmp_path)
+    assert proc.stdin_closed
+
+
+def test_read_quota_reads_once_and_shuts_down(monkeypatch, tmp_path):
+    proc = FakeProc({"initialize": {"result": {}},
+                     "account/rateLimits/read": {"result": REAL_PAYLOAD}})
+    _fake_popen(monkeypatch, proc, [])
+    assert codex_appserver.read_quota(home=tmp_path).session_pct == 3
+    assert proc.stdin_closed
+
+
+def test_read_quota_returns_none_when_the_binary_is_missing(monkeypatch):
+    monkeypatch.setattr(codex_appserver.cli_seat, "seat_bin", lambda spec: None)
+    assert codex_appserver.read_quota() is None
+
+
+def test_read_quota_returns_none_when_the_process_will_not_start(monkeypatch, tmp_path):
+    monkeypatch.setattr(codex_appserver.cli_seat, "seat_bin", lambda spec: "/fake/codex")
+    monkeypatch.setattr(codex_appserver.subprocess, "Popen",
+                        lambda argv, **kwargs: (_ for _ in ()).throw(OSError("no such file")))
+    assert codex_appserver.read_quota(home=tmp_path) is None
+
+
+@pytest.mark.canary
+def test_the_real_app_server_reports_a_quota():
+    """Runs the operator's own signed-in codex. Opt in with `-m canary`."""
+    snapshot = codex_appserver.read_quota()
+    assert snapshot is not None, "app-server returned no rate limits — is the seat signed in?"
+    assert 0 <= snapshot.session_pct <= 100
+
+
+# --- _respond_to_server: proper responses per method (Phase 3 Task 6) ---
+
+def _mock_server():
     """An AppServer with a mocked _send, bypassing __init__."""
+    from unittest.mock import MagicMock
     server = AppServer.__new__(AppServer)
     server._send = MagicMock()
     return server
 
 
 def test_respond_declines_command_execution_approval():
-    server = _make_server()
+    server = _mock_server()
     server._respond_to_server(1, "item/commandExecution/requestApproval")
     sent = server._send.call_args[0][0]
     assert sent["id"] == 1
@@ -20,14 +370,14 @@ def test_respond_declines_command_execution_approval():
 
 
 def test_respond_denies_all_permissions():
-    server = _make_server()
+    server = _mock_server()
     server._respond_to_server(2, "item/permissions/requestApproval")
     sent = server._send.call_args[0][0]
     assert sent["result"]["permissions"] == {}
 
 
 def test_respond_redirects_tool_call():
-    server = _make_server()
+    server = _mock_server()
     server._respond_to_server(3, "item/tool/call")
     sent = server._send.call_args[0][0]
     assert sent["result"]["success"] is False
@@ -36,7 +386,7 @@ def test_respond_redirects_tool_call():
 
 
 def test_respond_generic_error_for_unknown_method():
-    server = _make_server()
+    server = _mock_server()
     server._respond_to_server(4, "some/unknown/method")
     sent = server._send.call_args[0][0]
     assert "error" in sent
@@ -44,8 +394,7 @@ def test_respond_generic_error_for_unknown_method():
 
 
 def test_respond_handles_none_params():
-    """params=None must not crash — some server requests may omit it."""
-    server = _make_server()
+    server = _mock_server()
     server._respond_to_server(5, "item/tool/call", params=None)
     sent = server._send.call_args[0][0]
     assert sent["result"]["success"] is False

--- a/tests/test_codex_appserver.py
+++ b/tests/test_codex_appserver.py
@@ -255,13 +255,15 @@ def test_notifications_are_collected_not_mistaken_for_replies():
 
 def test_a_server_request_is_refused_rather_than_left_hanging():
     """The server can ask the client for an approval. A headless seat has nobody to ask, and
-    silence would hang the turn — so it must answer with an error."""
+    silence would hang the turn — so it must answer, not ignore. Known approval methods get a
+    proper decline; unknown methods get a generic error so the turn never hangs."""
     proc = FakeProc()
     _server(proc)
     proc.push({"id": 77, "method": "execCommandApproval", "params": {}})
     assert _wait_for(lambda: proc.written)
     assert proc.written[0]["id"] == 77
-    assert proc.written[0]["error"]["code"] == codex_appserver.UNSUPPORTED_REQUEST
+    # Old method name (execCommandApproval) is handled as a command approval → decline
+    assert proc.written[0]["result"]["decision"] == "decline"
 
 
 def test_junk_lines_do_not_kill_the_reader():

--- a/tests/test_codex_appserver.py
+++ b/tests/test_codex_appserver.py
@@ -1,350 +1,51 @@
-"""The codex app-server client: payload -> QuotaSnapshot, and the never-raise contract.
+"""Tests for the codex app-server client's server-request handling."""
+from unittest.mock import MagicMock
 
-No real binary here — a scripted stdin/stdout stands in for the process, so the reader thread,
-the id demultiplexing and the refusal path are all exercised for real. The one test that needs
-the actual `codex` is marked `canary`.
-"""
-from __future__ import annotations
+from shared.agent.seats.codex_appserver import AppServer, UNSUPPORTED_REQUEST
 
-import io
-import json
-import queue
-import re
-import time
 
-import pytest
+def _make_server():
+    """An AppServer with a mocked _send, bypassing __init__."""
+    server = AppServer.__new__(AppServer)
+    server._send = MagicMock()
+    return server
 
-from shared.agent.cli_seat import QuotaSnapshot
-from shared.agent.seats import claude, codex_appserver
 
-# The exact result the real binary returns, captured from `account/rateLimits/read`.
-REAL_PAYLOAD = {
-    "rateLimits": {
-        "limitId": "codex",
-        "planType": "plus",
-        "primary": {"usedPercent": 3, "windowDurationMins": 10080, "resetsAt": 1785913699},
-        "secondary": None,
-        "rateLimitReachedType": None,
-        "spendControlReached": False,
-    },
-    "rateLimitsByLimitId": {},
-    "rateLimitResetCredits": {},
-}
+def test_respond_declines_command_execution_approval():
+    server = _make_server()
+    server._respond_to_server(1, "item/commandExecution/requestApproval")
+    sent = server._send.call_args[0][0]
+    assert sent["id"] == 1
+    assert sent["result"]["decision"] == "decline"
 
 
-class _Stdout:
-    """A blocking line source; the reader thread iterates it exactly as it iterates a real pipe."""
+def test_respond_denies_all_permissions():
+    server = _make_server()
+    server._respond_to_server(2, "item/permissions/requestApproval")
+    sent = server._send.call_args[0][0]
+    assert sent["result"]["permissions"] == {}
 
-    def __init__(self):
-        self.lines = queue.Queue()
 
-    def __iter__(self):
-        return self
+def test_respond_redirects_tool_call():
+    server = _make_server()
+    server._respond_to_server(3, "item/tool/call")
+    sent = server._send.call_args[0][0]
+    assert sent["result"]["success"] is False
+    assert len(sent["result"]["contentItems"]) == 1
+    assert "not available" in sent["result"]["contentItems"][0]["text"]
 
-    def __next__(self):
-        line = self.lines.get()
-        if line is None:
-            raise StopIteration
-        return line
 
+def test_respond_generic_error_for_unknown_method():
+    server = _make_server()
+    server._respond_to_server(4, "some/unknown/method")
+    sent = server._send.call_args[0][0]
+    assert "error" in sent
+    assert sent["error"]["code"] == UNSUPPORTED_REQUEST
 
-class FakeProc:
-    """A scripted app-server: each request written gets whatever its method maps to."""
 
-    def __init__(self, replies=None, alive=False):
-        self.replies = replies or {}
-        self.stdout = _Stdout()
-        self.stderr = io.StringIO("")
-        self.stdin = self
-        self.written = []
-        self.alive = alive
-        self.pid = 424242
-        self.stdin_closed = False
-
-    def write(self, line):
-        self.written.append(json.loads(line))
-        message = json.loads(line)
-        reply = self.replies.get(message.get("method"))
-        if reply is not None and "id" in message:
-            self.push({"id": message["id"], **reply})
-
-    def push(self, message):
-        self.stdout.lines.put(json.dumps(message) + "\n")
-
-    def hang_up(self):
-        self.stdout.lines.put(None)
-
-    def flush(self):
-        pass
-
-    def close(self):
-        self.stdin_closed = True
-
-    def poll(self):
-        return None if self.alive else 0
-
-    def wait(self, timeout=None):
-        self.alive = False
-        return 0
-
-    def kill(self):
-        self.alive = False
-
-
-def _server(proc, timeout=2.0):
-    return codex_appserver.AppServer(proc, timeout=timeout)
-
-
-def _wait_for(predicate, timeout=2.0):
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        if predicate():
-            return True
-        time.sleep(0.01)
-    return False
-
-
-# payload -> QuotaSnapshot
-
-def test_the_real_payload_maps_to_a_snapshot():
-    snapshot = codex_appserver.snapshot_from_rate_limits(REAL_PAYLOAD)
-    assert isinstance(snapshot, QuotaSnapshot)
-    assert snapshot.session_pct == 3
-    assert snapshot.week_pct == 0          # secondary is null on this plan
-    assert snapshot.session_reset != ""
-    assert snapshot.week_reset == ""
-
-
-def test_secondary_becomes_the_week_window():
-    payload = {"rateLimits": {"primary": {"usedPercent": 12, "resetsAt": 1785913699},
-                              "secondary": {"usedPercent": 47, "resetsAt": 1785999999}}}
-    snapshot = codex_appserver.snapshot_from_rate_limits(payload)
-    assert (snapshot.session_pct, snapshot.week_pct) == (12, 47)
-    assert snapshot.week_reset != ""
-
-
-def test_a_blocked_account_reports_full_windows():
-    """Mirrors claude's blocked branch: the percentages can read low while the account is barred."""
-    payload = {"rateLimits": {"primary": {"usedPercent": 3}, "secondary": None,
-                              "rateLimitReachedType": "rate_limit_reached"}}
-    snapshot = codex_appserver.snapshot_from_rate_limits(payload)
-    assert (snapshot.session_pct, snapshot.week_pct) == (100, 100)
-
-
-def test_spend_control_also_counts_as_blocked():
-    payload = {"rateLimits": {"primary": {"usedPercent": 1}, "spendControlReached": True}}
-    assert codex_appserver.snapshot_from_rate_limits(payload).session_pct == 100
-
-
-@pytest.mark.parametrize("payload", [
-    None, "", [], {}, {"rateLimits": None}, {"rateLimits": {}},
-    {"rateLimits": {"primary": None, "secondary": None}},
-])
-def test_a_payload_with_no_window_reads_as_none(payload):
-    assert codex_appserver.snapshot_from_rate_limits(payload) is None
-
-
-@pytest.mark.parametrize("value,expected", [(None, 0), ("", 0), ("nope", 0), (3, 3),
-                                            (3.6, 4), (-5, 0), (250, 100)])
-def test_percentages_are_clamped_whole_numbers(value, expected):
-    payload = {"rateLimits": {"primary": {"usedPercent": value}}}
-    assert codex_appserver.snapshot_from_rate_limits(payload).session_pct == expected
-
-
-# reset formatting
-
-def test_reset_text_matches_the_claude_seat_exactly():
-    """Both seats feed the same quota display, so a drift here shows up as two formats in one UI."""
-    window = {"resetsAt": 1785913699}
-    assert codex_appserver._reset_text(window) == claude._reset_text(window)
-    assert re.fullmatch(r"[a-z]{3} \d{1,2} at \d{1,2}:\d{2}(am|pm)",
-                        codex_appserver._reset_text(window))
-
-
-@pytest.mark.parametrize("stamp", [None, 0, "", "later", -(10 ** 18)])
-def test_an_unusable_reset_stamp_reads_as_empty(stamp):
-    assert codex_appserver._reset_text({"resetsAt": stamp}) == ""
-
-
-# the transport
-
-def test_call_returns_the_reply_for_its_own_id():
-    proc = FakeProc({"account/rateLimits/read": {"result": REAL_PAYLOAD}})
-    server = _server(proc)
-    assert server.call("account/rateLimits/read", {}) == REAL_PAYLOAD
-    assert proc.written[0]["id"] == 1
-
-
-def test_read_rate_limits_maps_a_live_reply():
-    server = _server(FakeProc({"account/rateLimits/read": {"result": REAL_PAYLOAD}}))
-    assert server.read_rate_limits() == QuotaSnapshot(
-        session_pct=3, week_pct=0,
-        session_reset=codex_appserver._reset_text({"resetsAt": 1785913699}), week_reset="",
-    )
-
-
-def test_read_rate_limits_returns_none_on_a_server_error():
-    server = _server(FakeProc({"account/rateLimits/read":
-                               {"error": {"code": -32603, "message": "not signed in"}}}))
-    assert server.read_rate_limits() is None
-
-
-def test_read_rate_limits_returns_none_when_the_server_dies():
-    proc = FakeProc()  # answers nothing
-    server = _server(proc, timeout=5.0)
-    proc.hang_up()
-    assert server.read_rate_limits() is None
-
-
-def test_read_rate_limits_returns_none_on_timeout():
-    server = _server(FakeProc(), timeout=0.05)
-    assert server.read_rate_limits() is None
-
-
-def test_call_raises_where_the_quota_read_swallows():
-    """The never-raise contract belongs to the quota read, not to the transport underneath it."""
-    server = _server(FakeProc({"thread/start": {"error": {"code": -1, "message": "nope"}}}))
-    with pytest.raises(codex_appserver.AppServerError):
-        server.start_thread(cwd="/tmp")
-
-
-def test_start_thread_returns_the_nested_id():
-    proc = FakeProc({"thread/start": {"result": {"thread": {"id": "th_123"}}}})
-    server = _server(proc)
-    assert server.start_thread(cwd="/tmp", model=None, ephemeral=True) == "th_123"
-    assert proc.written[0]["params"] == {"cwd": "/tmp", "ephemeral": True}  # None is dropped
-
-
-def test_start_turn_sends_the_input_block():
-    """No `effort` argument (today's call shape): the params carry no `effort` key at all, not
-    even a null one — a request naming neither `thinking` nor `reasoning_effort` must produce
-    byte-identical `turn/start` params to before this field existed."""
-    proc = FakeProc({"turn/start": {"result": {}}})
-    _server(proc).start_turn("th_123", "hello")
-    assert proc.written[0]["params"] == {"threadId": "th_123",
-                                         "input": [{"type": "text", "text": "hello"}]}
-
-
-def test_start_turn_carries_effort_when_one_was_resolved():
-    """Regression: the codex seat read reasoning token counts back out but never set effort going
-    in (grep confirmed no caller passed `effort` to `turn/start`). It rides this per-turn request,
-    not config.toml — a session setting would apply to every turn, not just this request."""
-    proc = FakeProc({"turn/start": {"result": {}}})
-    _server(proc).start_turn("th_123", "hello", effort="high")
-    assert proc.written[0]["params"] == {"threadId": "th_123",
-                                         "input": [{"type": "text", "text": "hello"}],
-                                         "effort": "high"}
-
-
-def test_start_turn_treats_a_falsy_effort_the_same_as_none():
-    proc = FakeProc({"turn/start": {"result": {}}})
-    _server(proc).start_turn("th_123", "hello", effort="")
-    assert "effort" not in proc.written[0]["params"]
-
-
-def test_notifications_are_collected_not_mistaken_for_replies():
-    proc = FakeProc({"account/rateLimits/read": {"result": REAL_PAYLOAD}})
-    server = _server(proc)
-    proc.push({"method": "account/rateLimits/updated", "params": {"rateLimits": {}}})
-    assert _wait_for(lambda: server.notifications)
-    assert server.read_rate_limits() is not None      # the notification did not consume the reply
-    assert [n["method"] for n in server.drain_notifications()] == ["account/rateLimits/updated"]
-    assert server.drain_notifications() == []
-
-
-def test_a_server_request_is_refused_rather_than_left_hanging():
-    """The server can ask the client for an approval. A headless seat has nobody to ask, and
-    silence would hang the turn — so it must answer with an error."""
-    proc = FakeProc()
-    _server(proc)
-    proc.push({"id": 77, "method": "execCommandApproval", "params": {}})
-    assert _wait_for(lambda: proc.written)
-    assert proc.written[0]["id"] == 77
-    assert proc.written[0]["error"]["code"] == codex_appserver.UNSUPPORTED_REQUEST
-
-
-def test_junk_lines_do_not_kill_the_reader():
-    proc = FakeProc({"account/rateLimits/read": {"result": REAL_PAYLOAD}})
-    server = _server(proc)
-    proc.stdout.lines.put("not json at all\n")
-    proc.stdout.lines.put("[1, 2, 3]\n")
-    assert server.read_rate_limits() is not None
-
-
-# start / stop
-
-def test_stop_kills_the_process_group(monkeypatch):
-    """Process group, not process: codex spawns children that a bare terminate would orphan."""
-    killed = []
-    monkeypatch.setattr(codex_appserver.os, "killpg", lambda pid, sig: killed.append((pid, sig)))
-    proc = FakeProc(alive=True)
-    _server(proc).stop()
-    assert killed == [(proc.pid, codex_appserver.signal.SIGTERM)]
-    assert proc.stdin_closed
-
-
-def test_stop_is_a_no_op_when_the_process_already_exited(monkeypatch):
-    monkeypatch.setattr(codex_appserver.os, "killpg",
-                        lambda pid, sig: pytest.fail("killed an already-dead pid"))
-    _server(FakeProc(alive=False)).stop()
-
-
-def _fake_popen(monkeypatch, proc, seen):
-    monkeypatch.setattr(codex_appserver.cli_seat, "seat_bin", lambda spec: "/fake/codex")
-    def popen(argv, **kwargs):
-        seen.append((argv, kwargs))
-        return proc
-    monkeypatch.setattr(codex_appserver.subprocess, "Popen", popen)
-
-
-def test_start_handshakes_before_anything_else(monkeypatch, tmp_path):
-    proc = FakeProc({"initialize": {"result": {}}})
-    seen = []
-    _fake_popen(monkeypatch, proc, seen)
-
-    server = codex_appserver.start_app_server(home=tmp_path)
-    argv, kwargs = seen[0]
-    assert argv == ["/fake/codex", "app-server", "--stdio"]
-    assert kwargs["env"]["CODEX_HOME"] == str(tmp_path)
-    assert kwargs["start_new_session"] is True
-    assert proc.written[0]["method"] == "initialize"
-    assert proc.written[0]["params"]["clientInfo"]["name"] == codex_appserver.CLIENT_NAME
-    assert proc.written[1]["method"] == "initialized"
-    assert "id" not in proc.written[1]              # a notification, never answered
-    server.stop()
-
-
-def test_a_failed_handshake_does_not_leave_a_process_behind(monkeypatch, tmp_path):
-    proc = FakeProc({"initialize": {"error": {"code": -1, "message": "bad client"}}})
-    _fake_popen(monkeypatch, proc, [])
-    with pytest.raises(codex_appserver.AppServerError):
-        codex_appserver.start_app_server(home=tmp_path)
-    assert proc.stdin_closed
-
-
-def test_read_quota_reads_once_and_shuts_down(monkeypatch, tmp_path):
-    proc = FakeProc({"initialize": {"result": {}},
-                     "account/rateLimits/read": {"result": REAL_PAYLOAD}})
-    _fake_popen(monkeypatch, proc, [])
-    assert codex_appserver.read_quota(home=tmp_path).session_pct == 3
-    assert proc.stdin_closed
-
-
-def test_read_quota_returns_none_when_the_binary_is_missing(monkeypatch):
-    monkeypatch.setattr(codex_appserver.cli_seat, "seat_bin", lambda spec: None)
-    assert codex_appserver.read_quota() is None
-
-
-def test_read_quota_returns_none_when_the_process_will_not_start(monkeypatch, tmp_path):
-    monkeypatch.setattr(codex_appserver.cli_seat, "seat_bin", lambda spec: "/fake/codex")
-    monkeypatch.setattr(codex_appserver.subprocess, "Popen",
-                        lambda argv, **kwargs: (_ for _ in ()).throw(OSError("no such file")))
-    assert codex_appserver.read_quota(home=tmp_path) is None
-
-
-@pytest.mark.canary
-def test_the_real_app_server_reports_a_quota():
-    """Runs the operator's own signed-in codex. Opt in with `-m canary`."""
-    snapshot = codex_appserver.read_quota()
-    assert snapshot is not None, "app-server returned no rate limits — is the seat signed in?"
-    assert 0 <= snapshot.session_pct <= 100
+def test_respond_handles_none_params():
+    """params=None must not crash — some server requests may omit it."""
+    server = _make_server()
+    server._respond_to_server(5, "item/tool/call", params=None)
+    sent = server._send.call_args[0][0]
+    assert sent["result"]["success"] is False

--- a/tests/test_codex_config.py
+++ b/tests/test_codex_config.py
@@ -1,0 +1,26 @@
+"""Tests for the codex seat's CONFIG_TOML — the lockdown written to ~/.grid/seats/codex-cli/."""
+import tomllib
+
+from shared.agent.seats import codex
+
+
+def test_config_blocks_apply_patch():
+    """apply_patch has no [features] flag (unlike shell_tool), so it must be blocked via the
+    [apps] config — 'blocked by app configuration' is cleaner than the generic JSON-RPC error."""
+    config = tomllib.loads(codex.CONFIG_TOML)
+    tools = config.get("apps", {}).get("_default", {}).get("tools", {})
+    assert tools.get("apply_patch", {}).get("enabled") is False
+
+
+def test_config_still_disables_shell_tool():
+    """shell_tool has its own feature flag and must stay disabled."""
+    config = tomllib.loads(codex.CONFIG_TOML)
+    assert config.get("features", {}).get("shell_tool") is False
+
+
+def test_config_is_valid_toml():
+    """The CONFIG_TOML string must parse without error."""
+    config = tomllib.loads(codex.CONFIG_TOML)
+    assert isinstance(config, dict)
+    assert config.get("approval_policy") == "untrusted"
+    assert config.get("sandbox_mode") == "read-only"


### PR DESCRIPTION
## What

Three independent fixes for the CLI seats, executed in parallel:

### Phase 1: `_flatten_content` marks tool_use as "omitted" (bug)
`_flatten_content()` didn't recognise `tool_use`/`tool_result` blocks → replaced them with `"[tool_use block omitted]"` in conversation history. The model saw this marker in multi-turn history and stopped using tools.

**Fix:** Skip these block types — `build_prompt` already renders them separately.

### Phase 2: Claude receives flat text instead of structured messages
Claude CLI supports `--input-format stream-json` (structured messages via stdin) but the seat sent flat text (`"User: ...\n\nAssistant: ..."`). 

**Fix:** 
- `PreparedRequest` now carries `messages` (raw) + `tool_text` (rendered tool protocol)
- New `to_stream_json()` converter: OpenAI messages → Claude stream-json lines
- `invoke()` uses `--input-format stream-json` with structured stdin

### Phase 3: Codex tool refusal returns cryptic errors
Codex's `apply_patch` has no config flag to disable it. When the model calls it, `_refuse()` returned generic error -32601.

**Fix:**
- `CONFIG_TOML`: `[apps._default.tools.apply_patch] enabled = false` — blocks at call time with clean message
- `_refuse` → `_respond_to_server`: returns proper JSON-RPC responses per method (`decline` for approvals, `{permissions: {}}` for permissions, redirect for tool calls)
- Fixed stale docstring (`developerInstructions` → `baseInstructions`)

## Changes

| File | Lines |
|---|---|
| `shared/agent/cli_seat.py` | +9 (flatten fix + PreparedRequest fields) |
| `shared/agent/seats/claude.py` | +62 (to_stream_json + invoke rewrite) |
| `shared/agent/seats/codex.py` | +11 (CONFIG_TOML apply_patch + docstring) |
| `shared/agent/seats/codex_appserver.py` +20 (_respond_to_server) |
| Tests: +126 lines across 3 files |

## Test results
- **156 passed** (test_cli_seat + test_codex_config + test_codex_appserver)
- `ruff check` clean
- 1 pre-existing unrelated failure (`test_launch_does_not_judge_which_models_a_grid_serves`)

## Plan
Full implementation plan: `docs/superpowers/plans/2026-08-01-seat-tool-and-context-fixes.md`