### PR TITLE
fix(mac): read memory in use through vm_stat when psutil is absent

### DIFF
--- a/shared/system/host.py
+++ b/shared/system/host.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import os
 import platform
+import re
 import subprocess
 from dataclasses import dataclass
 
@@ -132,24 +133,87 @@ def _memory_snapshot() -> tuple[int, int, float]:
     return 0, 0, 0.0
 
 
+# `vm_stat` prints the page size in its own header, and it must be READ rather than assumed: Apple
+# Silicon pages are 16384 bytes where Intel's are 4096. Hardcoding 4096 would under-report every
+# Apple Silicon node by a factor of four — and to a plausible-looking figure, which is worse than an
+# obviously broken one because nobody goes looking.
+_VM_STAT_PAGE = re.compile(r"page size of (\d+) bytes")
+
+# The page classes macOS can hand back on demand. This is psutil's own definition of ``available``,
+# matched deliberately: the same machine must report the same occupancy whether or not psutil
+# happens to be installed, or the dashboard's memory bar would shift the day somebody pip-installs
+# it and the change would look like real movement. Verified against `psutil.virtual_memory()` on a
+# live Mac — the two agree to within the drift of reading them a moment apart.
+_VM_STAT_AVAILABLE = ("Pages free", "Pages speculative", "Pages inactive")
+
+
+def _vm_stat_used_bytes() -> int | None:
+    """System memory in use, from ``vm_stat``, or None when it cannot be read. macOS only.
+
+    Exists so an Apple Silicon node can draw its memory bar on a stock install. psutil is an
+    OPTIONAL dependency here — ``pyproject.toml`` never declares it and nothing in the CLI's
+    dependency tree pulls it in — so trusting psutil alone left this reading absent on any Mac that
+    happened not to have it, which on unified-memory hardware is the VRAM figure itself.
+
+    ``vm_stat`` ships with every macOS and needs no privileges. All three page counts must be
+    present: a missing one would read as zero and silently inflate "used", and a format change is
+    better answered with "unknown" than with a confident wrong number.
+    """
+    if platform.system() != "Darwin":
+        return None
+    try:
+        out = subprocess.check_output(["vm_stat"], timeout=3.0, stderr=subprocess.DEVNULL)
+        raw = out.decode("utf-8", "replace")
+    except (subprocess.SubprocessError, OSError):
+        return None
+    header = _VM_STAT_PAGE.search(raw)
+    if not header:
+        return None
+    page = int(header.group(1))
+
+    pages: dict[str, int] = {}
+    for line in raw.splitlines():
+        name, sep, value = line.partition(":")
+        if not sep:
+            continue
+        try:  # counts are printed with a trailing period ("Pages free:  177973.")
+            pages[name.strip()] = int(value.strip().rstrip("."))
+        except ValueError:
+            continue
+    if not all(key in pages for key in _VM_STAT_AVAILABLE):
+        return None
+
+    try:
+        total = int(_sysctl("hw.memsize"))
+    except ValueError:
+        return None
+    used = total - sum(pages[key] for key in _VM_STAT_AVAILABLE) * page
+    # A total and a page census read a few milliseconds apart can disagree; anything outside the
+    # pool is that disagreement, not a measurement.
+    return used if 0 < used <= total else None
+
+
 def memory_used_mb() -> float | None:
     """System memory in use, in MB — or None when this box cannot truly measure it.
 
-    None, not 0, and the distinction is the whole point: `_memory_snapshot`'s ``sysconf`` fallback
-    reports available == total because it has no way to ask, and a caller subtracting those would
-    publish a confident "0 MB in use" for a machine it never measured. Only psutil answers this
-    honestly, so only psutil is trusted here.
+    psutil when present, else ``vm_stat`` on macOS (`_vm_stat_used_bytes`), else nothing. What is
+    never used is `_memory_snapshot`'s ``sysconf`` fallback: it reports available == total because
+    it has no way to ask, and a caller subtracting those would publish a confident "0 MB in use"
+    for a machine it never measured. None, not 0 — the distinction is the whole point.
 
     Used by the Apple Silicon VRAM path, where the GPU shares this pool — see `gpu.load_snapshot`.
     """
+    used: int | None
     try:
         import psutil
 
         mem = psutil.virtual_memory()
         used = int(mem.total) - int(mem.available)
     except Exception:  # noqa: BLE001 — a probe, never a failure path
+        used = _vm_stat_used_bytes()
+    if used is None or used <= 0:
         return None
-    return used / (1024 * 1024) if used > 0 else None
+    return used / (1024 * 1024)
 
 
 def disk_gb(path: str) -> tuple[float, float] | None:

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -21449,6 +21449,70 @@ def test_a_mac_that_cannot_measure_reports_no_zeros(monkeypatch):
     assert gpu.load_snapshot() == {"gpu_count": 1.0, "memory_total_mb": 131072.0}
 
 
+# A Mac Studio's `vm_stat`, cut down to the lines the parser reads plus several it must step over.
+# The header's 16384 is the load-bearing detail — Apple Silicon pages are four times an Intel Mac's.
+_VM_STAT_ARM64 = """Mach Virtual Memory Statistics: (page size of 16384 bytes)
+Pages free:                              100000.
+Pages active:                            900000.
+Pages inactive:                          180000.
+Pages speculative:                        20000.
+Pages throttled:                              0.
+Pages wired down:                        400000.
+Pages occupied by compressor:            120000.
+"Translation faults":                 987654321.
+"""
+
+
+def test_apple_silicon_reads_memory_in_use_without_psutil(monkeypatch):
+    """psutil is optional and undeclared — nothing in the CLI's dependency tree installs it — so a
+    stock Mac has to reach this figure through `vm_stat`, which ships with every macOS and needs no
+    privileges. On unified memory the reading IS the VRAM bar, so losing it blanks the gauge."""
+    import sys
+
+    from shared.system import host
+
+    monkeypatch.setitem(sys.modules, "psutil", None)  # `import psutil` now raises ImportError
+    monkeypatch.setattr(host.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(host.subprocess, "check_output", lambda *a, **k: _VM_STAT_ARM64.encode())
+    monkeypatch.setattr(host, "_sysctl", lambda name: "137438953472")  # hw.memsize, 128 GiB
+
+    # 300_000 reclaimable pages of 16384 bytes out of a 128 GiB pool. Reading the page size as an
+    # Intel Mac's 4096 would answer 129900.1 — plausible on sight, and wrong by 3.5 GB.
+    assert host.memory_used_mb() == 126384.5
+
+
+def test_memory_in_use_is_absent_rather_than_guessed_when_vm_stat_cannot_be_read(monkeypatch):
+    """Every degraded shape must decline instead of publishing a number. Each of these would
+    otherwise read some count as zero and render as a confident occupancy on the dashboard."""
+    import sys
+
+    from shared.system import host
+
+    monkeypatch.setitem(sys.modules, "psutil", None)
+    monkeypatch.setattr(host, "_sysctl", lambda name: "137438953472")
+
+    def vm_stat_says(text: str) -> None:
+        monkeypatch.setattr(host.subprocess, "check_output", lambda *a, **k: text.encode())
+
+    monkeypatch.setattr(host.platform, "system", lambda: "Darwin")
+    vm_stat_says("Mach Virtual Memory Statistics:\nPages free: 100000.\n")
+    assert host.memory_used_mb() is None  # header carried no page size to scale by
+
+    vm_stat_says("Mach Virtual Memory Statistics: (page size of 16384 bytes)\nPages free: 100000.\n")
+    assert host.memory_used_mb() is None  # inactive and speculative never arrived
+
+    def explode(*a, **k):
+        raise OSError("vm_stat is not here")
+
+    monkeypatch.setattr(host.subprocess, "check_output", explode)
+    assert host.memory_used_mb() is None
+
+    # And a Linux node without psutil never shells out to a macOS tool in the first place.
+    monkeypatch.setattr(host.platform, "system", lambda: "Linux")
+    vm_stat_says(_VM_STAT_ARM64)
+    assert host.memory_used_mb() is None
+
+
 def test_serve_load_merges_vram_with_active_tasks(monkeypatch, tmp_path):
     from shared.system import gpu
 


### PR DESCRIPTION
`memory_used_mb` trusted psutil alone, and psutil is an OPTIONAL dependency this CLI never declares — pyproject lists fastapi, httpx, tomli-w, uvicorn, websocket-client and requests, none of which pull it in. So a stock install reported nothing, and on Apple Silicon that reading IS the VRAM bar: the GPU shares the unified pool, so `gpu.load_snapshot` pairs `hw.memsize` with this figure. Every Mac Silicon node without psutil drew an empty memory gauge, while a node that happened to have it drew a real one — the same build behaving two ways depending on what was already on the box.

`vm_stat` ships with every macOS, needs no privileges, and answers the same question. It is used only as a fallback, so nothing changes where psutil is installed, and it is never allowed to displace the None that means "this machine cannot measure it" — the sysconf path still reports available == total and must keep reporting nothing rather than a confident 0 MB.

Two details worth stating, both covered by tests:

- The page size is read from vm_stat's own header, not assumed. Apple Silicon pages are 16384 bytes against an Intel Mac's 4096, so a hardcoded 4096 would under-report every arm64 node fourfold — to a plausible-looking number, which is why the fixture pins the exact figure the correct page size produces.
- `available` is defined as free + speculative + inactive, matching psutil's own definition deliberately. Measured against `psutil.virtual_memory()` on a live Mac: 10733.4 MB vs 10745.9 MB, the 0.1% being the drift of reading the two a moment apart. A different definition would make the gauge jump the day someone pip-installs psutil, and that shift would read as real movement.

Unverified: whether Apple Silicon's AGXAccelerator publishes the temperature and power keys `apple.accelerator_stats` looks for. That path is shared with Intel and untouched here; if those keys are absent or spelled differently, the gauges show "not measured" until `_STAT_KEYS` learns the name.