### PR TITLE
fix(engine): install the Linux builds llama.cpp publishes, and fit context to the machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,16 +62,96 @@ grid up
 
 ### 2 · Add a computer
 
-Nothing installed on it yet? Grid ships an inference engine:
+A model needs an **inference engine** to run it — Grid does not run models itself. Bring one you
+already have, or install the one Grid ships (llama.cpp).
+
+You do not have to work out which build suits your hardware. Run this and it tells you what it
+found, what it installed, and whether anything faster is available to you:
 
 ```bash
-grid engine install llama.cpp                     # Metal on macOS, CUDA on Linux NVIDIA
-grid pull qwen36-35b-a3b-mtp                      # `grid catalog`, or any GGUF: <hf-repo>:<file>
-grid join http://192.168.1.25:8090 --serve qwen36-35b-a3b-mtp --name mac-studio
+grid engine install llama.cpp
 ```
 
+**On macOS** it downloads an official, SHA-256-verified release. Metal, no Homebrew, no admin
+rights, nothing else to decide:
+
+```
+Installed llama-server -> ~/.grid/bin/llama-server
+```
+
+**On Linux with an NVIDIA GPU** it reads your cards first, then installs the Vulkan build — real
+GPU inference on those same cards, without the multi-gigabyte CUDA toolkit:
+
+```
+Detected GPUs: sm_120, sm_120
+Installed llama-server -> ~/.grid/bin/llama-server
+
+This is the Vulkan build — it runs on your NVIDIA GPUs with no CUDA toolkit.
+CUDA is faster, and this machine can build it:
+    grid engine install llama.cpp --from-source
+```
+
+That last line is a live answer about *your* machine, not a generic suggestion. llama.cpp publishes
+no prebuilt CUDA for Linux, so CUDA has to be compiled here — and compiling is only worth starting
+if it can finish. Grid checks your toolchain and says so. When it can't, you get the reason instead
+of the offer:
+
+```
+CUDA would be faster, but not from this machine yet:
+  This CUDA toolkit cannot build for compute_120 — the newest it supports is compute_89.
+  RTX 50-series needs CUDA 12.8 or newer; install a current toolkit from NVIDIA rather
+  than your distro's default package.
+```
+
+So the choice in front of you is:
+
+| | you get | costs you | pick it when |
+|---|---|---|---|
+| **Vulkan** (default) | GPU inference now | one download | you want to be running today |
+| **CUDA** `--from-source` | the fastest backend | CUDA toolkit + a long compile | the box is a permanent node |
+
+`--from-source` runs the same check before it clones anything, so it refuses up front rather than
+failing partway through a build.
+
+**On Linux with no GPU** the same command installs the CPU build and says so.
+
+**Linux with no GPU** — same command, you get the CPU build.
+
+Now pull a model. `grid catalog` lists what the catalog ships, filtered to your hardware — or pull
+any GGUF on Hugging Face with `<hf-repo>:<file>`.
+
+```bash
+# Apple Silicon, 32 GB unified memory or more
+grid pull qwen36-35b-a3b-mtp
+# Saved ~/.grid/models/Qwen3.6-35B-A3B-UD-IQ3_S.gguf
+
+# NVIDIA, 24 GB VRAM or more
+grid pull qwen36-27b-mtp
+# Saved ~/.grid/models/Qwen3.6-27B-UD-Q5_K_XL.gguf
+```
+
+**`grid pull` takes a catalog label; `--serve` takes the filename on disk** — the one `pull` just
+printed, which `grid catalog` reprints any time under **Local models:**. `--advertise-as` hands the
+grid back a short name to ask for:
+
+```bash
+grid join http://192.168.1.25:8090 \
+    --serve Qwen3.6-35B-A3B-UD-IQ3_S.gguf \
+    --advertise-as qwen36-35b-a3b-mtp \
+    --name mac-studio
+
+# NVIDIA: --serve Qwen3.6-27B-UD-Q5_K_XL.gguf --advertise-as qwen36-27b-mtp --name gpu-box
+```
+
+The built-in engine sizes itself to the machine: at load it measures free memory and takes the
+largest context that fits, capped by what the model was trained for. Pin it with `--ctx-size N` when
+you need an exact window — that turns the automatic fit off, so an `N` this machine cannot hold
+fails to start rather than quietly shrinking. `--n-predict`, `--parallel`, `--temp`, `--flash-attn`,
+`--reasoning-budget` and `--endpoint-port` are there too — `grid join --help` and
+[docs/cli.md](docs/cli.md) have the full set.
+
 **Already running Ollama, vLLM or LM Studio?** Point Grid at it instead. `--at` is its address on
-your network.
+your network, and `-m` is the model that machine already serves.
 
 ```bash
 grid join http://192.168.1.25:8090 --at http://192.168.1.20:8000/v1 -m qwen3-coder --name gpu-4090
@@ -82,12 +162,15 @@ Repeat for each computer.
 ### 3 · Ask it something
 
 ```bash
-grid chat -m qwen3-coder "write a haiku about local GPUs"
+grid chat -m qwen36-35b-a3b-mtp "write a haiku about local GPUs"
 grid models --verbose
-# MODEL        ENGINE      WHERE
-# qwen3-coder  gpu-4090    http://192.168.1.20:8000/v1
-# gemma4-31b   mac-studio  http://192.168.1.10:8080/v1
+# MODEL               ENGINE      WHERE
+# qwen36-35b-a3b-mtp  mac-studio  http://192.168.1.10:8081/v1
+# qwen3-coder         gpu-4090    http://192.168.1.20:8000/v1
 ```
+
+The first name is the one you gave `--advertise-as`; the second is the model the 4090 was already
+serving behind Ollama.
 
 ### 4 · Point your apps at it
 
@@ -107,14 +190,14 @@ Add Grid as a provider in `~/.openclaw/openclaw.json`
 
 ```json
 {
-  "agents": { "defaults": { "model": { "primary": "grid/qwen3-coder" } } },
+  "agents": { "defaults": { "model": { "primary": "grid/qwen36-35b-a3b-mtp" } } },
   "models": {
     "providers": {
       "grid": {
         "baseUrl": "http://192.168.1.25:8090/v1",
         "apiKey": "local-grid",
         "api": "openai-completions",
-        "models": [{ "id": "qwen3-coder", "name": "Qwen3 Coder (via Grid)" }]
+        "models": [{ "id": "qwen36-35b-a3b-mtp", "name": "Qwen3.6 35B (via Grid)" }]
       }
     }
   }
@@ -132,7 +215,7 @@ Set the endpoint in `~/.hermes/config.yaml`
 ```yaml
 model:
   provider: custom
-  default: qwen3-coder
+  default: qwen36-35b-a3b-mtp
   base_url: http://192.168.1.25:8090/v1
 ```
 
@@ -152,7 +235,7 @@ from openai import OpenAI
 
 client = OpenAI(base_url="http://192.168.1.25:8090/v1", api_key="local-grid")
 client.chat.completions.create(
-    model="qwen3-coder",                # routed to the 4090 computer automatically
+    model="qwen36-35b-a3b-mtp",         # routed to the Mac Studio automatically
     messages=[{"role": "user", "content": "hello"}],
 )
 ```
@@ -201,9 +284,10 @@ one of the two it ships: `llama.cpp` for text, ComfyUI for media. Both work the 
 — only the grid you join differs (a remote name, or a local `grid_url`).
 
 ```bash
-grid engine install llama.cpp           # the text engine
+grid engine install llama.cpp           # the text engine — add --from-source for CUDA on Linux
 grid pull qwen36-35b-a3b-mtp            # a text MODEL — see `grid catalog`, or any HF GGUF
-grid join <grid> --serve qwen36-35b-a3b-mtp
+grid join <grid> --serve Qwen3.6-35B-A3B-UD-IQ3_S.gguf --advertise-as qwen36-35b-a3b-mtp
+                                        # --serve takes the FILENAME `grid pull` saved
 
 grid engine install comfyui             # the media engine
 grid engine pull image_generation       # a media BUNDLE — also image_editing, i2v

--- a/cli/engine.py
+++ b/cli/engine.py
@@ -95,36 +95,49 @@ def _install_llama_cpp(args: argparse.Namespace) -> int:
             return 0
         path = installer.install_macos_prebuilt()
         print(f"Installed llama-server -> {path}")
+        print("Metal build — it uses this Mac's GPU. Nothing else to install.")
         return 0
 
     from shared.system import gpu
 
     gpus = gpu.enumerate_gpus()
-    if not gpus and not args.target_sm:
-        raise SystemExit(
-            "No NVIDIA GPUs detected (nvidia-smi missing or returned nothing). "
-            "Pass --target-sm <sm_XX> to override."
-        )
-
     sm_required = (args.target_sm,) if args.target_sm else tuple(item.compute_cap_sm for item in gpus)
-    print(f"Detected GPUs: {', '.join(sm_required) if sm_required else '(none)'}")
+    if sm_required:
+        print(f"Detected GPUs: {', '.join(sm_required)}")
 
     if args.from_source:
-        target_sm = sm_required[0]
-        path = installer.install_from_source(target_sm)
-        print(f"Installed llama-server from source -> {path}")
+        if not sm_required:
+            raise SystemExit(
+                "--from-source builds the CUDA engine, but no NVIDIA GPU was detected "
+                "(nvidia-smi missing or returned nothing). Pass --target-sm <sm_XX> to override."
+            )
+        path = installer.install_from_source(sm_required[0])
+        print(f"Installed llama-server from source (CUDA {sm_required[0]}) -> {path}")
         return 0
 
-    tarball = installer.pick_tarball(gpus) if not args.target_sm else None
-    if not tarball and args.target_sm:
-        for candidate in installer.TARBALLS:
-            if args.target_sm in candidate.supports_sm:
-                tarball = candidate
-                break
-    if not tarball:
-        raise SystemExit(
-            "No pinned tarball covers this GPU set. Re-run with --from-source to build llama.cpp locally."
-        )
-    path = installer.install_pinned(tarball)
-    print(f"Installed llama-server ({tarball.label}) -> {path}")
+    # llama.cpp publishes CUDA binaries for Windows only — every Linux asset in a release is CPU,
+    # Vulkan, ROCm, SYCL or OpenVINO. So an NVIDIA box gets Vulkan, which runs on the same cards
+    # with no toolchain, and is told plainly how to get CUDA instead. This used to be two pinned
+    # entries with PLACEHOLDER urls that could never be filled, so the command simply dead-ended.
+    kind = "vulkan" if gpus else "cpu"
+    path = installer.install_linux_prebuilt(kind)
+    print(f"Installed llama-server -> {path}")
+    if not gpus:
+        print("No GPU detected — this is the CPU build.")
+        return 0
+
+    # Answer "can I have CUDA?" here, so nobody has to go and probe their own toolchain to find
+    # out. The same prober gates `--from-source`, so this can never advise a build that would
+    # then refuse to start.
+    print()
+    print("This is the Vulkan build — it runs on your NVIDIA GPUs with no CUDA toolkit.")
+    ready, blocker = installer.cuda_build_readiness(sm_required[0].removeprefix("sm_"))
+    if ready:
+        print("CUDA is faster, and this machine can build it:")
+        print("    grid engine install llama.cpp --from-source")
+    else:
+        print()
+        print("CUDA would be faster, but not from this machine yet:")
+        for line in blocker.splitlines():
+            print(f"  {line}")
     return 0

--- a/cli/models.py
+++ b/cli/models.py
@@ -363,7 +363,30 @@ def cmd_pull(args: argparse.Namespace) -> int:
     print(f"Downloading {repo}/{filename} ...")
     target = download.download(repo, filename, on_progress=download.stderr_progress)
     print(f"Saved {target}")
+    _pull_projector(repo, target)
     return 0
+
+
+def _pull_projector(repo: str, model_path) -> None:
+    """Fetch the repo's multimodal projector, if it has one, so vision needs no second command.
+
+    Saved as ``<model-stem>.mmproj.gguf`` rather than under its own name: every vision repo calls
+    its projector some spelling of ``mmproj-F16.gguf``, so keeping the original name would make two
+    vision models in one flat models directory overwrite each other, and would leave nothing tying
+    a projector to the weights it belongs to. `grid join --serve` reads this exact name back.
+    """
+    from shared.models import download, gguf
+
+    projector = download.find_projector(repo)
+    if not projector:
+        return
+    target = model_path.parent / (model_path.stem + gguf.PROJECTOR_SUFFIX)
+    if target.is_file():
+        print(f"Vision projector already present: {target.name}")
+        return
+    print(f"This is a vision model. Downloading {repo}/{projector} ...")
+    download.download(repo, projector, out=target, on_progress=download.stderr_progress)
+    print(f"Saved {target}")
 
 
 def cmd_ctx(args: argparse.Namespace) -> int:

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -225,12 +225,22 @@ def _add_engines(sub) -> None:
     tuning = join.add_argument_group("Built-in tuning (--serve)")
     tuning.add_argument("--endpoint-port", "--llama-port", type=int, default=8081)
     tuning.add_argument("--heartbeat-interval", type=float, default=15.0)
-    tuning.add_argument("--ctx-size", type=int, default=None)
+    tuning.add_argument("--ctx-size", type=int, default=None, metavar="N",
+                        help="Pin the context window to N tokens. Left unset, the engine measures "
+                             "free memory at load and takes the largest window that fits — pinning "
+                             "turns that off, so an N this machine cannot hold fails to start "
+                             "instead of shrinking. N=0 is not 'unset': it demands the model's "
+                             "full trained window and spills weights into system RAM to get it.")
     tuning.add_argument("--n-predict", type=int, default=None)
     tuning.add_argument("--parallel", type=int, default=None)
-    tuning.add_argument("--flash-attn", default=None)
+    tuning.add_argument("--flash-attn", default=None, metavar="on|off|auto",
+                        help="Left unset, the engine probes the backend and falls back on its own.")
     tuning.add_argument("--temp", type=float, default=None)
     tuning.add_argument("--reasoning-budget", type=int, default=None)
+    tuning.add_argument("--mmproj", default=None, metavar="FILE",
+                        help="Override the multimodal projector, naming a FILE in ~/.grid/models. "
+                             "Not normally needed: `grid pull` fetches a vision model's projector "
+                             "with it, and `--serve` finds it and enables vision on its own.")
 
     media = join.add_argument_group("Media")
     media.add_argument("--comfyui-port", type=int, default=8188)

--- a/cli/provider.py
+++ b/cli/provider.py
@@ -417,6 +417,7 @@ def _spawn_engine(
         "n_predict": getattr(args, "n_predict", None),
         "parallel": getattr(args, "parallel", None),
         "flash_attn": getattr(args, "flash_attn", None),
+        "mmproj": getattr(args, "mmproj", None),
         "temp": getattr(args, "temp", None),
         "reasoning_budget": getattr(args, "reasoning_budget", None),
         # API media engine (`--api <kind>`): the vendor gateway this engine bridges to. The KEY is
@@ -709,6 +710,7 @@ def run_engine_from_record(grid_id: str, engine_id: str) -> int:
         n_predict=record.get("n_predict"),
         parallel=record.get("parallel"),
         flash_attn=record.get("flash_attn"),
+        mmproj=record.get("mmproj"),
         temp=record.get("temp"),
         reasoning_budget=record.get("reasoning_budget"),
         api_kind=record.get("api_kind"),
@@ -766,6 +768,7 @@ def _run_engine(args: SimpleNamespace) -> int:
                 n_predict=args.n_predict,
                 parallel=args.parallel,
                 flash_attn=args.flash_attn,
+                mmproj=getattr(args, "mmproj", None),
                 temp=args.temp,
                 reasoning_budget=args.reasoning_budget,
                 alias=text_advertised_models[0],
@@ -801,7 +804,15 @@ def _run_engine(args: SimpleNamespace) -> int:
             "media_url": media_url,
             "name": args.name,
             "pricing": {},
-            "capabilities": _media_capabilities(advertised_models) if args.enable_media else {},
+            "capabilities": _merge_capabilities(
+                # `--at` names an engine somewhere on the network; a built-in one was just spawned
+                # here, so probe it over loopback rather than the address we advertise outward.
+                _text_capabilities(
+                    text_advertised_models, upstream,
+                    args.endpoint_url or f"http://127.0.0.1:{args.endpoint_port}/v1",
+                ) if text_advertised_models else {},
+                _media_capabilities(advertised_models) if args.enable_media else {},
+            ),
             "load": {"active_tasks": 0},
             "upstream": upstream,
         }
@@ -968,6 +979,42 @@ def _prepare_media_engine(args: SimpleNamespace) -> dict[str, Any]:
         media_port=args.media_port,
         advertise_host=args.advertise_host,
     )
+
+
+def _text_capabilities(advertised: list[str], upstream: dict[str, str], llm_url: str) -> dict[str, Any]:
+    """Probe this box's text models and describe what they can actually do.
+
+    Local mode used to advertise ``{}`` for every text engine, so a local grid knew a model's NAME
+    and nothing else — serve a vision model and the grid still called it text-only. The probe is
+    the same one the remote path runs; nothing here is remote-specific, it is just HTTP against the
+    engine that was launched a moment ago.
+
+    Probed by the name the engine answers to and keyed by the advertised one, matching the remote
+    path: with ``--advertise-as`` those differ, and asking an engine about a name it does not know
+    returns nothing. Best-effort — a probe failure costs the description, never the join.
+    """
+    from remote import probe
+
+    models: dict[str, Any] = {}
+    for name in advertised:
+        try:
+            env = probe.capabilities(llm_url, upstream.get(name, name), advertise_as=name)
+        except httpx.HTTPError:
+            continue
+        models.update((env or {}).get("models") or {})
+    return {"schema_version": 1, "models": models} if models else {}
+
+
+def _merge_capabilities(*envelopes: dict[str, Any]) -> dict[str, Any]:
+    """Fold several ``{schema_version, models}`` envelopes into one, or ``{}`` if all are empty.
+
+    An engine can serve text and media at once, and the relay wants a single envelope whose model
+    keys match the advertised list exactly — a missing key costs the whole registration.
+    """
+    models: dict[str, Any] = {}
+    for envelope in envelopes:
+        models.update((envelope or {}).get("models") or {})
+    return {"schema_version": 1, "models": models} if models else {}
 
 
 def _media_capabilities(models: list[str]) -> dict[str, Any]:

--- a/cli/remote_provider.py
+++ b/cli/remote_provider.py
@@ -1217,6 +1217,7 @@ def _build_record(
         "n_predict": getattr(args, "n_predict", None),
         "parallel": getattr(args, "parallel", None),
         "flash_attn": getattr(args, "flash_attn", None),
+        "mmproj": getattr(args, "mmproj", None),
         "temp": getattr(args, "temp", None),
         "reasoning_budget": getattr(args, "reasoning_budget", None),
         "started_at": runtime.utc_now(),

--- a/remote/serve.py
+++ b/remote/serve.py
@@ -559,6 +559,7 @@ def _bring_up_one(
         n_predict=record.get("n_predict"),
         parallel=record.get("parallel"),
         flash_attn=record.get("flash_attn"),
+        mmproj=record.get("mmproj"),
         temp=record.get("temp"),
         reasoning_budget=record.get("reasoning_budget"),
         alias=advertised[0],

--- a/shared/engine/installer.py
+++ b/shared/engine/installer.py
@@ -16,15 +16,23 @@ from pathlib import Path
 import httpx
 
 from shared import paths
-from shared.system import arch, gpu
+from shared.system import arch
 
 
 @dataclass(frozen=True)
-class TarballPin:
+class LinuxBuild:
+    """A pinned official llama.cpp release build for Linux.
+
+    There is no CUDA entry here, and that is not an omission: upstream publishes CUDA binaries for
+    **Windows only** (`llama-*-bin-win-cuda-12.4-x64.zip` and friends). Every Linux asset in a
+    llama.cpp release is CPU, Vulkan, ROCm, SYCL or OpenVINO. CUDA on Linux has to be compiled, which
+    is what `--from-source` does. Vulkan runs on NVIDIA cards perfectly well and needs no toolchain,
+    so it is what an NVIDIA box gets when the operator has not asked to build.
+    """
+
     label: str
     url: str
     sha256: str
-    supports_sm: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -39,6 +47,7 @@ class MacosBuild:
 
 
 LLAMA_RELEASE = "b10369"
+_RELEASE_BASE = f"https://github.com/ggml-org/llama.cpp/releases/download/{LLAMA_RELEASE}"
 
 MACOS_BUILDS: dict[str, MacosBuild] = {
     "arm64": MacosBuild(
@@ -54,55 +63,57 @@ MACOS_BUILDS: dict[str, MacosBuild] = {
 }
 
 
-TARBALLS: tuple[TarballPin, ...] = (
-    TarballPin(
-        label="cuda-12.4-ampere-ada",
-        url="https://github.com/ggml-org/llama.cpp/releases/download/PLACEHOLDER/llama-cuda12.4.zip",
-        sha256="PLACEHOLDER",
-        supports_sm=("sm_86", "sm_89"),
+def _linux_asset(kind: str, machine: str) -> str:
+    suffix = "x64" if machine == "x86_64" else "arm64"
+    infix = "vulkan-" if kind == "vulkan" else ""
+    return f"llama-{LLAMA_RELEASE}-bin-ubuntu-{infix}{suffix}.tar.gz"
+
+
+LINUX_BUILDS: dict[tuple[str, str], LinuxBuild] = {
+    ("vulkan", "x86_64"): LinuxBuild(
+        label="linux-vulkan-x64",
+        url=f"{_RELEASE_BASE}/{_linux_asset('vulkan', 'x86_64')}",
+        sha256="baa1deb5adda0baf72fc9d213d657b8388997d0e20b1a0e8bea48ff91b5cad00",
     ),
-    TarballPin(
-        label="cuda-12.8-blackwell",
-        url="https://github.com/ggml-org/llama.cpp/releases/download/PLACEHOLDER/llama-cuda12.8.zip",
-        sha256="PLACEHOLDER",
-        supports_sm=("sm_120",),
+    ("vulkan", "aarch64"): LinuxBuild(
+        label="linux-vulkan-arm64",
+        url=f"{_RELEASE_BASE}/{_linux_asset('vulkan', 'aarch64')}",
+        sha256="12f09eb4dc7df11940deda07329bf6b0bb643bf5aad323b8af778689528187f4",
     ),
-)
+    ("cpu", "x86_64"): LinuxBuild(
+        label="linux-cpu-x64",
+        url=f"{_RELEASE_BASE}/{_linux_asset('cpu', 'x86_64')}",
+        sha256="675a266f6cc8a8c7b85dc431a2472e372d0ff3741b7f4eb153dc786dff3964d1",
+    ),
+    ("cpu", "aarch64"): LinuxBuild(
+        label="linux-cpu-arm64",
+        url=f"{_RELEASE_BASE}/{_linux_asset('cpu', 'aarch64')}",
+        sha256="7a806180a5136358b76cc654eebf98efb6c7d6b0f6879a55e69697d944bd91f1",
+    ),
+}
 
 
-def pick_tarball(gpus: list[gpu.GpuInfo]) -> TarballPin | None:
-    if not gpus:
-        return None
-    required = {item.compute_cap_sm for item in gpus}
-    for tarball in TARBALLS:
-        if required.issubset(set(tarball.supports_sm)):
-            return tarball
-    return None
-
-
-def install_pinned(tarball: TarballPin) -> Path:
-    if tarball.sha256 == "PLACEHOLDER" or "PLACEHOLDER" in tarball.url:
+def pick_linux_build(kind: str, machine: str) -> LinuxBuild:
+    """The official Linux build for this backend and architecture."""
+    build = LINUX_BUILDS.get((kind, machine))
+    if not build:
         raise SystemExit(
-            f"Pinned tarball {tarball.label!r} has placeholder URL/sha. Fill in real values "
-            "in engine/installer.py before running "
-            "`grid engine install llama.cpp`, or pass --from-source."
+            f"No prebuilt llama.cpp for Linux {machine!r} ({kind}). "
+            "Re-run with --from-source to build it here."
         )
+    return build
+
+
+def install_linux_prebuilt(kind: str) -> Path:
+    """Install llama.cpp on Linux from the project's official release tarball."""
     paths.ensure_all()
+    build = pick_linux_build(kind, arch.normalized_machine())
     with tempfile.TemporaryDirectory(prefix="grid-engine-") as tmpdir:
-        tmp = Path(tmpdir)
-        extracted = fetch_and_extract(tarball.label, tarball.url, tarball.sha256, tmp)
-        found = _locate_llama_server(extracted)
-        if not found:
-            raise SystemExit(f"Extracted archive did not contain llama-server: {tarball.label}")
-        target = paths.llama_server_bin()
-        target.parent.mkdir(parents=True, exist_ok=True)
-        if target.exists() or target.is_symlink():
-            if target.is_dir():
-                raise SystemExit(f"Cannot install llama-server because {target} is a directory.")
-            target.unlink()
-        shutil.copy2(found, target)
-        target.chmod(0o755)
-        return target
+        extracted = fetch_and_extract(build.label, build.url, build.sha256, Path(tmpdir))
+        server = _locate_llama_server(extracted)
+        if not server:
+            raise SystemExit(f"Extracted archive did not contain llama-server: {build.label}")
+        return _install_prefix(server.parent)
 
 
 def pick_macos_build(machine: str) -> MacosBuild:
@@ -135,15 +146,18 @@ def install_macos_prebuilt() -> Path:
 
 def _install_prefix(source: Path) -> Path:
     """Place `llama-server` and the shared libraries it loads into their own directory, then point
-    `~/.grid/bin/llama-server` at it. The binary resolves its libraries via `@loader_path`, so they
-    must sit beside it — copying the binary alone yields one that cannot start."""
+    `~/.grid/bin/llama-server` at it. The binary resolves its libraries relatively — `@loader_path`
+    on macOS, `$ORIGIN` on Linux — so they must sit beside it; copying the binary alone yields one
+    that cannot start."""
     prefix = paths.llama_prefix_dir()
     if prefix.exists():
         shutil.rmtree(prefix)
     prefix.mkdir(parents=True, exist_ok=True)
 
     shutil.copy2(source / "llama-server", prefix / "llama-server")
-    for lib in source.glob("*.dylib"):
+    # `.so*`, not `.so`: Linux releases ship versioned sonames (`libggml-base.so.0`) that the
+    # binary loads by their full name, so a bare `*.so` glob installs an engine that cannot start.
+    for lib in [*source.glob("*.dylib"), *source.glob("*.so*")]:
         target = prefix / lib.name
         # Keep the release's versioned aliases as links; following them would copy each library
         # several times over.
@@ -172,11 +186,16 @@ def _link_bin(source: Path) -> Path:
 def install_from_source(target_sm: str) -> Path:
     paths.ensure_all()
     require_toolchain()
+    sm_digits = target_sm.removeprefix("sm_")
+    require_cuda_arch(sm_digits)
     src = _ensure_llama_cpp_source()
     build = src / "build"
     build.mkdir(parents=True, exist_ok=True)
-    sm_digits = target_sm.removeprefix("sm_")
     print(f"Configuring CUDA build for CMAKE_CUDA_ARCHITECTURES={sm_digits} ...")
+    # No -DCMAKE_BUILD_TYPE: llama.cpp's own CMakeLists already forces Release when the caller
+    # leaves it unset. And a plain `120` is correct — llama.cpp rewrites any `12X` to the
+    # architecture-specific `12Xa` itself, because Blackwell's FP4 tensor-core instructions are
+    # not forwards compatible.
     subprocess.check_call(
         [
             "cmake",
@@ -188,19 +207,8 @@ def install_from_source(target_sm: str) -> Path:
             f"-DCMAKE_CUDA_ARCHITECTURES={sm_digits}",
         ]
     )
-    subprocess.check_call(["cmake", "--build", str(build), "--target", "llama-server", "-j"])
-    candidates = list(build.rglob("llama-server"))
-    if not candidates:
-        raise SystemExit("Build completed but llama-server binary was not found.")
-    target = paths.llama_server_bin()
-    target.parent.mkdir(parents=True, exist_ok=True)
-    if target.exists() or target.is_symlink():
-        if target.is_dir():
-            raise SystemExit(f"Cannot install llama-server because {target} is a directory.")
-        target.unlink()
-    shutil.copy2(candidates[0], target)
-    target.chmod(0o755)
-    return target
+    _build_target(build)
+    return _install_prefix(_built_server(build).parent)
 
 
 def install_metal_from_source() -> Path:
@@ -221,37 +229,111 @@ def install_metal_from_source() -> Path:
             "-DCMAKE_BUILD_TYPE=Release",
         ]
     )
-    subprocess.check_call(["cmake", "--build", str(build), "--target", "llama-server", "--config", "Release", "-j"])
-    candidates = list(build.rglob("llama-server"))
-    if not candidates:
+    _build_target(build)
+    return _install_prefix(_built_server(build).parent)
+
+
+def _build_target(build: Path, target: str = "llama-server") -> None:
+    """Compile one target, with the job count BOUNDED.
+
+    A bare `-j` is passed straight through to make, which reads it as "unlimited jobs". A CUDA
+    build is hundreds of nvcc invocations that each want a GB or more, so unlimited means the
+    machine runs itself out of memory partway through a long build. Leave one core for the rest
+    of the system.
+    """
+    jobs = max(1, (os.cpu_count() or 2) - 1)
+    subprocess.check_call(
+        ["cmake", "--build", str(build), "--target", target, "--config", "Release", "-j", str(jobs)]
+    )
+
+
+def _built_server(build: Path) -> Path:
+    """The freshly built `llama-server`, preferring the canonical output directory.
+
+    llama.cpp sets `CMAKE_RUNTIME_OUTPUT_DIRECTORY` to `<build>/bin`, so that is where the binary
+    and the shared libraries it needs land together. A bare `rglob` can also match copies left
+    elsewhere in the tree and returns them in filesystem order, so picking the first result was
+    a coin flip between the real output and a stale one.
+    """
+    canonical = build / "bin" / "llama-server"
+    if canonical.is_file():
+        return canonical
+    found = sorted(build.rglob("llama-server"))
+    if not found:
         raise SystemExit("Build completed but llama-server binary was not found.")
-    target = paths.llama_server_bin()
-    target.parent.mkdir(parents=True, exist_ok=True)
-    if target.exists() or target.is_symlink():
-        if target.is_dir():
-            raise SystemExit(f"Cannot install llama-server because {target} is a directory.")
-        target.unlink()
-    shutil.copy2(candidates[0], target)
-    target.chmod(0o755)
-    return target
+    return found[0]
+
+
+BUILD_TOOLS = ("cmake", "g++", "nvcc", "git")
+
+
+def _nvcc_architectures() -> set[str]:
+    """What this CUDA toolkit can compile for, as ``{"compute_50", ...}``; empty if unknowable."""
+    try:
+        out = subprocess.run(
+            ["nvcc", "--list-gpu-arch"], capture_output=True, text=True, timeout=30, check=False
+        )
+    except (OSError, subprocess.SubprocessError):
+        return set()
+    return {line.strip() for line in (out.stdout or "").splitlines() if line.strip().startswith("compute_")}
+
+
+def cuda_build_readiness(sm_digits: str) -> tuple[bool, str]:
+    """Can this machine compile the CUDA engine for [sm_digits], and if not, what is in the way.
+
+    One prober, two callers, so the answer cannot differ between them: `--from-source` raises this
+    as an error before doing any work, and the plain install prints it as guidance. The whole point
+    is that nobody has to run `nvcc --list-gpu-arch` by hand to find out where they stand.
+
+    Returns ``(ready, message)``. When not ready the message is a complete, actionable paragraph.
+    """
+    missing = [tool for tool in BUILD_TOOLS if shutil.which(tool) is None]
+    if missing:
+        return False, (
+            f"CUDA needs {', '.join(missing)}, which this machine does not have.\n"
+            f"    {_toolchain_hint()}"
+        )
+    listed = _nvcc_architectures()
+    # An empty list means nvcc would not tell us — say nothing rather than block a build that may
+    # be perfectly fine, and let the compiler have the final word.
+    if listed and f"compute_{sm_digits}" not in listed:
+        newest = max(listed, key=lambda a: int(a.removeprefix("compute_").rstrip("af") or 0))
+        return False, (
+            f"This CUDA toolkit cannot build for compute_{sm_digits} — the newest it supports is "
+            f"{newest}. RTX 50-series needs CUDA 12.8 or newer; install a current toolkit from "
+            "NVIDIA rather than your distro's default package."
+        )
+    return True, ""
+
+
+def require_cuda_arch(sm_digits: str) -> None:
+    """Refuse to start a long build this machine cannot finish."""
+    ready, message = cuda_build_readiness(sm_digits)
+    if not ready:
+        raise SystemExit(message)
 
 
 def is_macos() -> bool:
     return platform.system() == "Darwin"
 
 
-def require_toolchain() -> None:
-    missing = [tool for tool in ("cmake", "g++", "nvcc", "git") if shutil.which(tool) is None]
-    if not missing:
-        return
+def _toolchain_hint() -> str:
+    """The install command for this distro's build tools."""
     distro = _detect_distro()
     if distro == "debian":
-        hint = "sudo apt update && sudo apt install -y build-essential cmake git nvidia-cuda-toolkit"
-    elif distro == "rhel":
-        hint = "sudo dnf install -y @development-tools cmake git cuda-toolkit"
-    else:
-        hint = "Install gcc/g++, cmake, git, and the CUDA toolkit via your distro's package manager."
-    raise SystemExit(f"Missing required build tools: {', '.join(missing)}.\nInstall them with:\n  {hint}")
+        return "sudo apt update && sudo apt install -y build-essential cmake git nvidia-cuda-toolkit"
+    if distro == "rhel":
+        return "sudo dnf install -y @development-tools cmake git cuda-toolkit"
+    return "Install gcc/g++, cmake, git, and the CUDA toolkit via your distro's package manager."
+
+
+def require_toolchain() -> None:
+    missing = [tool for tool in BUILD_TOOLS if shutil.which(tool) is None]
+    if not missing:
+        return
+    raise SystemExit(
+        f"Missing required build tools: {', '.join(missing)}.\nInstall them with:\n  {_toolchain_hint()}"
+    )
 
 
 def require_metal_toolchain() -> None:
@@ -336,12 +418,39 @@ def _locate_llama_server(root: Path) -> Path | None:
 
 
 
+_LLAMA_REPO = "https://github.com/ggml-org/llama.cpp"
+
+
 def _ensure_llama_cpp_source() -> Path:
+    """A checkout of llama.cpp at exactly the release Grid pins everywhere else.
+
+    Two bugs used to live here. It cloned the default branch, so `--from-source` built whatever
+    master happened to be that day while the prebuilt path installed a pinned, checksummed
+    release — one command, two versions. And an existing directory was returned untouched, so a
+    second run silently rebuilt a checkout that could be months old.
+    """
     src = paths.home() / "src" / "llama.cpp"
     src.parent.mkdir(parents=True, exist_ok=True)
-    if not src.exists():
-        print(f"Cloning llama.cpp into {src} ...")
-        subprocess.check_call(["git", "clone", "--depth", "1", "https://github.com/ggml-org/llama.cpp", str(src)])
+    if not (src / ".git").is_dir():
+        if src.exists():
+            shutil.rmtree(src)
+        print(f"Cloning llama.cpp {LLAMA_RELEASE} into {src} ...")
+        subprocess.check_call(
+            ["git", "clone", "--depth", "1", "--branch", LLAMA_RELEASE, _LLAMA_REPO, str(src)]
+        )
+        return src
+
+    print(f"Updating {src} to {LLAMA_RELEASE} ...")
+    try:
+        subprocess.check_call(
+            ["git", "-C", str(src), "fetch", "--depth", "1", "origin", "tag", LLAMA_RELEASE]
+        )
+        subprocess.check_call(["git", "-C", str(src), "checkout", "--force", LLAMA_RELEASE])
+    except subprocess.CalledProcessError as exc:
+        raise SystemExit(
+            f"Could not move {src} to {LLAMA_RELEASE} ({exc}). Delete that directory and re-run "
+            "to get a clean checkout."
+        ) from exc
     return src
 
 

--- a/shared/engine/launcher.py
+++ b/shared/engine/launcher.py
@@ -29,12 +29,23 @@ class LlamaProcess:
 
 @dataclass(frozen=True)
 class RuntimeProfile:
-    ctx_size: int
+    """Launch policy we actually mean to impose. Deliberately carries NO ctx_size and no
+    flash_attn: llama.cpp's own `--fit` sizes the context to the machine, and `--flash-attn auto`
+    probes the backend. Both are on by default in llama-server, and both are disabled *for the
+    dimension we pin* — `fit` "only modifies parameters that still hold their default value", so
+    every value we pass is a value we take responsibility for."""
+
     n_predict: int
     temp: float
     reasoning_budget: int
-    flash_attn: str = "on"
     parallel: int = 1
+    # `--n-gpu-layers all` on unified memory. When llama.cpp cannot fit a model it chooses between
+    # two levers: shrink the context, or spill layers to host memory — and it picks the spill,
+    # because `fit` assumes system memory is unlimited. On Apple Silicon the "host memory" it spills
+    # into is the same physical pool it just left, so the spill buys nothing and swaps the whole OS.
+    # Pinning the layers takes that lever away and forces the context lever instead. Left unset on
+    # discrete-VRAM hosts, where spilling to real system RAM is a legitimate partial offload.
+    gpu_layers: str | None = None
     min_p: float | None = None
     top_p: float | None = None
     top_k: int | None = None
@@ -43,7 +54,6 @@ class RuntimeProfile:
 
 
 APPLE_SILICON_RUNTIME = RuntimeProfile(
-    ctx_size=128000,
     n_predict=64000,
     temp=1.0,
     min_p=0.0,
@@ -51,10 +61,10 @@ APPLE_SILICON_RUNTIME = RuntimeProfile(
     top_k=20,
     presence_penalty=1.5,
     reasoning_budget=0,
+    gpu_layers="all",
     spec_draft_n_max=2,
 )
 NVIDIA_RUNTIME = RuntimeProfile(
-    ctx_size=128000,
     n_predict=64000,
     temp=0.7,
     reasoning_budget=8192,
@@ -113,16 +123,27 @@ def start_llm(
     temp: float | None = None,
     reasoning_budget: int | None = None,
     alias: str | None = None,
-    mmproj: str = "mmproj-BF16.gguf",
+    mmproj: str | None = None,
 ) -> LlamaProcess:
     paths.ensure_all()
     profile = runtime_profile()
-    ctx_size = profile.ctx_size if ctx_size is None else ctx_size
+    # No profile default for ctx_size or flash_attn — see RuntimeProfile. `None` here means "we did
+    # not ask", which is what leaves llama.cpp free to decide; anything else is an operator override
+    # arriving from `grid join --ctx-size / --flash-attn`, and is passed through untouched.
     n_predict = profile.n_predict if n_predict is None else n_predict
     parallel = profile.parallel if parallel is None else parallel
-    flash_attn = profile.flash_attn if flash_attn is None else flash_attn
     temp = profile.temp if temp is None else temp
     reasoning_budget = profile.reasoning_budget if reasoning_budget is None else reasoning_budget
+    if ctx_size == 0:
+        # `-c 0` is NOT the same as omitting `-c`. llama.cpp reads an explicit 0 as "give me the
+        # full trained window and do not reduce it", setting the fitter's floor to UINT32_MAX — so
+        # a model that does not fit spills its weights to system memory instead of shrinking. That
+        # is a slow, swap-heavy mode that looks like a typo for "unset". Make the user say it twice.
+        raise SystemExit(
+            "--ctx-size 0 asks llama.cpp for the model's full trained context and turns off the "
+            "automatic fit-to-memory, which will spill weights into system RAM. Omit --ctx-size to "
+            "let the engine size itself to this machine, or pass a real token count."
+        )
 
     model_path = paths.models_dir() / Path(model_file).name
     if not model_path.is_file():
@@ -140,30 +161,43 @@ def start_llm(
     cmd = [llama_server_path(), "-m", str(model_path)]
     if alias:
         cmd.extend(["--alias", alias])
+    # Vision turns itself on. A vision GGUF is text-only until its projector is loaded, and the
+    # projector is a SECOND file — so whether this model can see is a question about what is on
+    # this disk, not about what the operator remembered to type. `grid pull` saves a repo's
+    # projector as `<model-stem>.mmproj.gguf`, and that is what gets picked up here.
+    # `--mmproj` stays as an override for a projector fetched by hand or named something else.
     if mmproj:
         mmproj_path = paths.models_dir() / mmproj
-        if mmproj_path.is_file():
-            cmd.extend(["--mmproj", str(mmproj_path)])
-        else:
-            print(
-                f"warning: --mmproj {mmproj} not found at {mmproj_path}; "
-                "starting text-only"
+        if not mmproj_path.is_file():
+            raise SystemExit(
+                f"Multimodal projector not found: {mmproj_path}. Pull it next to the model, or "
+                "drop the projector argument to serve this model as text-only."
             )
+        cmd.extend(["--mmproj", str(mmproj_path)])
+    else:
+        discovered = gguf.projector_beside(model_path)
+        if discovered:
+            print(f"Vision: serving with projector {discovered.name}")
+            cmd.extend(["--mmproj", str(discovered)])
     cmd.extend(
         [
             "--host",
             "0.0.0.0",
             "--port",
             str(port),
-            "--jinja",
-            "--ctx-size",
-            str(ctx_size),
             "--n-predict",
             str(n_predict),
             "--temp",
             str(temp),
         ]
     )
+    # Emitted ONLY when the operator asked for one. Left unset, llama.cpp measures free device
+    # memory at load and takes the largest window that fits; naming a number here turns that off,
+    # which is the whole reason the old hardcoded 128000 broke small machines.
+    if ctx_size is not None:
+        cmd.extend(["--ctx-size", str(ctx_size)])
+    if profile.gpu_layers is not None:
+        cmd.extend(["--n-gpu-layers", profile.gpu_layers])
     if profile.min_p is not None:
         cmd.extend(["--min-p", str(profile.min_p)])
     if profile.top_p is not None:
@@ -176,13 +210,19 @@ def start_llm(
         [
             "--reasoning-budget",
             str(reasoning_budget),
-            "--flash-attn",
-            str(flash_attn),
             "--parallel",
             str(parallel),
+            # Redundant at the pinned build (context shift has defaulted to disabled since b6427),
+            # but kept: it is one argv entry, and it pins a default llama.cpp has already flipped
+            # once. Shifting silently discards the head of a conversation, so we never want it back.
             "--no-context-shift",
         ]
     )
+    # Unset means `--flash-attn auto`, which builds a probe graph and falls back when the backend
+    # cannot place the fused kernel. The old hardcoded `on` asserted instead of probing, so on a
+    # backend without FA support the op was scheduled off-device layer by layer with no warning.
+    if flash_attn is not None:
+        cmd.extend(["--flash-attn", str(flash_attn)])
     # Filename alone can't tell: unsloth ships a `Qwen3.6-35B-A3B-Q8_0.gguf` in both an
     # MTP repo and a plain one, byte-identical name, only one with the fused draft head.
     # Read the file's own header instead of trusting the name.

--- a/shared/models/download.py
+++ b/shared/models/download.py
@@ -39,6 +39,46 @@ def local_path(quantized_file: str) -> Path:
     return paths.models_dir() / Path(quantized_file).name
 
 
+# Preference order for a repo that ships several projector precisions. BF16 and F16 are the same
+# size and either works; F32 is double for no practical gain, so it is the last resort rather than
+# whichever happens to sort first.
+_PROJECTOR_PREFERENCE = ("mmproj-f16", "mmproj-bf16", "mmproj")
+
+
+def find_projector(repo: str, timeout: float = 15.0) -> str | None:
+    """The name of the multimodal projector in [repo], or ``None`` if it ships none.
+
+    Vision models on Hugging Face put the projector in the SAME repo as the weights (unsloth's
+    `gemma-3-4b-it-GGUF` carries `mmproj-BF16.gguf`, `mmproj-F16.gguf` and `mmproj-F32.gguf`
+    beside every quant), which is the same pairing llama.cpp's own `--mmproj-auto` relies on for
+    `-hf`. Best-effort by design: this runs inside `grid pull`, and a rate-limited or offline API
+    must cost the user a projector, never the model they actually asked for.
+    """
+    try:
+        resp = httpx.get(f"{HF_BASE}/api/models/{repo}", timeout=timeout, follow_redirects=True)
+        if resp.status_code != 200:
+            return None
+        siblings = resp.json().get("siblings")
+    except (httpx.HTTPError, ValueError, AttributeError):
+        return None
+    if not isinstance(siblings, list):
+        return None
+    names = [
+        s["rfilename"]
+        for s in siblings
+        if isinstance(s, dict)
+        and isinstance(s.get("rfilename"), str)
+        and s["rfilename"].endswith(".gguf")
+        and "mmproj" in s["rfilename"].lower()
+        and "/" not in s["rfilename"]  # top-level only; never a file from a nested variant dir
+    ]
+    for wanted in _PROJECTOR_PREFERENCE:
+        for name in sorted(names):
+            if name.lower().startswith(wanted):
+                return name
+    return None
+
+
 def download(repo: str, quantized_file: str, *, out: Path | None = None, on_progress=None) -> Path:
     target = out or local_path(quantized_file)
     part = target.with_suffix(target.suffix + ".part")

--- a/shared/models/gguf.py
+++ b/shared/models/gguf.py
@@ -48,6 +48,27 @@ def _read_value(f, vtype: int):
     raise ValueError(f"unknown gguf value type {vtype}")
 
 
+def _iter_kv(path: str | Path):
+    """Yield every ``(key, value)`` in a GGUF's header, or nothing at all if it isn't readable.
+
+    Every reader below walks the same header the same way; sharing the walk keeps them from
+    drifting on the parts that are easy to get subtly wrong (the version gate, array skipping).
+    Array values are yielded as ``None`` — their bytes are consumed, but no reader wants them.
+    """
+    with open(path, "rb") as f:
+        if f.read(4) != b"GGUF":
+            return
+        (version,) = struct.unpack("<I", f.read(4))
+        if version < 2:  # v1 used 32-bit lengths; not emitted by modern tooling
+            return
+        struct.unpack("<Q", f.read(8))  # tensor count (unused)
+        (kv_count,) = struct.unpack("<Q", f.read(8))
+        for _ in range(kv_count):
+            key = _read_str(f)
+            (vtype,) = struct.unpack("<I", f.read(4))
+            yield key, _read_value(f, vtype)
+
+
 def read_context_length(path: str | Path) -> int | None:
     """Return the model's trained context length, or ``None`` if unreadable.
 
@@ -55,31 +76,37 @@ def read_context_length(path: str | Path) -> int | None:
     the metadata.
     """
     try:
-        with open(path, "rb") as f:
-            if f.read(4) != b"GGUF":
-                return None
-            (version,) = struct.unpack("<I", f.read(4))
-            if version < 2:  # v1 used 32-bit lengths; not emitted by modern tooling
-                return None
-            struct.unpack("<Q", f.read(8))  # tensor count (unused)
-            (kv_count,) = struct.unpack("<Q", f.read(8))
+        arch: str | None = None
+        ctx: dict[str, int] = {}
+        for key, val in _iter_kv(path):
+            if key == "general.architecture":
+                arch = val
+            elif key.endswith(".context_length"):
+                ctx[key] = int(val)
 
-            arch: str | None = None
-            ctx: dict[str, int] = {}
-            for _ in range(kv_count):
-                key = _read_str(f)
-                (vtype,) = struct.unpack("<I", f.read(4))
-                val = _read_value(f, vtype)
-                if key == "general.architecture":
-                    arch = val
-                elif key.endswith(".context_length"):
-                    ctx[key] = int(val)
-
-            if arch and f"{arch}.context_length" in ctx:
-                return ctx[f"{arch}.context_length"]
-            return next(iter(ctx.values())) if ctx else None
+        if arch and f"{arch}.context_length" in ctx:
+            return ctx[f"{arch}.context_length"]
+        return next(iter(ctx.values())) if ctx else None
     except Exception:
         return None
+
+
+def is_projector(path: str | Path) -> bool:
+    """True when the file is a multimodal projector (an ``mmproj``), not a language model.
+
+    Read from the file's own header, because the name proves nothing: every vision repo on Hugging
+    Face ships its projector as some spelling of ``mmproj-F16.gguf``, so the name is neither unique
+    across models nor guaranteed on any one of them. ``clip.has_vision_encoder`` /
+    ``clip.has_audio_encoder`` are what llama.cpp itself keys on. Unreadable or malformed → False;
+    a caller must never hand llama-server a ``--mmproj`` it is not sure about.
+    """
+    try:
+        for key, val in _iter_kv(path):
+            if key in ("clip.has_vision_encoder", "clip.has_audio_encoder") and val:
+                return True
+        return False
+    except Exception:
+        return False
 
 
 def has_mtp_head(path: str | Path) -> bool:
@@ -91,21 +118,33 @@ def has_mtp_head(path: str | Path) -> bool:
     malformed file returns False; callers should not add MTP flags on doubt.
     """
     try:
-        with open(path, "rb") as f:
-            if f.read(4) != b"GGUF":
-                return False
-            (version,) = struct.unpack("<I", f.read(4))
-            if version < 2:
-                return False
-            struct.unpack("<Q", f.read(8))  # tensor count (unused)
-            (kv_count,) = struct.unpack("<Q", f.read(8))
-
-            for _ in range(kv_count):
-                key = _read_str(f)
-                (vtype,) = struct.unpack("<I", f.read(4))
-                val = _read_value(f, vtype)
-                if key.endswith(".nextn_predict_layers"):
-                    return bool(val)
-            return False
+        for key, val in _iter_kv(path):
+            if key.endswith(".nextn_predict_layers"):
+                return bool(val)
+        return False
     except Exception:
         return False
+
+
+PROJECTOR_SUFFIX = ".mmproj.gguf"
+
+
+def projector_beside(model_path: str | Path) -> Path | None:
+    """The projector paired with this model file, or ``None`` for a text-only model.
+
+    Pairing is by NAME, not by scanning the directory: `grid pull` saves a repo's projector as
+    ``<model-stem>.mmproj.gguf`` beside the model precisely so this lookup can be exact. A
+    directory scan cannot work — models live in one flat folder and every vision repo names its
+    projector the same handful of ways, so two vision models would each match the other's file.
+
+    The header is still checked before returning: the sidecar name is our own convention, and a
+    file that does not declare a vision or audio encoder must never reach ``--mmproj``.
+    """
+    model_path = Path(model_path)
+    # Built by hand, not `with_suffix`: model names carry dots inside the stem
+    # (`Qwen3.6-35B-A3B-UD-IQ3_S.gguf`), and `with_suffix` would treat `.6-35B-A3B-UD-IQ3_S`
+    # as the suffix and eat most of the name.
+    candidate = model_path.parent / (model_path.stem + PROJECTOR_SUFFIX)
+    if candidate.is_file() and is_projector(candidate):
+        return candidate
+    return None

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -11,6 +11,7 @@ import shlex
 import shutil
 import socket
 import stat
+import struct
 import subprocess
 import tarfile
 import threading
@@ -35,7 +36,7 @@ from shared.agent import codex_installer
 from shared.agent import installer as agent_installer
 from shared.engine import comfyui, installer, launcher
 from shared.system import arch
-from shared.models import api_catalog, catalog, download, media_bundles
+from shared.models import api_catalog, catalog, download, gguf, media_bundles
 from local import media_server
 from local.server import create_app
 from shared.system import detect
@@ -3235,6 +3236,207 @@ def test_launcher_start_llm_adds_alias_flag(monkeypatch, tmp_path):
         "--alias",
         "your-model",
     ]
+
+
+def _launch_argv(monkeypatch, tmp_path, **kwargs):
+    """Spawn a model through `start_llm` with the process faked out, and hand back the argv."""
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    model_path = paths.models_dir() / "your-model.gguf"
+    model_path.parent.mkdir(parents=True, exist_ok=True)
+    model_path.write_bytes(b"model")
+    calls = {}
+
+    def fake_popen(cmd, **kw):
+        calls["cmd"] = cmd
+        return FakeProc()
+
+    monkeypatch.setattr(launcher, "llama_server_path", lambda: "/usr/local/bin/llama-server")
+    monkeypatch.setattr(launcher.subprocess, "Popen", fake_popen)
+    launcher.start_llm("your-model.gguf", port=8081, **kwargs)
+    return calls["cmd"]
+
+
+def test_start_llm_leaves_the_fit_flags_unset_by_default(monkeypatch, tmp_path):
+    """The launch must NOT name a context size, a flash-attn mode, or a jinja toggle.
+
+    llama.cpp fits the context to free device memory on its own, but only for arguments still
+    holding their default — naming one takes that dimension away from the fitter. The old launch
+    hardcoded `--ctx-size 128000` and so allocated a 128k KV cache for a 4k model.
+    """
+    cmd = _launch_argv(monkeypatch, tmp_path)
+    for flag in ("--ctx-size", "--flash-attn", "--jinja", "--mmproj"):
+        assert flag not in cmd, f"{flag} must stay unset so llama.cpp can fit the model itself"
+    # Still ours to impose: one slot, and never silently drop the head of a conversation.
+    assert "--parallel" in cmd and "--no-context-shift" in cmd
+
+
+def test_start_llm_passes_through_an_operator_override(monkeypatch, tmp_path):
+    cmd = _launch_argv(monkeypatch, tmp_path, ctx_size=32000, flash_attn="off")
+    assert cmd[cmd.index("--ctx-size") + 1] == "32000"
+    assert cmd[cmd.index("--flash-attn") + 1] == "off"
+
+
+def test_start_llm_pins_gpu_layers_only_on_unified_memory(monkeypatch, tmp_path):
+    """Apple Silicon must not let llama.cpp spill layers to "system memory" — it is the same pool."""
+    monkeypatch.setattr(launcher, "runtime_profile", lambda: launcher.APPLE_SILICON_RUNTIME)
+    cmd = _launch_argv(monkeypatch, tmp_path)
+    assert cmd[cmd.index("--n-gpu-layers") + 1] == "all"
+
+    monkeypatch.setattr(launcher, "runtime_profile", lambda: launcher.NVIDIA_RUNTIME)
+    # Discrete VRAM: spilling to real system RAM is a legitimate partial offload, so leave it alone.
+    assert "--n-gpu-layers" not in _launch_argv(monkeypatch, tmp_path)
+
+
+def test_start_llm_refuses_ctx_size_zero(monkeypatch, tmp_path):
+    """`-c 0` reads as "full trained window, do not reduce" — a swap-heavy mode that looks like unset."""
+    with pytest.raises(SystemExit, match="full trained context"):
+        _launch_argv(monkeypatch, tmp_path, ctx_size=0)
+
+
+def test_start_llm_refuses_a_missing_projector(monkeypatch, tmp_path):
+    with pytest.raises(SystemExit, match="Multimodal projector not found"):
+        _launch_argv(monkeypatch, tmp_path, mmproj="mmproj-BF16.gguf")
+
+
+def _cuda_ready(monkeypatch, arches):
+    """Pretend the build tools are installed and nvcc reports [arches]."""
+    from shared.engine import installer
+
+    monkeypatch.setattr(installer.shutil, "which", lambda tool: f"/usr/bin/{tool}")
+    monkeypatch.setattr(installer, "_nvcc_architectures", lambda: set(arches))
+    return installer
+
+
+def test_cuda_readiness_names_the_missing_tools(monkeypatch):
+    from shared.engine import installer
+
+    monkeypatch.setattr(installer.shutil, "which", lambda tool: None)
+    ready, message = installer.cuda_build_readiness("120")
+    assert ready is False
+    assert "cmake" in message and "nvcc" in message
+
+
+def test_cuda_readiness_rejects_a_toolkit_too_old_for_the_card(monkeypatch):
+    """The whole point: say so BEFORE the clone, not `nvcc fatal` ten minutes into a build."""
+    installer = _cuda_ready(monkeypatch, ["compute_75", "compute_86", "compute_89"])
+    ready, message = installer.cuda_build_readiness("120")
+    assert ready is False
+    assert "compute_120" in message and "compute_89" in message
+
+    with pytest.raises(SystemExit, match="compute_120"):
+        installer.require_cuda_arch("120")
+
+
+def test_cuda_readiness_accepts_a_current_toolkit(monkeypatch):
+    installer = _cuda_ready(monkeypatch, ["compute_89", "compute_120"])
+    assert installer.cuda_build_readiness("120") == (True, "")
+    installer.require_cuda_arch("120")  # must not raise
+
+
+def test_cuda_readiness_does_not_block_when_nvcc_stays_silent(monkeypatch):
+    """An unreadable nvcc must not veto a build that would have worked — let the compiler decide."""
+    installer = _cuda_ready(monkeypatch, [])
+    ready, _ = installer.cuda_build_readiness("120")
+    assert ready is True
+
+
+def _write_gguf(path, kv):
+    """Write a minimal GGUF carrying [kv] as `{key: (value_type, value)}`. Enough for the readers."""
+    blob = b""
+    for key, (vtype, value) in kv.items():
+        blob += struct.pack("<Q", len(key)) + key.encode() + struct.pack("<I", vtype)
+        if vtype == 8:  # string
+            blob += struct.pack("<Q", len(value)) + value.encode()
+        elif vtype == 7:  # bool
+            blob += struct.pack("<?", value)
+        else:  # uint32
+            blob += struct.pack("<I", value)
+    path.write_bytes(
+        b"GGUF" + struct.pack("<I", 3) + struct.pack("<Q", 0) + struct.pack("<Q", len(kv)) + blob
+    )
+
+
+def test_projector_beside_pairs_by_sidecar_name(tmp_path):
+    """Two vision models share a flat directory, so the projector must be found by name, not scan."""
+    model = tmp_path / "Qwen3.6-VL-UD-IQ3_S.gguf"
+    _write_gguf(model, {"general.architecture": (8, "qwen3vl")})
+    # The dotted stem is the trap: `with_suffix` would read `.6-VL-UD-IQ3_S` as the suffix.
+    projector = tmp_path / "Qwen3.6-VL-UD-IQ3_S.mmproj.gguf"
+    _write_gguf(projector, {"clip.has_vision_encoder": (7, True)})
+
+    assert gguf.projector_beside(model) == projector
+
+
+def test_projector_beside_ignores_a_file_that_is_not_a_projector(tmp_path):
+    """The sidecar name is our own convention — the header is what actually decides."""
+    model = tmp_path / "text-only.gguf"
+    _write_gguf(model, {"general.architecture": (8, "llama")})
+    impostor = tmp_path / "text-only.mmproj.gguf"
+    _write_gguf(impostor, {"general.architecture": (8, "llama")})
+
+    assert gguf.projector_beside(model) is None
+
+
+def test_projector_beside_returns_none_for_a_text_model(tmp_path):
+    model = tmp_path / "text-only.gguf"
+    _write_gguf(model, {"general.architecture": (8, "llama")})
+    assert gguf.projector_beside(model) is None
+
+
+def test_start_llm_enables_vision_without_being_asked(monkeypatch, tmp_path):
+    """`grid join --serve <vision model>` must serve vision with no extra flag.
+
+    Whether a model can see is a fact about the files on this disk, not about what the operator
+    remembered to type — so the launcher looks, rather than waiting to be told.
+    """
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    paths.models_dir().mkdir(parents=True, exist_ok=True)
+    _write_gguf(paths.models_dir() / "your-model.mmproj.gguf", {"clip.has_vision_encoder": (7, True)})
+
+    cmd = _launch_argv(monkeypatch, tmp_path)
+    assert cmd[cmd.index("--mmproj") + 1] == str(paths.models_dir() / "your-model.mmproj.gguf")
+
+
+def test_find_projector_prefers_f16_and_tolerates_a_dead_api(monkeypatch):
+    siblings = [{"rfilename": n} for n in
+                ("model-Q4_K_M.gguf", "mmproj-F32.gguf", "mmproj-BF16.gguf", "mmproj-F16.gguf")]
+
+    monkeypatch.setattr(
+        download.httpx, "get",
+        lambda *a, **k: SimpleNamespace(status_code=200, json=lambda: {"siblings": siblings}),
+    )
+    assert download.find_projector("unsloth/whatever-GGUF") == "mmproj-F16.gguf"
+
+    # A rate-limited or offline API costs the projector, never the model the user asked for.
+    def boom(*a, **k):
+        raise download.httpx.ConnectError("no network")
+
+    monkeypatch.setattr(download.httpx, "get", boom)
+    assert download.find_projector("unsloth/whatever-GGUF") is None
+
+
+def test_find_projector_returns_none_for_a_text_only_repo(monkeypatch):
+    siblings = [{"rfilename": "model-Q4_K_M.gguf"}, {"rfilename": "README.md"}]
+    monkeypatch.setattr(
+        download.httpx, "get",
+        lambda *a, **k: SimpleNamespace(status_code=200, json=lambda: {"siblings": siblings}),
+    )
+    assert download.find_projector("unsloth/text-GGUF") is None
+
+
+def test_start_llm_serves_vision_when_a_projector_is_named(monkeypatch, tmp_path):
+    """A vision GGUF is text-only until its projector is loaded, so `--mmproj` is the whole switch.
+
+    Without it llama-server reports `modalities.vision: false` on /props and the grid advertises the
+    model as text-only — correctly, but the operator has no way to say otherwise.
+    """
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    projector = paths.models_dir() / "mmproj-F16.gguf"
+    projector.parent.mkdir(parents=True, exist_ok=True)
+    projector.write_bytes(b"projector")
+
+    cmd = _launch_argv(monkeypatch, tmp_path, mmproj="mmproj-F16.gguf")
+    assert cmd[cmd.index("--mmproj") + 1] == str(projector)
 
 
 def test_run_engine_launches_local_llama_server_by_default(monkeypatch, tmp_path):


### PR DESCRIPTION
## What was broken

**`grid engine install llama.cpp` dead-ended on every Linux NVIDIA box.**

```
Detected GPUs: sm_120, sm_120
Pinned tarball 'cuda-12.8-blackwell' has placeholder URL/sha.
Fill in real values in engine/installer.py
```

The table it matched against described files that do not exist: llama.cpp publishes CUDA binaries
for **Windows only**. Every Linux asset in a release is CPU, Vulkan, ROCm, SYCL or OpenVINO, so the
placeholder URLs were never fillable. Replaced with the four real Linux builds (Vulkan and CPU,
x64 and arm64), SHA-256 from the release API. An NVIDIA box now gets Vulkan — real GPU inference on
the same cards, no CUDA toolkit — and is told how to get CUDA.

**`--from-source` had four defects**, none covered by a test:

| | |
|---|---|
| copied only the binary | the `.so` files stayed in the build tree; deleting `~/.grid/src` killed the engine |
| bare `-j` | make reads that as *unlimited*, and a CUDA build is hundreds of memory-hungry `nvcc` jobs |
| `rglob(...)[0]` | filesystem order decided which binary got installed |
| cloned `master`, reused a stale checkout | one command produced two different versions |

**The launcher hardcoded `--ctx-size 128000`.** Reproduced live: a model with a 4096-token trained
context was given a 128k KV cache. llama.cpp's `--fit` already sizes the context to free device
memory, but only adjusts arguments left *unset*, so pinning it disabled the fitter — which then
spilled layers to host memory instead, the wrong lever on unified memory.

**Vision could not be turned on at all.** `--mmproj` defaulted to a hardcoded filename no caller
ever passed, so a vision model was always loaded text-only — and every text launch printed a
warning about a projector nobody asked for.

**Local mode advertised `"capabilities": {}`** for text engines, so a local grid knew a model's
name and nothing else.

## What changed

- Real Linux builds; `_install_prefix` now also copies `*.so*` (versioned sonames like
  `libggml.so.0.19.0` were being missed)
- `--from-source` pinned to `b10369`, fetches instead of reusing a stale checkout, bounded `-j`,
  installs libraries beside the binary
- One toolchain prober, two callers: the plain install *reports* whether CUDA is buildable here,
  `--from-source` *refuses* on the same answer — so it can never advise a build that would fail
- `--ctx-size` emitted only when the operator asks; `--flash-attn` left to `auto`; `--jinja` dropped
  (already default); `--n-gpu-layers all` on Apple Silicon so the fitter shrinks context instead of
  swapping; `--ctx-size 0` refused, since it means "full trained window, never reduce"
- `grid pull` fetches a vision model's projector as `<model-stem>.mmproj.gguf`; `--serve` finds it
  and enables vision with no flag
- Local mode runs the same capability probe as remote
- README quickstart made runnable end to end

## Verified by running

- Downloaded the real Vulkan tarball — SHA matched the pinned value; ran `_install_prefix` on it:
  39 libraries, binary executable, symlink correct
- Pinned clone, both paths — fresh clone and stale checkout both land on `b10369` (`6e62ba5`)
- All four branches of the CUDA readiness prober
- `find_projector` against the live Hugging Face API
- Launcher argv, default and with operator overrides
- 2935 tests, ruff clean

## NOT verified — please read before merging

Neither this branch nor `main` has ever executed these end to end. There is no NVIDIA GPU, no
`nvcc` and no `cmake` on the machine this was written on:

- `grid engine install llama.cpp` as a whole command on Linux (the pieces were verified separately)
- `grid engine install llama.cpp --from-source` — the cmake invocation has never run
- `grid pull` actually downloading, including the new projector fetch
- `grid join --serve` against a real `llama-server`
- vision end to end
- the Metal from-source path, which this also touches

One behaviour change worth flagging: both catalog models ship a projector, so `grid pull` now
downloads an extra ~0.93 GB for them.
