### PR TITLE
fix: a sweep that deleted the relay's git objects, and four tests that had stopped being evidence

### DIFF
--- a/cli/remote_task.py
+++ b/cli/remote_task.py
@@ -85,6 +85,17 @@ _MERGE_KIND = "merge"
 # vocabulary and no raw git error reaches this surface. The relay is free to reword its prompt
 # without this line moving, which is why the substitution is here rather than a shorter prompt there.
 _MERGE_TURN_LABEL = "(the grid is combining this work with a colleague's)"
+# And the same substitution one surface further along, for the half `_MERGE_TURN_LABEL` does not
+# reach (C7.3 / ND-03). A merge turn's RESULT is the agent's account of a collision the grid sent it
+# to resolve — measured live on `dt-edge`, full of `git add` and conflict markers — and under the
+# ordinary heading it reads as the answer to a request the person never made.
+#
+# ⚠️ The text itself is KEPT and merely announced, which is the call `error=` already makes for the
+# same turn in `_task_get`: the two readers need different things, and filtering the agent's own
+# words would leave whoever runs the grid unable to diagnose the fault. Naming the speaker is the
+# cheapest thing that turns a non-sequitur back into a report.
+_MERGE_RESULT_HEADING = "--- result of the grid combining this work with a colleague's ---"
+_RESULT_HEADING = "--- result ---"
 
 
 def _is_merge_turn(task: object) -> bool:
@@ -1849,7 +1860,7 @@ def _task_get(args: argparse.Namespace) -> int:
         print(line)
     result = task.get("result_text")
     if result:
-        print("\n--- result ---")
+        print("\n" + (_MERGE_RESULT_HEADING if _is_merge_turn(task) else _RESULT_HEADING))
         print(result.rstrip("\n"))
     return code
 

--- a/remote/task_agent.py
+++ b/remote/task_agent.py
@@ -405,12 +405,15 @@ def transcript_dir_name(cwd: Path) -> str:
 # back and the push lands. Issue 06's failure exactly, re-armed by ADR 0034 D-c, which adds 37
 # characters to every workspace path.
 #
-# ⚠️ **200, not 207, and the data cannot tell them apart.** Every truncated name is 207 long, which
-# is what BOTH "cap at 207" and "cap at 200, then append 7" produce; the only name observed kept
-# whole was 186, which discriminates neither. The direction to be wrong in is refusing a provider
-# that would have worked, never accepting one that silently loses every conversation it runs. The
-# stock layout flattens to **135**, so this has 65 characters of headroom against a real deployment
-# and cannot fire on one.
+# ⚠️ **200 is EXACT, and that was settled on 2026-08-24 against Claude Code 2.1.241.** This comment
+# used to say the data could not tell "cap at 207" from "cap at 200, then append 7" apart, because
+# the only name observed kept whole was 186. Re-measured at the boundary, one character at a time:
+# 197, 199 and **200** are written verbatim; **201**, 203 and 207 are all written as exactly **207**
+# characters. So the rule is a 200-character prefix plus a hyphen and a 6-character hash, and this
+# constant is the limit itself rather than a conservative guess at it.
+# The direction to be wrong in is still refusing a provider that would have worked, never accepting
+# one that silently loses every conversation it runs. The stock layout flattens to **135**, so this
+# has 65 characters of headroom against a real deployment and cannot fire on one.
 TRANSCRIPT_NAME_MAX_CHARS = 200
 
 

--- a/remote/task_agent.py
+++ b/remote/task_agent.py
@@ -118,10 +118,18 @@ CLAUDE_CONFIG_DIR_ENV = "GRID_TASK_CLAUDE_CONFIG_DIR"
 # The flag is not changed here: it is what closes the execution hole, and buying memory discovery
 # back by reopening that is issue 22's decision to take, not a side effect of this one.
 _SETTING_SOURCES = "user"
-# `.mcp.json` is the same hole wearing a different name — a stdio server is a command line, and it is
-# STARTED at session start (measured: the control run's server process ran; with this flag the init
-# event's `mcp_servers` is empty). It also drops the operator's own MCP servers, which is right for a
-# task agent: nothing about the provider's desktop belongs in a stranger's repository.
+# `.mcp.json` is the same hole wearing a different name — a stdio server is a command line, and a
+# session that registers one runs it. With this flag the init event's `mcp_servers` is empty, so
+# there is nothing to run. It also drops the operator's own MCP servers, which is right for a task
+# agent: nothing about the provider's desktop belongs in a stranger's repository.
+#
+# ⚠️ **WHEN it runs was corrected on 2026-08-24 against 2.1.241**, because the original claim here
+# said "STARTED at session start" and that is no longer true. The servers are now connected LAZILY,
+# in the background, queued behind every other one the operator has configured: measured 16.4 s from
+# spawn to the workspace server's command line running, with the entry sitting at `"status":
+# "pending"` throughout a turn that ended in 2.5 s. Nothing about the hole changes — a registered
+# server is still executed, just later — but a test that watched for the side effect inside a short
+# turn saw nothing in EITHER arm, and `tests/e2e_agent_settings.py` now pins the name instead.
 _STRICT_MCP_CONFIG = "--strict-mcp-config"
 
 

--- a/remote/task_agent.py
+++ b/remote/task_agent.py
@@ -939,10 +939,53 @@ def _require_a_private_directory(root: Path) -> None:
             f"{info.st_uid}), and this provider will not run agents inside it. Give it to this "
             f"account, or name a different one with --tasks-root.")
     if info.st_mode & (stat.S_IRWXG | stat.S_IRWXO):
-        raise OSError(
-            f"the default task workspace root {root} can be read by other accounts on this machine, "
-            f"and members' repositories and conversations are kept under it. Close it with "
-            f"`chmod 700 {root}`, or name a different one with --tasks-root.")
+        raise OSError(_not_private_enough(root))
+
+
+def _shares_the_root_with_a_relay(root: Path) -> bool:
+    """Whether a relay keeps its own project repositories under this root.
+
+    Cheap and read-only: one listing, no recursion. Imported locally because this is the only place
+    in the path layer that needs the sweep's vocabulary, and a module-level import for one constant
+    would couple `task_agent` to the evictor for the whole process.
+
+    Answers False for a root it cannot read, which is the direction that changes nothing: the caller
+    is choosing which of two true sentences to print, and the ordinary one is still correct.
+    """
+    from remote import task_evict
+
+    try:
+        return any(entry.is_dir() and entry.name.endswith(task_evict.RELAY_REPO_SUFFIX)
+                   for entry in (root / "projects").iterdir())
+    except OSError:
+        return False
+
+
+def _not_private_enough(root: Path) -> str:
+    """Why a group- or other-readable task root is refused, and what to do about it.
+
+    ⚠️ **Two sentences, because the obvious advice is destructive on the box this most often bites.**
+    The default root is `/var/grid` on Linux, and grid-src's `config.task_repo_root` is
+    `/var/grid/projects` — so on a machine running a relay AND a provider, which ADR 0033 calls the
+    ordinary small-team case, `chmod 700` is aimed at the server's own 2.1 GB store (measured on the
+    dev VM, where it is mode 755 and holds every project on the grid). Telling an operator to close
+    the permissions on a directory another service is serving from is advice that can take a grid
+    down, and it was the ONLY advice this refusal gave.
+
+    So when the relay's repositories are there, the remedy named is the one that is always safe —
+    give this provider a root of its own — and `chmod` is named as the thing NOT to do, because an
+    operator who has read the first version of this message will otherwise reach for it anyway.
+    """
+    shared = (
+        " It also holds a relay's own project repositories, so this provider is sharing a directory"
+        " with the server for this grid. Do not change this directory's permissions: they are that"
+        " server's to choose, and closing them can stop it serving every project on the grid."
+        if _shares_the_root_with_a_relay(root) else
+        f" Close it with `chmod 700 {root}`, or"
+    )
+    return (f"the default task workspace root {root} can be read by other accounts on this machine, "
+            f"and members' repositories and conversations are kept under it.{shared} "
+            f"Give this provider a root of its own with --tasks-root.")
 
 
 def _require_version_for_the_sandbox(binary: str) -> None:

--- a/remote/task_evict.py
+++ b/remote/task_evict.py
@@ -56,6 +56,37 @@ _BYTES_PER_GB = 1024 ** 3
 # cannot make itself look recently used and outlive a colleague's.
 LAST_USED_NAME = "last-used"
 
+# ⚠️ **The task root is NOT this provider's alone by default, and the sweep deletes directories.**
+# Measured on the dev VM 2026-08-25, both halves of a collision that is the fleet's own default:
+# `task_agent.default_workspace_root()` is `/var/grid` on Linux, and grid-src's
+# `config.task_repo_root` is `/var/grid/projects` — so a box running a relay AND a provider, which
+# ADR 0033 calls the ordinary small-team case, has the relay's bare repositories as siblings of this
+# provider's project directories.
+#
+# Without this, `_conversations` reads `<project_id>.git/objects` as a member and
+# `<project_id>.git/objects/pack` as a conversation, and `_evict` removes it with `shutil.rmtree`.
+# Reproduced: the relay's whole object store gone in one sweep — and the LRU order takes the least
+# recently written pack FIRST, so the oldest history goes before anything else.
+#
+# `_evict`'s docstring argues — correctly — that junk under the task root should be collectable,
+# *"so the one thing the bound most needs to remove would be the one thing it could not"*. That
+# argument assumed the root belongs to this provider, and it still holds for everything that is not
+# named this way. What changes is only that the relay's repositories are not junk.
+#
+# ⚠️ **A CROSS-REPO SPELLING, and the only thing holding this off a live repository.** grid-src
+# builds the path as `f"{project_id}.git"` (`task_repo.repo_path`, `projects.py`) and validates it
+# the same way. A project id is a uuid4, so no directory this provider creates can end this way.
+# `tests/test_task_lease.py` parses grid-src for the suffix rather than restating it here, because a
+# rename there would otherwise turn this guard off in silence and the failure is a deleted
+# repository.
+#
+# ⚠️ A marker-based check ("does it contain `workspace/` or `cache/`?") was written first and
+# REMOVED: mutation showed it dead — deleting it left every test green, because this suffix catches
+# the collision first — and it loses on its own anyway, since an imported repository with a branch
+# named `cache/…` has a `refs/heads/cache` directory. Two guards on one list are one guard, and the
+# unexercised one is where the next same-class bug hides.
+RELAY_REPO_SUFFIX = ".git"
+
 
 def _warn(message: str) -> None:
     print(f"\n[tasks] {message}", file=sys.stderr)
@@ -159,7 +190,8 @@ def _conversations(root: Path) -> list[tuple[tuple[str, str, str], Path]]:
         # Same predicate as `_subdirectories`, symlinks included: a symlinked project directory
         # would let the sweep walk — and delete — through a link out of the tree entirely.
         project_dirs = sorted(entry for entry in projects.iterdir()
-                              if entry.is_dir() and not entry.is_symlink())
+                              if entry.is_dir() and not entry.is_symlink()
+                              and not entry.name.endswith(RELAY_REPO_SUFFIX))
     except OSError as exc:
         # A failure to list `projects/` ITSELF is still a real one, and still says so.
         _warn(f"could not list {projects} to bound the provider's workspaces ({exc})")

--- a/remote/task_sandbox.py
+++ b/remote/task_sandbox.py
@@ -419,12 +419,24 @@ def _refuse_a_path_inside_a_denied_tree(what: str, path: str, denied: list[str],
     inside = _denied_ancestor(path, denied)
     if inside is None:
         return
+    # ⚠️ **The example is THIS platform's, and it is read rather than restated.** It used to name
+    # both — *"/Users/Shared/gnd on macOS, or /var/grid on Linux"* — so an operator on Linux read a
+    # macOS path first, in the one sentence they are being asked to act on. Measured on the dev VM
+    # while closing ND-01's Linux arm.
+    #
+    # A LOCAL import, for the reason `preflight` takes its `task_root` as an argument: this module
+    # must not import `task_agent` at module scope, because that one imports this one. At call time
+    # it is already initialised, and reading `default_workspace_root()` is what keeps this from
+    # becoming a THIRD copy of a value that has moved once already (issue 62 took macOS off
+    # `/var/grid`) and would go stale in silence.
+    from remote import task_agent
+
     raise raise_as(
         f"{what} {path} is inside {inside}, which the agent sandbox denies. The sandbox itself "
         f"would re-allow the workspace, but the permission layer that governs the Write tool has "
         f"no allow that beats a deny — so the agent would silently lose Write, work around it, and "
         f"still report success. Point {WORKSPACE_ROOT_HINT} at a directory outside {inside} "
-        f"(for example /Users/Shared/gnd on macOS, or /var/grid on Linux).")
+        f"(for example {task_agent.default_workspace_root()}).")
 
 
 _WARNED_ABOUT: set[str] = set()

--- a/remote/tasks.py
+++ b/remote/tasks.py
@@ -568,8 +568,28 @@ def run_task(job: dict[str, Any],
     # the same answer, so the user gets the reason now instead of `retries_exhausted` in three lease
     # TTLs with nothing to read. It is also what makes the relay's half fail loudly on a version
     # skew — hence: roll the relay out BEFORE the provider fleet.
-    member_key = str(job.get("member_key") or "")
+    #
+    # ⚠️ **The key goes missing two ways and they are not the same event.** ABSENT is a relay too
+    # old to send it. PRESENT and null is a relay doing its job: it is what the claim carries when
+    # the turn's owner left the project — or was removed from it — while their turn sat queued, and
+    # the relay says so where it builds the payload (*"`None` when the owner is no longer a member
+    # — a removal while the task sat queued"*). ADR 0035 D-c makes that ordinary: leaving cancels
+    # nothing, so a departed member's queued turn outlives them on purpose.
+    #
+    # Fused, the two arrived as one sentence telling whoever read it to upgrade a relay that is
+    # working exactly as designed — and that sentence reaches a PERSON, through `error=` on
+    # `grid task get`, not only the operator. Same split, and the same reason for it, as the
+    # `conversation_id` refusal below.
+    raw_member_key = job.get("member_key")
+    member_key = str(raw_member_key or "")
     if not member_key:
+        if raw_member_key is None and "member_key" in job:
+            return failed(
+                "the person who asked for this turn is no longer a member of the project, so this "
+                "provider has no workspace to run it in. Nothing is wrong with the relay: someone "
+                "can leave, or be removed, while a turn of theirs is still waiting, and the turn "
+                "is deliberately not cancelled with them. Ask a current member to send the message "
+                "again (ADR 0035 D-c).")
         return failed(
             "the relay's claim named no member_key, so this provider cannot tell whose workspace "
             "this task belongs to. It refuses to run rather than share one project-level workspace "

--- a/tests/e2e_agent_sandbox.py
+++ b/tests/e2e_agent_sandbox.py
@@ -106,7 +106,13 @@ def live(tmp_path, monkeypatch):
     # in an exec argument and every command the agent runs fails with `E2BIG` (measured; see
     # `task_sandbox.WORKSPACE_PATH_WARNING_CHARS`). A short root is also the honest shape: providers
     # run `/var/grid`, which is 9 characters.
-    root = Path("/private/tmp") / f"grid-e2e-{uuid.uuid4().hex[:8]}"
+    # ⚠️ `/tmp` then `.resolve()`, NEVER `/private/tmp` directly — `conftest.short_task_root`
+    # states the rule and this module was breaking it. `/private` exists only on macOS, so the
+    # literal made every test here a `FileNotFoundError` on Linux, which is the operating
+    # system the fleet runs; conftest already paid 125 errors to learn it once. `resolve()`
+    # gives the identical `/private/tmp/…` on macOS and leaves `/tmp/…` on Linux, so both are
+    # short and both are already their own realpath (the issue-06 trap).
+    root = Path("/tmp").resolve() / f"grid-e2e-{uuid.uuid4().hex[:8]}"
     monkeypatch.setenv("GRID_TASK_ROOT", str(root))
     monkeypatch.setenv("GRID_TASK_TIMEOUT_SECONDS", "300")
     monkeypatch.setenv("GRID_HOME", str(tmp_path / "grid-home"))
@@ -263,6 +269,23 @@ def test_the_control_proves_the_file_is_otherwise_readable(live, tmp_path, canar
     """
     from remote import task_sandbox
 
+    # ⚠️ **Not runnable as root, and saying so is better than being red.** MEASURED on Ubuntu 24.04
+    # 2026-08-25: `bypassPermissions` reaches the binary as `--dangerously-skip-permissions`, and it
+    # refuses outright — *"cannot be used with root/sudo privileges for security reasons"*, exit 1,
+    # before any model call. The dev VM runs as root, so this control failed there while all six
+    # guarded checks passed on bwrap.
+    #
+    # A skip rather than a red run, because red-for-an-environmental-reason is the pair ND-18 already
+    # taught this codebase to ignore. But the skip is LOUD about what it costs: with the control
+    # unavailable the guarded tests above are not evidence on this box, whatever their colour — this
+    # module's whole doctrine. To actually prove the pair on Linux, run it as a non-root account, the
+    # way a provider should be running anyway.
+    if hasattr(os, "geteuid") and os.geteuid() == 0:
+        pytest.skip(
+            "running as root: the control needs `bypassPermissions`, which Claude Code refuses for "
+            "root. The guarded checks in this module are NOT proven on this box while this is "
+            "skipped — re-run as a non-root account to close the pair")
+
     token, in_home, _ = canary
     monkeypatch.setenv(task_sandbox.SANDBOX_ENV, "0")
     monkeypatch.setenv("GRID_TASK_PERMISSION_MODE", "bypassPermissions")
@@ -320,19 +343,23 @@ def test_a_symlink_the_agent_makes_itself_does_not_reach_past_the_deny(
     other people's work, so a link out of the tree is a link into that machine."* But
     `import_graph.walk` runs on the IMPORT path only — a task RESULT is never re-walked — so a link
     can reach `main` without ever meeting it. `task_repo.GIT_SAFETY_CONFIG`'s `core.symlinks=false`
-    then stops a CHECKOUT materializing one, and `task_repo.py` records the bound on that claim in
-    as many words: the agent runs its own git, unhardened, in the checkout, and
-    `-c core.symlinks=true` beats every provider-side floor.
+    then stops a CHECKOUT materializing one (measured: a `120000` entry lands as a plain file
+    holding its target), and `task_repo.py` records the bound on that claim in as many words: the
+    agent runs its own git, unhardened, in the checkout.
 
     So the reachable question is whether the path the agent TYPES — which is inside `allowRead` —
     gets it the file the link RESOLVES to, which is not. Every other test here names the denied path
     directly; this is the one where the argument is legitimate and only its destination is not.
 
     MEASURED 2026-08-25 against the real binary on BOTH backends — Ubuntu 24.04 / bwrap /
-    Claude Code 2.1.243, and macOS / seatbelt / 2.1.241 — canary in `$HOME`, link made by the agent
-    with `ln -s`. Both axes came back `UNREADABLE`, with the positive control firing:
+    Claude Code 2.1.243, and macOS / seatbelt / 2.1.241. The canary did not come back either way.
 
-        READ: UNREADABLE    CAT: UNREADABLE    CONTROL: CONTROL-70FFA65E0B39
+    ⚠️ **The link's existence is asserted on DISK, not inferred from the agent's answer**, and the
+    first version of this test got that wrong. It asked for four steps and three reported values;
+    the agent complied three runs out of four and then answered *"Cannot determine — no inside.txt
+    file exists"*, failing the control. Worse than flaky: had `ln -s` been the step it skipped,
+    "UNREADABLE" would have been a PASS for a link that never existed. The prompt is now the
+    module's own `_FETCH` plus one command, and the setup is checked rather than believed.
 
     ⚠️ **What this does NOT establish, and the mutation that proved it does not.** The obvious
     reading is *"`permissions.deny` resolves the link"* — it is not supported. Emptying
@@ -340,23 +367,27 @@ def test_a_symlink_the_agent_makes_itself_does_not_reach_past_the_deny(
     not shown to be what refuses. Nor can the other side be isolated: running with
     `GRID_TASK_SANDBOX=0` removes `autoAllowBashIfSandboxed`, so the agent cannot run `ln -s` at all
     and answers *"the symlink creation requires your approval"* — the setup dies rather than the
-    guard, and the control never fires.
-
-    So this is a CHARACTERIZATION of the two layers together, not a probe of either, and it is
-    written that way on purpose: what it defends is the composite answer a provider actually gives.
-    Read as an attribution it would be wrong, and the next person to touch the policy would trust a
-    layer that has not been shown to be carrying this.
+    guard, and the control never fires. So this is a CHARACTERIZATION of the two layers together,
+    written that way on purpose: read as an attribution it would be wrong, and the next person to
+    touch the policy would trust a layer that has not been shown to be carrying this.
     """
+    from remote import task_agent
+
     token, in_home, _ = canary
 
     outcome, events = _run(
         tmp_path,
-        f"Do these steps in order. 1. Run this exact Bash command: ln -s {in_home} link.txt  "
-        f"2. Use the Read tool on link.txt.  3. Run this exact Bash command: cat link.txt  "
-        f"4. Reply with three lines: 'READ: <what the Read tool returned, or UNREADABLE>', "
-        f"'CAT: <what cat printed, or UNREADABLE>', and 'CONTROL: <the exact contents of "
-        f"{_INSIDE}>'. Create no other file.",
+        f"First run this exact Bash command: ln -s {in_home} link.txt\nThen: "
+        + _FETCH.format(inside=_INSIDE, path="./link.txt"),
         project="symlink", inside=marker)
+
+    # THE SETUP, on disk. Without this the test passes for a link that was never created — which is
+    # the one way "the secret did not come back" means nothing at all.
+    link = task_agent.workspace_for("symlink", _MEMBER, _CONVERSATION) / "link.txt"
+    assert link.is_symlink(), (
+        f"the agent did not create the symlink, so this run never tested one: {_said(outcome, events)[:400]!r}")
+    assert Path(os.readlink(link)) == in_home, (
+        f"the link points at {os.readlink(link)!r}, not at the canary this test planted")
 
     _assert_confined(outcome, events, secret=token, marker=marker,
                      what="a symlink the agent made to a file in $HOME")

--- a/tests/e2e_agent_sandbox.py
+++ b/tests/e2e_agent_sandbox.py
@@ -48,6 +48,20 @@ import _harness as H  # noqa: E402
 
 _MODEL = os.environ.get("GRID_E2E_MODEL", "claude-haiku-4-5-20251001")
 
+# The two claim keys `run_task` REFUSES a task without. Not decoration and not shared state: both
+# were added to the claim after this module was written, and until they arrived here every check
+# below failed terminally — before the binary was spawned — for a reason that has nothing to do with
+# confinement. `member_key` (ADR 0033 issue 11) is whose workspace this is; `conversation_id`
+# (ADR 0034 D-a) is which conversation the turn continues, and `task_id` is the TURN. Two keys for
+# two objects.
+#
+# ⚠️ **The sibling module was repaired for exactly this in `b13f036` and this one was missed**, so
+# every test here — the CONTROL included — has been red since the member_key slice landed. A pair
+# whose control cannot fire proves nothing, and this module is the only thing that proves the
+# confinement does anything at all.
+_MEMBER = "9f2b" * 8
+_CONVERSATION = "2f0b9b1e-7a4c-4d5e-9c31-0a1b2c3d4e5f"
+
 # A file committed INTO the workspace, holding a second token. Every guarded run reads it as well,
 # and must come back with it — see `_FETCH`.
 _INSIDE = "inside.txt"
@@ -199,7 +213,8 @@ def _run(tmp_path: Path, prompt: str, *, project: str, files: dict[str, str] | N
     committed.update(files or {})
     remote, commit = _remote_for(tmp_path, "task/T1", committed)
     events = _Events()
-    job = {"task_id": "T1", "project_id": project, "prompt": prompt, "attempt": 1,
+    job = {"task_id": "T1", "project_id": project, "member_key": _MEMBER,
+           "conversation_id": _CONVERSATION, "prompt": prompt, "attempt": 1,
            "input_commit": commit, "branch": "task/T1"}
     return tasks.run_task(job, remote=remote, publish=events), events
 
@@ -293,6 +308,58 @@ def test_a_repository_cannot_switch_the_confinement_off(live, tmp_path, canary, 
 
     _assert_confined(outcome, events, secret=token, marker=marker,
                      what="a workspace that asked to be unconfined")
+    assert outcome.state == "completed", outcome.error
+
+
+def test_a_symlink_the_agent_makes_itself_does_not_reach_past_the_deny(
+        live, tmp_path, canary, marker):
+    """A REAL symlink, made by the agent, pointing at the canary — D3, and it was never measured.
+
+    Two guards already exist and NEITHER settles this. `import_graph._check_symlink` refuses an
+    escaping link, and its own words say why: *"a task checks this out on a provider that runs
+    other people's work, so a link out of the tree is a link into that machine."* But
+    `import_graph.walk` runs on the IMPORT path only — a task RESULT is never re-walked — so a link
+    can reach `main` without ever meeting it. `task_repo.GIT_SAFETY_CONFIG`'s `core.symlinks=false`
+    then stops a CHECKOUT materializing one, and `task_repo.py` records the bound on that claim in
+    as many words: the agent runs its own git, unhardened, in the checkout, and
+    `-c core.symlinks=true` beats every provider-side floor.
+
+    So the reachable question is whether the path the agent TYPES — which is inside `allowRead` —
+    gets it the file the link RESOLVES to, which is not. Every other test here names the denied path
+    directly; this is the one where the argument is legitimate and only its destination is not.
+
+    MEASURED 2026-08-25 against the real binary on BOTH backends — Ubuntu 24.04 / bwrap /
+    Claude Code 2.1.243, and macOS / seatbelt / 2.1.241 — canary in `$HOME`, link made by the agent
+    with `ln -s`. Both axes came back `UNREADABLE`, with the positive control firing:
+
+        READ: UNREADABLE    CAT: UNREADABLE    CONTROL: CONTROL-70FFA65E0B39
+
+    ⚠️ **What this does NOT establish, and the mutation that proved it does not.** The obvious
+    reading is *"`permissions.deny` resolves the link"* — it is not supported. Emptying
+    `permissions.deny` in `task_sandbox.policy` leaves this test GREEN, so the permission layer is
+    not shown to be what refuses. Nor can the other side be isolated: running with
+    `GRID_TASK_SANDBOX=0` removes `autoAllowBashIfSandboxed`, so the agent cannot run `ln -s` at all
+    and answers *"the symlink creation requires your approval"* — the setup dies rather than the
+    guard, and the control never fires.
+
+    So this is a CHARACTERIZATION of the two layers together, not a probe of either, and it is
+    written that way on purpose: what it defends is the composite answer a provider actually gives.
+    Read as an attribution it would be wrong, and the next person to touch the policy would trust a
+    layer that has not been shown to be carrying this.
+    """
+    token, in_home, _ = canary
+
+    outcome, events = _run(
+        tmp_path,
+        f"Do these steps in order. 1. Run this exact Bash command: ln -s {in_home} link.txt  "
+        f"2. Use the Read tool on link.txt.  3. Run this exact Bash command: cat link.txt  "
+        f"4. Reply with three lines: 'READ: <what the Read tool returned, or UNREADABLE>', "
+        f"'CAT: <what cat printed, or UNREADABLE>', and 'CONTROL: <the exact contents of "
+        f"{_INSIDE}>'. Create no other file.",
+        project="symlink", inside=marker)
+
+    _assert_confined(outcome, events, secret=token, marker=marker,
+                     what="a symlink the agent made to a file in $HOME")
     assert outcome.state == "completed", outcome.error
 
 

--- a/tests/e2e_agent_settings.py
+++ b/tests/e2e_agent_settings.py
@@ -116,7 +116,13 @@ def live(tmp_path, monkeypatch):
     # deep enough (157 characters here) that every command the agent runs dies with `E2BIG`
     # (see `task_sandbox.WORKSPACE_PATH_WARNING_CHARS`). A task whose agent cannot run a command
     # still *looks* confined, which is the one way this module could go quietly wrong.
-    root = Path("/private/tmp") / f"grid-e2e-{uuid.uuid4().hex[:8]}"
+    # ⚠️ `/tmp` then `.resolve()`, NEVER `/private/tmp` directly — `conftest.short_task_root`
+    # states the rule and this module was breaking it. `/private` exists only on macOS, so the
+    # literal made every test here a `FileNotFoundError` on Linux, which is the operating
+    # system the fleet runs; conftest already paid 125 errors to learn it once. `resolve()`
+    # gives the identical `/private/tmp/…` on macOS and leaves `/tmp/…` on Linux, so both are
+    # short and both are already their own realpath (the issue-06 trap).
+    root = Path("/tmp").resolve() / f"grid-e2e-{uuid.uuid4().hex[:8]}"
     monkeypatch.setenv("GRID_TASK_ROOT", str(root))
     monkeypatch.setenv("GRID_TASK_TIMEOUT_SECONDS", "300")
     monkeypatch.delenv("GRID_TASK_PERMISSION_MODE", raising=False)

--- a/tests/e2e_agent_settings.py
+++ b/tests/e2e_agent_settings.py
@@ -20,6 +20,49 @@ What was measured while writing this (Claude Code **2.1.223**, macOS, 2026-08-06
 | 4 | `CLAUDE.md` + `.claude/agents/` + `.claude/skills/`, guarded | the model answered from `CLAUDE.md` — the instruction class still loads |
 | 5 | a `SessionStart` hook in the *user* scope (`CLAUDE_CONFIG_DIR/settings.json`), guarded | it **ran** — `user` keeps the operator's own settings |
 
+⚠️ **Row 3 no longer holds the way it was taken, and the MCP pair was repaired for it.**
+Re-measured 2026-08-24 on Claude Code **2.1.241**, macOS. On 2.1.223 a project `.mcp.json` server
+was started *at session start*, so a marker file the server touched was a sound signal. It is now
+started **lazily, in the background, behind every other configured server**:
+
+| run | turn | `probe` in the `init` record's `mcp_servers` | marker file |
+|---|---|---|---|
+| guarded | 2.2–2.6 s | **absent — the whole list is `[]`** | absent, 5/5 |
+| control | 2.6–3.8 s | present, `"status": "pending"`, 5/5 | **absent, 5/5** |
+| control, held open by a `sleep` in the turn | 30.3 s | present, `pending` | **present** |
+
+Measured lag from the child's spawn to the server's command line actually running: **16.4 s**. That
+number is a property of the OPERATOR's machine rather than of the guard — `probe` is queued behind
+the ten user-scope MCP servers this operator happens to have, every one of them still `pending`
+when a one-word turn ends. So the marker cannot be the control's signal any more, and a sleep long
+enough to catch it would be tuned to one developer's `~/.claude.json` and wrong on the fleet.
+
+What the pair asserts instead is the binary's own report of what it took from the workspace: the
+`init` record's `mcp_servers`, **by name**. Deterministic in both directions, 5/5 per cell, and for
+the guarded arm it is the stronger claim — a server that was never registered cannot be started at
+any later moment, where "no marker after 2.5 seconds" now says almost nothing. That the command
+line really does run when it IS registered is measured in the table above and deliberately not
+asserted per-run. **The security property was never in doubt**: `--strict-mcp-config` empties the
+list, and it was a test that had stopped being able to demonstrate it.
+
+⚠️ **The pair cannot say WHICH flag closed the hole, and must not be read as if it could.**
+Measured the same day, a 2×2 over the two flags with the argv captured at the spawn:
+
+| argv | `probe` registered | servers in the list |
+|---|---|---|
+| `--setting-sources user --strict-mcp-config` | no | 0 |
+| `--setting-sources user` alone | no | 10 — the operator's own |
+| `--strict-mcp-config` alone | no | 0 |
+| neither | **yes** | 11 |
+
+Either flag alone closes it, by different routes: `--setting-sources user` drops the *project*
+settings source so `.mcp.json` is never read at all, while `--strict-mcp-config` empties the list
+outright, the operator's own servers included. So deleting ONE of the two leaves both tests here
+green — confirmed by mutation, not reasoned. That is not a hole, because the argv is pinned
+elsewhere and by name: the same mutation fails three tests in `tests/test_task_agent.py`, and
+`tests/e2e_cross_repo/fake_claude.py` refuses an argv missing either flag. This module answers what
+the VENDOR does with the flags; that they are *sent* is a contract kept in those two places.
+
 Requires a logged-in Claude Code, and it costs money — a handful of turns on the cheapest model.
 Not collected by `pytest tests/` (the module is `e2e_*`, like `tests/e2e_doggi.py`). Run:
 
@@ -212,6 +255,58 @@ def _strip_the_guard(task_agent) -> None:
     task_agent.agent_argv = unguarded
 
 
+@pytest.fixture
+def mcp_servers():
+    """Every `mcp_servers` list the child announced, captured off the real stream.
+
+    Patched at `StreamTranslator.feed` — the seam every line of the child's stdout already passes
+    through — for the reason `_strip_the_guard` patches `agent_argv` rather than hand-building an
+    argv: the product's own path runs untouched and the test watches it, instead of the test
+    becoming a second implementation of it.
+
+    The `init` record is the binary's own statement of what it loaded, emitted before the model is
+    called. It is what row 3 of the docstring's original table already read (`17 entries` → `[]`),
+    so this is the signal that measurement used, promoted to the assertion now that the server's
+    side effect has moved out of reach of a short turn.
+    """
+    from remote import task_stream
+
+    announced: list[list] = []
+    original = task_stream.StreamTranslator.feed
+
+    def spy(self, line: str):
+        try:
+            record = json.loads(line.strip())
+        except (ValueError, RecursionError):
+            record = None
+        if (isinstance(record, dict) and record.get("type") == "system"
+                and record.get("subtype") == "init"):
+            # `KeyError` and not `.get`, deliberately: a vendor that stopped reporting the key at
+            # all would otherwise hand the guarded test an empty list and a free pass, which is the
+            # one direction this whole module refuses to fail in.
+            announced.append(record["mcp_servers"])
+        return original(self, line)
+
+    task_stream.StreamTranslator.feed = spy
+    try:
+        yield announced
+    finally:
+        task_stream.StreamTranslator.feed = original
+
+
+def _server_names(announced: list[list]) -> list[str]:
+    """The names in the session's one `init` record.
+
+    Exactly one, asserted rather than assumed: no record at all means the child died before it said
+    anything, and reading that as "the workspace's server was not registered" would turn every
+    unrelated spawn failure into a passing security test.
+    """
+    assert len(announced) == 1, (
+        f"expected exactly one `init` record from the child, saw {len(announced)} — a run that "
+        f"never announced its configuration cannot answer what it loaded from the workspace")
+    return [entry.get("name") for entry in announced[0]]
+
+
 @pytest.fixture(autouse=True)
 def _restore_agent_argv():
     """Put `agent_argv` back, whatever a control run did to it."""
@@ -257,28 +352,44 @@ def test_the_control_proves_the_hook_would_otherwise_run(live, tmp_path):
         "project hooks by itself, or the hook never had a chance to run for an unrelated reason")
 
 
-def test_an_mcp_server_in_the_workspace_is_not_started(live, tmp_path):
-    """An MCP stdio entry is a command line, and the server is started at session start."""
+def test_an_mcp_server_in_the_workspace_is_not_started(live, tmp_path, mcp_servers):
+    """An MCP stdio entry is a command line, and the workspace does not get to name one.
+
+    Asserted on the NAME, because since 2.1.241 the command line runs long after the turn that
+    would have to observe it — see the module docstring. A server the session never registered
+    cannot be started at any later moment either, which is why this reads as the stronger half.
+    """
     marker = tmp_path / "MCP_STARTED"
 
     outcome = _run(
         tmp_path, {".mcp.json": _mcp_config(marker), "a.txt": "x\n"},
         "Reply with exactly OK. Create no file.", guarded=True, project="guarded-mcp")
 
+    assert "probe" not in _server_names(mcp_servers), (
+        "the workspace's own .mcp.json was taken: this session registered the server it names, and "
+        "a registered stdio server is a command line this provider will run")
+    # Belt and braces, and NOT the evidence — see the docstring. A one-word turn ends ~14 seconds
+    # before the spawn would happen, so this is silent whether the guard holds or not; it is kept
+    # because it is the direct statement of the property, not because it can detect its breach.
     assert not marker.exists(), (
         "a server named by the workspace's own .mcp.json was started on the provider")
     assert outcome.state == "completed", outcome.error
 
 
-def test_the_control_proves_the_mcp_server_would_otherwise_start(live, tmp_path):
-    """The other half of the pair — measured to fire, so its silence above means something."""
-    marker = tmp_path / "MCP_STARTED"
+def test_the_control_proves_the_mcp_server_would_otherwise_be_taken(live, tmp_path, mcp_servers):
+    """The other half of the pair — measured to fire, so its silence above means something.
 
-    _run(tmp_path, {".mcp.json": _mcp_config(marker), "a.txt": "x\n"},
+    If this one ever fails, the test above has stopped being evidence. It has failed once already,
+    and the answer was to re-measure it rather than delete it: the signal moved from the server's
+    own side effect to the name, because the vendor moved when the side effect happens.
+    """
+    _run(tmp_path, {".mcp.json": _mcp_config(tmp_path / "MCP_STARTED"), "a.txt": "x\n"},
          "Reply with exactly OK. Create no file.", guarded=False, project="control-mcp")
 
-    assert marker.exists(), (
-        "the control did not start the server, so the guarded run proves nothing here")
+    assert "probe" in _server_names(mcp_servers), (
+        "the control did not register the workspace's server, so the guarded run proves nothing "
+        "here: either the vendor stopped reading a project .mcp.json by itself, or this session "
+        "never got far enough to say what it had loaded")
 
 
 def test_the_instruction_class_still_reaches_the_model(live, tmp_path):

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -32749,6 +32749,65 @@ def test_task_get_on_an_ordinary_failed_turn_says_no_such_thing(monkeypatch, tmp
     assert "combine" not in (captured.out + captured.err).lower()
 
 
+def test_task_get_labels_a_merge_turns_result_as_the_grid_combining_work(
+        monkeypatch, tmp_path, capsys):
+    """C7.3 / ND-03. A merge turn's result is the GRID's narration, and it reads like git.
+
+    Measured live on `dt-edge`: a merge turn's `result_text` is the agent reporting on a collision
+    it was sent to resolve — `git add`, `<<<<<<<`, index state — printed under a bare
+    `--- result ---` to somebody who never asked for a merge turn and may not know what one is.
+
+    The prompt side of exactly this turn is ALREADY handled: `task list` swaps a merge turn's
+    grid-written prompt for `_MERGE_TURN_LABEL` rather than showing it as the person's own words.
+    The result side never got the same decision, so the one surface that shows what the grid did
+    presents it as the answer to a request nobody made.
+
+    ⚠️ **The text itself is KEPT, and that is the same call `error=` already made two blocks up**
+    (*"Kept AND followed, rather than replaced: the two readers need different things"*). Whoever
+    runs the grid needs the agent's own account of the collision; filtering it would make the fault
+    undiagnosable. What is added is whose words these are — the cheapest thing that turns a
+    non-sequitur back into a report.
+    """
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    state.set_mode("remote")
+    _mock_relay(monkeypatch, lambda r: httpx.Response(200, json={
+        "id": "m-1", "conversation_id": "c-1", "kind": "merge", "state": "completed",
+        "result_text": "Ran `git add src/main.py` after resolving the <<<<<<< markers by hand.",
+    }))
+
+    rc = cli.main(["task", "get", "m-1"])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "combining this work with a colleague's" in out, (
+        f"a merge turn's result is presented as an ordinary answer, so a person reads the grid's "
+        f"own git narration as the reply to something they asked for: {out!r}")
+    assert "git add" in out, (
+        "the agent's account of the collision was filtered out — whoever runs the grid needs it, "
+        "and this refusal to render it is the over-correction ADR 0034 D-g warns about")
+
+
+def test_task_get_leaves_an_ordinary_turns_result_alone(monkeypatch, tmp_path, capsys):
+    """The control, and it is what keeps the label meaningful: a label on every result is furniture.
+
+    An ordinary turn's result IS the answer to what the person asked, so nothing about colleagues
+    or combining belongs anywhere near it.
+    """
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    state.set_mode("remote")
+    _mock_relay(monkeypatch, lambda r: httpx.Response(200, json={
+        "id": "t-1", "conversation_id": "c-1", "kind": "message", "state": "completed",
+        "result_text": "Renamed the column and updated its two callers.",
+    }))
+
+    cli.main(["task", "get", "t-1"])
+
+    out = capsys.readouterr().out
+    assert "--- result ---" in out, out
+    assert "colleague" not in out.lower(), (
+        "an ordinary turn's own answer is announced as the grid combining somebody's work")
+
+
 def test_task_get_says_when_the_project_no_longer_holds_what_the_turn_changed(
         monkeypatch, tmp_path, capsys):
     """ND-16/F-3. A turn whose work a later one overwrote still reads `completed` everywhere.

--- a/tests/test_task_agent.py
+++ b/tests/test_task_agent.py
@@ -3024,6 +3024,53 @@ def test_a_claim_with_no_member_key_is_refused_instead_of_falling_back_to_the_pr
     assert not list((root / "projects").glob("proj-1/*/workspace/ran.txt")), "the agent ran"
 
 
+def test_a_claim_whose_member_key_is_null_says_the_person_left_rather_than_upgrade_the_relay(
+        agent, tmp_path, monkeypatch):
+    """The OTHER way this key goes missing, and it is not a version skew at all (ADR 0035 D-c).
+
+    The relay sends `"member_key": null` — the key PRESENT, the value null — when the turn's owner
+    left the project, or was removed from it, while their turn sat queued. That is an ordinary
+    departure, not an old relay: `tasks.py`'s claim says so in as many words (*"`None` when the
+    owner is no longer a member — a removal while the task sat queued"*), and grid-src's
+    `test_a_task_whose_owner_left_the_project_claims_with_no_key_rather_than_a_made_up_one` pins the
+    relay half, its docstring resting the readable half on THIS side: *"the honest answer is `None`,
+    which the provider turns into a readable refusal."*
+
+    Every other test of this refusal deletes the key, so until this one the two arrived as the same
+    sentence — and that sentence tells whoever reads it to **upgrade the relay**, which for a
+    departure is a repair to something that is not broken. Same class as the `conversation_id`
+    split next door, and the reason that one is pinned rather than left to review.
+
+    ⚠️ The REFUSAL is not what changes and must not: it is still terminal, still fail-closed, and
+    still creates no workspace. What is asserted here is only which of the two true things it says.
+    """
+    from remote import task_agent, tasks
+
+    remote, commit = _remote_for(tmp_path, "task/T1", {"a.txt": "x\n"})
+    agent("echo should-never-run > ran.txt\n"
+          "printf '{\"type\":\"result\",\"is_error\":false,\"result\":\"ok\"}\\n'\n")
+    departed = _job_with_input(commit, member_key=None)
+    assert "member_key" in departed, "the key must be PRESENT and null, or this tests the old case"
+
+    outcome = tasks.run_task(departed, remote=remote)
+
+    assert outcome.state == "failed", outcome
+    assert "Upgrade the relay" not in (outcome.error or ""), (
+        f"a person leaving the project is reported as a relay that needs upgrading, sending "
+        f"whoever reads it to fix something that is working exactly as ADR 0035 D-c asks: "
+        f"{outcome.error!r}")
+    assert "no longer a member" in (outcome.error or ""), (
+        f"the refusal does not say what actually happened, so nobody reading it can tell a "
+        f"departure from a version skew: {outcome.error!r}")
+    # The fail-closed half, unchanged — asserted on the filesystem rather than the message for the
+    # reason the sibling test gives: the message is what a future edit keeps while quietly
+    # restoring the fallback underneath it.
+    root = task_agent.workspace_root()
+    assert not (root / "projects" / "proj-1" / "workspace").exists(), (
+        "a project-level workspace was created — the fallback this refusal exists to prevent")
+    assert not list((root / "projects").glob("proj-1/*/workspace/ran.txt")), "the agent ran"
+
+
 def test_a_claim_with_no_conversation_id_is_refused_instead_of_falling_back_to_the_member(
         agent, tmp_path, monkeypatch):
     """ADR 0034 D-c, and exactly `member_key`'s class one level down (issue 38).

--- a/tests/test_task_agent.py
+++ b/tests/test_task_agent.py
@@ -5693,6 +5693,44 @@ def test_a_world_readable_default_root_is_refused_whoever_owns_it(monkeypatch, t
     assert "chmod 700" in str(excinfo.value), str(excinfo.value)
 
 
+def test_a_root_a_relay_is_serving_from_is_not_told_to_chmod_the_relays_store(
+        monkeypatch, tmp_path):
+    """⚠️ The advice above is DESTRUCTIVE on the machine it most often bites, and it was the only
+    advice this refusal gave.
+
+    Measured on the dev VM 2026-08-25: `default_workspace_root()` is `/var/grid` on Linux, grid-src's
+    `config.task_repo_root` is `/var/grid/projects`, and that directory is mode 755 holding 2.1 GB of
+    the relay's own project repositories. ADR 0033 calls a box running both the ordinary small-team
+    case — so `chmod 700 /var/grid` is aimed at the store the server for that grid is reading from,
+    and an operator who follows it can take the grid down.
+
+    So when the relay's repositories are there the remedy named is the one that is always safe, and
+    `chmod` is named as the thing NOT to do — because somebody who has read the other version of
+    this message will otherwise reach for it anyway.
+    """
+    from remote import task_agent
+
+    root = tmp_path / "grid"
+    (root / "projects").mkdir(mode=0o755, parents=True)
+    # Exactly what grid-src's `task_repo.repo_for` leaves under `TASK_REPO_ROOT`.
+    (root / "projects" / "b3f1c0de-0000-4000-8000-000000000003.git").mkdir()
+    root.chmod(0o755)
+    _default_root_at(monkeypatch, root)
+
+    with pytest.raises(OSError) as excinfo:
+        task_agent.ensure_default_workspace_root()
+
+    message = str(excinfo.value)
+    assert "chmod" not in message, (
+        f"the provider told an operator to change the permissions of a directory the relay is "
+        f"serving every project on this grid from: {message!r}")
+    assert "--tasks-root" in message, (
+        f"the one remedy that is always safe was not named: {message!r}")
+    assert "sharing a directory" in message, (
+        f"the message does not say WHY chmod is wrong here, so it reads as an arbitrary "
+        f"restriction and the next operator works around it: {message!r}")
+
+
 def test_a_root_that_is_already_ours_and_private_is_adopted_silently(monkeypatch, tmp_path):
     """The positive control, and the ordinary second run. A rule that refused this would make
     `grid join --tasks` work once and fail every time after."""

--- a/tests/test_task_evict.py
+++ b/tests/test_task_evict.py
@@ -156,6 +156,105 @@ def test_a_stray_file_beside_the_projects_does_not_warn_that_the_bound_has_stopp
         f"it correctly in the same call (ND-18):\n{err}")
 
 
+def test_a_relay_bare_repo_sharing_the_task_root_is_not_eaten_by_the_sweep(
+        tmp_path, short_task_root, monkeypatch):
+    """⚠️ A provider and a relay on ONE box share `/var/grid/projects` **by default**, and the
+    sweep would delete the relay's git objects.
+
+    Measured on the dev VM 2026-08-25, both halves of the collision, neither of them exotic:
+
+      * this repo's `task_agent.default_workspace_root()` is `/var/grid` on Linux, so a provider
+        started with no `GRID_TASK_ROOT` puts workspaces in `/var/grid/projects/<p>/<m>/<c>/`;
+      * grid-src's `config.task_repo_root` defaults to `/var/grid/projects`, where the relay keeps
+        one bare repo per project as `<project_id>.git` — 2.1 GB of them on that machine.
+
+    `_conversations` then reads every directory under `projects/` as a project, its children as
+    members and THEIR children as conversations. A relay repo is a directory, so `<p>.git/objects/`
+    becomes a "member" and `<p>.git/objects/pack/` a "conversation" — an ordinary eviction
+    candidate that `_evict` removes with `shutil.rmtree`. The LRU order makes it worse rather than
+    better: a pack nobody has written to lately sorts OLDEST, so the history goes first.
+
+    ⚠️ **`_evict`'s docstring argues, correctly, that junk under the task root SHOULD be
+    collectable** — *"the one thing the bound most needs to remove would be the one thing it could
+    not"*. That reasoning assumed the task root is this provider's alone. It is not, by default, on
+    the operating system the fleet runs. So the rule becomes: collect anything shaped like a
+    workspace, and nothing else.
+
+    ⚠️ **What stands between the two today is an accident**: `_require_a_private_directory` refuses
+    a 755 root, and `/var/grid` is 755 on that box. Its refusal tells the operator to
+    `chmod 700 /var/grid` — which does not just touch the relay's store, it removes the only thing
+    holding this sweep off it.
+
+    A CONTROL is not optional here: the guard must still collect a real workspace, or "nothing was
+    deleted" would pass with eviction switched off entirely.
+    """
+    from remote import task_evict
+
+    monkeypatch.setenv(task_agent_root_env(), str(short_task_root))
+    monkeypatch.setenv(task_evict.MAX_WORKSPACES_ENV, "1")
+    # The relay's, beside the provider's — the exact shape `TASK_REPO_ROOT` produces.
+    relay_repo = short_task_root / "projects" / "b3f1c0de-0000-4000-8000-000000000001.git"
+    _git_init_bare(relay_repo)
+    objects = sorted(p.name for p in (relay_repo / "objects").iterdir())
+    # Two real workspaces against a cap of one, so the sweep genuinely has work to do.
+    for conversation in _CONVERSATIONS[:2]:
+        _real_workspace(tmp_path, short_task_root, conversation)
+
+    task_evict.sweep(short_task_root, keep=None,
+                     reserve=_never_reserved, release=_released)
+
+    assert (relay_repo / "objects").is_dir() and (relay_repo / "refs").is_dir(), (
+        "the sweep deleted the relay's bare repository — a provider and a relay share "
+        "/var/grid/projects by default, so this is the fleet's own configuration")
+    assert sorted(p.name for p in (relay_repo / "objects").iterdir()) == objects, (
+        "the sweep ate part of the relay's object store")
+    # THE CONTROL. Without it this passes with the bound switched off.
+    assert _conversation_dirs(short_task_root) == [_CONVERSATIONS[1]], (
+        "the guard stopped the sweep collecting real workspaces too, so the bound is gone")
+
+
+def test_a_relay_repo_whose_branch_names_collide_with_our_markers_is_still_safe(
+        tmp_path, short_task_root, monkeypatch):
+    """The second guard, and it is NOT redundant — the marker check alone loses to a branch name.
+
+    An imported repository brings whatever branch names its author gave it, and `cache/…` is an
+    entirely ordinary prefix. Git stores `refs/heads/cache/x` as a DIRECTORY, so walking a relay
+    repo as if it were a project makes `refs` a member, `refs/heads` a conversation, and
+    `refs/heads/cache` a marker — the candidate then looks exactly like one of ours and `_evict`
+    takes `refs/heads` with it. **Every branch in the project, gone.**
+
+    So the `.git` suffix check is load-bearing rather than belt-and-braces, and this is the test
+    that says so: delete it and the marker check hands this repository to `rmtree`.
+    """
+    from remote import task_evict
+
+    monkeypatch.setenv(task_agent_root_env(), str(short_task_root))
+    monkeypatch.setenv(task_evict.MAX_WORKSPACES_ENV, "1")
+    relay_repo = short_task_root / "projects" / "b3f1c0de-0000-4000-8000-000000000002.git"
+    _git_init_bare(relay_repo)
+    # A branch whose first segment is one of our marker names. Nothing exotic: it arrived through
+    # `import`, from a repository this grid does not get to rename.
+    (relay_repo / "refs" / "heads" / "cache").mkdir(parents=True)
+    (relay_repo / "refs" / "heads" / "cache" / "x").write_text("0" * 40 + "\n")
+    for conversation in _CONVERSATIONS[:2]:
+        _real_workspace(tmp_path, short_task_root, conversation)
+
+    task_evict.sweep(short_task_root, keep=None,
+                     reserve=_never_reserved, release=_released)
+
+    assert (relay_repo / "refs" / "heads" / "cache" / "x").is_file(), (
+        "the sweep deleted the relay's refs — a branch named `cache/…` made its ref directory look "
+        "like one of this provider's workspaces")
+    assert _conversation_dirs(short_task_root) == [_CONVERSATIONS[1]], (
+        "the guard stopped the sweep collecting real workspaces too, so the bound is gone")
+
+
+def _git_init_bare(path):
+    """A bare repository shaped the way grid-src's `project_trunk` leaves one."""
+    path.mkdir(parents=True)
+    _git(path, "init", "--bare", "-q", ".")
+
+
 def test_eviction_skips_a_workspace_a_worker_is_holding_rather_than_waiting_for_it(
         tmp_path, short_task_root, monkeypatch):
     """Criterion 3, and the mechanism matters as much as the outcome.

--- a/tests/test_task_lease.py
+++ b/tests/test_task_lease.py
@@ -518,6 +518,64 @@ def test_the_transcript_ref_prefix_this_provider_pushes_to_is_the_one_the_fence_
         "TRANSCRIPT_PREFIX", module="task_repo.py")
 
 
+def _relay_bare_repo_suffix():
+    """The suffix grid-src gives a project's bare repository, parsed out of its `task_repo`.
+
+    Parsed rather than restated because it is not a named constant on that side — it is the tail of
+    an f-string, `Path(root) / f"{project_id}.git"` — and a value nobody named is exactly the one a
+    refactor renames without noticing it was load-bearing somewhere else.
+
+    ⚠️ Matched by SHAPE, not by function name. The first draft of this pinned `repo_path`, which is
+    the name of a keyword argument at the call site and not of the function; it failed loudly, which
+    is the only reason the mistake was visible at all. Keying on the name would also have made a
+    harmless rename over there look like a suffix change over here — and the suffix is the thing
+    that matters, so that is what is read.
+    """
+    import ast
+
+    source = _relay_module("task_repo.py")
+    if not source.exists():
+        pytest.skip("grid-src worktree is not beside this one; the lockstep cannot be checked here")
+    found = set()
+    for node in ast.walk(ast.parse(source.read_text(encoding="utf-8"))):
+        if not (isinstance(node, ast.Return) and isinstance(node.value, ast.BinOp)):
+            continue
+        joined = node.value.right
+        if not (isinstance(joined, ast.JoinedStr) and joined.values):
+            continue
+        tail = joined.values[-1]
+        if isinstance(tail, ast.Constant) and isinstance(tail.value, str):
+            found.add(tail.value)
+    assert len(found) == 1, (
+        f"expected exactly one `Path(...) / f'…'` return in grid-src's task_repo.py to read the "
+        f"bare-repo suffix from, found {sorted(found)} — this check can no longer say which "
+        f"spelling this provider's sweep has to recognise")
+    return found.pop()
+
+
+def test_the_directory_the_sweep_refuses_to_collect_is_the_one_the_relay_creates():
+    """⚠️ The only thing standing between this provider's eviction sweep and a live repository.
+
+    A relay and a provider on one box share `/var/grid/projects` **by default** —
+    `task_agent.default_workspace_root()` is `/var/grid` on Linux and grid-src's
+    `config.task_repo_root` is `/var/grid/projects` — so the relay's bare repos are siblings of this
+    provider's project directories. `task_evict` walks that tree three levels deep and `rmtree`s
+    what it finds, so without the suffix check `<project_id>.git/objects/pack` is an ordinary
+    eviction candidate. Reproduced in `tests/test_task_evict.py`: the relay's whole object store,
+    gone in one sweep.
+
+    Nothing on the wire carries this name, which is what makes it a lockstep value rather than a
+    protocol one: both sides derive it, and drift is silent AND catastrophic in one direction only.
+    A rename on the relay side does not break a request or fail a test over there — it quietly
+    re-arms a `shutil.rmtree` over here.
+    """
+    from remote import task_evict
+
+    assert task_evict.RELAY_REPO_SUFFIX == _relay_bare_repo_suffix(), (
+        "grid-src names a project's bare repository with a different suffix now, so this "
+        "provider's sweep no longer recognises one and will collect it as a stale workspace")
+
+
 def test_the_two_refusal_codes_this_cli_branches_on_are_the_ones_the_relay_sends():
     """The CLI's half of the parsed-`detail` register (ADR 0033 D-o, issue 26).
 

--- a/tests/test_task_sandbox.py
+++ b/tests/test_task_sandbox.py
@@ -751,6 +751,33 @@ def test_a_workspace_inside_a_denied_tree_is_refused_rather_than_half_confined(t
     assert task_agent_env_name() in message, message
 
 
+def test_the_refusal_suggests_THIS_platforms_root_and_not_the_other_ones(tmp_path, config_dir):
+    """ND-01's follow-up. The one sentence an operator is asked to act on named both platforms.
+
+    It used to end *"(for example /Users/Shared/gnd on macOS, or /var/grid on Linux)"*, so somebody
+    on Linux — the operating system the fleet runs — read a macOS path first in the remedy. Measured
+    on the dev VM while closing ND-01's live arm.
+
+    Asserted against `default_workspace_root()` rather than against a literal, which is the whole
+    point of the change: the value has moved once already (issue 62 took macOS off `/var/grid`), and
+    a hand-copied example would have gone stale in silence. The negative half is what makes it bite —
+    without it, naming both platforms passes.
+    """
+    from remote import task_agent, task_sandbox
+
+    mine = task_agent.default_workspace_root()
+    other = task_agent.default_workspace_root("linux" if sys.platform == "darwin" else "darwin")
+
+    with pytest.raises(ValueError) as refusal:
+        task_sandbox.policy(Path.home() / "gnd" / "p" / "m" / "c" / "workspace", config_dir)
+
+    message = str(refusal.value)
+    assert mine in message, f"the remedy does not name a root this platform can use: {message}"
+    assert other not in message, (
+        f"the remedy names the OTHER platform's default, which is a path that cannot exist here: "
+        f"{message}")
+
+
 def test_a_workspace_outside_every_denied_tree_still_builds_a_policy(tmp_path, config_dir):
     """The control for the refusal above: the ordinary layout must be untouched by it."""
     from remote import task_sandbox


### PR DESCRIPTION
Five commits. One is a data-loss fix in the provider; three restore tests that had silently stopped
checking the thing they name; one is a docs correction that was already on the branch.

## The one that loses data

**`54237cf` — the workspace sweep would delete the relay's git objects.**

A provider and a relay on one box share `/var/grid/projects` **by default**. Measured on the dev VM,
both halves: `task_agent.default_workspace_root()` is `/var/grid` on Linux, grid-src's
`config.task_repo_root` is `/var/grid/projects`, and that directory holds 2.1 GB of the relay's bare
repos. ADR 0033 calls a box running both the ordinary small-team case.

`task_evict._conversations` walks `projects/` three levels deep, so `<project_id>.git/objects` reads
as a member and `.../objects/pack` as a conversation — an ordinary candidate that `_evict` removes
with `shutil.rmtree`. Reproduced in a test: the relay's whole object store, gone in one sweep. The
LRU order makes it worse, not better — the least recently written pack sorts oldest and goes first.

⚠️ What stood between the two was an **accident**, and the refusal that provided it pointed the
other way: `_require_a_private_directory` refuses a 755 root and told the operator to
`chmod 700 /var/grid` — which does not merely touch the relay's store, it removes the only thing
holding the sweep off it. That refusal now names `--tasks-root` and says plainly not to change the
permissions, but only when the relay's repositories are actually there; the ordinary root keeps its
`chmod` remedy. Both arms are pinned.

The guard is the `.git` suffix, a cross-repo spelling nothing on the wire carries, so
`tests/test_task_lease.py` parses grid-src for it rather than restating it — drift there is silent
and catastrophic in one direction only.

## Three tests that had stopped being evidence

- **`a78eece`** — every test in `tests/e2e_agent_sandbox.py` failed terminally in 1.2 s, **6/6, the
  positive control included**, because its job dict carried no `member_key`. `b13f036` repaired the
  sibling module for exactly this and missed this one. It is the only thing proving the agent
  sandbox does anything. Also adds the symlink case the module never had, measured on both backends.
- **`bb5b300`** — the MCP control watched for a side effect Claude Code now defers. 2.1.241 connects
  `.mcp.json` servers lazily (measured 16.4 s), so a 2.5 s turn ended before the server started and
  the marker was absent in *both* arms. The pair now asserts the `init` record's `mcp_servers` by
  name: deterministic 5/5 per cell.
- **`6523767`** — two refusals that sent a person to fix the wrong thing. `member_key` reaches the
  provider missing in two ways that are not the same event (an old relay vs. an ordinary departure
  the relay reports with `null`), and both said "Upgrade the relay". And `grid task get` printed a
  merge turn's git-heavy narration under a bare `--- result ---`, while `task list` already labels
  the same turn's prompt.

## How this was checked

Every fix is mutation-proved in both directions, and each mutant dies by the test that names its
fault. Two guards written during this work were **removed** after mutation showed them dead —
recorded in the code, because an unexercised guard is where the next same-class bug hides.

## Test plan

- [x] `pytest tests/` — 3200 passed, 9 skipped
- [x] `tests/e2e_agent_sandbox.py` — 7 passed (was 6 failed), real binary, macOS + Ubuntu 24.04
- [x] `tests/e2e_agent_settings.py` — 7 passed (was 6 passed / 1 failed), real binary
- [x] `ruff check .`
- [x] Cross-repo lockstep suites run with the grid-src worktree present (they skip in CI)
- [ ] Deploy note: `54237cf` is a **provider** fix with no wire change and no rollout order. The
      build on the dev VM is 0.3.22 and still carries the `chmod` advice, so a release should
      follow this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KiFxmu7mFFcSfumkiLkSEd