### PR TITLE
fix(docs): drop the unused locals ruff has been failing main on

### DIFF
--- a/docs/model_orchestration_patterns/build_diagrams.py
+++ b/docs/model_orchestration_patterns/build_diagrams.py
@@ -263,7 +263,7 @@ class Diagram:
 
         def lrange(box):
             """(x0, x1) the label really occupies, honouring its anchor."""
-            mx, base, bw, bh, anchor = box[0], box[1], box[2], box[3], box[4]
+            mx, bw, anchor = box[0], box[2], box[4]
             if anchor == "end":
                 return (mx - bw, mx)
             if anchor == "start":
@@ -323,7 +323,6 @@ class Diagram:
                     box[5] = fs
 
         # ---- relaxation: node clearance + label-label spread + canvas clamp.
-        import math
         GAP = 6.0          # clearance between any two labels
         NODE_CLR = 3.0     # extra so a label never touches a node's border
         for _ in range(120):
@@ -402,7 +401,7 @@ class Diagram:
         for box in boxes:
             if box is None:
                 continue
-            bw, bh = box[2], box[3]
+            bh = box[3]
             x0, x1 = lrange(box)
             if x0 < 0:
                 box[0] += -x0
@@ -413,7 +412,7 @@ class Diagram:
 
     def _elabel(self, p, e, box):
         lab = e["label"]
-        mx, baseline, bw, bh, anchor, fs = box[0], box[1], box[2], box[3], box[4], box[5]
+        mx, baseline, anchor, fs = box[0], box[1], box[4], box[5]
         p.append(f'  <text x="{mx:.0f}" y="{baseline:.0f}" text-anchor="{anchor}" '
                  f'fill="{INK}" font-size="{fs}">{esc(lab)}</text>')
 


### PR DESCRIPTION
`main`'s CI has been red on `lint` for at least the last five pushes — every one a docs commit from the orchestration-patterns work, none of them touching the code the failure is in. This turns it green.

## The six

All in `docs/model_orchestration_patterns/build_diagrams.py`:

| where | rule | what |
|---|---|---|
| `lrange` | F841 ×2 | `base`, `bh` unpacked, never read |
| relaxation block | F401 | `import math` — no `math.` anywhere in the file |
| canvas clamp | F841 | `bw` unpacked, never read |
| `_elabel` | F841 ×2 | `bw`, `bh` unpacked, never read |

`bh` at the canvas clamp **stays** — it is read two lines below, at the `box[1] = min(max(...))` clamp. Only `bw` goes there.

Nothing computed is lost: each site reads a list by index, so dropping the name drops no work.

## Test plan

- [x] `ruff check .` → **All checks passed**
- [x] Behaviour-preserving, proven by regenerating the diagrams: `python3 build_diagrams.py` rewrites every committed SVG **byte-identically** after the change — `git status` shows only the `.py` itself
- [x] Positive control run first: the **unmodified** script also reproduces the committed SVGs exactly, so the check is capable of seeing a difference rather than passing vacuously

🤖 Generated with [Claude Code](https://claude.com/claude-code)