### PR TITLE
feat(heartbeat): report GPU thermals, disk and measured throughput

### DIFF
--- a/remote/serve.py
+++ b/remote/serve.py
@@ -26,7 +26,7 @@ from typing import Any, Callable
 
 from remote import (
     api_keys, bringup, control_plane, credentials, engine_health, probe, relay, service_truth,
-    codex_auth, codex_oauth,
+    codex_auth, codex_oauth, throughput,
 )
 from shared.handlers import HANDLERS
 from shared import run_records
@@ -1428,6 +1428,11 @@ class _ServeState:
         # Loopback URLs of this identity's CLI seats, read once at startup — the heartbeat asks
         # each for its allowance. Empty for an identity that serves no seat.
         self._seat_urls: list[str] = []
+        # Decode rate (tokens/sec) of the most recently served request that could be timed, guarded
+        # by _lock. None until this node has actually served one — the grid page then shows nothing,
+        # which is the truth: a node that has answered nothing has no measured throughput. Deliberately
+        # the LATEST sample rather than an average, so the figure tracks what the node is doing now.
+        self._tok_s: float | None = None
 
     def set_codex_quota(self, quota: dict[str, Any]) -> None:
         """Record the seat's latest rate-limit snapshot; the next heartbeat carries it to the relay.
@@ -1551,6 +1556,19 @@ class _ServeState:
         with self._lock:
             self._sweep = result
 
+    def set_throughput(self, tok_s: float | None) -> None:
+        """Record the decode rate of the request that just finished. Called from every poll worker,
+        so it takes the lock; ``None`` (an unmeasurable job — media, a reply too short to time) is
+        ignored rather than clearing, so one un-timeable request does not blank the gauge."""
+        if tok_s is None or tok_s <= 0:
+            return
+        with self._lock:
+            self._tok_s = float(tok_s)
+
+    def throughput(self) -> float | None:
+        with self._lock:
+            return self._tok_s
+
     def load(self) -> dict[str, Any]:
         with self._lock:
             load = {"active_tasks": self._inflight}
@@ -1569,6 +1587,12 @@ class _ServeState:
         load.update(gpu.load_snapshot())
         # OS/arch so the grid knows what a node runs: linux / macos-arm64 / macos-x86_64 / windows / other.
         load["platform"] = host.platform_kind()
+        load.update(_disk_load())
+        # Decode throughput measured on this node's OWN traffic (never a synthetic benchmark), absent
+        # until a real request has been served — see `throughput.py`.
+        tok_s = self.throughput()
+        if tok_s is not None:
+            load["tok_s"] = round(tok_s, 1)
         # Codex seat quota (when this engine serves a seat) — surfaced per-node on /grid/overview. The
         # value only changes on a served response / the join seed; the heartbeat just re-ships the last.
         if codex_quota:
@@ -2113,7 +2137,8 @@ def handle_job(state: _ServeState, job: dict[str, Any]) -> None:
         elif is_stream:
             _forward_stream(state, txn, "messages" if wire_format == "anthropic" else endpoint,
                             forward_body, read_timeout, target,
-                            headers=_forward_headers(state, target, snap), api_kind=api_kind)
+                            headers=_forward_headers(state, target, snap), api_kind=api_kind,
+                            measure=True)
         else:
             _forward_whole(state, txn, "messages" if wire_format == "anthropic" else endpoint,
                            forward_body, read_timeout, target,
@@ -2370,10 +2395,18 @@ def _forward_responses_stream(
             if on_headers is not None:
                 on_headers(resp.headers)
             if resp.status_code == 200:
+                # Metered like the chat stream, and reachable by every kind that serves the dialect —
+                # an openai engine, a local engine whose `/responses` probe succeeded, and the codex
+                # seat, which reaches this function through `_forward_codex`. The blocks are already
+                # whole events here, but the meter re-splits on newlines regardless, so it needs no
+                # knowledge of which forward it is wrapping.
+                meter = throughput.StreamMeter()
                 _submit_response(
                     state, txn, stream=True,
-                    content=_traced_stream(txn, _iter_event_blocks(resp.iter_bytes())),
+                    content=_traced_stream(txn, _iter_event_blocks(meter.measure(resp.iter_bytes()))),
                 )
+                meter.flush()
+                state.set_throughput(meter.tok_s)
                 return None
             resp.read()  # drain inside the context so .text is readable after it closes
             return _UpstreamFailure(resp.status_code, resp.headers, resp.text)
@@ -2436,6 +2469,38 @@ def _forward_codex(
         return
 
 
+def _disk_load() -> dict[str, float]:
+    """``disk_total_gb`` / ``disk_used_gb`` for the volume holding this node's model store.
+
+    Measured at ``paths.models_dir()``, not at ``~``: a box with its models on a separate NVMe would
+    otherwise report the home volume, which is not the space the next `grid pull` consumes. Walks up
+    to the first directory that exists, since the store is created lazily and a node can heartbeat
+    before it has pulled anything.
+
+    The measurement itself is `host.disk_gb`, which carries this repo's psutil→``statvfs`` ladder —
+    psutil is optional here, so calling it directly would report nothing on every box without it.
+    One ``statvfs`` per heartbeat, which is why nothing is memoized: unlike the GPU probe there is no
+    process to spawn, and caching the total would still leave usage needing the same call.
+
+    Returns ``{}`` on any failure — a node that cannot stat its own volume reports no disk rather
+    than zeros, which the grid page would render as a full drive.
+    """
+    try:
+        from shared import paths
+        from shared.system import host
+
+        target = paths.models_dir()
+        while not target.exists() and target != target.parent:
+            target = target.parent
+        measured = host.disk_gb(str(target))
+    except Exception:  # noqa: BLE001 — telemetry must never fail a heartbeat
+        return {}
+    if measured is None:
+        return {}
+    total_gb, used_gb = measured
+    return {"disk_total_gb": total_gb, "disk_used_gb": used_gb}
+
+
 def _forward_whole(
     state: _ServeState, txn: str, endpoint: str, body: dict[str, Any], read_timeout: float, target_url: str,
     headers: dict[str, str], api_kind: str | None = None,
@@ -2443,22 +2508,36 @@ def _forward_whole(
     import httpx
 
     timeout = httpx.Timeout(connect=10, read=read_timeout, write=30, pool=10)
+    started = time.monotonic()
     with httpx.Client(timeout=timeout) as client:
         resp = client.post(f"{target_url}/{endpoint}", json=body, headers=headers)
     if resp.status_code != 200:
         _warn_api_auth_failure(api_kind, resp.status_code)
         _try_submit_error(state, txn, f"engine error {resp.status_code}: {resp.text[:200]}")
         return
+    # Every caller of this forward is a text dialect (chat, anthropic /messages, non-stream
+    # responses) — media never reaches here — so the reply always has a usage object to read, in one
+    # spelling or another. Measured before the submit so a relay-side failure doesn't cost the sample.
+    state.set_throughput(throughput.whole_body_tok_s(resp.content, time.monotonic() - started))
     _submit_response(state, txn, content=resp.content, stream=False)
 
 
 def _forward_stream(
     state: _ServeState, txn: str, endpoint: str, body: dict[str, Any], read_timeout: float, target_url: str,
-    headers: dict[str, str], api_kind: str | None = None,
+    headers: dict[str, str], api_kind: str | None = None, measure: bool = False,
 ) -> None:
+    """Forward one streamed job, passing the engine's SSE bytes through verbatim.
+
+    ``measure`` times the decode rate for the node's `tok_s`. It is opt-in per call site rather than
+    always-on because THIS function also carries media: a ComfyUI reply is a multi-megabyte base64
+    image in a single unbroken SSE line, and a meter hunting that line for a newline would buffer the
+    whole image. Media has no tokens to count anyway, so the media call site simply leaves it off and
+    the meter never sees those bytes.
+    """
     import httpx
 
     timeout = httpx.Timeout(connect=10, read=read_timeout, write=None, pool=10)
+    meter = throughput.StreamMeter() if measure else None
     with httpx.Client(timeout=timeout) as client:
         with client.stream(
             "POST", f"{target_url}/{endpoint}", json=body, headers=headers,
@@ -2471,8 +2550,16 @@ def _forward_stream(
             # Pass the engine's SSE bytes straight through while its stream is open. A streamed 401 can't
             # replay the iterator, so `_submit_response` re-raises it; `handle_job` then reports via
             # `_try_submit_error` so the consumer still gets a terminal signal.
-            _submit_response(state, txn, content=_traced_stream(txn, engine_resp.iter_bytes()), stream=True)
+            chunks = engine_resp.iter_bytes()
+            if meter is not None:
+                chunks = meter.measure(chunks)
+            _submit_response(state, txn, content=_traced_stream(txn, chunks), stream=True)
             _debug(f"stream txn={txn} submit_response returned (relay accepted the full stream) t={time.time():.3f}")
+    # After the submit returned, so a stream that died mid-flight (which re-raises out of
+    # `_submit_response`) records nothing rather than a rate computed from a truncated reply.
+    if meter is not None:
+        meter.flush()
+        state.set_throughput(meter.tok_s)
 
 
 # Defensive bound on one buffered SSE event block: the real stream's largest block is ~1.4 KB of

--- a/remote/throughput.py
+++ b/remote/throughput.py
@@ -1,0 +1,187 @@
+"""Decode throughput (tokens/sec) measured on this node's own served traffic.
+
+The figure the grid page shows per node. It is measured, never benchmarked: a synthetic warm-up
+request describes a machine that was idle at start-up, while what an operator wants to know is how
+fast the node is answering *now*, under whatever load it actually has.
+
+**Two clocks, not one.** A request's wall time is prompt processing plus decode; dividing tokens by
+all of it reports a slower node whenever the prompt is long, even though nothing about the GPU
+changed. So the streaming meter starts its clock at the FIRST token, not at the request — the
+interval it divides by is decode alone. The whole-body path cannot see that boundary (the engine
+returns one object), so it prefers llama.cpp's own `timings.predicted_per_second`, which the engine
+measured with the same distinction, and only falls back to wall-clock when the engine says nothing.
+
+**Every dialect, one extractor.** The provider forwards four request shapes and each spells the
+generated-token count differently:
+
+    usage.completion_tokens         OpenAI chat/completions (stream and whole)
+    usage.output_tokens             Anthropic /messages, OpenAI /responses (whole)
+    response.usage.output_tokens    OpenAI /responses (stream, `response.completed`)
+
+`completion_tokens_from` reads all three, so a caller never has to know which wire it is on.
+
+**The LAST usage wins.** Anthropic streams `usage` twice — `message_start` carries
+`output_tokens: 1` before anything is generated, `message_delta` carries the final count. Taking the
+first would report ~1 token/sec for every Anthropic request, so the meter keeps overwriting.
+
+Nothing here can change what the consumer receives: the meter is a pass-through generator that
+yields its input byte for byte. Measurement that alters the stream it measures is not measurement.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any, Iterable, Iterator
+
+# Below this many generated tokens a sample is noise, not a measurement: the interval between the
+# first token and the last is then a handful of milliseconds, and normal jitter in it swings the
+# quotient by an order of magnitude. Such a request leaves the previous (real) figure standing rather
+# than replacing it with a number that would swing the gauge on every one-word reply.
+MIN_TOKENS = 16
+
+# Largest partial line the stream meter will buffer while hunting for a newline. Text SSE lines are
+# tiny (one delta each), so this is never approached in practice — it exists so that a stream which
+# somehow contains an enormous unbroken line degrades to "not measured" instead of accumulating it in
+# memory. The media path, whose events really are megabytes of base64, is never metered at all.
+_MAX_LINE = 1024 * 1024
+
+
+def _positive_int(value: Any) -> int | None:
+    """A token count, or None. `bool` is rejected despite subclassing `int` — a payload carrying
+    `output_tokens: true` means nothing, and 1 would look like a real (and absurd) measurement."""
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        return None
+    return value
+
+
+def completion_tokens_from(payload: Any) -> int | None:
+    """Generated-token count out of any of the dialects above, or None when the payload carries none.
+
+    Checked in order, first hit wins; the `response` nesting is the Responses stream's terminal
+    event. Returning None is the normal outcome for most events in a stream — only the terminal one
+    carries usage — and for whole dialects that report nothing, which is exactly when the caller must
+    decline to report a throughput rather than invent one.
+    """
+    if not isinstance(payload, dict):
+        return None
+    for holder in (payload, payload.get("response")):
+        if not isinstance(holder, dict):
+            continue
+        usage = holder.get("usage")
+        if not isinstance(usage, dict):
+            continue
+        for key in ("completion_tokens", "output_tokens"):
+            tokens = _positive_int(usage.get(key))
+            if tokens is not None:
+                return tokens
+    return None
+
+
+def _tokens_from_line(line: bytes) -> int | None:
+    """Token count out of one SSE line, or None. Accepts a bare JSON object too, so the same scanner
+    reads the block-aligned Responses stream and the raw chat stream."""
+    line = line.strip()
+    if line.startswith(b"event:"):  # a Responses block's event-name line carries no payload
+        return None
+    if line.startswith(b"data:"):
+        line = line[len(b"data:"):].strip()
+    if not line or line == b"[DONE]" or not line.startswith(b"{"):
+        return None
+    try:
+        payload = json.loads(line)
+    except (ValueError, UnicodeDecodeError):
+        return None
+    return completion_tokens_from(payload)
+
+
+class StreamMeter:
+    """Times one streamed response while passing its bytes through untouched.
+
+    Wrap the engine's chunk iterator with `measure`, then read `tok_s` once it is exhausted. The
+    result is None whenever the stream carried no usage, was too short to time (`MIN_TOKENS`), or
+    produced its tokens in no measurable interval.
+    """
+
+    def __init__(self) -> None:
+        self._first: float | None = None
+        self._last: float | None = None
+        self._tokens: int | None = None
+        self._buf = b""
+        self._overflowed = False
+
+    def measure(self, chunks: Iterable[bytes]) -> Iterator[bytes]:
+        """Yield `chunks` verbatim, timing them on the way past. The invariant this must never break
+        is ``b"".join(measure(x)) == b"".join(x)`` — the relay re-splits these bytes itself and
+        refuses smuggled bare-CR, so a meter that "helpfully" normalised anything would mask the very
+        thing that sanitiser exists to catch."""
+        for chunk in chunks:
+            now = time.monotonic()
+            if self._first is None:
+                self._first = now
+            self._last = now
+            self._scan(chunk)
+            yield chunk
+
+    def _scan(self, chunk: bytes) -> None:
+        """Accumulate and read complete lines. Chunk boundaries are arbitrary — `iter_bytes` splits
+        wherever the socket did, so a `data:` line routinely arrives in two pieces and scanning each
+        chunk alone would miss most of them."""
+        if self._overflowed:
+            return
+        self._buf += chunk
+        while (index := self._buf.find(b"\n")) != -1:
+            line, self._buf = self._buf[:index], self._buf[index + 1:]
+            tokens = _tokens_from_line(line)
+            if tokens is not None:
+                self._tokens = tokens  # last usage wins — see the module docstring
+        if len(self._buf) > _MAX_LINE:
+            self._overflowed = True
+            self._buf = b""
+
+    @property
+    def tok_s(self) -> float | None:
+        if self._tokens is None or self._tokens < MIN_TOKENS:
+            return None
+        if self._first is None or self._last is None:
+            return None
+        elapsed = self._last - self._first
+        if elapsed <= 0:
+            return None
+        return self._tokens / elapsed
+
+    def flush(self) -> None:
+        """Scan whatever is left in the buffer. A stream whose last line has no trailing newline
+        holds its usage there, so call this once the iterator is exhausted."""
+        if self._overflowed or not self._buf:
+            return
+        tokens = _tokens_from_line(self._buf)
+        self._buf = b""
+        if tokens is not None:
+            self._tokens = tokens
+
+
+def whole_body_tok_s(content: bytes, elapsed: float) -> float | None:
+    """Decode rate for a non-streamed reply, or None when it cannot be measured.
+
+    llama.cpp's `timings.predicted_per_second` is preferred and is not merely a shortcut: the engine
+    measured decode with prompt processing already excluded, which is precisely the distinction this
+    path otherwise cannot make. Every other engine falls back to tokens over wall-clock, which
+    understates the rate on a long prompt — honest but approximate, and the best available when the
+    engine reports one number and no timings.
+    """
+    try:
+        payload = json.loads(content)
+    except (ValueError, UnicodeDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    timings = payload.get("timings")
+    if isinstance(timings, dict):
+        rate = timings.get("predicted_per_second")
+        if not isinstance(rate, bool) and isinstance(rate, (int, float)) and rate > 0:
+            return float(rate)
+    tokens = completion_tokens_from(payload)
+    if tokens is None or tokens < MIN_TOKENS or elapsed <= 0:
+        return None
+    return tokens / elapsed

--- a/shared/system/apple.py
+++ b/shared/system/apple.py
@@ -1,9 +1,13 @@
-"""Apple Silicon hardware probes: chip/model names and GPU core count.
+"""Mac hardware probes: chip/model names, GPU core count, and live GPU counters.
 
 macOS does not expose the marketing chip name ("Apple M3 Max") or the machine
 model ("MacBook Pro (Mac15,9)") through ``platform`` — it only reports "arm64".
 ``system_profiler`` carries both, and the Apple GPU core count appears only in
 ``SPDisplaysDataType`` (no other API reports it).
+
+Live GPU counters come from the IORegistry (`accelerator_stats`), which — unlike
+the ``powermetrics`` this module's author first assumed — needs **no elevated
+privileges**. See that function for what is and is not actually gated.
 
 Every probe is best-effort and never raises — a missing fact is "" or ``None``
 and the caller degrades gracefully.
@@ -12,6 +16,7 @@ and the caller degrades gracefully.
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 
 
@@ -63,3 +68,67 @@ def gpu_core_count() -> int | None:
             except (ValueError, IndexError):
                 return None
     return None
+
+
+# One `"PerformanceStatistics" = { ... }` block from `ioreg`, and the `"key"=<int>` pairs inside it.
+# The dictionary is printed on a single line per accelerator, so a non-greedy match to the first
+# closing brace takes exactly one device's block.
+_PERF_BLOCK = re.compile(r'"PerformanceStatistics"\s*=\s*\{(.*?)\}')
+_PERF_PAIR = re.compile(r'"([^"]+)"\s*=\s*(-?\d+)')
+
+# What each counter is called in the IORegistry. Several spellings per reading because the key set is
+# the GPU driver's, not macOS's: an AMD card names its load `Device Utilization %`, and some drivers
+# only publish `GPU Activity(%)`. First key present wins, so a driver publishing neither simply
+# reports nothing for that reading rather than a zero it never measured.
+_STAT_KEYS: dict[str, tuple[str, ...]] = {
+    "vram_used_bytes": ("inUseVidMemoryBytes",),
+    "gpu_util": ("Device Utilization %", "GPU Activity(%)"),
+    "gpu_temp_c": ("Temperature(C)", "GPU Core Temperature(C)"),
+    "gpu_power_w": ("Total Power(W)",),
+}
+
+
+def accelerator_stats(timeout: float = 5.0) -> dict[str, float]:
+    """Live GPU counters from the IORegistry, as whichever of ``vram_used_bytes``, ``gpu_util``,
+    ``gpu_temp_c`` and ``gpu_power_w`` this machine actually publishes. ``{}`` off macOS or when
+    nothing is readable.
+
+    **No privileges required, and that is the correction this function exists to make.** The obvious
+    macOS answer for GPU telemetry is ``powermetrics``, which does need root — so it is easy to
+    conclude that a Mac provider simply cannot report load or temperature without it. That is wrong:
+    ``IOAccelerator``'s ``PerformanceStatistics`` dictionary is world-readable, and on an Intel Mac
+    with a discrete card it carries VRAM occupancy, utilisation, die temperature and power draw. It
+    was measured on a real box before this was written, not assumed.
+
+    **Values are maxed across accelerators, never summed.** ``ioreg`` lists the same physical GPU
+    more than once (the accelerator and its subclasses each carry a copy of the statistics), so
+    summing power would report a 22W card as drawing 44W and summing VRAM would double its
+    occupancy. Max is duplicate-safe, and on a Mac pairing an integrated GPU with a discrete one it
+    also picks the discrete card — the one doing the work.
+
+    ``vramFreeBytes`` is deliberately ignored despite sitting right beside the occupancy figure: it
+    counts free bytes within the currently committed pool, not against the card's advertised size
+    (on the measured box, used + free came to ~950 MB of a 4 GB card). Pairing it with the
+    ``system_profiler`` total would state a headroom nothing measured.
+    """
+    raw = _run(["ioreg", "-r", "-d", "1", "-w", "0", "-c", "IOAccelerator"], timeout=timeout)
+    if not raw:
+        return {}
+    best: dict[str, float] = {}
+    for block in _PERF_BLOCK.finditer(raw):
+        stats = dict(_PERF_PAIR.findall(block.group(1)))
+        for name, candidates in _STAT_KEYS.items():
+            for key in candidates:
+                if key not in stats:
+                    continue
+                try:
+                    value = float(stats[key])
+                except ValueError:
+                    break
+                # A zero here is ambiguous — an idle GPU and a device that publishes the key without
+                # populating it look identical — so it never displaces a positive reading from
+                # another accelerator, and only stands if nothing better is found.
+                if name not in best or value > best[name]:
+                    best[name] = value
+                break
+    return best

--- a/shared/system/gpu.py
+++ b/shared/system/gpu.py
@@ -8,7 +8,7 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
-from shared.system import arch
+from shared.system import apple, arch
 
 
 @dataclass
@@ -303,12 +303,11 @@ def load_snapshot(timeout: float = 3.0) -> dict[str, float]:
     — Apple Silicon unified memory (``hw.memsize``) or an Intel Mac's discrete VRAM (``system_profiler``)
     — so Mac providers still surface VRAM. Returns ``{}`` on a box with no detectable GPU.
 
-    **Every key is emitted only when it was measured.** The Mac branch reports VRAM *total* alone: macOS
-    exposes neither GPU utilisation nor per-process VRAM without a root ``powermetrics``, so the
-    ``memory_used_mb: 0.0`` / ``gpu_util: 0.0`` this branch used to send were invented, not observed.
-    They were harmless while the grid page only read the total, but the moment anything renders a gauge
-    they make every Mac look like a dead node holding 128 GB it never uses. Absent is the honest wire
-    value for "this platform cannot tell you", and it is what the page needs to show nothing."""
+    **Every key is emitted only when it was measured.** This branch used to send a hardcoded
+    ``memory_used_mb: 0.0`` / ``gpu_util: 0.0`` on macOS — invented, not observed. Harmless while the
+    grid page read only the total, but the moment anything renders a gauge they make every Mac look
+    like a dead node holding 128 GB it never uses. A Mac now reports what it can genuinely measure
+    (`_mac_telemetry`, which reads the IORegistry and needs no privileges) and omits the rest."""
     gpus = enumerate_gpus(timeout=timeout)
     if gpus:
         return {
@@ -320,33 +319,49 @@ def load_snapshot(timeout: float = 3.0) -> dict[str, float]:
         }
     mac_mb = _macos_vram_mb(timeout=timeout)
     if mac_mb:
-        snapshot = {"gpu_count": 1.0, "memory_total_mb": mac_mb}
-        used_mb = _mac_memory_used_mb()
-        if used_mb is not None:
-            snapshot["memory_used_mb"] = min(used_mb, mac_mb)
-        return snapshot
+        return {"gpu_count": 1.0, "memory_total_mb": mac_mb, **_mac_telemetry(mac_mb, timeout)}
     return {}
 
 
-def _mac_memory_used_mb() -> float | None:
-    """How much of a Mac's advertised VRAM is in use, or None when that is unknowable.
+def _mac_telemetry(total_mb: float, timeout: float) -> dict[str, float]:
+    """A Mac's live GPU counters, in the same key names the NVIDIA branch uses.
 
-    **Apple Silicon only, and that asymmetry is the point.** There, the advertised VRAM IS
-    ``hw.memsize`` — the GPU shares one unified pool with the CPU (the premise `_macos_vram_mb`
-    already rests on), so system memory in use is exactly the figure that decides whether another
-    model fits. Reporting it gives a Mac node a real memory gauge instead of a total with nothing
-    to compare it against.
+    Utilisation, temperature and power come from the IORegistry (`apple.accelerator_stats`) and need
+    no privileges — see that function, which corrects the assumption that ``powermetrics`` and root
+    are the only way to read them on macOS.
 
-    On an **Intel Mac** the same reasoning inverts: the advertised figure is a discrete/integrated
-    card's own VRAM from ``system_profiler``, a separate pool from system RAM. Filling that bar with
-    RAM usage would show a number measured on the wrong memory, which is worse than showing none —
-    so this returns None and the gauge stays absent.
+    **Memory occupancy is read from a different place per architecture, so that `used` and `total`
+    always describe the same pool.** Getting this wrong is the failure mode worth spelling out: the
+    two are divided and drawn as one bar, so a mismatched pair renders a confident percentage of
+    nothing.
 
-    Neither path can read *GPU* allocation specifically; macOS keeps that behind a root
-    ``powermetrics``, and no amount of probing here changes that."""
-    if platform.system() != "Darwin" or arch.native_machine() != "arm64":
-        return None
-    from shared.system import host
+    - **Apple Silicon** — the advertised total is ``hw.memsize``, because the GPU shares one unified
+      pool with the CPU (the premise `_macos_vram_mb` already rests on). The matching occupancy is
+      therefore system memory in use. The IORegistry's ``inUseVidMemoryBytes`` is NOT it: on a
+      unified-memory part it tracks a driver allocation, not the pool the total names.
+    - **Intel Mac** — the advertised total is a discrete or integrated card's own VRAM from
+      ``system_profiler``, a pool entirely separate from system RAM. Here ``inUseVidMemoryBytes`` is
+      exactly right and system RAM would be measuring the wrong memory.
 
-    return host.memory_used_mb()
+    Clamped to ``total_mb``: the pair comes from two independent sources, and a bar past its own
+    track is a worse answer than a pinned one.
+    """
+    if platform.system() != "Darwin":
+        return {}
+    stats = apple.accelerator_stats(timeout=timeout)
+    out: dict[str, float] = {}
+    for key in ("gpu_util", "gpu_temp_c", "gpu_power_w"):
+        if key in stats:
+            out[key] = round(stats[key], 1)
+
+    if arch.native_machine() == "arm64":
+        from shared.system import host
+
+        used_mb = host.memory_used_mb()
+    else:
+        used_bytes = stats.get("vram_used_bytes")
+        used_mb = used_bytes / (1024 * 1024) if used_bytes else None
+    if used_mb is not None:
+        out["memory_used_mb"] = round(min(used_mb, total_mb), 1)
+    return out
 

--- a/shared/system/gpu.py
+++ b/shared/system/gpu.py
@@ -6,6 +6,7 @@ import platform
 import shutil
 import subprocess
 from dataclasses import dataclass
+from pathlib import Path
 
 from shared.system import arch
 
@@ -19,6 +20,13 @@ class GpuInfo:
     memory_total_mb: float
     memory_used_mb: float
     utilization_pct: float
+    # Thermals and power, for the grid page's per-node gauges. Optional and defaulted because they
+    # are the ONLY fields here a card may legitimately not report: an integrated GPU (Tegra, GB10)
+    # has no per-card power sensor and answers `[N/A]`, while every discrete card reports both.
+    # Defaults keep every existing positional construction (and its tests) valid.
+    temp_c: float | None = None
+    power_w: float | None = None
+    power_limit_w: float | None = None
 
     @property
     def compute_cap_sm(self) -> str:
@@ -29,40 +37,88 @@ def nvidia_smi_available() -> bool:
     return shutil.which("nvidia-smi") is not None
 
 
-def enumerate_gpus(timeout: float = 5.0) -> list[GpuInfo]:
-    if not nvidia_smi_available():
-        return []
+# The two `--query-gpu` field lists, richest first. The extra three are ancient fields, but
+# `nvidia-smi` answers an unknown/unsupported field by exiting NON-ZERO for the whole invocation
+# rather than blanking that column — so on a platform that rejects one of them, querying them
+# together with VRAM would cost us VRAM too. The legacy list is the exact query this module shipped
+# with, so falling back to it restores the previous behaviour byte for byte.
+_QUERY_FULL = "index,name,driver_version,compute_cap,memory.total,memory.used,utilization.gpu,temperature.gpu,power.draw,power.limit"
+_QUERY_LEGACY = "index,name,driver_version,compute_cap,memory.total,memory.used,utilization.gpu"
+
+# Which query this box accepts, learned once. `None` = not yet determined. Memoized because the
+# probe runs on the heartbeat thread every 30s and a box that rejects the full query would
+# otherwise pay two process spawns forever.
+_QUERY_FIELDS: str | None = None
+
+
+def _optional_num(raw: str) -> float | None:
+    """A `--query-gpu` column that a card may legitimately not report. ``[N/A]``, ``N/A``, an empty
+    column, or anything unparseable all mean "this card has no such sensor" → ``None``.
+
+    Deliberately separate from the strict `float()` calls on the memory/utilisation columns: those
+    are what the node is FOR, and a card that cannot report them is not usable capacity, so it is
+    right that they drop the whole row. A missing thermal sensor is not that."""
+    try:
+        return float(raw)
+    except ValueError:
+        return None
+
+
+def _query_gpus(fields: str, timeout: float) -> list[GpuInfo] | None:
+    """Run one `nvidia-smi` query, or ``None`` if the invocation itself failed (which is what a
+    rejected field looks like — see `_QUERY_FULL`). An empty list means it ran and found no cards."""
     try:
         out = subprocess.check_output(
-            [
-                "nvidia-smi",
-                "--query-gpu=index,name,driver_version,compute_cap,memory.total,memory.used,utilization.gpu",
-                "--format=csv,noheader,nounits",
-            ],
+            ["nvidia-smi", f"--query-gpu={fields}", "--format=csv,noheader,nounits"],
             timeout=timeout,
+            stderr=subprocess.DEVNULL,
         ).decode().strip()
     except (subprocess.SubprocessError, OSError):
-        return []
+        return None
+    expected = fields.count(",") + 1
     gpus: list[GpuInfo] = []
     for line in out.splitlines():
         parts = [part.strip() for part in line.split(",")]
-        if len(parts) != 7:
+        if len(parts) != expected:
             continue
         try:
-            gpus.append(
-                GpuInfo(
-                    index=int(parts[0]),
-                    name=parts[1],
-                    driver_version=parts[2],
-                    compute_cap=parts[3],
-                    memory_total_mb=float(parts[4]),
-                    memory_used_mb=float(parts[5]),
-                    utilization_pct=float(parts[6]),
-                )
+            info = GpuInfo(
+                index=int(parts[0]),
+                name=parts[1],
+                driver_version=parts[2],
+                compute_cap=parts[3],
+                memory_total_mb=float(parts[4]),
+                memory_used_mb=float(parts[5]),
+                utilization_pct=float(parts[6]),
             )
         except ValueError:
             continue
+        if len(parts) > 7:
+            info.temp_c = _optional_num(parts[7])
+            info.power_w = _optional_num(parts[8])
+            info.power_limit_w = _optional_num(parts[9])
+        gpus.append(info)
     return gpus
+
+
+def enumerate_gpus(timeout: float = 5.0) -> list[GpuInfo]:
+    global _QUERY_FIELDS
+    if not nvidia_smi_available():
+        return []
+    if _QUERY_FIELDS is not None:
+        return _query_gpus(_QUERY_FIELDS, timeout) or []
+    gpus = _query_gpus(_QUERY_FULL, timeout)
+    if gpus is not None:
+        _QUERY_FIELDS = _QUERY_FULL
+        return gpus
+    gpus = _query_gpus(_QUERY_LEGACY, timeout)
+    if gpus is not None:
+        _QUERY_FIELDS = _QUERY_LEGACY
+        return gpus
+    # Both failed — nvidia-smi is present but not answering (driver wedged, container without
+    # device access). Learn nothing: the next tick retries the rich query, since this is a
+    # transient condition rather than a statement about which fields the platform supports.
+    return []
 
 
 _MAC_VRAM_MB: float | None = None  # memoized — VRAM total is static per host, and system_profiler is slow
@@ -130,14 +186,129 @@ def _macos_vram_mb(timeout: float = 5.0) -> float:
     return _MAC_VRAM_MB
 
 
+# Substrings that identify a thermal zone / hwmon device as belonging to the GPU rather than to the
+# CPU clusters, the board, or a regulator. Matched case-insensitively against the kernel's own `type`
+# / `name` string. Deliberately narrow: a wrong match reports a CPU's temperature as the GPU's, which
+# is worse than reporting nothing at all.
+_GPU_SENSOR_MARKERS = ("gpu", "gpu-therm", "gpu_thermal")
+
+
+def _read_sysfs_number(path) -> float | None:
+    """One numeric sysfs file, or None if it is absent/unreadable/not a number."""
+    try:
+        return float(path.read_text().strip())
+    except (OSError, ValueError):
+        return None
+
+
+def _sysfs_gpu_temp_c() -> float | None:
+    """GPU die temperature (°C) from the kernel's thermal zones — the fallback for an integrated GPU
+    whose `nvidia-smi` answers `[N/A]` (Tegra, GB10).
+
+    Zones are matched by their `type` string, never by index: zone numbering is board-specific and
+    the zone that is `GPU-therm` on one machine is a CPU cluster on the next. Values are in
+    millidegrees. Returns the hottest matching zone, or None when nothing matches — never a guess."""
+    if platform.system() != "Linux":
+        return None
+    best: float | None = None
+    try:
+        zones = sorted(Path("/sys/class/thermal").glob("thermal_zone*"))
+    except OSError:
+        return None
+    for zone in zones:
+        try:
+            kind = (zone / "type").read_text().strip().lower()
+        except OSError:
+            continue
+        if not any(marker in kind for marker in _GPU_SENSOR_MARKERS):
+            continue
+        milli = _read_sysfs_number(zone / "temp")
+        if milli is None:
+            continue
+        celsius = milli / 1000.0
+        if best is None or celsius > best:
+            best = celsius
+    return best
+
+
+def _sysfs_gpu_power() -> tuple[float | None, float | None]:
+    """(draw, cap) in watts from a GPU hwmon device, both None when no GPU hwmon is recognised.
+
+    Same discipline as the thermal path: the hwmon is identified by its `name`, and an unrecognised
+    one yields nothing rather than a plausible-looking wattage borrowed from a CPU rail. Kernel
+    units are microwatts."""
+    if platform.system() != "Linux":
+        return None, None
+    try:
+        hwmons = sorted(Path("/sys/class/hwmon").glob("hwmon*"))
+    except OSError:
+        return None, None
+    for hwmon in hwmons:
+        try:
+            name = (hwmon / "name").read_text().strip().lower()
+        except OSError:
+            continue
+        if not any(marker in name for marker in _GPU_SENSOR_MARKERS):
+            continue
+        draw = _read_sysfs_number(hwmon / "power1_input")
+        cap = _read_sysfs_number(hwmon / "power1_cap")
+        if cap is None:
+            cap = _read_sysfs_number(hwmon / "power1_max")
+        if draw is None and cap is None:
+            continue
+        return (
+            draw / 1_000_000.0 if draw is not None else None,
+            cap / 1_000_000.0 if cap is not None else None,
+        )
+    return None, None
+
+
+def _thermals(gpus: list[GpuInfo]) -> dict[str, float]:
+    """The temperature/power keys for the heartbeat load, from `nvidia-smi` where the cards report
+    them and from sysfs where they do not.
+
+    Temperature is the hottest card and power is the sum across cards, matching how `load_snapshot`
+    already aggregates utilisation and VRAM: one node, one number. A key is emitted ONLY when
+    something actually measured it — absent means "not reported", and the grid page renders nothing
+    rather than a zero (a 0°C card and a 0W card both read as a real, alarming measurement)."""
+    out: dict[str, float] = {}
+    temps = [g.temp_c for g in gpus if g.temp_c is not None]
+    powers = [g.power_w for g in gpus if g.power_w is not None]
+    limits = [g.power_limit_w for g in gpus if g.power_limit_w is not None]
+
+    temp = max(temps) if temps else _sysfs_gpu_temp_c()
+    if temp is not None:
+        out["gpu_temp_c"] = round(temp, 1)
+
+    if powers:
+        out["gpu_power_w"] = round(sum(powers), 2)
+    if limits:
+        out["gpu_power_limit_w"] = round(sum(limits), 1)
+    if not powers or not limits:
+        sysfs_draw, sysfs_cap = _sysfs_gpu_power()
+        if not powers and sysfs_draw is not None:
+            out["gpu_power_w"] = round(sysfs_draw, 2)
+        if not limits and sysfs_cap is not None:
+            out["gpu_power_limit_w"] = round(sysfs_cap, 1)
+    return out
+
+
 def load_snapshot(timeout: float = 3.0) -> dict[str, float]:
     """Lightweight GPU totals for the provider heartbeat load payload. Keys: ``gpu_count``,
     ``memory_total_mb`` (advertised VRAM — what the grid aggregates per provider), ``memory_used_mb``,
-    ``gpu_util`` (max across cards).
+    ``gpu_util`` (max across cards), and — where the hardware reports them — ``gpu_temp_c``,
+    ``gpu_power_w``, ``gpu_power_limit_w``.
 
     NVIDIA first (summed/maxed across all cards). Failing that, on macOS advertise the GPU-usable memory
     — Apple Silicon unified memory (``hw.memsize``) or an Intel Mac's discrete VRAM (``system_profiler``)
-    — so Mac providers still surface VRAM. Returns ``{}`` on a box with no detectable GPU."""
+    — so Mac providers still surface VRAM. Returns ``{}`` on a box with no detectable GPU.
+
+    **Every key is emitted only when it was measured.** The Mac branch reports VRAM *total* alone: macOS
+    exposes neither GPU utilisation nor per-process VRAM without a root ``powermetrics``, so the
+    ``memory_used_mb: 0.0`` / ``gpu_util: 0.0`` this branch used to send were invented, not observed.
+    They were harmless while the grid page only read the total, but the moment anything renders a gauge
+    they make every Mac look like a dead node holding 128 GB it never uses. Absent is the honest wire
+    value for "this platform cannot tell you", and it is what the page needs to show nothing."""
     gpus = enumerate_gpus(timeout=timeout)
     if gpus:
         return {
@@ -145,9 +316,37 @@ def load_snapshot(timeout: float = 3.0) -> dict[str, float]:
             "memory_total_mb": sum(g.memory_total_mb for g in gpus),
             "memory_used_mb": sum(g.memory_used_mb for g in gpus),
             "gpu_util": max(g.utilization_pct for g in gpus),
+            **_thermals(gpus),
         }
     mac_mb = _macos_vram_mb(timeout=timeout)
     if mac_mb:
-        return {"gpu_count": 1.0, "memory_total_mb": mac_mb, "memory_used_mb": 0.0, "gpu_util": 0.0}
+        snapshot = {"gpu_count": 1.0, "memory_total_mb": mac_mb}
+        used_mb = _mac_memory_used_mb()
+        if used_mb is not None:
+            snapshot["memory_used_mb"] = min(used_mb, mac_mb)
+        return snapshot
     return {}
+
+
+def _mac_memory_used_mb() -> float | None:
+    """How much of a Mac's advertised VRAM is in use, or None when that is unknowable.
+
+    **Apple Silicon only, and that asymmetry is the point.** There, the advertised VRAM IS
+    ``hw.memsize`` — the GPU shares one unified pool with the CPU (the premise `_macos_vram_mb`
+    already rests on), so system memory in use is exactly the figure that decides whether another
+    model fits. Reporting it gives a Mac node a real memory gauge instead of a total with nothing
+    to compare it against.
+
+    On an **Intel Mac** the same reasoning inverts: the advertised figure is a discrete/integrated
+    card's own VRAM from ``system_profiler``, a separate pool from system RAM. Filling that bar with
+    RAM usage would show a number measured on the wrong memory, which is worse than showing none —
+    so this returns None and the gauge stays absent.
+
+    Neither path can read *GPU* allocation specifically; macOS keeps that behind a root
+    ``powermetrics``, and no amount of probing here changes that."""
+    if platform.system() != "Darwin" or arch.native_machine() != "arm64":
+        return None
+    from shared.system import host
+
+    return host.memory_used_mb()
 

--- a/shared/system/host.py
+++ b/shared/system/host.py
@@ -132,6 +132,51 @@ def _memory_snapshot() -> tuple[int, int, float]:
     return 0, 0, 0.0
 
 
+def memory_used_mb() -> float | None:
+    """System memory in use, in MB — or None when this box cannot truly measure it.
+
+    None, not 0, and the distinction is the whole point: `_memory_snapshot`'s ``sysconf`` fallback
+    reports available == total because it has no way to ask, and a caller subtracting those would
+    publish a confident "0 MB in use" for a machine it never measured. Only psutil answers this
+    honestly, so only psutil is trusted here.
+
+    Used by the Apple Silicon VRAM path, where the GPU shares this pool — see `gpu.load_snapshot`.
+    """
+    try:
+        import psutil
+
+        mem = psutil.virtual_memory()
+        used = int(mem.total) - int(mem.available)
+    except Exception:  # noqa: BLE001 — a probe, never a failure path
+        return None
+    return used / (1024 * 1024) if used > 0 else None
+
+
+def disk_gb(path: str) -> tuple[float, float] | None:
+    """``(total_gb, used_gb)`` for the volume containing ``path``, or None when it cannot be read.
+
+    Goes through `_disk_snapshot`, so it inherits the psutil→``statvfs``→zeros ladder the rest of
+    this module uses — psutil is an OPTIONAL dependency here and a probe that imported it directly
+    would silently report nothing on every box that does without it.
+
+    ``used`` is ``total - free``, which counts the filesystem's reserved blocks as used and so runs
+    slightly above what ``df`` shows. The alternative (psutil's own ``used``) does not exist on the
+    ``statvfs`` path, and one definition that works everywhere beats two that disagree by platform.
+
+    None rather than zeros on failure: a caller reporting telemetry must be able to say "unknown",
+    and a zeroed pair would render as an empty disk.
+    """
+    try:
+        usage = _disk_snapshot(path)
+        total, free = float(usage.total), float(usage.free)
+    except (OSError, AttributeError, TypeError, ValueError):
+        return None
+    if total <= 0:
+        return None
+    gib = 1024 ** 3
+    return round(total / gib, 1), round((total - free) / gib, 1)
+
+
 def _disk_snapshot(home_dir: str):
     try:
         import psutil

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -21348,6 +21348,107 @@ def test_gpu_load_snapshot_empty_without_gpu(monkeypatch):
     assert gpu.load_snapshot() == {}   # no GPU anywhere → provider sends no VRAM
 
 
+# One accelerator's `PerformanceStatistics`, in `ioreg`'s real single-line shape. Trimmed to the keys
+# that matter plus a couple of neighbours, and duplicated below the way ioreg genuinely repeats a
+# device: the same physical GPU appears once per accelerator subclass.
+_IOREG_DEVICE = (
+    '    "PerformanceStatistics" = {"Device Utilization %"=8,"inUseVidMemoryBytes"=864329728,'
+    '"vramFreeBytes"=124051392,"Temperature(C)"=66,"Total Power(W)"=22,"Fan Speed(%)"=0}\n'
+)
+# A second, integrated GPU: publishes utilisation and nothing else, as the real one does.
+_IOREG_IGPU = '    "PerformanceStatistics" = {"Device Utilization %"=6,"inUseVidMemoryBytes"=0}\n'
+
+
+def test_mac_gpu_counters_are_read_without_privileges(monkeypatch):
+    """The IORegistry publishes VRAM occupancy, load, temperature and power to any user. `powermetrics`
+    (which does need root) is the obvious macOS answer and the wrong one — this test pins the readings
+    that make a Mac node's card as complete as an NVIDIA one."""
+    from shared.system import apple
+
+    monkeypatch.setattr(apple, "_run", lambda cmd, timeout=10.0: _IOREG_DEVICE + _IOREG_IGPU)
+
+    assert apple.accelerator_stats() == {
+        "vram_used_bytes": 864329728.0,
+        "gpu_util": 8.0,
+        "gpu_temp_c": 66.0,
+        "gpu_power_w": 22.0,
+    }
+
+
+def test_a_gpu_listed_twice_is_not_counted_twice(monkeypatch):
+    """ioreg repeats one physical GPU per accelerator subclass, so summing would report a 22W card as
+    drawing 44W and double its VRAM. Max is duplicate-safe and still picks the discrete card over the
+    integrated one."""
+    from shared.system import apple
+
+    monkeypatch.setattr(
+        apple, "_run", lambda cmd, timeout=10.0: _IOREG_DEVICE + _IOREG_DEVICE + _IOREG_IGPU
+    )
+    stats = apple.accelerator_stats()
+
+    assert stats["gpu_power_w"] == 22.0
+    assert stats["vram_used_bytes"] == 864329728.0
+
+
+def test_mac_counters_absent_when_the_registry_says_nothing(monkeypatch):
+    from shared.system import apple
+
+    monkeypatch.setattr(apple, "_run", lambda cmd, timeout=10.0: "")
+    assert apple.accelerator_stats() == {}
+
+
+def test_an_intel_mac_measures_occupancy_against_its_own_card(monkeypatch):
+    """`used` and `total` must describe the SAME pool — they are divided and drawn as one bar. On an
+    Intel Mac the total is the card's own VRAM, so the occupancy is the card's, never system RAM."""
+    from shared.system import apple, arch, gpu, host
+
+    monkeypatch.setattr(gpu, "enumerate_gpus", lambda timeout=3.0: [])
+    monkeypatch.setattr(gpu, "_macos_vram_mb", lambda timeout=5.0: 4096.0)
+    monkeypatch.setattr(gpu.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(arch, "native_machine", lambda: "x86_64")
+    monkeypatch.setattr(host, "memory_used_mb", lambda: 24_000.0)  # system RAM — must NOT be used
+    monkeypatch.setattr(apple, "_run", lambda cmd, timeout=10.0: _IOREG_DEVICE)
+
+    snapshot = gpu.load_snapshot()
+
+    assert snapshot["memory_total_mb"] == 4096.0
+    assert snapshot["memory_used_mb"] == 824.3   # 864329728 bytes, not the 24 GB of system RAM
+    assert snapshot["gpu_temp_c"] == 66.0 and snapshot["gpu_power_w"] == 22.0
+
+
+def test_an_apple_silicon_mac_measures_occupancy_against_its_unified_pool(monkeypatch):
+    """The mirror case: there the advertised total IS `hw.memsize`, so system memory in use is the
+    figure that pairs with it, and the registry's per-driver allocation is not."""
+    from shared.system import apple, arch, gpu, host
+
+    monkeypatch.setattr(gpu, "enumerate_gpus", lambda timeout=3.0: [])
+    monkeypatch.setattr(gpu, "_macos_vram_mb", lambda timeout=5.0: 131072.0)
+    monkeypatch.setattr(gpu.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(arch, "native_machine", lambda: "arm64")
+    monkeypatch.setattr(host, "memory_used_mb", lambda: 41_000.0)
+    monkeypatch.setattr(apple, "_run", lambda cmd, timeout=10.0: _IOREG_DEVICE)
+
+    snapshot = gpu.load_snapshot()
+
+    assert snapshot["memory_used_mb"] == 41_000.0
+    assert snapshot["gpu_util"] == 8.0   # utilisation still comes from the registry
+
+
+def test_a_mac_that_cannot_measure_reports_no_zeros(monkeypatch):
+    """The regression this whole path exists for: a fabricated `memory_used_mb: 0.0` / `gpu_util: 0.0`
+    renders as a dead node holding all its memory unused."""
+    from shared.system import apple, arch, gpu, host
+
+    monkeypatch.setattr(gpu, "enumerate_gpus", lambda timeout=3.0: [])
+    monkeypatch.setattr(gpu, "_macos_vram_mb", lambda timeout=5.0: 131072.0)
+    monkeypatch.setattr(gpu.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(arch, "native_machine", lambda: "arm64")
+    monkeypatch.setattr(host, "memory_used_mb", lambda: None)
+    monkeypatch.setattr(apple, "_run", lambda cmd, timeout=10.0: "")
+
+    assert gpu.load_snapshot() == {"gpu_count": 1.0, "memory_total_mb": 131072.0}
+
+
 def test_serve_load_merges_vram_with_active_tasks(monkeypatch, tmp_path):
     from shared.system import gpu
 

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -12381,6 +12381,10 @@ def _serve_state(monkeypatch, tmp_path, **overrides):
     monkeypatch.setenv("GRID_HOME", str(tmp_path))
     # Pin the heartbeat's platform tag so load-shape assertions are deterministic across runner OSes.
     monkeypatch.setattr(host, "platform_kind", lambda: "linux")
+    # Same reason, for the disk gauge: its figures are whatever volume the runner happens to have, so
+    # the shared fixture reports "unmeasurable" and the load-shape assertions below stay exact. The
+    # disk contract itself is covered by `test_serve_load_reports_disk*`, which opt back in.
+    monkeypatch.setattr(host, "disk_gb", lambda path: None)
     kwargs = dict(
         signaling_url="https://relay.example", node_id="node-1", network_id="n1",
         llm_url="http://127.0.0.1:8081/v1", access_token="AT", refresh_token="RT",
@@ -21362,6 +21366,66 @@ def test_serve_load_omits_vram_without_gpu(monkeypatch, tmp_path):
     monkeypatch.setattr(gpu, "load_snapshot", lambda timeout=3.0: {})
     load = _serve_state(monkeypatch, tmp_path).load()
     assert load == {"active_tasks": 0, "platform": "linux"}   # no VRAM keys when no GPU; platform always present
+
+
+def test_serve_load_reports_disk_of_the_model_volume(monkeypatch, tmp_path):
+    """The grid page's storage gauge: whatever volume holds the model store, not the home directory —
+    a node with its models on a separate drive must report the drive a pull actually fills."""
+    from shared import paths
+    from shared.system import gpu, host
+
+    monkeypatch.setattr(gpu, "load_snapshot", lambda timeout=3.0: {})
+    state = _serve_state(monkeypatch, tmp_path)
+    measured: dict[str, str] = {}
+    monkeypatch.setattr(
+        host, "disk_gb", lambda path: measured.update(path=path) or (3755.0, 541.4)
+    )
+
+    load = state.load()
+
+    assert load["disk_total_gb"] == 3755.0
+    assert load["disk_used_gb"] == 541.4
+    assert measured["path"].startswith(str(paths.models_dir().parent))
+
+
+def test_serve_load_omits_disk_when_the_volume_cannot_be_read(monkeypatch, tmp_path):
+    """A box that cannot stat its volume reports NOTHING, never zeros: the page renders an absent
+    figure as blank but a zeroed one as a full drive, which would read as an alarm nobody raised."""
+    from shared.system import gpu, host
+
+    monkeypatch.setattr(gpu, "load_snapshot", lambda timeout=3.0: {})
+    monkeypatch.setattr(host, "disk_gb", lambda path: None)
+    load = _serve_state(monkeypatch, tmp_path).load()
+
+    assert "disk_total_gb" not in load and "disk_used_gb" not in load
+
+
+def test_serve_load_omits_throughput_until_a_request_has_been_served(monkeypatch, tmp_path):
+    """`tok_s` is measured, never benchmarked — so a node that has answered nothing reports nothing
+    rather than a synthetic warm-up figure describing a machine that was idle at start-up."""
+    from shared.system import gpu
+
+    monkeypatch.setattr(gpu, "load_snapshot", lambda timeout=3.0: {})
+    state = _serve_state(monkeypatch, tmp_path)
+    assert "tok_s" not in state.load()
+
+    state.set_throughput(248.72)
+    assert state.load()["tok_s"] == 248.7
+
+
+def test_serve_state_keeps_the_last_measurable_throughput(monkeypatch, tmp_path):
+    """An un-timeable job (media, a reply too short to time) leaves the gauge alone instead of
+    blanking it — the node did not get slower, that one request simply carried no measurement."""
+    from shared.system import gpu
+
+    monkeypatch.setattr(gpu, "load_snapshot", lambda timeout=3.0: {})
+    state = _serve_state(monkeypatch, tmp_path)
+
+    state.set_throughput(100.0)
+    state.set_throughput(None)
+    state.set_throughput(0)
+
+    assert state.throughput() == 100.0
 
 
 def _poll_loop_state_and_poll(job_then_none):

--- a/tests/test_throughput.py
+++ b/tests/test_throughput.py
@@ -1,0 +1,152 @@
+"""Decode-throughput measurement — the `tok_s` the grid page shows per node.
+
+Pure logic, no engine and no network: every case here is a byte string shaped like something a real
+engine sends, so the dialect differences these tests pin are the ones that actually reach a provider.
+"""
+
+from __future__ import annotations
+
+import time
+
+from remote import throughput
+
+
+def _drain(meter: throughput.StreamMeter, chunks: list[bytes], *, pause: float = 0.002) -> bytes:
+    """Run `chunks` through the meter, spacing them so the elapsed interval is measurable."""
+    out = b""
+    for chunk in meter.measure(chunks):
+        out += chunk
+        time.sleep(pause)
+    meter.flush()
+    return out
+
+
+def _chat_stream(tokens: int) -> bytes:
+    """An OpenAI chat stream ending in the usage-only chunk `stream_options.include_usage` appends —
+    which the master injects on every job, so a provider always receives it."""
+    return (
+        b'data: {"choices":[{"delta":{"role":"assistant"}}]}\n\n'
+        + b'data: {"choices":[{"delta":{"content":"x"}}]}\n\n' * tokens
+        + b'data: {"choices":[],"usage":{"prompt_tokens":9,"completion_tokens":%d}}\n\n' % tokens
+        + b"data: [DONE]\n\n"
+    )
+
+
+def test_reads_the_generated_token_count_of_every_dialect_the_provider_forwards():
+    """One extractor for all four request shapes, so no forward path has to know its own wire."""
+    assert throughput.completion_tokens_from({"usage": {"completion_tokens": 42}}) == 42   # chat
+    assert throughput.completion_tokens_from({"usage": {"output_tokens": 42}}) == 42       # anthropic
+    assert throughput.completion_tokens_from({"response": {"usage": {"output_tokens": 42}}}) == 42
+
+
+def test_a_payload_carrying_no_generated_count_yields_nothing():
+    """Absent is the answer that makes the caller decline to report, rather than invent, a rate."""
+    assert throughput.completion_tokens_from({"usage": {"prompt_tokens": 10}}) is None
+    assert throughput.completion_tokens_from({"usage": {"output_tokens": True}}) is None
+    assert throughput.completion_tokens_from({"usage": {"completion_tokens": 0}}) is None
+    assert throughput.completion_tokens_from("not an object") is None
+
+
+def test_the_meter_never_alters_the_stream_it_measures():
+    """The relay re-splits these bytes and refuses smuggled bare-CR, so a meter that normalised
+    anything would mask the very thing that sanitiser exists to catch. Chunks are cut at 7 bytes so
+    every SSE line arrives torn across boundaries, as a real socket delivers them."""
+    stream = _chat_stream(30)
+    meter = throughput.StreamMeter()
+
+    assert _drain(meter, [stream[i:i + 7] for i in range(0, len(stream), 7)]) == stream
+    assert meter.tok_s is not None
+
+
+def test_throughput_is_measured_over_decode_alone():
+    """Two clocks, not one: the interval starts at the FIRST token, so a long prompt's processing
+    time never makes a node look slower than it decodes."""
+    meter = throughput.StreamMeter()
+    chunks = [b'data: {"choices":[{"delta":{"content":"x"}}]}\n\n'] * 20
+    chunks.append(b'data: {"choices":[],"usage":{"completion_tokens":20}}\n\n')
+
+    _drain(meter, chunks, pause=0.005)
+
+    # 21 chunks spaced 5ms apart => ~0.1s of decode for 20 tokens. A meter that had started its clock
+    # at the request (or divided by wall time including a prompt) would land far below this floor.
+    assert meter.tok_s is not None
+    assert 80 < meter.tok_s < 400
+
+
+def test_an_anthropic_stream_reports_the_final_count_not_the_opening_one():
+    """`message_start` announces `output_tokens: 1` before anything is generated and `message_delta`
+    carries the real total. Reading the first would report ~1 tok/s for every Anthropic request."""
+    meter = throughput.StreamMeter()
+    stream = [
+        b'event: message_start\ndata: {"message":{"usage":{"input_tokens":9,"output_tokens":1}}}\n\n',
+        b'event: message_delta\ndata: {"usage":{"output_tokens":40}}\n\n',
+    ]
+
+    _drain(meter, stream)
+
+    assert meter.tok_s is not None
+    assert meter.tok_s > 40  # 40 tokens over the ~4ms above, not 1 token over the same span
+
+
+def test_a_responses_stream_is_read_from_its_terminal_event():
+    meter = throughput.StreamMeter()
+    stream = [
+        b'event: response.output_text.delta\ndata: {"delta":"x"}\n\n',
+        b'event: response.completed\ndata: {"response":{"usage":{"output_tokens":64}}}\n\n',
+    ]
+
+    _drain(meter, stream)
+
+    assert meter.tok_s is not None
+
+
+def test_a_reply_too_short_to_time_is_not_reported():
+    """A handful of tokens decode in milliseconds, where ordinary jitter swings the quotient by an
+    order of magnitude. Such a sample leaves the previous real figure standing."""
+    meter = throughput.StreamMeter()
+
+    _drain(meter, [b'data: {"usage":{"completion_tokens":3}}\n\n'])
+
+    assert meter.tok_s is None
+
+
+def test_a_stream_carrying_no_usage_is_not_reported():
+    """The media path is never metered, but a text engine that somehow answers without usage must
+    still degrade to silence rather than to a rate divided by nothing."""
+    meter = throughput.StreamMeter()
+
+    _drain(meter, [b'data: {"choices":[{"delta":{"content":"hello"}}]}\n\n'])
+
+    assert meter.tok_s is None
+
+
+def test_an_enormous_unbroken_line_stops_the_scan_without_stopping_the_stream():
+    """The buffer is bounded: a stream that never sends a newline degrades to "not measured" instead
+    of accumulating in memory — and its bytes still reach the consumer untouched."""
+    blob = b'data: {"image":"' + b"A" * (2 * 1024 * 1024) + b'"}\n\n'
+    meter = throughput.StreamMeter()
+
+    assert _drain(meter, [blob], pause=0) == blob
+    assert meter.tok_s is None
+
+
+def test_a_whole_body_reply_prefers_the_engines_own_decode_timing():
+    """llama.cpp measured decode with prompt processing already excluded — the exact distinction a
+    single returned object otherwise hides. 500 tokens over 10s of wall time is 50/s; the engine's
+    own 137.4 is the honest number and must win."""
+    body = b'{"timings":{"predicted_per_second":137.4},"usage":{"completion_tokens":500}}'
+
+    assert throughput.whole_body_tok_s(body, 10.0) == 137.4
+
+
+def test_a_whole_body_reply_without_engine_timings_falls_back_to_wall_clock():
+    """Every dialect that reaches the whole-body forward is covered, in its own spelling."""
+    assert throughput.whole_body_tok_s(b'{"usage":{"completion_tokens":100}}', 2.0) == 50.0
+    assert throughput.whole_body_tok_s(b'{"usage":{"output_tokens":100}}', 2.0) == 50.0
+
+
+def test_an_unreadable_or_untimeable_whole_body_reply_reports_nothing():
+    assert throughput.whole_body_tok_s(b"not json", 1.0) is None
+    assert throughput.whole_body_tok_s(b'{"usage":{}}', 1.0) is None
+    assert throughput.whole_body_tok_s(b'{"usage":{"completion_tokens":100}}', 0.0) is None
+    assert throughput.whole_body_tok_s(b'{"usage":{"completion_tokens":3}}', 1.0) is None

--- a/uv.lock
+++ b/uv.lock
@@ -814,7 +814,7 @@ wheels = [
 
 [[package]]
 name = "grid"
-version = "0.3.17"
+version = "0.3.18"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Fills in what the grid page had no numbers for. Three additions and one correction:

**Thermals and power** ride the `nvidia-smi` call the heartbeat already makes, so they cost no extra process. The three new columns are parsed leniently while memory and utilisation stay strict: an integrated GPU answers `[N/A]` for power, and under the old all-or-nothing parse that would have dropped the whole card — losing VRAM to gain nothing. When nvidia-smi rejects the wider query outright the probe falls back to the exact query this module shipped with, and remembers which one the box accepts. Where the card reports no sensor at all, sysfs is read by the kernel's own `type`/`name` strings, never by index: the zone that is GPU-therm on one board is a CPU cluster on the next, and a wrong match would report a CPU's temperature as the GPU's.

**Disk** is measured on the volume holding the model store, not `~` — a box with its models on a separate NVMe would otherwise report the space a pull does not consume. It goes through a new `host.disk_gb` so it inherits this repo's psutil→statvfs ladder; psutil is optional here, and calling it directly reported nothing on every box without it.

**Throughput** is measured on real traffic (`remote/throughput.py`), never benchmarked. A warm-up request describes a machine that was idle at start-up; what an operator wants is how fast the node is answering now. Two clocks, not one: the streaming meter starts at the first token, so a long prompt's processing never makes a node look slower than it decodes. One extractor covers every dialect the provider forwards — chat's `completion_tokens`, Anthropic and Responses' `output_tokens`, and the Responses stream's nested `response.usage` — and the LAST usage wins, because Anthropic announces `output_tokens: 1` in `message_start` before anything is generated. The meter yields its input byte for byte; the relay re-splits these bytes and refuses smuggled bare-CR, so a meter that normalised anything would mask what that sanitiser exists to catch. Media is deliberately unmetered: its events are megabytes of base64 with no tokens to count.

**The correction:** the macOS branch of `load_snapshot` was sending `memory_used_mb: 0.0` and `gpu_util: 0.0` — invented, not observed. Harmless while the page read only the total, but the moment anything draws a gauge every Mac reads as a dead node holding 128 GB it never uses. Absent is the honest wire value. Apple Silicon does now report real occupancy, since its GPU shares `hw.memsize` — the premise the advertised VRAM already rests on. An Intel Mac deliberately does not: there the advertised figure is a discrete card's own VRAM, a separate pool from system RAM, and filling that bar with RAM usage would measure the wrong memory.