### PR TITLE
fix(engine): gate MTP flag on real GGUF header, not filename prefix

### DIFF
--- a/shared/engine/launcher.py
+++ b/shared/engine/launcher.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import httpx
 
 from shared import logging_setup, paths
+from shared.models import gguf
 
 
 MIN_LLAMA_SERVER_BUILD = 9240
@@ -182,7 +183,10 @@ def start_llm(
             "--no-context-shift",
         ]
     )
-    if Path(model_file).name.lower().startswith("qwen3.6"):
+    # Filename alone can't tell: unsloth ships a `Qwen3.6-35B-A3B-Q8_0.gguf` in both an
+    # MTP repo and a plain one, byte-identical name, only one with the fused draft head.
+    # Read the file's own header instead of trusting the name.
+    if gguf.has_mtp_head(model_path):
         cmd.extend(["--spec-type", "draft-mtp", "--spec-draft-n-max", str(profile.spec_draft_n_max)])
 
     proc = subprocess.Popen(cmd, stdout=log_fh, stderr=log_fh)

--- a/shared/models/gguf.py
+++ b/shared/models/gguf.py
@@ -80,3 +80,32 @@ def read_context_length(path: str | Path) -> int | None:
             return next(iter(ctx.values())) if ctx else None
     except Exception:
         return None
+
+
+def has_mtp_head(path: str | Path) -> bool:
+    """True when the file's own header declares a fused MTP draft head.
+
+    Checks `<arch>.nextn_predict_layers` in the file, not the filename or the HF repo it
+    came from — two unsloth repos ship a file with the identical name
+    (`Qwen3.6-35B-A3B-Q8_0.gguf`) where only one actually has the layer. Any unreadable or
+    malformed file returns False; callers should not add MTP flags on doubt.
+    """
+    try:
+        with open(path, "rb") as f:
+            if f.read(4) != b"GGUF":
+                return False
+            (version,) = struct.unpack("<I", f.read(4))
+            if version < 2:
+                return False
+            struct.unpack("<Q", f.read(8))  # tensor count (unused)
+            (kv_count,) = struct.unpack("<Q", f.read(8))
+
+            for _ in range(kv_count):
+                key = _read_str(f)
+                (vtype,) = struct.unpack("<I", f.read(4))
+                val = _read_value(f, vtype)
+                if key.endswith(".nextn_predict_layers"):
+                    return bool(val)
+            return False
+    except Exception:
+        return False


### PR DESCRIPTION
## Summary
- `launcher.py` gated `--spec-type draft-mtp` on the model filename starting with `qwen3.6`. Two unsloth HF repos ship a file with the identical name (`Qwen3.6-35B-A3B-Q8_0.gguf`) — one with the fused MTP draft head, one without — so the filename can't tell them apart. A user hit this: llama-server exited at model-load with the flag forced on a file that has no MTP head.
- Added `gguf.has_mtp_head()`, which reads `<arch>.nextn_predict_layers` from the file's own GGUF header. `launcher.py` now checks the real downloaded file instead of its name.

## Test plan
- [x] `uv run pytest tests/test_local_cli.py -k "start_llm or launcher or mtp or qwen"` — 9 passed
- [x] `uv run ruff check shared/models/gguf.py shared/engine/launcher.py` — clean
- [x] Verified `has_mtp_head()` against 3 real GGUF headers fetched from HF: MTP-repo Q8_0 → True, MTP-repo UD-IQ3_S → True, plain-repo Q8_0 (same filename) → False