### PR TITLE
Tell the grid what machine this is, and keep telling it

### DIFF
--- a/remote/relay.py
+++ b/remote/relay.py
@@ -217,16 +217,32 @@ def deregister_node(signaling_url: str, access_token: str, node_id: str) -> None
     _guard(resp, "deregister")
 
 
-def heartbeat(signaling_url: str, access_token: str, *, load: dict[str, Any]) -> str:
+def heartbeat(
+    signaling_url: str,
+    access_token: str,
+    *,
+    load: dict[str, Any],
+    meta: dict[str, Any] | None = None,
+) -> str:
     """Keep the node live (``POST /nodes/heartbeat``). Returns ``"ok"`` or ``"missing"`` (404 →
     the node was pruned, so the caller re-registers). 401 raises ``RelayUnauthorized``.
 
-    The body carries only ``load`` — the relay identifies the node from the bearer token, not a
-    body field (grid-src parity).
+    The node is identified by the bearer token, never a body field (grid-src parity), so the body
+    carries only what the relay cannot already know: this node's ``load``, and optionally its
+    presentation ``meta``.
+
+    ``meta`` repeats what registration already sent, and that repetition is the point. Registration
+    happens once, so a field the grid page gained afterwards — ``chip``, ``device`` — would stay
+    blank on a machine that has been up and serving for weeks. Sending it here means a restart is
+    enough to correct a node, rather than a re-register nobody performs by hand. The relay merges it
+    over what it holds and ignores it entirely on an older build, so this is safe to send always.
     """
+    body: dict[str, Any] = {"load": load}
+    if meta:
+        body["meta"] = meta
     try:
         with _client(signaling_url, access_token, timeout=10.0) as client:
-            resp = client.post("/nodes/heartbeat", json={"load": load})
+            resp = client.post("/nodes/heartbeat", json=body)
     except httpx.HTTPError as exc:
         raise RelayError(f"heartbeat transport error: {exc}") from None
     if resp.status_code == 404:

--- a/remote/serve.py
+++ b/remote/serve.py
@@ -30,6 +30,7 @@ from remote import (
 )
 from shared.handlers import HANDLERS
 from shared import run_records
+from shared.system import node_hardware
 from shared.filelock import file_lock
 from shared.media import media_gating  # stdlib-only module; safe to import eagerly
 from shared.models import api_catalog
@@ -1067,7 +1068,7 @@ def _assemble_snapshot(
 
 
 def _meta(record: dict[str, Any], engine_id: str) -> dict[str, Any]:
-    """How the node appears on the grid page: name + engine kind label.
+    """How the node appears on the grid page: name, engine kind label, and the machine itself.
 
     The display name comes from the record's ``meta_name`` (the ``--name`` a remote operator gave, or
     the box's hostname when omitted), falling back to ``engine_id`` for a record written before the
@@ -1092,6 +1093,12 @@ def _meta(record: dict[str, Any], engine_id: str) -> dict[str, Any]:
         else:
             label = "llama.cpp"
     meta = {"name": record.get("meta_name") or engine_id, "engine": label}
+    # What the machine IS — chip on Apple Silicon, card elsewhere. Without it the grid page can only
+    # say the hostname and the OS ("Grid-Relay · macOS"), which is the same sentence for a laptop
+    # and for a 192 GB Mac Studio. Empty fields are dropped rather than sent blank: the relay merges
+    # meta over what it holds, so a probe that failed this run must not erase a name that worked on
+    # the last one. Cached in `node_hardware`, so the heartbeat path pays nothing.
+    meta.update(node_hardware.meta_fields())
     # The seat tier of an API engine (codex: free/plus/pro/…), surfaced on the grid page next to the
     # engine kind. A public label, never a secret — distinct from the token/account_id we never emit.
     # Union identities can gather several engines; take the first spec that carries one (only API
@@ -1765,7 +1772,12 @@ def heartbeat_once(state: _ServeState, *, _allow_refresh: bool = True) -> str:
     """One heartbeat; 404 → re-register (node pruned), 401 → refresh + retry once."""
     token = state.token()
     try:
-        result = relay.heartbeat(state.signaling_url, token, load=state.load())
+        # The hardware fields ride along on every beat — only those, not the whole meta: name and
+        # engine are already right from registration, while `chip`/`device` are the ones a node that
+        # joined before they existed can never correct any other way. Cached, so this costs nothing.
+        result = relay.heartbeat(
+            state.signaling_url, token, load=state.load(), meta=node_hardware.meta_fields(),
+        )
     except relay.RelayUnauthorized:
         if _allow_refresh and state.refresh(stale_token=token):
             return heartbeat_once(state, _allow_refresh=False)

--- a/shared/system/node_hardware.py
+++ b/shared/system/node_hardware.py
@@ -1,0 +1,168 @@
+"""What this machine IS, in the shape the grid page reads.
+
+Produces the relay's node-meta contract — ``device`` / ``chip`` / ``device_class`` / ``memory_gb`` —
+so a machine on the grid shows as something a person recognises instead of a hostname and an OS
+name. The relay stores these verbatim and ``build_grid_overview`` hands them to the app, which
+prints ``chip`` when there is one and ``device`` otherwise.
+
+That preference is the whole reason both fields exist, and it is not arbitrary:
+
+- **Apple Silicon is named by its CHIP** ("Apple M4 Pro"). The GPU has no name of its own — it is
+  part of the SoC — so "Apple GPU" would tell a reader nothing they can act on, while the chip name
+  is exactly what they would say out loud about the machine.
+- **Everything else is named by its CARD** ("NVIDIA GeForce RTX 4090 ×2"). That is what decides what
+  the box can run; its CPU brand is noise beside it, and on a rented GPU box the CPU is often
+  something nobody chose.
+
+Probed **once and cached**. ``system_profiler`` takes seconds to answer and this is read on every
+heartbeat; hardware does not change under a running process, and a swapped card needs a restart —
+which is also when the next probe would happen.
+
+Best-effort throughout: every field may come back empty, and the grid page is built to say less
+rather than guess. A wrong "RTX 4090" is worse than a blank, because somebody would route work to it.
+"""
+
+from __future__ import annotations
+
+import platform
+import subprocess
+
+from shared.system import apple, arch, gpu, host
+
+# Filled by the first `describe()` and reused after — see the module docstring on why this is not
+# re-probed. `None` means "not probed yet", distinct from a probe that legitimately found nothing.
+_cached: dict | None = None
+
+
+def _is_apple_silicon() -> bool:
+    # `native_machine()` sees through Rosetta (x86_64 Python on Apple Silicon), the same check
+    # `device._is_apple_silicon` makes — an Intel-looking interpreter on an M-series box must still
+    # be named by its chip.
+    return platform.system() == "Darwin" and arch.native_machine() == "arm64"
+
+
+def _memory_gb() -> int | None:
+    """Unified memory on Apple Silicon, in whole GB, or None when it can't be read."""
+    mb = gpu._sysctl_memsize_mb()
+    return int(round(mb / 1024)) if mb else None
+
+
+def _apple() -> dict:
+    model, chip = apple.describe_chip()
+    return {
+        # Both, though the app prints only the chip: `device` is the fallback for a machine whose
+        # chip line failed to parse, and it costs nothing to carry the model name we already read.
+        "device": model or "",
+        "chip": chip or None,
+        "memory_gb": _memory_gb(),
+        "device_class": "gpu",
+    }
+
+
+def _nvidia() -> dict | None:
+    """The card(s) this box has, or None when nothing answered — a CPU-only node, or a driver that
+    isn't installed. None rather than a placeholder: see the module docstring."""
+    try:
+        cards = gpu.enumerate_gpus()
+    except Exception:
+        cards = []
+    if not cards:
+        return None
+    primary = cards[0]
+    # "×2" rather than listing both: two identical cards are the common case and the name is a
+    # label, not an inventory. A mixed pair still reads as the primary — the memory figures the
+    # page shows come from telemetry, which counts them properly.
+    suffix = f" ×{len(cards)}" if len(cards) > 1 else ""
+    vram_gb = (
+        int(round(primary.memory_total_mb / 1024)) if primary.memory_total_mb else None
+    )
+    return {
+        "device": f"{primary.name}{suffix}",
+        "chip": None,
+        "memory_gb": vram_gb,
+        "device_class": "gpu",
+    }
+
+
+def _macos_gpu() -> dict | None:
+    """The graphics card an **Intel** Mac has, from ``system_profiler SPDisplaysDataType``.
+
+    `enumerate_gpus` only knows `nvidia-smi`, and no Intel Mac has an NVIDIA card — so without this
+    a MacBook Pro with a Radeon Pro 560X fell through to the CPU branch and advertised itself as
+    "i386", which is the machine's architecture written in a way nobody recognises.
+
+    A machine reports several chipsets (an integrated Intel one alongside a discrete AMD one). The
+    discrete card is the one that decides what the box can run, and on a Mac the integrated one is
+    always the Intel-branded entry — so anything not Intel-branded wins, and a machine with only
+    integrated graphics still gets named rather than dropped.
+    """
+    try:
+        out = subprocess.check_output(
+            ["system_profiler", "SPDisplaysDataType"], timeout=10.0, stderr=subprocess.DEVNULL
+        ).decode("utf-8", errors="replace")
+    except (subprocess.SubprocessError, OSError):
+        return None
+    names = [
+        line.split(":", 1)[1].strip()
+        for line in out.splitlines()
+        if line.strip().startswith("Chipset Model:")
+    ]
+    names = [n for n in names if n]
+    if not names:
+        return None
+    discrete = [n for n in names if "intel" not in n.lower()]
+    vram_mb = gpu._macos_profiler_vram_mb()
+    return {
+        "device": (discrete or names)[0],
+        "chip": None,
+        "memory_gb": int(round(vram_mb / 1024)) if vram_mb else None,
+        "device_class": "gpu",
+    }
+
+
+def _cpu_only() -> dict:
+    # `host.cpu_brand()`, not `platform.processor()`: the latter answers "i386" on macOS and
+    # "x86_64" on Linux — the architecture, not the processor, and useless on a page whose job is to
+    # say what the machine is.
+    return {
+        "device": host.cpu_brand() or platform.machine() or "CPU",
+        "chip": None,
+        "memory_gb": None,
+        "device_class": "server",
+    }
+
+
+def _probe() -> dict:
+    if _is_apple_silicon():
+        return _apple()
+    if platform.system() == "Darwin":
+        # An Intel Mac: no NVIDIA card exists for it, so ask macOS directly before falling back.
+        return _macos_gpu() or _cpu_only()
+    return _nvidia() or _cpu_only()
+
+
+def describe() -> dict:
+    """``{device, chip, memory_gb, device_class}`` for this machine. Never raises.
+
+    A copy each call, so a caller merging it into a meta dict can't mutate the cache and change what
+    every later heartbeat reports.
+    """
+    global _cached
+    if _cached is None:
+        try:
+            _cached = _probe()
+        except Exception:
+            # A probe that fails must not take the node down with it: an unnamed machine still
+            # serves models perfectly well, and the page is built to show less rather than guess.
+            _cached = {}
+    return dict(_cached)
+
+
+def meta_fields() -> dict:
+    """[describe] with the empty fields dropped — what actually goes on the wire.
+
+    Empties are omitted rather than sent blank because the relay **merges** meta over what it holds:
+    a probe that came back short this run would otherwise erase a name that a previous run got
+    right, and the page would go blank for a reason nobody could see from either side.
+    """
+    return {k: v for k, v in describe().items() if v not in (None, "")}

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -16605,7 +16605,7 @@ def test_serve_heartbeat_tick_rotates_a_due_seat_even_when_the_relay_errors(monk
         _mock_serve_engine(monkeypatch, vendor)
         ticks = []
 
-        def fake_heartbeat(url, tok, *, load):
+        def fake_heartbeat(url, tok, *, load, meta=None):
             ticks.append(1)
             if len(ticks) >= 2:
                 state.stop.set()  # end the loop AFTER tick 2's wait
@@ -16647,7 +16647,7 @@ def test_serve_heartbeat_refresh_failure_never_stops_the_engine(monkeypatch, tmp
     _mock_serve_engine(monkeypatch, vendor)
     ticks = []
 
-    def fake_heartbeat(url, tok, *, load):
+    def fake_heartbeat(url, tok, *, load, meta=None):
         ticks.append(1)
         if len(ticks) >= 3:
             state.stop.set()
@@ -17091,7 +17091,10 @@ def test_serve_heartbeat_once_ok_reports_inflight_load(monkeypatch, tmp_path):
     monkeypatch.setattr(gpu, "load_snapshot", lambda timeout=3.0: {})  # no-GPU box: load is just active_tasks + platform
     state = _serve_state(monkeypatch, tmp_path)
     seen = {}
-    monkeypatch.setattr(relay, "heartbeat", lambda url, tok, *, load: seen.update(load=load) or "ok")
+    monkeypatch.setattr(
+        relay, "heartbeat",
+        lambda url, tok, *, load, meta=None: seen.update(load=load, meta=meta) or "ok",
+    )
     assert serve.heartbeat_once(state) == "ok"
     assert seen["load"] == {"active_tasks": 0, "platform": "linux"}
 
@@ -17100,7 +17103,7 @@ def test_serve_heartbeat_once_re_registers_when_pruned(monkeypatch, tmp_path):
     from remote import relay, serve
 
     state = _serve_state(monkeypatch, tmp_path)
-    monkeypatch.setattr(relay, "heartbeat", lambda url, tok, *, load: "missing")
+    monkeypatch.setattr(relay, "heartbeat", lambda url, tok, *, load, meta=None: "missing")
     calls = []
     monkeypatch.setattr(serve, "register_once", lambda s: calls.append(s))
     assert serve.heartbeat_once(state) == "missing"
@@ -17254,7 +17257,7 @@ def test_serve_heartbeat_loop_stops_when_auth_exhausted(monkeypatch, tmp_path):
 
     state = _serve_state(monkeypatch, tmp_path, refresh_token=None)  # nothing to refresh with
 
-    def _raise_unauth(url, tok, *, load):
+    def _raise_unauth(url, tok, *, load, meta=None):
         raise relay.RelayUnauthorized()
 
     monkeypatch.setattr(relay, "heartbeat", _raise_unauth)
@@ -17310,7 +17313,7 @@ def test_serve_heartbeat_loop_records_a_relay_failure_and_heals_on_the_next_beat
 
     beats = []
 
-    def flaky(url, tok, *, load):
+    def flaky(url, tok, *, load, meta=None):
         beats.append(1)
         state.stop.set()  # exactly one tick per _heartbeat_loop call
         if len(beats) == 1:
@@ -17355,7 +17358,7 @@ def test_serve_heartbeat_loop_does_not_touch_the_record_on_a_healthy_tick(monkey
     monkeypatch.setattr(run_records, "mutate_record",
                         lambda *a, **k: mutations.append(a[:2]) or real_mutate(*a, **k))
 
-    def ok(url, tok, *, load):
+    def ok(url, tok, *, load, meta=None):
         state.stop.set()
         return "ok"
 
@@ -17400,7 +17403,7 @@ def test_serve_retries_the_registration_stamp_until_it_lands(monkeypatch, tmp_pa
     serve.register_once(state)  # registers with the relay; the record write is lost
     assert run_records.read_record("n1", "remote").get("registered_at") is None
 
-    def ok(url, tok, *, load):
+    def ok(url, tok, *, load, meta=None):
         state.stop.set()
         return "ok"
 
@@ -17435,7 +17438,7 @@ def test_serve_keeps_retrying_a_heal_whose_own_write_failed(monkeypatch, tmp_pat
 
     beats = []
 
-    def flaky(url, tok, *, load):
+    def flaky(url, tok, *, load, meta=None):
         beats.append(1)
         state.stop.set()
         if len(beats) == 1:
@@ -17562,7 +17565,11 @@ def test_meta_labels_all_external_union_as_external(monkeypatch, tmp_path):
         {"endpoint_url": "http://e1/v1", "models": ["a"], "engine_label": None},
         {"endpoint_url": "http://e2/v1", "models": ["b"], "engine_label": None},
     ]}
-    assert serve._meta(multi_external, "remote") == {"name": "mybox", "engine": "external"}
+    got = serve._meta(multi_external, "remote")
+    # Subset, not the whole dict: `_meta` also carries what the machine IS (device / chip / …),
+    # which is whatever box runs this suite. Asserting equality tied the engine-label rule to the
+    # test runner's hardware.
+    assert (got["name"], got["engine"]) == ("mybox", "external")
 
     single_external = {"endpoint_url": "http://h/v1", "models": ["a"]}  # flat single external → external
     assert serve._meta(single_external, "remote")["engine"] == "external"

--- a/tests/test_node_hardware.py
+++ b/tests/test_node_hardware.py
@@ -1,0 +1,156 @@
+"""How a node names itself on the grid page.
+
+The rule the page depends on: Apple Silicon is named by its CHIP, everything else by its CARD. The
+tests below drive each branch with the probes stubbed, because the real answer is whatever machine
+happens to run the suite — and the branch that matters most (Apple Silicon) is one no CI box has.
+
+The blank cases are as load-bearing as the named ones. The relay MERGES this over what it already
+holds, so a field that comes back empty must be dropped rather than sent: sending it blank would
+erase a name a previous run got right, on a page where nobody could see why.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from shared.system import node_hardware
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    """The module probes once and caches. Every test drives a different machine, so reset around
+    each — including after, so a stubbed answer never leaks into the next test or the real one."""
+    node_hardware._cached = None
+    yield
+    node_hardware._cached = None
+
+
+def _stub(
+    monkeypatch, *, system="Linux", apple_silicon=False, chip=("", ""), gpus=(),
+    profiler="", cpu="",
+):
+    """Drive one machine. `system` matters as much as the probes: the Intel-Mac branch is chosen by
+    the OS, so a test that leaves it alone silently exercises whatever box runs the suite."""
+    monkeypatch.setattr(node_hardware.platform, "system", lambda: system)
+    monkeypatch.setattr(node_hardware, "_is_apple_silicon", lambda: apple_silicon)
+    monkeypatch.setattr(node_hardware.apple, "describe_chip", lambda: chip)
+    monkeypatch.setattr(node_hardware.gpu, "enumerate_gpus", lambda *a, **k: list(gpus))
+    monkeypatch.setattr(node_hardware.gpu, "_sysctl_memsize_mb", lambda *a, **k: 196608.0)
+    monkeypatch.setattr(node_hardware.gpu, "_macos_profiler_vram_mb", lambda *a, **k: 4096.0)
+    monkeypatch.setattr(node_hardware.host, "cpu_brand", lambda: cpu)
+    monkeypatch.setattr(
+        node_hardware.subprocess, "check_output", lambda *a, **k: profiler.encode()
+    )
+
+
+class _Card:
+    def __init__(self, name, memory_total_mb=24576.0):
+        self.name = name
+        self.memory_total_mb = memory_total_mb
+
+
+def test_apple_silicon_is_named_by_its_chip(monkeypatch):
+    # The GPU is part of the SoC and has no name of its own — "Apple GPU" tells a reader nothing,
+    # while "Apple M4 Pro" is what they would say out loud about the machine.
+    _stub(monkeypatch, apple_silicon=True, chip=("Mac Studio", "Apple M4 Pro"))
+    got = node_hardware.describe()
+
+    assert got["chip"] == "Apple M4 Pro"
+    assert got["device"] == "Mac Studio"
+    assert got["memory_gb"] == 192
+
+
+def test_a_gpu_box_is_named_by_its_card(monkeypatch):
+    # The card decides what the box can run; its CPU brand is noise beside it.
+    _stub(monkeypatch, gpus=[_Card("NVIDIA GeForce RTX 4090")], cpu="AMD EPYC 7402P")
+    got = node_hardware.describe()
+
+    assert got["device"] == "NVIDIA GeForce RTX 4090"
+    assert got["chip"] is None
+    assert got["memory_gb"] == 24
+
+
+def test_several_identical_cards_read_as_one_name_with_a_count(monkeypatch):
+    # The name is a label, not an inventory — the memory figures the page shows come from telemetry,
+    # which counts them properly.
+    _stub(monkeypatch, gpus=[_Card("NVIDIA GeForce RTX 4090"), _Card("NVIDIA GeForce RTX 4090")])
+    assert node_hardware.describe()["device"] == "NVIDIA GeForce RTX 4090 ×2"
+
+
+def test_an_intel_mac_reports_its_discrete_card_over_the_integrated_one(monkeypatch):
+    # `enumerate_gpus` only knows nvidia-smi and no Intel Mac has an NVIDIA card, so this branch is
+    # the only thing standing between a MacBook Pro and advertising itself as "i386". The integrated
+    # chipset on a Mac is always the Intel-branded one; the discrete card is what matters.
+    _stub(
+        monkeypatch,
+        system="Darwin",
+        profiler=(
+            "Graphics/Displays:\n"
+            "      Chipset Model: Intel UHD Graphics 630\n"
+            "      Chipset Model: Radeon Pro 560X\n"
+        ),
+    )
+    got = node_hardware.describe()
+
+    assert got["device"] == "Radeon Pro 560X"
+    assert got["memory_gb"] == 4
+
+
+def test_an_intel_mac_with_only_integrated_graphics_is_still_named(monkeypatch):
+    _stub(monkeypatch, system="Darwin", profiler="      Chipset Model: Intel Iris Plus Graphics\n")
+    assert node_hardware.describe()["device"] == "Intel Iris Plus Graphics"
+
+
+def test_a_cpu_only_box_reports_its_processor_not_its_architecture(monkeypatch):
+    # `platform.processor()` answers "i386" on macOS and "x86_64" on Linux — the architecture, not
+    # the processor, and useless on a page whose job is to say what the machine is.
+    _stub(monkeypatch, cpu="Intel(R) Xeon(R) Gold 6248")
+    got = node_hardware.describe()
+
+    assert got["device"] == "Intel(R) Xeon(R) Gold 6248"
+    assert got["device_class"] == "server"
+
+
+def test_empty_fields_never_go_on_the_wire(monkeypatch):
+    # The relay merges this over what it holds, so a blank would erase a good name rather than
+    # leave it — a regression nobody could see from either side.
+    _stub(monkeypatch, apple_silicon=True, chip=("", ""))
+    monkeypatch.setattr(node_hardware.gpu, "_sysctl_memsize_mb", lambda *a, **k: 0.0)
+
+    assert node_hardware.describe() == {
+        "device": "",
+        "chip": None,
+        "memory_gb": None,
+        "device_class": "gpu",
+    }
+    assert node_hardware.meta_fields() == {"device_class": "gpu"}
+
+
+def test_a_probe_that_throws_leaves_the_node_serving(monkeypatch):
+    # An unnamed machine serves models perfectly well; taking the node down over a cosmetic field
+    # would trade a blank line for an outage.
+    monkeypatch.setattr(node_hardware, "_probe", lambda: (_ for _ in ()).throw(OSError("boom")))
+
+    assert node_hardware.describe() == {}
+    assert node_hardware.meta_fields() == {}
+
+
+def test_the_probe_runs_once_however_often_it_is_read(monkeypatch):
+    # Read on every heartbeat, and `system_profiler` takes seconds to answer.
+    calls = []
+    monkeypatch.setattr(
+        node_hardware, "_probe", lambda: calls.append(1) or {"device": "RTX 4090"}
+    )
+    for _ in range(5):
+        node_hardware.describe()
+
+    assert len(calls) == 1
+
+
+def test_a_caller_cannot_mutate_the_cache(monkeypatch):
+    # Both call sites merge this into a meta dict; a shared reference would let one of them change
+    # what every later heartbeat reports.
+    _stub(monkeypatch, gpus=[_Card("NVIDIA GeForce RTX 4090")])
+    node_hardware.describe()["device"] = "tampered"
+
+    assert node_hardware.describe()["device"] == "NVIDIA GeForce RTX 4090"


### PR DESCRIPTION
A node advertised its name and engine kind and nothing about the hardware, so the grid page could only say "Grid-Relay · macOS" — the same sentence for a laptop and for a 192 GB Mac Studio. Measured on prod: every node in the fleet reports `chip: null, device: ""`.

`node_hardware.describe()` fills that in, by one rule:

- **Apple Silicon is named by its CHIP** ("Apple M4 Pro"). The GPU is part of the SoC and has no name of its own, so "Apple GPU" would tell a reader nothing they can act on, while the chip is what they would say out loud.
- **Everything else is named by its CARD** ("NVIDIA GeForce RTX 4090 ×2"). That decides what the box can run; the CPU brand is noise beside it.

Intel Macs get their own branch. `enumerate_gpus` only knows `nvidia-smi` and no Intel Mac has an NVIDIA card, so without it a MacBook Pro with a Radeon Pro 560X fell through to the CPU path and advertised itself as "i386" — its architecture, written in a way nobody recognises. `system_profiler` answers properly; the integrated chipset on a Mac is always the Intel-branded one, so the discrete card wins. The CPU-only fallback moves to `host.cpu_brand()` for the same reason: `platform.processor()` returns the architecture, not the processor.

Probed once and cached. `system_profiler` takes seconds and this is read on every heartbeat; hardware does not change under a running process.

The heartbeat carries it, not just registration. Registration happens once, so a field the page gains afterwards stays blank on a machine that has been up for weeks — nothing re-registers a node that is serving fine. Sending it on every beat means a restart is enough to correct one. Only the hardware fields ride along: name and engine are already right from registration, and the relay merges what it receives, so a partial payload is the safe shape.

Empty fields are dropped rather than sent blank, for that same merge: a probe that came back short this run must not erase a name the last one got right.

A probe that throws leaves the node serving. An unnamed machine works perfectly well, and taking a node down over a cosmetic field would trade a blank line for an outage.