### PR TITLE
fix(cli): one word for a task — and a default-project help line that is true

### DIFF
--- a/cli/parser.py
+++ b/cli/parser.py
@@ -655,7 +655,7 @@ def _add_project(sub) -> None:
     # push, the apply writes only `main`, and there is no revert — so without this the
     # conversation's NEXT turn is silently cut from a lost attempt's work.
     wip = project_sub.add_parser(
-        "wip", help="Work on a conversation's branch — the ref its turns are cut from")
+        "wip", help="Work on a conversation's branch — the ref its tasks are cut from")
     wip_sub = wip.add_subparsers(dest="wip_action", required=True)
 
     wip_reset = wip_sub.add_parser(
@@ -667,11 +667,11 @@ def _add_project(sub) -> None:
     # `test_a_refusal_only_ever_offers_a_command_that_really_works`, which is what that test is for.
     project_arg.add_conversation(
         wip_reset,
-        help="Which conversation's branch to move. `grid task get <turn-id>` prints the "
-             "conversation a turn belongs to.")
+        help="Which conversation's branch to move. `grid task get <task-id>` prints the "
+             "conversation a task belongs to.")
     wip_reset.add_argument(
         "--commit", required=True,
-        help="Where to put the branch. `grid task get <id>` prints the `base_commit` a turn was "
+        help="Where to put the branch. `grid task get <id>` prints the `base_commit` a task was "
              "cut from, which is usually the commit you want.")
     wip_reset.add_argument("--grid", default=None, help="Grid to act on (default: active grid).")
     wip_reset.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
@@ -685,10 +685,10 @@ def _add_project(sub) -> None:
         help="Where the project is: what it holds, what is running, and who can serve it",
         description=(
             "Where the project is.\n\n"
-            "What is holding your turns was answerable before only by attempting a create and "
+            "What is holding your tasks was answerable before only by attempting a create and "
             "reading the refusal. It is a read now, and it costs nothing.\n\n"
             "It is also how an application notices the project changed without running `git fetch`: "
-            "the grid applies every finished turn to the project itself, so what the project "
+            "the grid applies every finished task to the project itself, so what the project "
             "holds changes whenever anybody's work lands."),
         formatter_class=argparse.RawDescriptionHelpFormatter)
     project_arg.add_project(status)
@@ -923,9 +923,10 @@ def _add_task(sub) -> None:
     project_arg.add_project(
         create, required=False,
         help="Project id to run in, from `grid project list` (default: your own project named "
-             "'default', created on first use). You may run as many conversations in a project as "
-             "you like and they run alongside each other; the messages inside one conversation run "
-             "in the order you sent them. A colleague's work never blocks yours.")
+             "'default', when you already have one — it is never created for you). You may run "
+             "as many conversations in a project as you like and they run alongside each other; "
+             "the messages inside one conversation run in the order you sent them. A colleague's "
+             "work never blocks yours.")
     create.add_argument(
         "--file", action="append", default=None, metavar="LOCAL[:DEST]",
         help="File to upload with the task; repeatable. Committed with the task before any "
@@ -979,10 +980,10 @@ def _add_task(sub) -> None:
             "Send a follow-up message into a conversation. It runs after whatever that "
             "conversation is already doing — your messages inside one conversation run in the "
             "order you sent them, and you can type ahead without waiting.\n\n"
-            "The conversation id is printed by `grid task create`, and is on every turn that "
+            "The conversation id is printed by `grid task create`, and is on every task that "
             "`grid task get` and `grid task list` report.\n\n"
             "Only the person who started a conversation can send into it. A colleague can read "
-            "its turns; to work alongside them, start your own with `grid task create`."),
+            "its tasks; to work alongside them, start your own with `grid task create`."),
         formatter_class=argparse.RawDescriptionHelpFormatter)
     send.add_argument(
         "conversation_id",
@@ -991,7 +992,7 @@ def _add_task(sub) -> None:
     send.add_argument(
         "--file", action="append", default=None, metavar="LOCAL[:DEST]",
         help="File to upload with the message; repeatable. Committed before any provider can claim "
-             "the turn, so the agent always finds it. Placed at the file's own name unless you give "
+             "the task, so the agent always finds it. Placed at the file's own name unless you give "
              "a destination (e.g. ./conf.toml:config/conf.toml).")
     send.add_argument(
         "--dir", action="append", default=None, metavar="LOCAL[:DEST]",
@@ -1000,10 +1001,10 @@ def _add_task(sub) -> None:
              "`.git/`, `.grid/`, `.claude/`, `.mcp.json` and symlinks are skipped and reported.")
     send.add_argument(
         "--follow", action="store_true",
-        help="Watch the turn after sending it, and exit with its outcome — 0 completed, non-zero "
+        help="Watch the task after sending it, and exit with its outcome — 0 completed, non-zero "
              "otherwise, exactly as `grid task follow` does. Ctrl-C stops the watching, not the "
-             "turn. A message waiting for an earlier one in the same conversation simply shows "
-             "nothing until its turn comes.")
+             "task. A message waiting for an earlier one in the same conversation simply shows "
+             "nothing until the earlier one finishes.")
     send.add_argument("--grid", default=None, help="Grid to act on (default: active grid).")
     send.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
     send.set_defaults(handler=cmd_remote_task)
@@ -1042,7 +1043,10 @@ def _add_task(sub) -> None:
             "`--json` prints exactly what it always did; only the exit status is new. To watch a "
             "task instead of asking once, use `grid task follow`."),
         formatter_class=argparse.RawDescriptionHelpFormatter)
-    get.add_argument("task_id", help="Task id returned by `grid task create`.")
+    get.add_argument(
+        "task_id",
+        help="Task id, from `grid task create` or `grid task list`. Not the conversation id "
+             "— that one goes to `grid task send`.")
     get.add_argument("--grid", default=None, help="Grid to act on (default: active grid).")
     get.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
     get.set_defaults(handler=cmd_remote_task)
@@ -1057,21 +1061,25 @@ def _add_task(sub) -> None:
     follow = task_sub.add_parser("follow", help="Watch a task's output as it runs")
     what = follow.add_mutually_exclusive_group()
     what.add_argument("task_id", nargs="?", default=None,
-                      help="Turn id, as reported by `grid task get` and `grid task list`.")
+                      help="Task id, from `grid task create` or `grid task list`. Not the "
+                           "conversation id — that one goes to --conversation.")
     what.add_argument(
         "--conversation", default=None, metavar="<conversation-id>",
-        help="Watch a whole conversation instead of one turn — every turn's output in order, "
+        help="Watch a whole conversation instead of one task — every task's output in order, "
              "including steps the grid added itself. Ends when the conversation goes quiet.")
     follow.add_argument(
         "--after-seq", type=int, default=-1, dest="after_seq",
         help="Resume after this event sequence number (default: -1, from the start). "
-             "A conversation's sequence is its own and is not a turn's.")
+             "A conversation's sequence is its own and is not a task's.")
     follow.add_argument("--grid", default=None, help="Grid to act on (default: active grid).")
     follow.add_argument("--json", action="store_true", help="Emit one JSON event per line.")
     follow.set_defaults(handler=cmd_remote_task)
 
     fetch = task_sub.add_parser("fetch", help="Fetch a finished task's result into a directory")
-    fetch.add_argument("task_id", help="Task id returned by `grid task create`.")
+    fetch.add_argument(
+        "task_id",
+        help="Task id, from `grid task create` or `grid task list`. Not the conversation id "
+             "— that one goes to `grid task send`.")
     fetch.add_argument(
         "--into", default=None, metavar="DIR",
         help="Where to put the result (default: ./<task-id>). Created if missing; an existing "
@@ -1121,7 +1129,7 @@ def _add_task(sub) -> None:
             "Stop a task that has not finished.\n\n"
             "Until this existed the only way out of a task nobody wanted any more was to wait for "
             "its deadline — an hour if it was running, and up to four if it was still waiting for "
-            "a provider. A turn the grid queued to resolve a collision — one nobody typed — is the "
+            "a provider. A task the grid queued to resolve a collision — one nobody typed — is the "
             "usual reason to reach for it.\n\n"
             "The CONVERSATION survives. Cancelling stops this run and nothing else, so the next "
             "message you send continues where it left off — there is no way to end a conversation, "
@@ -1136,7 +1144,10 @@ def _add_task(sub) -> None:
             "Nothing is rewound: whatever the agent had already done is kept, so "
             "`grid task fetch` still works on it."),
         formatter_class=argparse.RawDescriptionHelpFormatter)
-    cancel.add_argument("task_id", help="Task id, from `grid task list` or `grid task create`.")
+    cancel.add_argument(
+        "task_id",
+        help="Task id, from `grid task create` or `grid task list`. Not the conversation id "
+             "— that one goes to `grid task send`.")
     cancel.add_argument("--grid", default=None, help="Grid to act on (default: active grid).")
     cancel.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
     cancel.set_defaults(handler=cmd_remote_task)
@@ -1155,7 +1166,10 @@ def _add_task(sub) -> None:
             "details kept, which is also an answer rather than a problem.\n\n"
             "To take a change back out, `grid task undo <task-id>`."),
         formatter_class=argparse.RawDescriptionHelpFormatter)
-    diff.add_argument("task_id", help="Task id, from `grid task list` or `grid task create`.")
+    diff.add_argument(
+        "task_id",
+        help="Task id, from `grid task create` or `grid task list`. Not the conversation id "
+             "— that one goes to `grid task send`.")
     diff.add_argument("--grid", default=None, help="Grid to act on (default: active grid).")
     diff.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
     diff.set_defaults(handler=cmd_remote_task)
@@ -1179,7 +1193,10 @@ def _add_task(sub) -> None:
             "This is not the same as `grid task cancel`, which stops a task that is still running "
             "and changes nothing."),
         formatter_class=argparse.RawDescriptionHelpFormatter)
-    undo.add_argument("task_id", help="Task id, from `grid task list` or `grid task create`.")
+    undo.add_argument(
+        "task_id",
+        help="Task id, from `grid task create` or `grid task list`. Not the conversation id "
+             "— that one goes to `grid task send`.")
     undo.add_argument("--grid", default=None, help="Grid to act on (default: active grid).")
     undo.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
     undo.set_defaults(handler=cmd_remote_task)

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -509,7 +509,13 @@ def _add_project(sub) -> None:
     # should find it where they were just sent.
     starter = project_sub.add_parser(
         "init",
-        help="Give an empty project a trunk, so tasks can run in it",
+        # ⚠️ No git word in the SUMMARY, and `test_project_inits_summary_speaks_the_same_words`
+        # keeps it that way. `init` is GIT_PLANE — its long description below may say `trunk`, and
+        # does — but this one line is different twice over: it is what `grid project --help` shows
+        # everybody who is merely browsing, and `_no_trunk_message` sends a brand-new person here
+        # BY NAME with the words "give it something to start from". Two registers for one step,
+        # one sentence apart, and the person reading them has never heard of a trunk.
+        help="Give an empty project a starting point, so tasks can run in it",
         description=(
             "Create the project's `main` at a single empty root commit.\n\n"
             "A project has no trunk when it is created, and a task cannot be cut from nothing. "

--- a/cli/project_arg.py
+++ b/cli/project_arg.py
@@ -40,7 +40,7 @@ _FORMS = "_project_forms"
 
 _LIST_HINT = "`grid project list` shows the ids you are a member of."
 _MEMBER_HINT = "`grid project member list` prints the key for each member."
-_CONVERSATION_HINT = ("`grid task get <turn-id>` prints the conversation a turn belongs to, and "
+_CONVERSATION_HINT = ("`grid task get <task-id>` prints the conversation a task belongs to, and "
                       "`grid task create` prints the one it opened.")
 
 
@@ -129,7 +129,7 @@ def add_path(parser: argparse.ArgumentParser, *, help: str) -> None:
 
 
 def add_conversation(parser: argparse.ArgumentParser, *,
-                     help: str = "Conversation id from `grid task get <turn-id>`.") -> None:
+                     help: str = "Conversation id from `grid task get <task-id>`.") -> None:
     """Register both spellings of a conversation id, and mark the parser as a two-positional shape.
 
     The third shape beside `add_member` and `add_directory`, added by ADR 0034 D-e (issue 41) when

--- a/cli/remote_project.py
+++ b/cli/remote_project.py
@@ -700,7 +700,7 @@ def _project_status(args: argparse.Namespace) -> int:
     if running:
         # The whole point of "what am I waiting on, and since when". Without the id there is nothing
         # to wait on, read or follow.
-        print(f"\nYou have {len(running)} turn(s) in flight:")
+        print(f"\nYou have {len(running)} task(s) in flight:")
         for turn in running:
             since = turn.get("created_at")
             print(f"  {turn['id']} ({turn.get('state') or 'unknown'}"
@@ -781,7 +781,7 @@ def _print_your_running_cap(answer: dict) -> None:
         # a body no healthy relay can produce: `config.validate_task_budgets` refuses to boot below
         # 1. Saying nothing is the right answer for a reply that contradicts its own server.
         return
-    print(f"\nyour running turns: {running} of {limit}")
+    print(f"\nyour running tasks: {running} of {limit}")
     if running >= limit:
         # The one sentence that is worth printing, and it exists to STOP a reading. Everything below
         # this line is about the fleet, and at the cap the fleet is not what the member is waiting

--- a/cli/remote_task.py
+++ b/cli/remote_task.py
@@ -1708,6 +1708,44 @@ def _note_an_unreadable_state(task_id: str, state: Any) -> None:
           f"See what it sent with `grid task get {task_id} --json`", file=sys.stderr)
 
 
+def _say_why_nothing_has_claimed_it(base: str, token: str, task: dict) -> None:
+    """Answer "why has nothing picked this up" where the question is actually asked.
+
+    The answer already existed, one command away, in `grid project status` — so completely that
+    `_QUEUE_EXPIRED_NOTE` has to name that command by hand. A person in their first hour has no
+    reason to run it and, until their task expires hours later, no reason to think anything is
+    wrong: a queue of one on a grid with no provider looks exactly like a queue of one on a busy
+    grid. This closes that gap by reading the fleet at the two moments the question exists.
+
+    Rendering goes through `project_providers`, the SAME helper `grid project status` uses, rather
+    than a second copy of the sentences: `serves_you` is the one state `online` gets backwards
+    (ADR 0033 D-f, issue 24), and two renderers of that rule would eventually disagree about it.
+
+    ⚠️ **Best-effort, and silent on every failure — deliberately.** This is an extra sentence beside
+    a report that has already succeeded, and `grid task get`'s exit code is a verdict about the
+    TASK. A status read that 5xxs, times out, or answers something unreadable must change neither
+    the report nor the code; a fleet this cannot read is exactly the "say nothing" case
+    `project_providers` is built around. `SystemExit` is in the tuple because it is this CLI's
+    clean-error idiom and `relay` raises it for an ordinary refusal — letting it through would
+    turn "I could not check the fleet" into the task's own verdict, which is the bug this guard
+    exists to prevent rather than a theoretical one.
+    """
+    project_id = task.get("project_id")
+    if not isinstance(project_id, str) or not project_id.strip():
+        # An older relay's task view carries no `project_id`. Nothing to ask about — and guessing
+        # one would read a project the caller never named.
+        return
+    from cli import project_providers
+    from remote import relay
+
+    try:
+        answer = relay.project_status(base, token, project_id)
+    except (Exception, SystemExit):
+        return
+    if isinstance(answer, dict):
+        project_providers.print_providers(answer.get("providers"))
+
+
 def _task_get(args: argparse.Namespace) -> int:
     from remote import relay
 
@@ -1748,6 +1786,12 @@ def _task_get(args: argparse.Namespace) -> int:
 
     print(f"task {task.get('id') or args.task_id}")
     print(f"state={task.get('state') or 'unknown'}")
+    if state == "queued":
+        # Only `queued`, and only here: `task get` is polled in a loop, so the extra read is paid
+        # in the states that raise the question and nowhere else. `preparing` is excluded on
+        # purpose — the relay is still writing the task's own inputs, and no provider could have
+        # claimed it yet, so a fleet report there would blame the fleet for the relay's own step.
+        _say_why_nothing_has_claimed_it(base, token, task)
     if task.get("provider_id"):
         print(f"provider={task['provider_id']}")
     if task.get("claude_session_id"):
@@ -1756,6 +1800,11 @@ def _task_get(args: argparse.Namespace) -> int:
         print(f"error={task['error']}")
         if task["error"] == QUEUE_EXPIRED:
             print(_QUEUE_EXPIRED_NOTE)
+            # The note ends by naming `grid project status`. Answering it here instead of sending
+            # somebody there is the whole of G-01's lesson applied one surface further along: this
+            # is the state that EMPTIES the queue, so it is also the state in which the member who
+            # was never served has the least to go on.
+            _say_why_nothing_has_claimed_it(base, token, task)
     if _is_merge_turn(task) and code == _EXIT_ENDED_BADLY:
         # ADR 0034 D-g (issue 42): a merge turn that fails must not be a person's last word. The
         # relay's `error` above is the PROVIDER's diagnostic — it names the paths git still has

--- a/cli/remote_task.py
+++ b/cli/remote_task.py
@@ -814,8 +814,8 @@ def _task_follow(args: argparse.Namespace) -> int:
         # refusal is here — and it names both, because somebody who typed neither does not yet know
         # a conversation is a thing they can follow.
         raise SystemExit(
-            "Say what to follow: a turn id, or a whole conversation.\n"
-            "  grid task follow <turn-id>\n"
+            "Say what to follow: a task id, or a whole conversation.\n"
+            "  grid task follow <task-id>\n"
             "  grid task follow --conversation <conversation-id>")
 
     stop = _follow_stream(

--- a/cli/remote_task.py
+++ b/cli/remote_task.py
@@ -1493,8 +1493,12 @@ def _task_list(args: argparse.Namespace) -> int:
     `--all` widens it from the caller's own runs to every member's, which is the point on a shared
     project: a team wants to see what the team ran, and the relay fences the answer on membership.
 
-    **Without a project it lists the caller's own turns across every project they can reach**, which
-    is the application's home screen. The relay refuses `--all` there — see `relay.list_tasks` — so
+    **Without a project it lists the caller's own tasks across every project they can reach** — the
+    rows an application's home screen is built FROM, which is not the same as being one. This prints
+    one row per TASK, in time order and ungrouped, so a five-task conversation is five rows and not
+    a thread. Grouping by `conversation_id` is the client's job and `docs/FE-integration.md` says so;
+    the flat log is the right shape for a terminal and for a script, and a CLI that grouped would owe
+    both of them a `--flat` to undo it. The relay refuses `--all` there — see `relay.list_tasks` — so
     every row on that page is the caller's own, which is why the MEMBER column becomes PROJECT
     rather than being added beside it: a column whose every cell is the same value costs 36
     characters to say nothing, and which project a conversation is in is the one thing a

--- a/docs/FE-integration.md
+++ b/docs/FE-integration.md
@@ -1,0 +1,465 @@
+# FE integration — driving the grid CLI from a mobile app
+
+**Audience: a coding agent building the client.** Everything here is a contract verified against the
+CLI's own source, not a description of intent. Where a number appears it was measured. Follow it
+literally; where it says "branch on this", branch on exactly that and nothing else.
+
+The feature is **distributed tasks for non-developers** (ADR 0034): a person describes work in
+words, some machine runs a coding agent on the project, and the result appears in the project by
+itself. Nobody merges, approves, or types a git command — **and your UI must not reintroduce any of
+that.** §7 is not styling advice; it is the product.
+
+Companion documents: [`tasks-quickstart.md`](./tasks-quickstart.md) is the full command reference,
+[`tasks-macos-walkthrough.md`](./tasks-macos-walkthrough.md) is a human walkthrough of the same flow.
+
+---
+
+## 1. Read this before you design anything
+
+### The CLI cannot run on the phone
+
+`grid` is a Python wheel plus macOS/Linux binaries. iOS does not permit spawning arbitrary
+executables at all; there is no Android build. **"Wrapping the CLI" therefore always means the CLI
+runs somewhere else and the app drives it.** Decide which of these you are building before writing
+a line:
+
+| | **A · Companion host** (recommended for v1) | **B · Direct relay HTTP** |
+|---|---|---|
+| Shape | `grid … --json` runs on a machine the user owns; a thin shim spawns it and forwards stdout / stderr / exit code. The app talks to the shim | The app calls the relay's `/relay/v1` routes itself with a grid access token |
+| You get for free | credential storage and refresh, the postcondition guards (§6), the refusal vocabulary, the git plane | nothing — you re-implement all of it |
+| You must build | one process-spawning shim | token lifecycle, every guard in §6, and you own the cross-repo wire contracts by hand |
+| Blocks on | a host being reachable | nothing |
+
+**The non-dev flow needs no local git.** `task create/send/get/list/follow/cancel/undo` and
+`project files/file/download/status/diff` are all plain relay calls — issue 45 exists precisely so a
+user's machine needs no developer tools. Only `project import`, `project clone`, `task fetch` and
+`project refresh` need git, and none of them are on the path a non-dev user walks. So **B is viable
+later**; start with A because the CLI encodes guards you would otherwise discover in production.
+
+**Either way the document shapes below are identical**, because `--json` on stdout is the relay's own
+document passed through unchanged — the CLI validates a few postconditions but never reshapes a
+payload.
+
+### Auth is out of band
+
+`grid login` is a **device-code flow that requires a browser** and writes credentials to `~/.grid`
+on the host. Your app cannot perform it. Provision the host once, out of band; the app assumes a
+logged-in host. A 24-hour session is refreshed by `grid sync` without a browser.
+
+> ⚠️ `grid sync` prints `Your grid session has expired…` and **still exits 0**. Never treat its exit
+> code as proof of a live session — check that the command you actually wanted succeeded.
+
+---
+
+## 2. The domain model
+
+Five nouns. Get the first two right and most bugs disappear.
+
+| noun | what it is | id shape | your app |
+|---|---|---|---|
+| **project** | a repository the grid hosts, with members. Addressed by **id, never by name** | uuid | a workspace / folder the user picks |
+| **conversation** | one agent session you return to; many tasks. **This is the thread the user comes back to** | uuid | a chat thread |
+| **task** | one message + one agent run inside a conversation. **This is what the user calls "a task"** | uuid | one message bubble + its result |
+| **member** | a person on the grid, identified inside a project by `member_key` | 32-hex | an avatar. `member_key` is **per grid** — it is not an email and not a user id |
+| **worktree** | the provider's checkout of one conversation | — | **never surface it.** Listed here only so you do not mistake a provider-side concept for something the app owns |
+
+> ⚠️ **Three JSON keys still spell a task `turn`**: `active_turns`, `member_running_turns` and
+> `member_running_cap`. Read them by those exact names — but show the user the word **task**. The
+> CLI's own help, output and refusals say `task` everywhere; `turn` is not a word your users see.
+
+Also: **`main`** is the project's trunk — everybody's finished work. Created once, then **the grid
+moves it**. There is no branch for the app to choose, show, or switch.
+
+### The one distinction that breaks apps
+
+`grid task create` returns **two** ids and they address different objects:
+
+```
+{ "id": "<task-id>", "conversation_id": "<conversation-id>", ... }
+```
+
+| takes a **task** id | takes a **conversation** id |
+|---|---|
+| `task get`, `task follow <id>`, `task cancel`, `task diff`, `task undo`, `task fetch` | `task send`, `task follow --conversation <id>`, `project commit` |
+
+Store both on every message you render. Passing one where the other belongs is a 404 that reads like
+"it disappeared".
+
+### Ordering rules — the whole concurrency model
+
+- **Inside one conversation**: messages run **strictly in the order sent, one at a time**. The user
+  may type ahead; queue them and show them as pending. There is no parallelism to expose.
+- **Across conversations**: everything runs at once. A colleague never blocks the user.
+- **Only the person who started a conversation can send into it.** A colleague can read its tasks.
+  "Reply" on someone else's thread must create a *new* conversation, not fail.
+
+---
+
+## 3. The machine contract
+
+### stdout, stderr, exit code
+
+- `--json` puts the relay's document on **stdout**. Pass it through; do not reshape.
+- Refusals go to **stderr** as one line of JSON, and **the human sentence follows on the next
+  line**. ⚠️ **Parse the FIRST line only** — `JSON.parse(wholeStderr)` fails.
+
+```json
+{"error":{"code":"project_has_no_trunk","message":"…","status":422}}
+```
+
+| field | meaning |
+|---|---|
+| `code` | machine-readable refusal code, or `null` for a local refusal / a relay that sent plain prose |
+| `message` | **never empty**, guaranteed. Show it to the user |
+| `status` | the relay's HTTP status, or `null` if the relay was never reached. `null` means *"we could not ask"* — not a verdict. Do not cache a `null`-status failure as a fact about the project |
+
+### Exit codes
+
+| code | meaning |
+|---|---|
+| `0` | success |
+| `1` | failed, timed out, **or any refusal**, **or the relay was unreachable** |
+| `2` | **not finished yet** — and this is the *only* code a poller may read as "ask again" |
+
+`2` exists so waiting is expressible: `0` would claim an outcome nobody reached, `1` would claim it
+went wrong. A state this CLI cannot place — one a newer relay invented — is reported as **unfinished**
+with a note on stderr, never as success or failure. Mirror that: unknown state ⇒ keep polling.
+
+### Task states
+
+```
+preparing → queued → running → completed | failed | timed_out
+```
+
+Terminal = `completed`, `failed`, `timed_out`. A **cancelled** task arrives as `failed` with
+`error = "cancelled"`. Anything else you receive: treat as non-terminal and keep polling.
+
+### The event stream
+
+`task follow --json` writes **one JSON object per line** on stdout:
+
+```json
+{"seq": 12, "event": {"type": "task.output", "...": "..."}}
+{"seq": 13, "task_id": "<task-id>", "event": {"type": "...", "...": "..."}}
+```
+
+`task_id` is present only when following a **conversation** (you need it to attribute each event to a
+task). Rules:
+
+| | task follow | conversation follow |
+|---|---|---|
+| ends on event `type` | `task.terminal` (carries `state`) | `conversation.idle` |
+| exit code | `0` iff the terminal event's `state == "completed"` | `0` iff the stream was watched to its end — **not** the last task's outcome |
+| cursor | `--after-seq <last seq seen>`; default `-1` = from the start | same, **but a conversation's sequence is its own and is not a task's** |
+
+Resuming with `--after-seq n` replays exactly what follows — **no gap and no repeat**. Persist the
+cursor per stream; on reconnect, resume rather than restart, or the user sees the conversation twice.
+
+A conversation has **no terminal state** — "is this finished?" is not a fact the grid owns. Do not
+invent a "done" badge for a thread; `conversation.idle` means *quiet right now*.
+
+---
+
+## 4. Command surface the app needs
+
+Every command also takes `--grid <id>` and `--json`.
+
+| what the user is doing | command | returns |
+|---|---|---|
+| list workspaces | `project list --json` | `{"projects":[…]}` |
+| new workspace, ready at once | `project create --name <n> --empty --json` | `{"id":…, "bootstrap":{"status":"initialized","commit":…,"trunk":"main"}}` |
+| first message | `task create --project <pid> --prompt <p> --json` | `{"id":<task>, "conversation_id":<conv>, "state":…}` |
+| next message | `task send <conv> --prompt <p> --json` | a task document |
+| attach files to a message | add `--file LOCAL[:DEST]` (repeatable) | committed **before** any provider claims the task |
+| watch one task | `task follow <task> --json --after-seq <n>` | event lines |
+| watch a thread | `task follow --conversation <conv> --json --after-seq <n>` | event lines with `task_id` |
+| poll one task | `task get <task> --json` | task document; **exit 2 = ask again** |
+| thread list / home screen | `task list --json` (no `--project`) | `{"tasks":[…], "next_after":…}` — the caller's own conversations **across every project** |
+| one project's activity | `task list --project <pid> --all --json` | the whole team's; `--all` **requires** a project |
+| browse the project | `project files <pid> [path] --json` | `{"entries":[{"name","type","size","executable"}], "commit":…}` |
+| open a file | `project file <pid> <path> --json` | `{"content","encoding","size","limit","too_large","truncated"}` |
+| export | `project download <pid> --output <f>.zip --json` | `{"project_id","path","bytes"}` |
+| what did this change | `task diff <task> --json` | the change, and **who asked for it** |
+| take it back | `task undo <task> --json` | `{"undone":true,"trunk_commit":…}` |
+| stop a run | `task cancel <task> --json` | the conversation survives |
+| where is the project | `project status <pid> --json` | see below — this is your change signal |
+| invite | `project member add <pid> --email <e> --json` | they must have signed in to the grid once |
+
+**Pagination**: `task list` returns `next_after` when there is more; pass it as `--after`. Absent ⇒
+last page. `--limit` defaults to 50, max 200.
+
+### `project status --json` — the keys worth reading
+
+| key | type | use |
+|---|---|---|
+| `main_commit` | string | **the project's change signal.** Diff it against the one you hold to notice that anybody's work landed. This is how you detect the apply in Step 4 |
+| `trunk` | string | the trunk's **ref name** (`"main"`), *not* an object. ⚠️ Never render it — it is a git word on a non-dev home screen, which is why the CLI deliberately prints `version=<main_commit>` instead |
+| `active_turns` | array of `{id, state, created_at}` | the caller's tasks in flight. **Absent ⇒ show nothing** — never treat a missing key as zero |
+| `queue` | `{queued, running}` | why nothing is moving, project-wide |
+| `member_running_turns` / `member_running_cap` | int | how much of their own allowance the user is using. **Both must be present integers or say nothing.** ⚠️ `running > cap` is a legitimate reading, not a bug to clamp — a merge task is exempt from the cap but still counts |
+| `archived` | bool | `=== true` ⇒ read-only |
+| `visibility` | string | `=== "private"` ⇒ members only. Absent ⇒ grid-visible |
+| `providers` | — | who could take the work |
+
+---
+
+## 5. The end-to-end flow, step by step
+
+### Step 0 — host is logged in
+
+Out of band (§1). Verify cheaply at app start with any read, e.g. `project list --json`.
+
+### Step 1 — get a project that can accept work
+
+A new project has **no trunk**, and a task cannot be cut from nothing. For a non-dev app there is
+exactly one correct call:
+
+```
+project create --name <name> --empty --json
+```
+
+⚠️ **Check the postcondition, do not trust the 201.** `bootstrap` is the one key in this whole plane
+that degrades **silently** against an older relay — the key is dropped, you get a 201, and the
+project has no trunk:
+
+```ts
+if (doc.bootstrap?.status !== "initialized") throw new Error("project was not bootstrapped");
+```
+
+`--empty` is **irreversible**: a project that holds anything can never import an existing repository.
+That is fine for an app that starts from nothing; never offer both paths in the same wizard.
+
+If you ever see `code: "project_has_no_trunk"`, the project is unusable — do not retry the task, fix
+the project. This is one of only two codes you branch on (§6).
+
+### Step 2 — the first message
+
+```
+task create --project <pid> --prompt "<what the user typed>" --json
+```
+
+Store `id` (task) **and** `conversation_id`. Render the thread from the conversation id from now on.
+
+### Step 3 — watch it
+
+Prefer **conversation** follow for a chat UI — one stream carries every task plus the steps the grid
+adds itself:
+
+```
+task follow --conversation <conv> --json --after-seq <cursor>
+```
+
+Persist `seq` after every line. On reconnect, resume from it.
+
+If you cannot hold a long-lived process (mobile background limits make this normal), poll instead:
+
+```ts
+// exit 2 is the ONLY "ask again"
+const rc = await run(["task","get",turnId,"--json"]);
+if (rc === 2) { scheduleRetry(); } else if (rc === 0) { done(); } else { showRefusal(); }
+```
+
+### Step 4 — ⚠️ the task finishing is not the project changing
+
+`--follow` returning, and `state: "completed"`, mean **the task reported**. The grid applies the
+result to the project a moment later — **measured at about 3 seconds** on a small project. The
+relay does this outside the report on purpose, because the provider's lease has only ~25–30s left at
+that moment and a merge does not fit in it.
+
+So: **never read a file immediately after a task completes and render it as the result.** Poll
+`project status --json` and wait for **`main_commit`** to change from the value you held before the
+task. An app that skips this shows the user their old content and looks broken.
+
+### Step 5 — show the result
+
+`project files` / `project file` for browsing, `task diff <task>` for "what did this message change".
+`diff` also names **who asked for it**, which is what makes a shared project legible.
+
+### Step 6 — the next message
+
+```
+task send <conv> --prompt "<…>" --json
+```
+
+It runs after whatever that conversation is already doing. Let the user type ahead freely; show
+queued messages as pending. Tasks **compose** — the second builds on the first, it does not start
+over.
+
+### Step 7 — steps the grid takes on its own
+
+When two people touch the same file, the grid puts a **merge task** into the losing conversation and
+an agent reconciles it. Your app will receive tasks nobody typed.
+
+```ts
+const isGridStep = task.kind === "merge";   // EQUALITY, never truthiness
+```
+
+- `kind === "merge"` ⇒ render as **a step the grid took**, with your own words. Never as a message
+  from the user.
+- `kind` **missing or anything else** ⇒ a person's message. A missing key must never invent a
+  refusal or a special case.
+- ⚠️ A merge task's `result_text` is the **model's own output** and is full of git vocabulary
+  (`git add`, `<<<<<<<`, "committed as f0e7cfa"). Do **not** show it raw to a non-dev user. `kind` is
+  what lets you avoid it.
+
+### Step 8 — undoing
+
+```
+task undo <task> --json
+```
+
+Removes exactly what that one task changed; everything done since stays. Only the person who asked
+for the task, or the project's owner, may undo it. Expect these refusals and show `message`:
+
+| code | status | meaning |
+|---|---|---|
+| `undo_conflicts` | 409 | somebody built on the same files. It names them. The way forward is a new message, not a retry |
+| `already_undone` | 409 | undone before |
+| `nothing_to_undo` | — | the task failed, or its result has not reached the project yet |
+
+### Step 9 — cancelling
+
+```
+task cancel <task> --json
+```
+
+The **conversation survives**; the next message continues. The agent stops within ~30s, on the
+provider's next lease renewal. Any project member may cancel any task in it — often the person who
+needs to is not the one who started it.
+
+> ⚠️ **Do not promise the user their work is kept.** `grid task cancel --help` says `task fetch`
+> still works on a cancelled task; measured, it returns the tree from *before* the agent ran. Nothing
+> that had already landed is lost, but a cancelled task has no result to recover.
+
+---
+
+## 6. The five failures that will not announce themselves
+
+Every one of these has already been got wrong once. All are silent: green paths, wrong behaviour.
+
+1. **A new key on an existing endpoint degrades silently; a new route gives a loud 404.** So verify
+   new keys by their **postcondition in the reply** — `bootstrap.status === "initialized"` after
+   create, the echoed `project_id` after `task create`. Neither prevents a bad write; both stop you
+   reporting it as success.
+2. **Compare wire enums for equality, never truthiness.** `kind`, `archived`, `visibility`,
+   `undone`, `serves_you`, the cap keys. `if (task.kind)` is a bug; `if (task.kind === "merge")` is
+   the contract. A missing key must never produce a refusal.
+3. **Exit `2` is the only "ask again".** `1` covers a failed task *and* an unreachable relay, so a
+   poller that retries on `1` loops forever on a genuine failure. And `until grid task get "$id"`
+   without an `rc` check waits forever on a failed task.
+4. **Read the first line of stderr.** JSON on line 1, an English sentence on line 2.
+5. **Do not branch on more than two refusal codes.** Exactly `project_has_no_trunk` and
+   `project_already_has_trunk` are worth reading; **display every other refusal verbatim**. Each
+   relay message already names the way forward, and every extra code you parse is another thing a
+   reworded relay breaks. If you want to pin something in a test, pin the *remedy sentence*, not the
+   code.
+
+Two more that are about state rather than parsing:
+
+- **Archived project**: every read still works; writes are refused `project_archived` (409) naming
+  `grid project unarchive`. Render it read-only rather than broken.
+- **Private project**: a non-member's read is **byte-identical** to the refusal for a project id that
+  does not exist. You cannot tell "forbidden" from "absent", and you must not try — that is the
+  design.
+
+---
+
+## 7. UI rules that come from the product, not from taste
+
+ADR 0034's premise is that the user never learns git. The CLI's own surface is scanned against a
+git-vocabulary denylist. Your app is the other half of that, and nothing enforces it for you.
+
+- **Never show**: branch, merge, rebase, commit, ref, trunk, HEAD, conflict markers, SHAs.
+- **"Where is my work?"** is answered by `project files` / `project file` / `task diff`, not by a
+  history view.
+- **A merge task is a step, not a message** (§7 above).
+- **There is no approve button.** Finished work reaches the project by itself; the affordance is
+  `task undo` *afterwards*, which is a different interaction from a review queue. Do not build one.
+- **There is no "end conversation".** The grid holds no such state.
+- **Do not show a progress percentage.** A task has states, not progress; `preparing → queued →
+  running` is the honest display, and `queued` means "waiting for a machine", which is worth saying.
+
+---
+
+## 8. Reference driver
+
+```ts
+type Refusal = { code: string | null; message: string; status: number | null };
+
+async function grid(args: string[]): Promise<{rc: number; out: string; err: string}> {
+  // Architecture A: spawn on the companion host. --json is always appended.
+  return spawnOnHost("grid", [...args, "--json"]);
+}
+
+function refusalOf(stderr: string): Refusal | null {
+  const firstLine = stderr.split("\n", 1)[0];           // ← line 1 only
+  try { return JSON.parse(firstLine).error ?? null; } catch { return null; }
+}
+
+async function createProject(name: string) {
+  const { rc, out, err } = await grid(["project", "create", "--name", name, "--empty"]);
+  if (rc !== 0) throw refusalOf(err) ?? new Error("project create failed");
+  const doc = JSON.parse(out);
+  if (doc.bootstrap?.status !== "initialized") throw new Error("not bootstrapped");  // postcondition
+  return doc.id as string;
+}
+
+async function firstMessage(projectId: string, prompt: string) {
+  const { rc, out, err } = await grid(["task", "create", "--project", projectId, "--prompt", prompt]);
+  if (rc !== 0) {
+    const r = refusalOf(err);
+    if (r?.code === "project_has_no_trunk") throw new Error("project unusable — do not retry");
+    throw new Error(r?.message ?? "could not start");
+  }
+  const doc = JSON.parse(out);
+  return { turnId: doc.id as string, conversationId: doc.conversation_id as string };
+}
+
+async function awaitTurn(turnId: string): Promise<"completed" | "failed"> {
+  for (;;) {
+    const { rc } = await grid(["task", "get", turnId]);
+    if (rc === 2) { await sleep(5000); continue; }      // the ONLY ask-again
+    return rc === 0 ? "completed" : "failed";
+  }
+}
+
+// ⚠️ completed !== visible. Wait for the project to move (~3s, measured).
+// `main_commit` is the project's change signal — the CLI's own source says an application
+// diffs it against the one it holds to notice that anybody's work landed.
+async function awaitApplied(projectId: string, mainCommitBefore: string) {
+  for (;;) {
+    const { out } = await grid(["project", "status", projectId]);
+    if (JSON.parse(out).main_commit !== mainCommitBefore) return;
+    await sleep(2000);
+  }
+}
+
+async function* followConversation(conversationId: string, cursor: number) {
+  // Each stdout line is {seq, task_id?, event:{type,...}}; persist seq, resume with --after-seq.
+  for await (const line of streamLines(
+      ["task", "follow", "--conversation", conversationId, "--after-seq", String(cursor)])) {
+    const { seq, task_id, event } = JSON.parse(line);
+    yield { seq, turnId: task_id as string | undefined, event };
+    if (event.type === "conversation.idle") return;     // quiet — NOT "finished"
+  }
+}
+```
+
+---
+
+## 9. Acceptance checklist
+
+Before calling the integration done, prove each of these against a live grid:
+
+- [ ] Two ids are stored per message; `send` is never given a task id
+- [ ] `bootstrap.status === "initialized"` is asserted after every project create
+- [ ] A poller treats **only** exit 2 as retryable, and terminates on 1
+- [ ] Refusals are parsed from **line 1** of stderr, and `message` is what the user sees
+- [ ] Exactly two refusal codes are branched on; everything else is displayed verbatim
+- [ ] `kind === "merge"` renders as a grid step, and its `result_text` is never shown raw
+- [ ] The UI waits for the project to move before showing a task's result as visible
+- [ ] Stream reconnect uses `--after-seq` and produces no duplicate bubbles
+- [ ] Typing ahead in one conversation queues in order and is shown as pending
+- [ ] "Reply" on a colleague's conversation starts a new one instead of failing
+- [ ] An archived project renders read-only; a private one is indistinguishable from absent
+- [ ] No git vocabulary appears anywhere in the UI, including error surfaces

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -375,7 +375,7 @@ What the passthrough contract means for the app, in plain language:
 - **Requests leave the grid for the vendor** (OpenAI), forwarded by the member whose seat serves
   them — and **spend that member's own monthly Codex allowance**.
 - **The vendor is forced stateless**: the relay refuses `store: true`, `previous_response_id`, and
-  `conversation` up front (in the vendor's own error shape), so every turn resends the full
+  `conversation` up front (in the vendor's own error shape), so every task resends the full
   history — exactly how the Codex CLI already behaves. A long session therefore grows toward the
   relay's request body-size cap, which is the practical session bound.
 - **The relay still retains stream chunks for its task TTL** — like every other grid endpoint —
@@ -952,23 +952,23 @@ another's, and a 403 would confirm the project exists.
 
 ### Each conversation has a branch, and the trunk is where work lands
 
-A turn is cut from — and settles back onto — **`wip/<conversation-id>`**, the branch of the
+A task is cut from — and settles back onto — **`wip/<conversation-id>`**, the branch of the
 conversation it belongs to. A member does not have a branch; each of their conversations has one.
 That is what lets several conversations of one person run at the same time without their results
 racing for a single ref, and it is why `grid project commit` and `grid project wip reset` are
 addressed by a conversation rather than by a member.
 
-**A turn settles onto that branch whether it succeeded or failed**, which is the part worth knowing.
-A failed turn is not thrown away: the next message you send in that conversation starts from where
+**A task settles onto that branch whether it succeeded or failed**, which is the part worth knowing.
+A failed task is not thrown away: the next message you send in that conversation starts from where
 the last one broke, which is the state the conversation's own transcript remembers. The trunk is the
-ref that is success-only — a turn reaches it by succeeding, and by nothing else.
+ref that is success-only — a task reaches it by succeeding, and by nothing else.
 
 A project's `main` therefore has to **exist before its first task**: a project created with no
 commits refuses task creation with a message saying so. Three things give it one — `grid project
 create --empty`, which does it in the same request; `grid project init`, for a project that already
 exists; and `grid project import`, for a repository that already exists. **The relay is `main`'s
 only writer** — a `git push` of `main` is refused whatever state the project is in — so those three
-create it, the relay's own apply of each finished turn moves it afterwards, and nothing else touches
+create it, the relay's own apply of each finished task moves it afterwards, and nothing else touches
 it.
 
 ### Cloning a project onto your own machine
@@ -985,14 +985,14 @@ written into `.git/config` once would expire in place. The helper reads only you
 store: `git pull` keeps working when the control plane is unreachable.
 
 You are put on **the project's trunk**, which is everybody's work: the grid applies every successful
-turn to it, so a clone that follows it holds what the whole team has done, including your own. It
+task to it, so a clone that follows it holds what the whole team has done, including your own. It
 used to check out `wip/<your key>` instead, because under the old release model work stopped on each
 member's branch until somebody promoted it and the trunk could hold none of yours. The trunk is now
 the answer to "give me the project", which is what this command is for.
 
 **`git push` is refused**, and that is the design rather than a permission to ask for. The project is
 written by the grid alone, which is what stops work running right now having the ground moved under
-it: a push holds nothing, so it could fast-forward a branch while a turn cut from it is still going.
+it: a push holds nothing, so it could fast-forward a branch while a task cut from it is still going.
 To land work from a clone: `grid project commit <conversation-id>` for files, or `grid task create`
 for an agent.
 
@@ -1031,7 +1031,7 @@ the branch tracks nothing; HEAD is detached.
 
 "The grid does not have this branch" has two opposite histories, and the command does not guess
 between them: a conversation's branch is not there until work lands on it, and a `task/<id>` branch
-is collected again once its turn is over. From inside a clone the two look identical.
+is collected again once its task is over. From inside a clone the two look identical.
 
 Diverging deserves a note, because it is the only one where the obvious next step is wrong. `git
 pull` there "works" by making a merge commit you can never push — members do not push — so refresh
@@ -1084,7 +1084,7 @@ Nothing undoes it — not `grid project delete`, which refuses a project that ha
 
 `grid project init <project-id>` is the same operation for a project that is already there, and it
 is what to run if `--empty` was not passed and no import is coming. Both make **one empty root
-commit** and hold **no files**: work reaches `main` by being applied there — a turn, or `grid project
+commit** and hold **no files**: work reaches `main` by being applied there — a task, or `grid project
 commit` — and never by a bootstrap, so a request carrying files is refused rather than quietly
 ignored.
 
@@ -1133,7 +1133,7 @@ depends on a repository's conventions has to say so.
 
 ### Your work appears by itself
 
-There is nothing to run after a turn finishes. **The grid applies every successful turn to the
+There is nothing to run after a task finishes. **The grid applies every successful task to the
 project itself** — fast-forward when it can, a merge commit when git can combine the two, and (from
 issue 42) a merge step in the conversation that caused the collision when it cannot.
 
@@ -1147,10 +1147,10 @@ Two consequences worth knowing:
 
 - **The trunk has no known-good property left.** Nothing asserts it builds or runs — and nothing did
   before either, except a person's judgement at promote time.
-- **A conversation of five turns puts four intermediate states into the project.** Colleagues used to
-  see each other's work when somebody thought it was ready; they now see it at every turn.
+- **A conversation of five tasks puts four intermediate states into the project.** Colleagues used to
+  see each other's work when somebody thought it was ready; they now see it at every task.
 
-The apply runs **outside** the request that reports a turn finished, so "done" and "in the project"
+The apply runs **outside** the request that reports a task finished, so "done" and "in the project"
 are a moment apart rather than the same instant. That is deliberate: the provider stops renewing its
 lease before it reports, so anything the relay did inside that request would be spending a budget
 nobody is watching.
@@ -1163,7 +1163,7 @@ has to be readable by a program: a document on stdout, a code it can branch on, 
 Mobile is out of scope by construction; iOS and Android sandboxes forbid executing a separate binary.
 
 `tests/e2e_cross_repo/app_flow.sh` is the worked example, run as a test on every change: it opens a
-conversation, sends two more messages into it, follows the whole conversation across the turn
+conversation, sends two more messages into it, follows the whole conversation across the task
 boundary, reads the outcome and branches on it — using only `--json` and exit codes.
 
 **Every command an application drives takes `--json`**, and each prints exactly one document on
@@ -1181,7 +1181,7 @@ they are the only place git vocabulary appears at all. A test sweeps every other
 and help text for it (`tests/test_application_surface.py`).
 
 **Exit codes.** `0` completed · `1` ended badly, and any refusal · `2` not finished yet.
-`2` is the only code a poller may read as "ask again": `1` covers both a failed turn and a relay that
+`2` is the only code a poller may read as "ask again": `1` covers both a failed task and a relay that
 could not be reached, and `0` would say "fine" about an outcome nobody has reached.
 
 ```sh
@@ -1225,7 +1225,7 @@ grid task list --project abc123 --all   # every member's, in one project
 grid project files    <project-id> [<path>]
 grid project file     <project-id> <path> [--output <file>]
 grid project download <project-id> [--output <file>]
-grid task    diff     <turn-id>
+grid task    diff     <task-id>
 ```
 
 These need **no git on your machine** and no clone. They read the project as it stands now — the
@@ -1313,13 +1313,13 @@ knows the work is a better place to settle it than an automatic reversal.
 grid project status <project-id>
 ```
 
-`grid project status` shows where the project's trunk is, which of your turns are in flight and since
+`grid project status` shows where the project's trunk is, which of your tasks are in flight and since
 when, and how deep the project's queue is. Before it, "what is holding my slot" meant attempting a
 create and reading the refusal — a write, used as a question.
 
-It also says **how many of your turns are running, and how many may** — the grid caps how much of the
+It also says **how many of your tasks are running, and how many may** — the grid caps how much of the
 fleet one person can hold at once, so your colleague's single message is never stuck behind twenty of
-yours. Nothing is ever refused because of it: a turn over the cap simply waits for one of your own to
+yours. Nothing is ever refused because of it: a task over the cap simply waits for one of your own to
 finish, and starts by itself. At the cap the status says so in as many words, because that is the one
 state where the queue and provider numbers below it are **not** the explanation — the fleet may be
 completely idle, and adding a provider to it would change nothing.
@@ -1331,13 +1331,13 @@ from a withdrawn one, and those need three different actions — wait, run `grid
 named time. Nothing is printed when the whole fleet is serving.
 
 `grid project status` is also how an application notices the project changed without running
-`git fetch`, and it got simpler when the grid started applying turns itself: **the trunk's commit
+`git fetch`, and it got simpler when the grid started applying tasks itself: **the trunk's commit
 moves whenever anybody's work lands**, so one id is the whole signal. It used to take one id per
 member, because work stopped on each member's own branch until somebody promoted.
 
-One case is not a moved commit, and it is the one that runs longest: a turn whose result collides
+One case is not a moved commit, and it is the one that runs longest: a task whose result collides
 with somebody else's moves no ref, because a person has to be asked (issue 42). That shows up as a
-held turn — `active_turns`, and the member's `active_task_ids`, both **lists** since ADR 0034 D-b —
+held task — `active_turns`, and the member's `active_task_ids`, both **lists** since ADR 0034 D-b —
 so an application watching only the commit id would see nothing for the whole time somebody is
 waiting on it.
 
@@ -1356,16 +1356,16 @@ grid project commit <conversation-id> -m "drop the dead module" --delete src/leg
 **It commits into a conversation**, not into a project — so it takes a conversation id and no
 project id at all, and the branch it writes is that conversation's. That is what makes it the fix for
 the answer you just read: the next message you send there starts from what you committed. The id is
-printed by `grid task create` and `grid task send`, and `grid task get <turn-id> --json` reports the
-conversation a turn belongs to.
+printed by `grid task create` and `grid task send`, and `grid task get <task-id> --json` reports the
+conversation a task belongs to.
 
-**Its change reaches the project by itself**, exactly as a finished turn's does — the grid applies
+**Its change reaches the project by itself**, exactly as a finished task's does — the grid applies
 it, and there is nothing to run afterwards. Under the old release model this command ended by telling
 you to promote.
 
 **It is not a way to push.** The write still goes through the grid, still lands on exactly one ref,
 and the grid still serializes it against work that is running. So it is refused while that
-conversation has a turn in flight, and the refusal names the turn. Your other conversations are
+conversation has a task in flight, and the refusal names the task. Your other conversations are
 unaffected — the lock is the conversation's, not yours.
 
 **Executable bits look after themselves.** Editing a file the project already holds as executable
@@ -1390,21 +1390,21 @@ grid project wip reset <project-id> <conversation-id> --commit <oid>
 ```
 
 `wip reset` moves a **conversation's** branch back to a commit you name — the way out of the one
-state nothing else can undo. If a turn's result is written into git but its completion is then
-interrupted, that conversation's branch is left ahead of the turn branch, every retry is refused as a
-non-fast-forward, and the conversation's *next* turn would be cut from the lost attempt's work.
-`grid task get <id> --json` reports the `base_commit` a turn was cut from, which is usually the commit
+state nothing else can undo. If a task's result is written into git but its completion is then
+interrupted, that conversation's branch is left ahead of the task branch, every retry is refused as a
+non-fast-forward, and the conversation's *next* task would be cut from the lost attempt's work.
+`grid task get <id> --json` reports the `base_commit` a task was cut from, which is usually the commit
 to reset to.
 
 **It survives the release commands that were deleted, and that is deliberate.** The grid applying
-turns for you does not put this state out of reach: the apply moves the trunk, never a conversation's
+tasks for you does not put this state out of reach: the apply moves the trunk, never a conversation's
 branch, so a settle interrupted halfway still leaves one ahead. It remains the documented recovery
 because nothing else moves a branch backwards — members do not push, the apply writes only the trunk,
 and there is no revert.
 
 Any member may reset any conversation's branch — someone who leaves the team otherwise strands
 everything their conversations were holding, since nothing can adopt or transfer one. It is refused
-while **that conversation** has a turn running, because moving the base out from under an attempt in
+while **that conversation** has a task running, because moving the base out from under an attempt in
 flight would fail its result for a reason nobody caused. That is narrower than the rule it replaces,
 which refused while the *member* had anything running at all.
 
@@ -1426,7 +1426,7 @@ has already started, use `grid task cancel`.
 `grid project delete <id>` removes the project, its members and its repository, and **cannot be
 undone**. It is refused unless the project has never had a trunk and has never had a task — in that
 state there is provably nothing in it to lose, because a conversation's branch is only ever created
-by pointing at `main` and a turn branch only exists for a turn. Anything else is refused, naming `archive`. It asks
+by pointing at `main` and a task branch only exists for a task. Anything else is refused, naming `archive`. It asks
 before it acts; `--yes` skips the prompt, and is required from a script because a non-terminal stdin
 counts as declining.
 
@@ -1454,7 +1454,7 @@ Both are the project **owner's**, like archive and delete.
 Someone outside a private project is refused with exactly the answer they would get for a project id
 that does not exist — the same words, the same code. That is deliberate: the id is the only thing
 standing between one team's source and another's, so a refusal that told them the project was real
-would turn every project route into a way to test ids.
+would task every project route into a way to test ids.
 
 Writes are included, not just reads: someone reaching a project this way can create tasks, commit
 files and reset a conversation's branch in it, exactly as a member added by hand can. That is what
@@ -1493,16 +1493,16 @@ close your laptop in between.
 
 `create` starts a **conversation** and sends its first message; `send` sends the next one into a
 conversation that already exists, so the agent still knows what you were talking about. The
-conversation id is printed by `create` and appears on every turn `get` and `list` report — it is a
-different id from the turn's, which is what `get`, `follow`, `fetch` and `cancel` address.
+conversation id is printed by `create` and appears on every task `get` and `list` report — it is a
+different id from the task's, which is what `get`, `follow`, `fetch` and `cancel` address.
 
 Messages inside one conversation run **in the order you sent them, one at a time**, so you can type
 ahead without waiting; conversations of yours run alongside each other. Only the person who started
-a conversation can send into it — a colleague can read its turns, and works alongside you by
+a conversation can send into it — a colleague can read its tasks, and works alongside you by
 starting their own with `create`.
 
 > ⚠️ A message sent **while an earlier one is still running** is accepted and queued, but it starts
-> from the project as it stood before that earlier turn, so the two do not yet combine and the
+> from the project as it stood before that earlier task, so the two do not yet combine and the
 > second may end `retries_exhausted`. Until that is fixed, reply after the previous answer comes
 > back.
 
@@ -1515,28 +1515,28 @@ per line for a script to consume.
 
 ### Watching a whole conversation
 
-`grid task follow <task-id>` watches **one turn** and ends when that turn does. `grid task follow
+`grid task follow <task-id>` watches **one task** and ends when that task does. `grid task follow
 --conversation <conversation-id>` watches the **whole conversation** instead — message, agent
 working, result, next message — as one continuous thing, with one sequence and one cursor.
 
-It is not the same as watching each turn in turn, and the difference is what it is for: it carries
-turns that did not exist when you attached. When your work collides with a colleague's, the grid
+It is not the same as watching each task in turn, and the difference is what it is for: it carries
+tasks that did not exist when you attached. When your work collides with a colleague's, the grid
 adds a step to your conversation to combine the two — nobody asks for it — and it simply appears in
-this stream. Watching turn by turn, you would be looking at a finished screen while that step ran.
+this stream. Watching task by task, you would be looking at a finished screen while that step ran.
 
-The stream **ends when the conversation goes quiet**: no turn running, and nothing left for the grid
+The stream **ends when the conversation goes quiet**: no task running, and nothing left for the grid
 to do by itself. Send the next message and follow again — your cursor still means what it meant, so
 nothing is replayed. It exits `0` when it was watched to that end and non-zero if the connection was
-lost or the grid refused; it does **not** report a turn's outcome, because a conversation does not
-have one. `grid task get` and `grid task follow <turn-id>` are what answer that.
+lost or the grid refused; it does **not** report a task's outcome, because a conversation does not
+have one. `grid task get` and `grid task follow <task-id>` are what answer that.
 
 `--after-seq` applies to whichever you are following, but the two numbers are **not the same
-number** — a turn's sequence starts again at `0` for every turn, and a conversation's runs across
+number** — a task's sequence starts again at `0` for every task, and a conversation's runs across
 all of them. Do not pass one to the other.
 
-With `--json`, each line is `{"seq": …, "task_id": …, "event": {…}}` — `task_id` says which turn the
+With `--json`, each line is `{"seq": …, "task_id": …, "event": {…}}` — `task_id` says which task the
 event came from, so an application can group them, and it is `null` on the final
-`{"type": "conversation.idle"}` line, which belongs to no turn. The per-turn stream's `--json` shape
+`{"type": "conversation.idle"}` line, which belongs to no task. The per-task stream's `--json` shape
 is unchanged.
 
 `list` shows tasks oldest first. Give it a project and it shows that project's; **give it none and
@@ -1624,7 +1624,7 @@ one command where leaving it out is not an error: the task then runs in your own
 own, and only an id ever reaches the relay. If you do not have one, nothing is created and the
 command says which project it needs; a project you never asked for, discoverable only through the
 error line that followed it, was worse than being asked. `list` may also leave it out and means
-something different by it: your own turns across every project you can reach, which is the
+something different by it: your own tasks across every project you can reach, which is the
 application's home screen — a **wider** answer, never a substituted one, so there is nothing to
 discover after the fact.
 
@@ -1632,32 +1632,32 @@ discover after the fact.
 `grid project init` followed by `grid task create`, for work that starts from nothing. It is
 **one-way**: a project that has a trunk can never import an existing repository, so reach for
 `grid project import` instead if you have one. Your uploaded files go on the new conversation's
-branch and reach the trunk when the turn succeeds, exactly as on any other task — the trunk it
+branch and reach the trunk when the task succeeds, exactly as on any other task — the trunk it
 creates is empty until then. Passing it at a project that already has a trunk is not an error; there
 is simply nothing to initialize and the task runs.
 
 A project with no trunk refuses tasks, and the refusal names both ways forward with your own prompt
 and `--file` arguments already in them, so the fix is one paste rather than a retype.
 
-**One turn of a conversation runs at a time**, and that is the only sequencing there is: turns of one
+**One task of a conversation runs at a time**, and that is the only sequencing there is: tasks of one
 conversation are strictly ordered, each starting from the last one's result, while your other
 conversations run alongside it and so does everybody else's work. **Creating work never fails for want
-of capacity**: a turn that cannot start yet waits in the project's queue rather than being refused,
+of capacity**: a task that cannot start yet waits in the project's queue rather than being refused,
 and `grid project status` is where you see how deep that queue is.
 
-`grid task cancel <task-id>` ends a turn that has not finished. Its **conversation survives**: the
+`grid task cancel <task-id>` ends a task that has not finished. Its **conversation survives**: the
 next message you send continues where it left off, because cancelling stops a run and a conversation
 has no state to end.
 Before it existed the only way out of a run nobody wanted any more was to wait for its deadline —
 an hour if it was running, and up to four if it was still waiting for a provider. **Any member may
-cancel any turn in the project**, which is the point on a shared one: the colleague whose run has
+cancel any task in the project**, which is the point on a shared one: the colleague whose run has
 been stuck all afternoon is often the person who needs to stop it, and the event log records who did.
 
-The conversation is free to take its next turn immediately; the agent itself stops within about half
+The conversation is free to take its next task immediately; the agent itself stops within about half
 a minute, on the provider's next lease renewal. Against a provider that has not been updated yet it simply runs to completion
 with nothing waiting on it — harmless, and the reason this needs no particular rollout order.
-**Nothing is rewound**: the turn's branch is left exactly where the agent got to, so
-`grid task fetch` still works on a cancelled turn.
+**Nothing is rewound**: the task's branch is left exactly where the agent got to, so
+`grid task fetch` still works on a cancelled task.
 
 ### Sending files with a task
 
@@ -1697,8 +1697,8 @@ An empty folder is refused by name, and so is one every file of which is ignored
 `.gitignore`, because reporting a visibly-full directory as empty reads as a bug.
 
 The files travel in the **same request** as the prompt, and that ordering is the guarantee, not a
-convenience: each project is a git repository the relay owns, and creating a turn cuts `task/<id>`
-from its conversation's branch, commits the input, and only *then* makes the turn claimable.
+convenience: each project is a git repository the relay owns, and creating a task cuts `task/<id>`
+from its conversation's branch, commits the input, and only *then* makes the task claimable.
 "The task exists" and "its input is in git" are one event, so a provider can never claim a task and
 check out before the files arrive — which would run the agent against missing input with nothing to
 say why the answer is wrong. `get --json` reports the `input_commit` the files landed on.
@@ -1735,8 +1735,8 @@ a marker the command writes itself, not the presence of a `.git`, because your o
 one of those too.
 
 **The result lands on the conversation's branch either way — success or failure — and reaches the
-project only on success.** The branch is the conversation's memory, so a failed turn stays on it and
-the next message continues from there rather than from before it; the trunk is what a turn has to
+project only on success.** The branch is the conversation's memory, so a failed task stays on it and
+the next message continues from there rather than from before it; the trunk is what a task has to
 succeed to reach, and the grid applies it there without being asked. A failed attempt still commits
 and still pushes its own `task/<id>` branch, so you can fetch it, read what the agent did before it
 broke, and cherry-pick what was right — `get --json` reports the `result_commit` for both outcomes.
@@ -1788,15 +1788,15 @@ produces a confidently wrong answer.
 
 **A workspace belongs to one *conversation*** — `<root>/projects/<project_id>/<member>/<conversation>/workspace`.
 Both levels below the project are the same argument made twice. A project can have several people in
-it, and bringing a workspace to a turn's input starts with `reset --hard` and `clean -ffdx`, so
-sharing one directory between two members would mean each one's turn wiped the other's. And one
+it, and bringing a workspace to a task's input starts with `reset --hard` and `clean -ffdx`, so
+sharing one directory between two members would mean each one's task wiped the other's. And one
 member can hold several conversations, which are several Claude Code sessions — and since a session's
 transcript directory is derived from the working directory, one directory can only ever be one
 session. Two conversations sharing a workspace would each resume the other's.
 
 The relay names both the member and the conversation on the claim. A provider that is not told
-either **refuses to run the turn**, terminally and with a message saying which key is missing,
-rather than building a shorter path — a guess would put the conversation somewhere the next turn
+either **refuses to run the task**, terminally and with a message saying which key is missing,
+rather than building a shorter path — a guess would put the conversation somewhere the next task
 never looks, and every other signal would read healthy while it happened.
 
 **A member's conversations share one copy of the project's history.** Each workspace is a git
@@ -1812,11 +1812,11 @@ workspace, and it is the one thing a task's agent can reach outside its own dire
 and it will also keep deleting while free space is below that line. When a member's last workspace
 goes, so does their copy of the history. Two things are worth knowing:
 
-- **A turn is never refused for disk.** A provider over its bound makes room and runs; it does not
-  decline work, because a declined turn is somebody's message left unanswered for a reason nothing
+- **A task is never refused for disk.** A provider over its bound makes room and runs; it does not
+  decline work, because a declined task is somebody's message left unanswered for a reason nothing
   can report to them.
 - **An evicted conversation loses nothing.** Its transcript is on the relay
-  (`refs/grid/agent/<conversation>`) and its files are in the project, so the next turn rebuilds the
+  (`refs/grid/agent/<conversation>`) and its files are in the project, so the next task rebuilds the
   workspace and carries on in the same session. What it costs is one fetch. A workspace a worker is
   actually using is never touched — it is skipped, never waited for.
 
@@ -1845,20 +1845,20 @@ If the renewals stop — the provider was killed, lost power, or its agent died 
 report — the lease lapses and the relay **reclaims** the task: it goes back to the queue, its branch
 is reset to exactly the input you uploaded, and the next provider to claim it starts from there. You
 see this in `grid task follow` as a retry line, and it is careful about what the reset does and does
-not cover: **the turn's own branch is reset; anything the lost attempt did outside git is not.** The
+not cover: **the task's own branch is reset; anything the lost attempt did outside git is not.** The
 one case it cannot undo is a settle interrupted between its git write and its terminal record —
 that work is already on the conversation's branch and stays there — so the line names the recovery
 too, `grid project wip reset <project-id> <conversation-id> --commit <base>`. The event log keeps one
-sequence across the whole turn, so a client attached across a retry loses nothing and never sees its
+sequence across the whole task, so a client attached across a retry loses nothing and never sees its
 cursor come to mean something else.
 
-Retries are capped (3 attempts by default). A turn that exhausts them fails with
-`retries_exhausted`, and its conversation is free to take the next one. A retried turn goes back
+Retries are capped (3 attempts by default). A task that exhausts them fails with
+`retries_exhausted`, and its conversation is free to take the next one. A retried task goes back
 onto the *queue* clock, so time spent waiting for a second provider is not charged to the run budget
 the first one was using — and if nobody picks it up, it ends as `queue_expired` rather than being
 blamed for running too long.
 
-Separately, any turn that outlives whichever budget applies to it — including one sitting `queued` on
+Separately, any task that outlives whichever budget applies to it — including one sitting `queued` on
 a grid with no provider at all, which is given the longer of the two — is ended as `timed_out`, so a
 conversation can never be held indefinitely by work nothing is doing.
 
@@ -1870,7 +1870,7 @@ Once the workspace is ready the task spawns **Claude Code** in print mode agains
 `stream-json` output is republished as the task's events while it runs: `task.session` (the
 conversation id), `task.tool_use` (a tool name and the file it targets), `task.tool_result` (how
 that call ended), `task.output` (what the agent says), `task.stderr`, and `task.result` (the agent's
-own account of the run — turns and duration). `follow` prints a `task.tool_result` **only when the
+own account of the run — tasks and duration). `follow` prints a `task.tool_result` **only when the
 call failed**: one arrives for every tool call, and a task makes hundreds, so narrating the
 successful ones would bury the output under an id nobody can act on. Two more bracket the start of a
 follow-up task:
@@ -1894,8 +1894,8 @@ keeps the workers it did start.
 > ⚠️ **Anything above 1 is unverified.** No value greater than 1 has been run against a real relay,
 > and the specific unknown is **two Claude Code children sharing one `CLAUDE_CONFIG_DIR`** — the
 > issue-01 spike listed it as an open question and never measured it. The parts that can be reasoned
-> about hold: a workspace belongs to a (project, member, conversation) triple, and only one turn of a
-> conversation ever runs at a time, so two concurrent turns are always in different directories. What
+> about hold: a workspace belongs to a (project, member, conversation) triple, and only one task of a
+> conversation ever runs at a time, so two concurrent tasks are always in different directories. What
 > has not been observed is the agent itself under concurrency. Raise this only on a provider you can watch, and
 > expect to be the first to find out.
 
@@ -1923,7 +1923,7 @@ Three properties of that are worth knowing:
 The third bound is **disk**, and it behaves differently from the other two on purpose: it never stops
 a provider claiming. `GRID_TASK_MAX_WORKSPACES` (8) is how many conversations keep a working
 directory on this machine, and `GRID_TASK_MIN_FREE_GB` (off) is a floor under free space. A provider
-over either one deletes the least recently used workspaces at the start of the next turn and then
+over either one deletes the least recently used workspaces at the start of the next task and then
 runs it. Nothing is lost by that — see [What a provider actually
 runs](#what-a-provider-actually-runs) — and a workspace in use is never touched. Sizing it is
 arithmetic an operator can do: on the repository these figures were measured against, each extra
@@ -1961,7 +1961,7 @@ The mechanism is the repository. Claude Code keeps a session's transcript — an
 `memory/` — in a folder named after its working directory, and it writes through a symlink, so the
 provider points that folder at `.grid/agent/<member>/` inside that conversation's workspace. The
 transcript is then published to **`refs/grid/agent/<conversation>`**, a ref of its own that the
-provider holding the conversation's lease pushes at the end of every turn, and fetches before the
+provider holding the conversation's lease pushes at the end of every task, and fetches before the
 next one starts. This is why every provider must agree on `GRID_TASK_ROOT` — the folder's name is
 derived from the *absolute* path, so a different root is a different conversation.
 
@@ -1971,8 +1971,8 @@ it, and no colleague receives it. Nothing about a conversation reaches the proje
 
 Two consequences worth knowing:
 
-- **A failed turn's conversation is published, but an automatic retry does not inherit it.** What
-  the agent did is kept, so the next thing you type continues from it. A retry of the same turn is
+- **A failed task's conversation is published, but an automatic retry does not inherit it.** What
+  the agent did is kept, so the next thing you type continues from it. A retry of the same task is
   different: it resets to the conversation as it stood *before* the attempt that failed, rather than
   re-reading whatever confused the agent into failing.
 - **If the transcript is missing or unreadable, the task starts a fresh session rather than
@@ -1982,13 +1982,13 @@ Two consequences worth knowing:
   survives everything: progress events stop if the provider loses the task's lease mid-run, so the
   reason is also carried on the final report and recorded by the relay.
   This covers a conversation that genuinely has no transcript yet. It does **not** cover a provider
-  that was told one exists and could not fetch it — that turn is left for another provider to retry
+  that was told one exists and could not fetch it — that task is left for another provider to retry
   rather than quietly starting over, because the two are indistinguishable from the workspace and
   only one of them is harmless.
 
 A conversation's transcript is kept while the conversation is in use and collected once it has been
 idle for `TASK_CONVERSATION_RETENTION_SECONDS` (30 days by default; `0` keeps them forever). It is
-measured from the conversation's most recent turn, never from any single turn ending — a
+measured from the conversation's most recent task, never from any single task ending — a
 conversation has no "finished" state.
 
 The conversation is written only by the provider: the relay refuses any uploaded file under
@@ -2092,7 +2092,7 @@ Nothing else is needed on Ubuntu 24.04. It restricts unprivileged user namespace
 (`kernel.apparmor_restrict_unprivileged_userns=1`), which stops the sandbox nesting the namespace it
 uses to run each command — the provider handles that in the policy it sends, and it was measured on
 a 24.04 host that a task can then read its workspace, install a dependency from PyPI, and still not
-read a file outside the workspace. **Do not** turn that sysctl off to "fix" a task that fails to run
+read a file outside the workspace. **Do not** task that sysctl off to "fix" a task that fails to run
 commands; check `bubblewrap` and `socat` first.
 
 The environment variables that tune a provider, all optional:
@@ -2102,8 +2102,8 @@ The environment variables that tune a provider, all optional:
 | `GRID_TASKS` | off | `1` to claim tasks at all |
 | `GRID_MAX_TASKS` | `1` | how many tasks this provider runs at once. **Anything above 1 is unverified** — two Claude Code children sharing one config directory has never been measured (see [How much a provider takes on](#how-much-a-provider-takes-on)). No upper limit is imposed: the ceiling that actually binds is the provider's own Claude subscription, which is read at runtime rather than guessed at. A value that is not a positive whole number falls back to `1` and says so |
 | `GRID_TASK_ROOT` | `/var/grid` | root of the workspace tree (`<root>/projects/<project_id>/<member>/<conversation>/workspace`). **Keep it short** — the whole path becomes one directory name and grid adds ~126 characters below the root. **Every provider in a grid must agree** — Claude Code derives a session's transcript directory from the working directory, so a provider using a different root cannot resume a session another one started |
-| `GRID_TASK_MAX_WORKSPACES` | `8` | how many conversations keep a working directory on this provider. Past this, the least recently used are deleted at the start of the next turn — never by refusing work, and never one a worker is using. An evicted conversation rebuilds itself on its next turn at the cost of one fetch. A value that is not a positive whole number falls back to `8` and says so |
-| `GRID_TASK_MIN_FREE_GB` | off | a floor under free space on the filesystem holding `GRID_TASK_ROOT`. Set it and the provider keeps evicting workspaces while free space is below it. Off by default because it is a promise about a disk the provider does not own alone: a machine already below the line for reasons of its own would evict everything on every turn and re-fetch it |
+| `GRID_TASK_MAX_WORKSPACES` | `8` | how many conversations keep a working directory on this provider. Past this, the least recently used are deleted at the start of the next task — never by refusing work, and never one a worker is using. An evicted conversation rebuilds itself on its next task at the cost of one fetch. A value that is not a positive whole number falls back to `8` and says so |
+| `GRID_TASK_MIN_FREE_GB` | off | a floor under free space on the filesystem holding `GRID_TASK_ROOT`. Set it and the provider keeps evicting workspaces while free space is below it. Off by default because it is a promise about a disk the provider does not own alone: a machine already below the line for reasons of its own would evict everything on every task and re-fetch it |
 | `GRID_TASK_TIMEOUT_SECONDS` | `3600` | how long one agent run may take before the provider gives up on it |
 | `GRID_TASK_PERMISSION_MODE` | `acceptEdits` | any mode `claude --permission-mode` accepts, **except `bypassPermissions` while the sandbox is on** — the provider refuses that combination. Measured: with that mode the agent reads files outside its workspace even with the whole policy in force, because the `Read` tool runs inside Claude Code, which the sandbox does not confine |
 | `GRID_TASK_SANDBOX` | on | `0` runs agents **unconfined** — no filesystem or network confinement, and the Claude Code version check is skipped with it |
@@ -2176,7 +2176,7 @@ set of request data that leaves the grid; the full conversation never does.
 | Field | What it is | Bound |
 |---|---|---|
 | system head | head of the first `system` message, truncated | ≤ 500 chars |
-| recent user tails | tails of the **last 3 `user` messages** (oldest→newest), each truncated — so a terse final message still carries the task context set in the turns leading up to it | ≤ 2000 chars each |
+| recent user tails | tails of the **last 3 `user` messages** (oldest→newest), each truncated — so a terse final message still carries the task context set in the tasks leading up to it | ≤ 2000 chars each |
 | message count | number of messages in the request | integer |
 | approx input size | total characters across all message content | integer |
 | tool names | declared function **names** only — never arguments or JSON schemas | list of names |
@@ -2197,7 +2197,7 @@ set of request data that leaves the grid; the full conversation never does.
   reached **through the platform's LLM proxy** — you never hold, store, or hand out an advisor key or URL.
 - **On whose account** — the ranking call runs on the platform's advisor-proxy key (not your key, and
   not the consumer's); the served request is billed to the consumer as the chosen model.
-- **Never sent** — the full conversation, `assistant`/`tool` turns, `user` turns older than the last
+- **Never sent** — the full conversation, `assistant`/`tool` tasks, `user` tasks older than the last
   three, tool-call arguments or schemas, raw image/audio bytes or URLs, per-engine
   pricing/capacity/throughput, or any API key.
 

--- a/docs/tasks-macos-walkthrough.md
+++ b/docs/tasks-macos-walkthrough.md
@@ -1,0 +1,554 @@
+# Two people and one provider, on one Mac
+
+A distributed task is a conversation you hand to the grid: you post a prompt, some machine runs a
+coding agent against your project, and the result appears in the project by itself. This page is the
+**run** — three terminals on one Mac, in order, from nothing to two colleagues working in the same
+project at the same time.
+
+[`tasks-quickstart.md`](./tasks-quickstart.md) is the reference: every command, every environment
+variable, every pair of commands that are easy to confuse. Read this one first if you have never
+seen the feature work; read that one when you want to know what a flag does.
+
+Everything below was exercised end to end on macOS against a live relay — Claude Code **2.1.234**,
+git **2.54.0**, grid **0.3.19** — with two real accounts, one provider, and about 35 real agent
+tasks. Where a number appears (24 seconds, 3 seconds, 1 second) it was measured on a three-file
+project, not estimated. The four traps in §0 are the ones that actually cost time on that run.
+
+---
+
+## What you need
+
+| | |
+|---|---|
+| **Claude Code ≥ 2.1.221**, signed in | The provider runs it and pays for every task out of that subscription. Below 2.1.221 the provider refuses to start rather than run agents unconfined |
+| **The `grid` CLI**, remote mode | `curl -fsSL https://raw.githubusercontent.com/autonomous-ai/autonomous-grid/main/install.sh \| sh` |
+| **Two accounts on the same grid** | Two people is the point. One is the grid's owner; the second is an ordinary member |
+| **git** | Only for making the sample repository, and only on the machine that imports it. Reading a project needs no git at all — that is §7 |
+
+You do **not** need a second computer. Two identities live side by side on one Mac, because every
+`grid` command reads `GRID_HOME` for "who am I".
+
+---
+
+## The shape
+
+```
+  one Mac                                              elsewhere
+  ┌────────────────────────────────────────────┐
+  │ terminal 1   GRID_HOME=~/.grid-alice       │       ┌──────────────────┐
+  │              Alice — grid owner, client    │ ────▶ │  the relay       │
+  │                                            │       │                  │
+  │ terminal 2   GRID_HOME=~/.grid-bob         │ ────▶ │  owns `main`     │
+  │              Bob — second member, client   │       │  hands out tasks │
+  │                                            │       │                  │
+  │ terminal 3   the provider                  │ ◀──── │  applies results │
+  │              GRID_TASKS=1 grid join        │       └──────────────────┘
+  │              └─ runs `claude`, once a task │
+  └────────────────────────────────────────────┘
+```
+
+**A provider serves the grid, not a person.** It claims whatever task is next, whoever asked for it,
+so it can run out of Alice's `GRID_HOME` and still run Bob's work. Keep it in its own terminal
+anyway: it is a long-lived process and you will want to read its log.
+
+Set this up once, in each of the first two terminals:
+
+```bash
+# terminal 1
+export GRID_HOME=~/.grid-alice
+# terminal 2
+export GRID_HOME=~/.grid-bob
+```
+
+Every `grid` command below runs in the terminal whose person it names.
+
+---
+
+## 0. Clear four traps before you start
+
+Each of these fails **quietly** — nothing crashes, and the symptom shows up somewhere else entirely.
+Five minutes here saves an afternoon.
+
+### T1 · `claude` on your `PATH` may not be the real one
+
+The provider resolves `claude` from `PATH` **first**, and keeps what it finds. Editors and terminal
+wrappers routinely put a temporary shim earlier on `PATH`; on the measured run a provider had been
+serving for six days through a shim whose file no longer existed.
+
+```bash
+which claude          # if this is not ~/.local/bin/claude (or your real install), read on
+claude --version      # must be >= 2.1.221
+```
+
+**Fix:** start the provider with the real directory first on `PATH` — it is already in the §3
+command. Do not rely on whatever `PATH` your terminal happens to have.
+
+### T2 · Each `GRID_HOME` remembers the control plane it signed into
+
+`grid login` writes the control-plane URL into that home's `credentials.toml`, and from then on **it
+wins over `GRID_CONTROL_PLANE_URL`**. Setting the environment variable and expecting it to move an
+existing home is how a grid gets created somewhere you did not mean.
+
+```bash
+grep -m1 '^api_url' ~/.grid-alice/credentials.toml
+grep -m1 '^api_url' ~/.grid-bob/credentials.toml
+```
+
+Both should name the same control plane. `grid ls` will **not** tell you — it reads a local cache
+and never calls the control plane, so it happily lists grids from a different one.
+
+**Fix:** for a fresh start, use home directories that have never been logged in, and let `grid login`
+set them.
+
+### T3 · `GRID_TASK_ROOT` must live **outside** `$HOME`
+
+The agent sandbox denies the whole of `$HOME` and re-allows the workspace inside it. On macOS that
+re-allow does not reach the permission layer that governs the agent's `Write` tool: put the task root
+in your home and **the agent's file writes are refused**, silently. Measured on 2.1.234, same prompt
+both ways:
+
+| `GRID_TASK_ROOT` | agent's `Write` | tasks to finish |
+|---|---|---|
+| `~/grid-tasks` (inside `$HOME`) | refused — the agent works around it with shell redirects | 5, 24s |
+| `/Users/Shared/grid-tasks` | works first time | 3, 15s |
+
+The task still reports `completed`, which is what makes it expensive to find.
+
+```bash
+mkdir -p /Users/Shared/grid-tasks
+```
+
+Keep the path **short**. Grid adds ~126 characters below the root, and the whole path becomes one
+directory name for the agent's transcript; past about 200 characters the name is truncated and the
+conversation cannot be found again. `/Users/Shared/grid-tasks` leaves plenty of room.
+
+### T4 · The Claude seat wants port 8099
+
+`--api claude` starts a local seat on **8099** (codex uses 8098). A second one dies *after* printing
+its banner, so it looks like it started.
+
+```bash
+lsof -nP -iTCP:8099 -sTCP:LISTEN     # must be empty
+```
+
+**Fix:** stop the process that holds it, or pass `--seat-port 8199` in §3.
+
+---
+
+## 1. Sign in as two people
+
+```bash
+# terminal 1
+grid login          # opens a browser; sign in as alice@example.com
+# terminal 2
+grid login          # sign in as bob@example.com
+```
+
+Sessions last 24 hours. When one expires, `grid sync` refreshes it without a browser.
+
+> ⚠️ `grid sync` prints `Your grid session has expired…` and still **exits 0**. A script cannot tell
+> success from expiry by exit code alone; read the output, or check that the command you actually
+> wanted succeeded.
+
+---
+
+## 2. Create the grid and admit Bob
+
+```bash
+# terminal 1 — Alice
+grid up demo                                   # creates it on first run
+grid sync
+grid members add demo bob@example.com --role both
+```
+
+```bash
+# terminal 2 — Bob
+grid sync                                      # the new grid appears; no second login needed
+```
+
+If `grid up` is refused with `domain_network_locked`, your account cannot create the default network
+type; use `grid up demo --type permissioned-providers`.
+
+If `grid join` in the next step answers `503 routing temporarily unavailable`, the grid is still
+warming up. Wait about 90 seconds and run it again.
+
+---
+
+## 3. Start the provider (terminal 3)
+
+```bash
+PATH="$HOME/.local/bin:$PATH" \
+GRID_HOME=~/.grid-alice \
+GRID_TASKS=1 \
+GRID_MAX_TASKS=2 \
+GRID_TASK_ROOT=/Users/Shared/grid-tasks \
+grid join demo --api claude
+```
+
+| | |
+|---|---|
+| `GRID_TASKS=1` | **Required.** Task serving is off by default and can never turn itself on — it spends your Claude subscription |
+| `GRID_MAX_TASKS=2` | Two tasks at once. §9 needs it: with one worker the two colleagues simply take tasks and never meet |
+| `GRID_TASK_ROOT` | See T3 |
+| `PATH=…` | See T1 |
+
+Leave it running. It claims work every 30 seconds; an idle claim is a `204`, and that is the healthy
+state — not an error.
+
+**Two notes on the subscription.** Every agent this provider runs draws on the same Claude
+subscription, so that rate limit — not your CPU — is the ceiling. When the window is spent the
+provider **stops claiming and resumes when the vendor's window resets**; you see it as a
+`task.rate_limit` line rather than as failures. And `GRID_MAX_TASKS` above 1 puts two Claude Code
+children under one config directory, which `cli.md` flags as unverified; 2 is what the measured run
+used, without incident. Do not raise it far on a provider you cannot watch.
+
+**About `GRID_TASK_CLAUDE_CONFIG_DIR`:** leave it unset and every task inherits *your* Claude
+settings — your hooks, your `~/.claude/CLAUDE.md`, your skills. That is usually not what you want on
+a machine you also work on. Pointing it at a dedicated directory works, but that directory needs its
+own login first, or every task fails with an empty `the agent exited 1:` and `Not logged in`:
+
+```bash
+CLAUDE_CONFIG_DIR=~/.claude-grid-provider claude       # then /login, then quit
+CLAUDE_CONFIG_DIR=~/.claude-grid-provider claude -p "reply with OK"   # must answer
+```
+
+**A task's own files cannot configure the agent that reads them.** The agent loads the operator's
+user-scope settings and never the repository's, so a `.claude/settings.json` arriving in somebody's
+task cannot run anything on your machine. The consequence is worth knowing before you write prompts:
+**a repository's own `CLAUDE.md` is not in the agent's context either**, though it stays on disk and
+the agent can read it if you ask. Put the standing instructions in the prompt, or tell the agent to
+read the file.
+
+---
+
+## 4. Alice's first project, and her first task
+
+A project is a git repository the grid hosts. It has **no trunk** when created, and a task cannot be
+cut from nothing — so give it one of the two possible starts. **The choice cannot be taken back.**
+
+**Starting from nothing:**
+
+```bash
+grid project create --name scratch --empty --json     # ready to work in immediately
+```
+
+**Bringing a repository you already have** — make one to play with:
+
+```bash
+mkdir -p ~/fixture && cd ~/fixture && git init -q
+printf 'RED\n' > colors.txt
+printf '# app\n' > README.md
+printf '#!/bin/sh\necho hi\n' > run.sh && chmod +x run.sh
+git add -A && git commit -qm "start" && cd -
+
+grid project create --name app --json                 # note the id it prints — no trunk yet
+grid project import ~/fixture <project-id>
+```
+
+Import took **about a second** on those three files; on a 29,000-commit repository it is about
+twenty seconds, because the relay reads every tree the history reaches before `main` exists. It is
+refused — leaving the project with no trunk, deliberately — if the repository has a submodule, a
+path under `.grid/`, or a symlink pointing outside itself. `.claude/` is fine. Executable bits
+survive: `run.sh` comes back as executable through import *and* through every read below.
+
+Now the first task:
+
+```bash
+grid task create --project <project-id> \
+  --prompt "replace the contents of colors.txt with the single word BLUE" \
+  --follow
+```
+
+`--follow` streams the agent and exits with the task's outcome. The three-file version of this
+finished in **24 seconds**.
+
+> ⚠️ **`--follow` returning does not mean the project shows it yet.** The task reports first and the
+> grid applies it to `main` a moment later — measured at **about 3 seconds** on this project. A
+> script that reads the file the instant `--follow` returns reads the *old* value. Poll
+> `grid project status --json` (or the file itself) instead of assuming.
+
+Keep two ids from the output: the **task id** and the **conversation id**. They are different
+objects, and the distinction is the one thing worth internalising here — the conversation is the
+Claude session you come back to, a task is one message and one agent run inside it.
+
+---
+
+## 5. A conversation is many tasks
+
+```bash
+grid task send <conversation-id> \
+  --prompt "append the word GREEN on a new line of colors.txt" --follow
+```
+
+`colors.txt` now reads `BLUE` then `GREEN`. The second task **built on** the first rather than
+starting from the project as it was when the conversation began — each task is cut from where the
+previous one left off.
+
+You can type ahead. Send three messages without waiting:
+
+```bash
+grid task send <conversation-id> --prompt "add a line ONE to colors.txt"
+grid task send <conversation-id> --prompt "add a line TWO to colors.txt"
+grid task send <conversation-id> --prompt "add a line THREE to colors.txt"
+grid task list --project <project-id> --json
+```
+
+They run **in the order you sent them, one at a time**. Inside one conversation there is no
+concurrency; across conversations there is nothing but.
+
+Only the person who started a conversation can send into it. A colleague reads it and starts their
+own.
+
+---
+
+## 6. Watch the whole conversation, not one task
+
+```bash
+grid task follow --conversation <conversation-id>
+```
+
+One stream carrying every task in order — including steps the grid added itself — ending with
+`conversation.idle` when it goes quiet. On the measured run this replayed events 0 through 43 across
+five tasks with nothing missing and nothing repeated.
+
+Interrupt it and pick up where you stopped:
+
+```bash
+grid task follow --conversation <conversation-id> --after-seq 43
+```
+
+You get 44 onward. A conversation's sequence numbers are its own — they are not a task's.
+
+---
+
+## 7. Read the project on a machine with no git
+
+This is what makes the feature usable by people who do not want a checkout.
+
+```bash
+grid project files <project-id>                    # top level
+grid project files <project-id> src                # inside a folder
+grid project file  <project-id> colors.txt         # one file, printed
+grid project file  <project-id> logo.png --output logo.png
+grid project download <project-id> --output app.zip
+```
+
+None of these shells out to git — verified with `PATH` pointing at an empty directory, where even
+`sh` was missing, and they still answered. What you see is the project as it stands now: everybody's
+finished work, applied as each task completed.
+
+Edges answer deliberately rather than guessing. A path is taken **literally**, so `*.txt` is a file
+named `*.txt` and not a wildcard; it comes back `no_such_path` rather than silently matching
+something. `../../etc/passwd` is `invalid_request`. A file too large to print names its size and
+points at `download`.
+
+To see what one task did, and who asked for it:
+
+```bash
+grid task diff <task-id>
+```
+
+---
+
+## 8. Bring Bob into the project
+
+```bash
+# terminal 1 — Alice
+grid project member add <project-id> --email bob@example.com
+grid project member list <project-id>
+```
+
+Bob must have signed in to the grid at least once (§1–2) before he can be added.
+
+> **On grid-wide sharing.** `grid project share` records that anyone on the grid may work in the
+> project without being added — but it only takes **effect** on a grid configured to share projects
+> that way, which is a per-email-domain grid the CLI cannot create. On the network types `grid up`
+> makes, the CLI says so plainly: *"It is recorded, but this grid does not share projects grid-wide
+> — only its members can reach it, exactly as before."* So add Bob explicitly, as above.
+>
+> `grid project private` restricts a project to its members, and it is honest everywhere. A
+> non-member reading a private project gets **byte-for-byte the same refusal** as for a project id
+> that does not exist — there is no way to discover that it is there.
+
+Now Bob works:
+
+```bash
+# terminal 2 — Bob
+grid task create --project <project-id> --prompt "add a file bob.txt containing hello" --follow
+grid task list --project <project-id> --all        # what the team ran, not only your own
+```
+
+---
+
+## 9. Two people at once
+
+This is the part that has no equivalent in a single-user tool, and the part worth watching the
+provider's log during.
+
+**Different files.** Have Alice and Bob each start a task touching a different file, within a few
+seconds of each other:
+
+```bash
+# terminal 1 — Alice
+grid task create --project <pid> --prompt "create alpha.txt containing A" --follow
+```
+```bash
+# terminal 2 — Bob, within a few seconds
+grid task create --project <pid> --prompt "create beta.txt containing B" --follow
+```
+
+Both complete. **Neither is refused for racing**, and both land on `main` — one of them arriving as
+a merge the grid made itself. Nobody ran a command to make that happen.
+
+**The same file.** Now have both change `colors.txt`:
+
+```bash
+# terminal 1 — Alice
+grid task create --project <pid> --prompt "make colors.txt say ALPHAONLY"
+```
+```bash
+# terminal 2 — Bob, within a few seconds
+grid task create --project <pid> --prompt "make colors.txt say BETAONLY"
+```
+
+One wins. The loser does not fail and is not asked to fix anything: the grid puts a **merge task**
+into that person's own conversation, resuming the same agent session that caused the collision, and
+the agent reconciles. On the measured run the result kept both intentions — `colors.txt` ended up
+holding `ALPHAONLY` and `BETAONLY` — and any messages the loser had already typed ahead ran
+afterwards, in order.
+
+```bash
+grid task list --project <pid> --all --json \
+  | python3 -c 'import json,sys; [print(t["id"], t.get("kind")) for t in json.load(sys.stdin)["tasks"]]'
+```
+
+A merge task is `"kind": "merge"`; a message you typed is `"message"`. An application should render
+the first as a step the grid took and never as something a person said.
+
+> The merge task's own result text comes from the model, and it talks like a developer — it will say
+> things like *"merge resolved and committed as f0e7cfa"*. `kind` is how you avoid showing that to
+> someone who does not want to know the project is a git repository.
+
+**If you have `grid project status --json` handy**, it reports `member_running_turns` and
+`member_running_cap`: how many tasks of yours are running, and how many the grid will run at once for
+one person. A task held back by that cap is queued, never refused, and never expires because of it —
+and a merge task is exempt, so a person at their cap whose work collides is not deadlocked.
+
+---
+
+## 10. Taking it back
+
+**Undo** — the change reaches the project with nobody asked to approve it, so this is how you decline
+afterwards:
+
+```bash
+grid task undo <task-id>
+```
+
+It removes exactly what that one task changed. Everything done since **stays**: the project is not
+rewound, it simply no longer contains that change, and `main` moves *forward* to say so. On the
+measured run, undoing a middle task left both the task before it and the task after it intact.
+
+If somebody has since built on the same files, it refuses with `undo_conflicts` (exit 1) and names
+them — no git vocabulary, and `main` does not move. Ask for what you want in a new message instead.
+Undoing twice is `already_undone`. Only the person who asked for the task, or the project's owner,
+may undo it.
+
+**Cancel** — stop a task that has not finished. The conversation survives; the next message you send
+continues:
+
+```bash
+grid task cancel <task-id>
+```
+
+The agent stops within about half a minute, on the provider's next lease renewal.
+
+> ⚠️ `grid task cancel --help` says *"Nothing is rewound: whatever the agent had already done is
+> kept, so `grid task fetch` still works on it."* **Measured, it does not:** a cancelled task has no
+> result, and `grid task fetch` returns the tree from *before* the agent did anything. Nothing is
+> lost that had landed — the next message simply starts a fresh session from the last good state —
+> but do not plan on recovering a cancelled task's work. This is a wrong promise in the help text,
+> not a data-loss bug.
+
+---
+
+## 11. Driving it from a script
+
+The whole flow is expressible in JSON and exit codes, with no English parsed anywhere. `grid task
+get` is the piece that makes waiting expressible:
+
+| exit | meaning |
+|---|---|
+| `0` | completed |
+| `1` | failed, timed out, **or any refusal** |
+| `2` | not finished yet — the only code a poller may read as "ask again" |
+
+```bash
+until grid task get "$id" >/dev/null; do
+  rc=$?
+  [ "$rc" -eq 2 ] || exit "$rc"        # it finished, and not well
+  sleep 10
+done
+```
+
+Dropping the `rc` check tasks this into a loop that waits forever on a task that failed.
+
+Refusals arrive as `{"error":{"code":…,"message":…,"status":…}}`. Two gotchas measured on the run:
+
+- **`--json` writes the envelope to stderr, and stdout stays empty.** Read stderr for the reason.
+- **Read the FIRST line of stderr.** Some refusals put the JSON on line 1 and a plain English
+  sentence on line 2; `json.load(stderr)` on the whole stream fails.
+
+Useful machine-readable reads: `grid project create --json` (check `bootstrap.status` is
+`initialized`), `grid project status --json`, `grid task list --json` with no `--project` for your
+conversations across every project you can reach.
+
+---
+
+## 12. Stop and clean up
+
+```bash
+# terminal 3: Ctrl-C, then
+grid leave demo                 # stop and unregister the engine
+# terminal 1
+grid project archive <project-id>     # keeps everything, accepts no new work
+grid down demo                        # take the grid offline; config persists
+```
+
+`archive` destroys nothing and every read still works — it is the right way to retire a project.
+`grid project delete` refuses anything that holds work (`project_not_empty`), by design; it exists
+for the project you created by a typo.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Every task fails, `the agent exited 1:` with no message | `GRID_TASK_CLAUDE_CONFIG_DIR` points at a directory with no login | `/login` in that directory, or unset the variable (§3) |
+| `Claude Code isn't installed on this provider` | `PATH` had a shim that has since vanished | Restart the provider with the real directory first on `PATH` (T1) |
+| Tasks complete but the agent says its writes were blocked | Task root inside `$HOME` | Move `GRID_TASK_ROOT` outside `$HOME` (T3) |
+| Provider printed its banner then went quiet | Port 8099 already held by another seat | `lsof -nP -iTCP:8099`; free it or `--seat-port 8199` (T4) |
+| `grid join` → `503 routing temporarily unavailable` | Grid still warming up | Wait ~90s, retry |
+| A grid appeared somewhere you did not expect | That home's stored `api_url` outranks `GRID_CONTROL_PLANE_URL` | T2 — check the file, not the environment |
+| Nothing is claimed, no errors | `GRID_TASKS` not set | It is off by default and never turns itself on |
+| Provider stopped claiming, `task.rate_limit` in the log | Subscription window spent | It resumes by itself when the vendor's window resets |
+| `grid leave demo` → `Grid not found: 'demo'` while `grid ls` lists it | Observed; cause not established | Use the grid id: `grid leave grid-…` |
+| `git push` to a project is refused | The grid is `main`'s only writer | `grid task create`, or `grid project commit <conversation-id>` for files with no agent |
+
+---
+
+## What this walkthrough does not show you
+
+Stated so the sections above are not read as more than they are:
+
+- **Two providers.** One machine claims everything here. Cross-provider resume — a conversation
+  continuing on a different provider — is designed for and tested elsewhere, but you cannot see it
+  with one node. (You *can* see the mechanism: stop the provider, delete `GRID_TASK_ROOT` entirely,
+  restart, and send another message. The agent still remembers the conversation, because the session
+  travels with the project and not with the disk.)
+- **A large repository.** Three files. Import cost and per-conversation disk cost both scale, and a
+  conversation costs a working tree rather than a second copy of history — about 306 MiB against
+  1.04 GiB on a 792 MiB repository.
+- **Anything under load.** Two members and two workers is enough to show the behaviour and nowhere
+  near enough to say anything about throughput.

--- a/docs/tasks-quickstart.md
+++ b/docs/tasks-quickstart.md
@@ -8,10 +8,10 @@ come back later for it, and you reply into the same conversation. Nothing is hel
 can take an hour.
 
 **Two words carry the weight on this page.** A *task* is the conversation — one Claude Code session,
-something you come back to. A *turn* is one run inside it: one message you send, one agent run, one
-provider. `grid task create` starts a conversation and its first turn, `grid task send` adds the next
-turn, and every other `grid task` command — `get`, `follow`, `fetch`, `cancel` — addresses a single
-**turn**.
+something you come back to. A *task* is one run inside it: one message you send, one agent run, one
+provider. `grid task create` starts a conversation and its first task, `grid task send` adds the next
+task, and every other `grid task` command — `get`, `follow`, `fetch`, `cancel` — addresses a single
+**task**.
 
 Everything here is **remote mode only** (`grid mode remote`).
 
@@ -22,9 +22,9 @@ Everything here is **remote mode only** (`grid mode remote`).
 | Thing | What it is |
 |---|---|
 | **project** | A git repository the grid hosts, with its own members. Addressed by **id**, never by name. |
-| **`main`** | The project's trunk, and everybody's work. It is created once — by `init` or by `import` — and afterwards **the grid moves it itself**, applying every turn that succeeds. |
-| **task** | A conversation: one Claude Code session, many turns, one thing you name and return to. |
-| **turn** | One message and one agent run inside a task. Cut from the conversation's branch, settles back onto it. |
+| **`main`** | The project's trunk, and everybody's work. It is created once — by `init` or by `import` — and afterwards **the grid moves it itself**, applying every task that succeeds. |
+| **task** | A conversation: one Claude Code session, many tasks, one thing you name and return to. |
+| **task** | One message and one agent run inside a task. Cut from the conversation's branch, settles back onto it. |
 | **`wip/<conversation-id>`** | A conversation's branch — **one per conversation**, not one per person. You never push to it; the grid writes it, and applies what it holds to `main`. |
 | **member_key** | A 32-hex id for you *in this grid*. Printed by `grid project member list`. Not your email, and **different in every grid**. |
 | **provider** | A machine running `grid join` with task serving on. It runs the agent and pays for it with its own Claude subscription. |
@@ -94,18 +94,18 @@ grid task create <project-id> --prompt 'make these pass' --dir ./fixtures:test/d
 grid task send   <conversation-id> --prompt 'now cover the timeout case'
 ```
 
-`create` starts a conversation; `send` adds the next turn to one that already exists, so the agent
+`create` starts a conversation; `send` adds the next task to one that already exists, so the agent
 still knows what you were talking about. **`create` prints the conversation id** — keep it, because
 it is what `send`, `grid project commit` and `grid project wip reset` all take. `grid task get
-<turn-id> --json` reports the conversation a turn belongs to if you lose it.
+<task-id> --json` reports the conversation a task belongs to if you lose it.
 
-Turns of one conversation run **in the order you sent them, one at a time**, so you can type ahead;
+Tasks of one conversation run **in the order you sent them, one at a time**, so you can type ahead;
 different conversations run alongside each other, yours and everybody else's. Only the person who
-started a conversation can send into it — a colleague reads its turns and works alongside you by
+started a conversation can send into it — a colleague reads its tasks and works alongside you by
 starting their own.
 
-> ⚠️ A message sent **while an earlier turn is still running** is accepted and queued, but it starts
-> from the project as it stood before that earlier turn, so the two do not yet combine and the second
+> ⚠️ A message sent **while an earlier task is still running** is accepted and queued, but it starts
+> from the project as it stood before that earlier task, so the two do not yet combine and the second
 > may end `retries_exhausted`. Until that is fixed, reply after the previous answer comes back.
 
 Every command on this page that takes a project id also accepts it as `--project <project-id>`, and
@@ -133,14 +133,14 @@ grid task create <project-id> --init-project --prompt 'scaffold a FastAPI servic
 `--init-project` gives the project its empty trunk first, then runs the task — `grid project init`
 and `grid task create` in one. Same one-way door as `init` itself: a project that has a trunk can
 never import an existing repository, so use `grid project import` if you have one. Your uploaded
-files go on **the new conversation's branch**; they reach the trunk when the turn succeeds, not
+files go on **the new conversation's branch**; they reach the trunk when the task succeeds, not
 before. Passing it at a project that already has a trunk does nothing and the task simply runs.
 
 With no project id at all, the task goes to your own project called `default` **if you already have
 one**. If you do not, nothing is created and the command tells you which project it needs.
 `task create` and `task list` are the two commands that may leave it out, and they mean different
 things by it: `create` falls back to your `default` project, while `list` with no project shows your
-own turns **across every project you can reach** — one list, one cursor, which is what an
+own tasks **across every project you can reach** — one list, one cursor, which is what an
 application's home screen is.
 
 ```bash
@@ -151,10 +151,10 @@ grid task fetch  <task-id> --into /tmp/result
 grid task cancel <task-id>
 ```
 
-`<task-id>` is a **turn's** id, which is what these five commands address — it is a different id from
-the conversation's, and both are printed when a turn is created.
+`<task-id>` is a **task's** id, which is what these five commands address — it is a different id from
+the conversation's, and both are printed when a task is created.
 
-To watch the **whole conversation** rather than one turn — every turn's output in order, including
+To watch the **whole conversation** rather than one task — every task's output in order, including
 steps the grid adds itself when your work collides with a colleague's:
 
 ```bash
@@ -162,7 +162,7 @@ grid task follow --conversation <conversation-id>
 ```
 
 It ends when the conversation goes quiet, and exits `0` for having watched it to that end. It does
-not report a turn's outcome; a conversation does not have one.
+not report a task's outcome; a conversation does not have one.
 
 **Create and watch in one command**, and act on how it went:
 
@@ -170,10 +170,10 @@ not report a turn's outcome; a conversation does not have one.
 grid task create <project-id> --prompt 'add a retry' --follow && ./deploy.sh
 ```
 
-`--follow` prints the id, then watches the turn with the same resumable stream `grid task follow`
-uses. Ctrl-C stops the watching, never the turn — the id is on screen first so you can reattach.
+`--follow` prints the id, then watches the task with the same resumable stream `grid task follow`
+uses. Ctrl-C stops the watching, never the task — the id is on screen first so you can reattach.
 
-Both `follow` and `get` exit with the turn's own outcome. `get` has a third code, for a turn that has
+Both `follow` and `get` exit with the task's own outcome. `get` has a third code, for a task that has
 not finished:
 
 | state | `grid task get` exit |
@@ -196,19 +196,19 @@ covers a failed task *and* a command that could not reach the relay. Name the va
 `status`: in zsh `status` is a read-only alias for `$?`, so that loop would bail on its first poll
 and blame a running task.
 
-`--all` on `task list` shows every member's turns, not only yours. It needs a project id: the
+`--all` on `task list` shows every member's tasks, not only yours. It needs a project id: the
 grid's work is listed one project at a time, and "everyone's, everywhere" is refused rather than
 quietly narrowed back to your own.
 
-**One turn of a conversation runs at a time, and that is the only queue there is.** Creating a
+**One task of a conversation runs at a time, and that is the only queue there is.** Creating a
 conversation never fails for want of capacity, and your other conversations keep running while one of
-them works. A turn that cannot start yet waits in the project's queue; `grid project status` says how
+them works. A task that cannot start yet waits in the project's queue; `grid project status` says how
 deep that queue is and how many providers could be taking it.
 
-`cancel` frees the conversation to take its next turn immediately; the agent stops within about half
-a minute. Nothing is rewound — the turn's branch is left where the agent got to, so `fetch` still
+`cancel` frees the conversation to take its next task immediately; the agent stops within about half
+a minute. Nothing is rewound — the task's branch is left where the agent got to, so `fetch` still
 works on it — and **the conversation survives**, so the next message you send continues where it left
-off. Any member may cancel any turn in the project, and the event log records who did.
+off. Any member may cancel any task in the project, and the event log records who did.
 
 ---
 
@@ -216,14 +216,14 @@ off. Any member may cancel any turn in the project, and the event log records wh
 
 ```bash
 grid project clone <project-id> /tmp/my-app     # a real git repo, on the project's TRUNK
-grid project status <project-id>                # the trunk, your turns in flight, the queue
+grid project status <project-id>                # the trunk, your tasks in flight, the queue
 ```
 
 The clone puts you on `main`, because the trunk is now everybody's work — the grid applies every
-successful turn to it, yours included. It runs `grid credential` whenever git needs a token, so
+successful task to it, yours included. It runs `grid credential` whenever git needs a token, so
 nothing is written to disk and a refreshed token is picked up automatically. **`git push` is
 refused** — that is the design, not a permission to request: the project is written by the grid alone
-so a turn running right now cannot have the ground moved under it.
+so a task running right now cannot have the ground moved under it.
 
 Re-running `clone` on the same directory updates it. Day to day, plain `git fetch` is lighter.
 
@@ -237,8 +237,8 @@ grid project commit <conversation-id> -m 'drop the old shim' --delete src/shim.p
 
 It takes a **conversation id, and no project id** — the change goes onto that conversation's branch,
 so the next message you send there starts from it, and the grid applies it to the trunk by itself
-exactly as it applies a turn. There is nothing to run afterwards. It is refused while that
-conversation has a turn in flight, naming the turn; your other conversations are unaffected.
+exactly as it applies a task. There is nothing to run afterwards. It is refused while that
+conversation has a task in flight, naming the task; your other conversations are unaffected.
 
 Executable bits look after themselves: editing a file the project already has as executable keeps it
 executable. `--delete` on a path that is not in that conversation's branch is **refused** rather than
@@ -248,14 +248,14 @@ quietly ignored — git's own answer there is to report success and do nothing.
 
 ## Sharing work: there is nothing to run
 
-**The grid applies every successful turn to `main` itself** — a fast-forward when it can, and a merge
+**The grid applies every successful task to `main` itself** — a fast-forward when it can, and a merge
 commit when git can combine the two. Your work appears in the project because it finished, not
 because you asked for it.
 
 When git cannot combine them — you and somebody else changed the same lines — nothing moves yet, and
-the turn is held. Resolving that inside the conversation that caused the collision is the next
-release's work; until it lands, a held turn is what you see, and it is the one case where a finished
-turn does not show up as a moved trunk commit.
+the task is held. Resolving that inside the conversation that caused the collision is the next
+release's work; until it lands, a held task is what you see, and it is the one case where a finished
+task does not show up as a moved trunk commit.
 
 `grid project promote`, `grid project integrate` and `grid project check` **no longer exist**. They
 were built for a developer holding a release: `main` was a branch somebody decided to move, and once
@@ -267,11 +267,11 @@ Two things that follow, and they are the cost rather than the benefit:
 
 - **The trunk has no known-good property left.** Nothing asserts that `main` builds or runs. Nothing
   did before either, except a person's judgement at promote time — and that person is gone.
-- **A conversation of five turns puts four intermediate states into the project.** Colleagues used to
-  see each other's work when somebody decided it was ready. They now see it at every turn. That is
+- **A conversation of five tasks puts four intermediate states into the project.** Colleagues used to
+  see each other's work when somebody decided it was ready. They now see it at every task. That is
   the deliberate trade for removing the human, not an oversight.
 
-The apply happens **just after** the turn is reported finished, not in the same instant, so "done"
+The apply happens **just after** the task is reported finished, not in the same instant, so "done"
 and "in the project" are a moment apart. Watch `grid project status`: the trunk's own commit moves
 whenever anybody's work lands, so one id is the whole change signal.
 
@@ -281,14 +281,14 @@ whenever anybody's work lands, so one id is the whole change signal.
 grid project wip reset <project-id> <conversation-id> --commit <sha>
 ```
 
-This survived the commands above, deliberately. If a turn's result is written into git but its
-completion is then interrupted, the conversation's branch is left ahead of the turn branch, every
-retry is refused, and that conversation's *next* turn would be cut from the lost attempt's work.
+This survived the commands above, deliberately. If a task's result is written into git but its
+completion is then interrupted, the conversation's branch is left ahead of the task branch, every
+retry is refused, and that conversation's *next* task would be cut from the lost attempt's work.
 Nothing else moves a branch backwards — members do not push, the grid's apply only ever writes the
 trunk, and there is no revert.
 
-`grid task get <turn-id> --json` reports the `base_commit` a turn was cut from, which is usually the
-commit you want. It is refused while that conversation has a turn running.
+`grid task get <task-id> --json` reports the `base_commit` a task was cut from, which is usually the
+commit you want. It is refused while that conversation has a task running.
 
 ---
 
@@ -308,7 +308,7 @@ every read still works, so `clone`, `status`, `task list` and `task fetch` all c
 Delete exists for the project created by a typo. It is refused for anything that holds work, naming
 archive, so it cannot take a colleague's conversation with it.
 
-Neither cancels a turn that is already running. Archiving stops new work **starting**; to stop work
+Neither cancels a task that is already running. Archiving stops new work **starting**; to stop work
 that has already started, use `grid task cancel <task-id>`.
 
 ### `grid members` vs `grid project member`
@@ -344,13 +344,13 @@ Both put files in. Only one of them then lets an agent loose on them.
 - `task create --file` (and `task send --file`) — the files are committed **and then** an agent runs,
   which may change the very line you were fixing.
 
-Both occupy a conversation's one running turn while they work, so neither can land underneath a run
+Both occupy a conversation's one running task while they work, so neither can land underneath a run
 of its own.
 
 ### `grid project clone` vs `grid task fetch`
 
 - `clone` — a working copy of the **project**, on the trunk, that you keep and update. For working.
-- `fetch` — the result of **one turn**, into a directory. For reading what an agent did.
+- `fetch` — the result of **one task**, into a directory. For reading what an agent did.
 
 `fetch` without `--into` creates `./<task-id>` in the current directory. Run it inside another git
 repo and you get nested repos that `git status` shows as untracked — and a mistaken `cd` then makes
@@ -363,7 +363,7 @@ Only one of them prints a "behind", and they answer different questions.
 | | Reports | Asks | Needs |
 |---|---|---|---|
 | `refresh <pid>` | your **clone** against the grid's copy of the branch you are on | nothing — git only | to be run in a clone |
-| `status <pid>` | where the **project** is: its trunk, your turns in flight, the queue | the relay | nothing local |
+| `status <pid>` | where the **project** is: its trunk, your tasks in flight, the queue | the relay | nothing local |
 
 So `refresh` answers "has anything landed since I last looked", and `status` answers "what is
 happening in this project right now". `status` stopped measuring a distance when promote went: the
@@ -375,7 +375,7 @@ files; `status` never looks at them.
 Both update a clone. Only one can lose work.
 
 - `refresh` — fetches and reports. Never touches your working tree, so it works with local commits, a
-  dirty tree, or a turn in flight.
+  dirty tree, or a task in flight.
 - `clone` over the same directory — **resets** your branch to the fetched tip, and therefore refuses
   outright when you have commits the grid has not seen.
 
@@ -389,20 +389,20 @@ Both update a clone. Only one can lose work.
 
 ### `grid task list` vs `grid list`
 
-`grid task list <project-id>` lists a project's turns, and `grid task list` with no id lists your
+`grid task list <project-id>` lists a project's tasks, and `grid task list` with no id lists your
 own across every project. `grid list` (alias of `grid ls`) lists **grids**.
 
 ### `grid task cancel` vs `grid leave`
 
-`cancel` stops one turn. `leave` stops this machine serving a grid at all — it is a provider
+`cancel` stops one task. `leave` stops this machine serving a grid at all — it is a provider
 command and has nothing to do with tasks you submitted.
 
 ### `main` vs a conversation's branch
 
 `grid project clone` puts you on `main`, and that is the change worth internalising: the trunk holds
-everybody's finished work, because the grid applies every successful turn to it. A conversation's own
-branch, `wip/<conversation-id>`, is the scratch space in between — a turn is cut from it and settles
-back onto it, **whether the turn succeeded or failed**, which is what lets the next message carry on
+everybody's finished work, because the grid applies every successful task to it. A conversation's own
+branch, `wip/<conversation-id>`, is the scratch space in between — a task is cut from it and settles
+back onto it, **whether the task succeeded or failed**, which is what lets the next message carry on
 from where the last one broke. Only success reaches `main`.
 
 You never name a conversation's branch to git. The two commands that take a conversation id —
@@ -425,7 +425,7 @@ serving is **opt-in and off by default**.
 
 ```bash
 export GRID_TASKS=1                 # required — nothing claims tasks without it
-export GRID_MAX_TASKS=2             # turns run at once (default 1)
+export GRID_MAX_TASKS=2             # tasks run at once (default 1)
 export GRID_TASK_ROOT=/var/grid     # where workspaces live — keep it SHORT (see below)
 grid join <grid> --api claude       # a provider must join an engine; the task loop lives inside it
 ```
@@ -433,9 +433,9 @@ grid join <grid> --api claude       # a provider must join an engine; the task l
 | Variable | Default | Meaning |
 |---|---|---|
 | `GRID_TASKS` | off | `1`/`true`/`yes`/`on` to claim tasks |
-| `GRID_MAX_TASKS` | `1` | concurrent turns |
+| `GRID_MAX_TASKS` | `1` | concurrent tasks |
 | `GRID_TASK_ROOT` | `/var/grid` | workspace root — `<root>/projects/<project>/<member>/<conversation>/workspace`, with the member's one copy of the project's history beside it at `<member>/store.git`. **Keep it short**: the whole path becomes one directory name for the agent's transcript, and grid adds ~126 characters below the root. A provider refuses a workspace whose name would exceed the limit rather than losing the conversation silently |
-| `GRID_TASK_MAX_WORKSPACES` | `8` | how many conversations keep a working directory here. Past this the least recently used are deleted before the next turn — a turn is never refused for disk, and a workspace in use is never touched. An evicted conversation comes back on its next turn, same session and same files, at the cost of one fetch |
+| `GRID_TASK_MAX_WORKSPACES` | `8` | how many conversations keep a working directory here. Past this the least recently used are deleted before the next task — a task is never refused for disk, and a workspace in use is never touched. An evicted conversation comes back on its next task, same session and same files, at the cost of one fetch |
 | `GRID_TASK_MIN_FREE_GB` | off | keep evicting while free space on the task root's filesystem is below this |
 | `GRID_TASK_TIMEOUT_SECONDS` | `3600` | budget for one run |
 | `GRID_TASK_SANDBOX` | on | `0` disables confinement — for debugging only |
@@ -480,15 +480,15 @@ wrote before it reaches the trunk — so treat it as the agreement a team makes 
    `grid project member add` for the project.
 3. Everyone runs `grid project clone` and keeps that working copy.
 4. Decide who runs providers. One provider serves the whole team, and `GRID_MAX_TASKS` is how many
-   turns the team can run at once — not how many each person gets. What each person gets is the
+   tasks the team can run at once — not how many each person gets. What each person gets is the
    grid's own **running cap** (`TASK_MEMBER_RUNNING_CAP`, 3 by default, set on the relay): the most
-   turns one member may have running at a time, so somebody working quickly cannot put twenty turns
-   in front of a colleague's one. Nothing is ever refused because of it — a turn over the cap waits
+   tasks one member may have running at a time, so somebody working quickly cannot put twenty tasks
+   in front of a colleague's one. Nothing is ever refused because of it — a task over the cap waits
    for one of that person's own to finish, and `grid project status` shows where they stand.
 
 ### Every day
 
-Each member works in their **own conversations**, and a conversation's branch is nobody else's. Turns
+Each member works in their **own conversations**, and a conversation's branch is nobody else's. Tasks
 inside one are sequential; everything else runs at the same time as everything else, so two people —
 or two of your own conversations — never block each other.
 
@@ -497,18 +497,18 @@ morning     grid project status <pid>          # what did the team land overnigh
             git -C ~/my-app fetch             # or grid project refresh, in the clone
 
 work        grid task create <pid> --prompt '…'         # a new conversation
-            grid task follow <turn-id>
+            grid task follow <task-id>
             grid task send   <conversation-id> --prompt '…'   # the answer was nearly right
-            grid task fetch  <turn-id> --into /tmp/r          # read it
+            grid task fetch  <task-id> --into /tmp/r          # read it
             grid project commit <conversation-id> -m '…' --file …   # touch up without an agent
 ```
 
-There is no third stage. Every turn that succeeds is applied to `main` by the grid, so the work you
+There is no third stage. Every task that succeeds is applied to `main` by the grid, so the work you
 did this morning is in the project before you go looking for it.
 
 ### The four rules that matter
 
-**1. The trunk moves without asking, so read it often.** `main` now changes whenever anybody's turn
+**1. The trunk moves without asking, so read it often.** `main` now changes whenever anybody's task
 lands — several times a day on a team of five. Fetching in the morning is no longer a courtesy;
 it is how you find out what the project became overnight.
 
@@ -517,21 +517,21 @@ and there was only ever one before — a person's judgement at promote time. `ma
 known-good branch: nothing asserts that it builds or that its tests pass. If your team needs that
 property, it is work you have to add.
 
-**3. A conversation is the unit of work, so name it in your head.** Five turns in one conversation
+**3. A conversation is the unit of work, so name it in your head.** Five tasks in one conversation
 put four intermediate states into the project, which colleagues see. That is the price of nobody
 having to promote. Prefer one conversation that finishes a thing to five that each leave it half
 done, and start a separate conversation for unrelated work rather than steering an existing one.
 
-**4. Spread work across conversations, not across turns.** Turns of one conversation are strictly
+**4. Spread work across conversations, not across tasks.** Tasks of one conversation are strictly
 ordered, so three follow-up messages cost three waits; three *conversations* cost one, because they
 run at the same time. And for now, wait for each answer before replying — a message sent while the
-previous turn is still running is accepted but does not yet build on it. If a turn is stuck,
+previous task is still running is accepted but does not yet build on it. If a task is stuck,
 `grid task cancel` frees its conversation immediately, and the conversation itself survives.
 
 ### Reading the team's state
 
 ```bash
-grid project status <pid>                    # the trunk, your turns in flight, the queue
+grid project status <pid>                    # the trunk, your tasks in flight, the queue
 grid task list <pid> --all                   # what the whole team is running right now
 grid project member list <pid>               # who is in the project, and their keys
 ```
@@ -541,8 +541,8 @@ application — or a person — watches one id instead of one per member.
 
 ### What no one can do
 
-- Push to the project. Work lands through a turn or `grid project commit`.
+- Push to the project. Work lands through a task or `grid project commit`.
 - Move `main` by hand. It is created by `init` or `import`, once, and afterwards only the grid's own
   apply advances it.
-- Run two turns of one conversation at once, or move a branch a running turn was cut from.
+- Run two tasks of one conversation at once, or move a branch a running task was cut from.
 - Read another project's code, even knowing its id.

--- a/tests/test_application_surface.py
+++ b/tests/test_application_surface.py
@@ -128,6 +128,24 @@ _GIT_PLANE_FUNCTIONS = frozenset({
 _REPO = pathlib.Path(__file__).resolve().parent.parent
 
 
+def _subparser(parser, name, *, summary=False):
+    """The named subparser, or — with `summary=True` — the one-line help the PARENT prints for it.
+
+    The summary lives on the parent's choice map, not on the child, which is exactly why the
+    per-command `GIT_PLANE` exemption reaches it: `_leaves` reads the child.
+    """
+    for action in parser._actions:
+        if not hasattr(action, "_name_parser_map") or name not in action._name_parser_map:
+            continue
+        if not summary:
+            return action._name_parser_map[name]
+        for choice in action._get_subactions():
+            if choice.dest == name:
+                return choice.help or ""
+        return ""
+    raise AssertionError(f"no subcommand called {name!r}")
+
+
 def offences(text: str) -> list[str]:
     """The git words in `text`, lowercased. Public so issue 41's E2E can use the same reading."""
     return [match.group(0).lower() for match in _PATTERN.finditer(text or "")]
@@ -174,6 +192,29 @@ def test_the_surface_an_application_drives_speaks_no_git():
         "git vocabulary on the surface an application drives (ADR 0034 D-m). Reword it, or — if the "
         "word really is being used in its ordinary English sense — add it to `ALLOWED` with the "
         "reason:\n  " + "\n  ".join(sorted(found)))
+
+
+def test_project_inits_summary_speaks_the_same_words_that_send_people_to_it():
+    """`grid project init` is GIT_PLANE, and its summary line still may not say `trunk`.
+
+    The exemption in `GIT_PLANE` is per COMMAND, so it covers a subcommand's whole `--help` — which
+    is right for the long description (somebody who chose to read it is doing git-shaped work) and
+    wrong for exactly one line. The summary is what `grid project --help` prints to everybody who is
+    only browsing the list, and `init` is the single GIT_PLANE command a brand-new person is sent to
+    BY NAME: `_no_trunk_message` offers it with the words "give it something to start from",
+    deliberately git-free (ADR 0034 D-m, issue 46). It said "trunk" one sentence later.
+
+    Narrow on purpose — this pins `init` and not every summary. `wip` and `commit` are git words in
+    the COMMAND NAME, chosen for people who have git, and no wording fixes those.
+    """
+    from cli.parser import build_parser
+
+    project = _subparser(build_parser(), "project")
+    summary = _subparser(project, "init", summary=True)
+
+    assert summary, "grid project init lost its summary line"
+    assert not offences(summary), (
+        f"the line every browser of `grid project --help` reads: {summary!r} -> {offences(summary)}")
 
 
 def test_the_scan_really_walked_the_surface():

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -25350,6 +25350,158 @@ def test_task_get_does_not_blame_capacity_for_a_task_that_really_ran(
     assert "no provider" not in out.lower()
 
 
+def _queued_task_and_fleet(providers, *, task=None, status_code=200, seen=None):
+    """Route a `task get` at a queued task and the project-status read that follows it.
+
+    Two endpoints, because the whole point of the behaviour under test is that the second one is
+    consulted — a single canned reply could not tell "asked and rendered" from "never asked".
+    `seen` collects the paths, so a test can assert on the call that did NOT happen.
+    """
+    task = task or {"id": "T1", "state": "queued", "project_id": "P1", "error": None}
+
+    def handler(request):
+        path = request.url.path
+        if seen is not None:
+            seen.append(path)
+        if path.endswith("/status"):
+            return httpx.Response(status_code, json={"providers": providers})
+        return httpx.Response(200, json=task)
+
+    return handler
+
+
+def test_task_get_says_why_a_queued_task_has_not_started(monkeypatch, tmp_path, capsys):
+    """The first hour: a task sits `queued` and nothing says the grid has nobody to run it.
+
+    The answer existed only in `grid project status`, which a new person has no reason to run and
+    is not told to — so the silence lasted until `queue_expired` hours later.
+    """
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    state.set_mode("remote")
+
+    _mock_relay(monkeypatch, _queued_task_and_fleet({"online": 0, "paused": 0}))
+    cli.main(["task", "get", "T1"])
+
+    out = capsys.readouterr().out
+    assert "state=queued" in out
+    assert "No provider is online" in out, f"the reason it is waiting, beside the task:\n{out}"
+    assert "grid join" in out, f"and the thing to do about it:\n{out}"
+
+
+def test_task_get_tells_a_queued_member_their_domain_is_not_served(monkeypatch, tmp_path, capsys):
+    """`serves_you: false` is the state `online` gets exactly backwards (ADR 0033 D-f, issue 24).
+
+    A healthy fleet number beside work no provider will ever be offered reads as "the grid is
+    busy". Same helper as `project status`, so the two surfaces cannot answer differently.
+    """
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    state.set_mode("remote")
+
+    _mock_relay(monkeypatch, _queued_task_and_fleet(
+        {"online": 3, "paused": 0, "serves_you": False}))
+    cli.main(["task", "get", "T1"])
+
+    out = capsys.readouterr().out
+    assert "does not serve your account's email domain" in out, out
+    assert "No provider is online" not in out, (
+        "three providers ARE online — the unserved sentence must replace the fleet count, "
+        f"not stack with a number that contradicts it:\n{out}")
+
+
+def test_task_get_stays_quiet_about_the_fleet_when_somebody_can_take_it(
+        monkeypatch, tmp_path, capsys):
+    """The positive control. A queued task on a healthy fleet is ordinary, and saying so on every
+    poll is the noise that makes the sentence that matters invisible."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    state.set_mode("remote")
+
+    _mock_relay(monkeypatch, _queued_task_and_fleet({"online": 2, "paused": 0}))
+    cli.main(["task", "get", "T1"])
+
+    out = capsys.readouterr().out
+    assert "state=queued" in out
+    assert "provider" not in out.lower(), f"nothing is wrong, so nothing is said:\n{out}"
+
+
+def test_task_get_never_asks_about_the_fleet_for_a_task_that_finished(
+        monkeypatch, tmp_path, capsys):
+    """The cost bound. `task get` is polled in a loop, so the extra read happens only in the states
+    that raise the question — never on the path a script hammers."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    state.set_mode("remote")
+    seen = []
+
+    _mock_relay(monkeypatch, _queued_task_and_fleet(
+        {"online": 0, "paused": 0}, seen=seen,
+        task={"id": "T1", "state": "completed", "project_id": "P1", "result_text": "hi"}))
+    cli.main(["task", "get", "T1"])
+
+    assert not any(p.endswith("/status") for p in seen), (
+        f"a finished task raises no question about capacity, so it must cost no read: {seen}")
+
+
+def test_task_get_json_is_untouched_by_the_fleet_read(monkeypatch, tmp_path, capsys):
+    """`--json` owes the caller the relay's document and nothing else. An extra sentence on stdout
+    would be a parse error in the one mode an application drives."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    state.set_mode("remote")
+    seen = []
+    task = {"id": "T1", "state": "queued", "project_id": "P1", "error": None}
+
+    _mock_relay(monkeypatch, _queued_task_and_fleet({"online": 0, "paused": 0}, task=task, seen=seen))
+    cli.main(["task", "get", "T1", "--json"])
+
+    assert json.loads(capsys.readouterr().out) == task
+    assert not any(p.endswith("/status") for p in seen), (
+        f"nothing to render means nothing to fetch: {seen}")
+
+
+def test_a_fleet_read_that_fails_never_becomes_the_tasks_verdict(monkeypatch, tmp_path, capsys):
+    """⚠️ The guard that matters. This is an EXTRA sentence beside a report that already
+    succeeded, and `task get`'s exit code is a verdict about the TASK — so a status call that
+    5xxs, times out or answers something unreadable must change neither the report nor the code.
+    """
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    state.set_mode("remote")
+
+    _mock_relay(monkeypatch, _queued_task_and_fleet(None, status_code=500))
+    code = cli.main(["task", "get", "T1"])
+
+    out = capsys.readouterr().out
+    assert "state=queued" in out, f"the task's own report survives the fleet read:\n{out}"
+    assert code == 2, "still 'ask again' — the fleet has no say in whether the task finished"
+
+
+def test_a_task_that_expired_waiting_is_told_who_was_online(monkeypatch, tmp_path, capsys):
+    """`_QUEUE_EXPIRED_NOTE` names `grid project status` by hand — so the person who most needs the
+    answer was sent to run a second command. Answer it where the question is asked."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    state.set_mode("remote")
+
+    _mock_relay(monkeypatch, _queued_task_and_fleet({"online": 0, "paused": 0}, task={
+        "id": "T1", "state": "timed_out", "error": "queue_expired", "project_id": "P1"}))
+    cli.main(["task", "get", "T1"])
+
+    out = capsys.readouterr().out
+    assert "error=queue_expired" in out
+    assert "No provider is online" in out, f"the answer, not a pointer to it:\n{out}"
+
+
+def test_a_task_view_with_no_project_asks_nothing(monkeypatch, tmp_path, capsys):
+    """An older relay's task view carries no `project_id`. There is nothing to ask about, and
+    guessing one would read a project the caller never named."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    state.set_mode("remote")
+    seen = []
+
+    _mock_relay(monkeypatch, _queued_task_and_fleet(
+        {"online": 0, "paused": 0}, seen=seen, task={"id": "T1", "state": "queued"}))
+    cli.main(["task", "get", "T1"])
+
+    assert "state=queued" in capsys.readouterr().out
+    assert not any(p.endswith("/status") for p in seen), f"nothing to ask about: {seen}"
+
+
 def test_task_follow_says_which_budget_a_timed_out_task_spent(capsys):
     """The same distinction where a person actually watches a task end."""
     from cli import remote_task

--- a/tests/test_train_capture.py
+++ b/tests/test_train_capture.py
@@ -203,6 +203,14 @@ def test_prune_drops_old_days_only():
     old.parent.mkdir(parents=True, exist_ok=True)
     old.write_text('{"id":"x"}\n', encoding="utf-8")
     capture.record("today", "answer", model="m")
+    # ⚠️ Appends go to a BACKGROUND writer (`capture._append`), so today's file does not exist the
+    # instant `record` returns — the autouse `_flush_writes` fixture only runs at teardown, which is
+    # after every assertion below. Every other test in this file that reads back what it wrote
+    # flushes by hand; this one did not, and failed on CI (3.12) while passing on a developer's Mac.
+    #
+    # It also made the last assertion VACUOUS in the other direction: with nothing on disk, `prune`
+    # was never actually asked to spare today's file, which is the whole thing this test is for.
+    capture.flush()
     assert capture.prune() == 1
     assert not old.exists()
     assert list(capture.capture_dir().glob("traffic-*.jsonl"))   # today's file survived


### PR DESCRIPTION
Two corrections to what the task plane tells a person, found auditing the command surface for a
non-developer, plus the app-integration guide that had to move with them.

## 1. A help string that promised behaviour a decision had removed

`grid task create --help` claimed the caller's own `default` project is *"created on first use"*.
It is not, deliberately: `_own_default_project` looks it up and refuses with `_NO_PROJECT` when it
is absent, because minting one as a side effect of a forgotten flag left people owning projects
they had not asked for (**ADR 0033 D-o, issue 26**).

The help promised back exactly the behaviour that decision removed — on the most-run command of the
plane. Somebody following it omitted `--project` and met a refusal instead.

## 2. One word for the object: `task`, never `turn`

Six subcommands take a turn id spelled `task_id`. Five described it as a *"Task id"*; `follow`
alone said *"Turn id"* — so the one word a person matches against the two ids `grid task create`
prints was the one word that moved.

All six now carry the same sentence, and it names what the id is **not**:

> Task id, from `grid task create` or `grid task list`. Not the conversation id — that one goes to
> `grid task send`.

Handing the wrong one over gets a bare 404 that reads like "it disappeared". That is the confusion
here able to cost somebody work.

`turn` is then gone from every string a person can see — help, printed output and refusals,
`project_arg._CONVERSATION_HINT` included, since that one feeds several refusals at once.
`conversation` stays: it names the thread, and it is not jargon.

## 3. `docs/FE-integration.md` taught the opposite model

Section 2 had `task` = the CONVERSATION with `turn` a noun of its own. An app built from that table
would have shipped a second, incompatible model of the same two ids — the confusion the document
itself calls *"the one distinction that breaks apps"*. 49 occurrences converted, each checked rather
than swapped.

This is the file's **first commit**; it existed only in the worktree until now.

## Nothing on the wire moved

`active_turns`, `member_running_turns` and `member_running_cap` keep their exact names — only the
labels printed beside them changed, and a note now sits beside the doc's noun table so nobody reads
a key name off the prose. No relay change, no rollout order in either direction.

Two spots were reworded rather than substituted, because a blind swap would have been wrong:
- `"nothing until its turn comes"` — that `turn` is the English idiom, not the noun.
- `grid project wip` cross-referenced `grid task get <turn-id>`, a command this PR renames.

## Test plan

- [x] `.venv/bin/ruff check .` — clean
- [x] `.venv/bin/pytest tests/` — **3028 passed, 9 skipped**, identical before and after the
      `public/main` merge. The 9 skips are the cross-repo checks, which need grid-src beside the
      worktree and skip in CI.
- [x] `tests/test_application_surface.py` (16) — the vocabulary scan that keeps git words off the
      20-command application surface, still green
- [x] Verified no test pinned any changed string before editing (exact-literal sweep over `tests/`)
- [x] Rendered `--help` for `task create`, `task follow`, `project` and read the output
- [x] `public/main` merged in and re-tested before opening this PR

> Merge with a **merge commit**, not squash — per `.claude/rules/common/git-workflow.md`, squashing
> makes `staging` conflict with `main` on every later sync.