### PR TITLE
ci: gate the release on the test suite, and make Nuitka's C compiles cacheable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
   pull_request:
+  # release.yml calls this so a release is gated on the SAME suite a PR is, rather than on
+  # a human remembering to watch it. It runs in parallel with the Nuitka binaries there, which
+  # take ~10 min, so the whole gate is free in wall-clock terms.
+  workflow_call:
 
 jobs:
   lint:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,17 @@ name: Release
 on:
   push:
     tags: ["v*"]
+  # Warms the ccache on the DEFAULT branch, which is the only way a release can inherit one.
+  # An Actions cache is scoped to the ref that wrote it, and a release only ever runs on a
+  # fresh `refs/tags/vX.Y.Z` — so a tag run can never restore the PREVIOUS tag's cache. What
+  # it can restore is the default branch's, which nothing else here would ever write, since
+  # the binaries are built on no other trigger.
+  #
+  # Measured 2026-08-26 (runs 32933722202 cold / 32934676605 warm): x86_64 12m27s -> 4m00s,
+  # arm64 11m01s -> 4m16s, 590 of 591 C files served from ccache. A scheduled run publishes
+  # nothing: all three release steps are gated on `github.event_name == 'push'`.
+  schedule:
+    - cron: "0 3 * * 1"
   workflow_dispatch: {}   # allow manual runs for dry-tests (no release is created)
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,9 +45,22 @@ jobs:
       # ccache is not on the GitHub image, and Nuitka says so itself, twice per build:
       # "You are not using ccache, re-compilation of identical code will be slower than
       # necessary." Nuitka's Scons backend picks it up off PATH with no flag of its own.
+      #
+      # CCACHE_DIR is NOT optional. Nuitka stores its ccache under its OWN cache directory
+      # (~/.cache/Nuitka/ccache on Linux) unless the variable is already set — see
+      # nuitka/build/SconsCaching.py: `if "CCACHE_DIR" not in os.environ`. Measured on the
+      # dry run of this change (run 32932548044, 2026-08-26): without it Nuitka compiled all
+      # 590 C files through ccache, yet actions/cache watched an empty ~/.cache/ccache and
+      # logged "Path Validation Error … hence no cache is being saved", `ccache -s` reported
+      # 0.0 GiB, and the repo gained no cache entry at all.
+      # It goes through $GITHUB_ENV so the build step and the stats step below cannot drift
+      # onto two different directories; a job-level `env:` cannot do it because $HOME is not
+      # expanded there.
       - name: Install patchelf (Linux standalone needs it) + ccache
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y patchelf ccache
+        run: |
+          sudo apt-get update && sudo apt-get install -y patchelf ccache
+          echo "CCACHE_DIR=$HOME/.cache/ccache" >> "$GITHUB_ENV"
       # Measured on v0.3.23: of a 9m24s x86_64 build, 5m32s is gcc compiling the 591 C files
       # Nuitka generates. Most of those are the frozen dependencies (pydantic, fastapi,
       # uvicorn, starlette, httpx, stdlib), which are byte-identical between patch releases —

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,17 @@ permissions:
   contents: write   # create the release + upload assets
 
 jobs:
+  # The same suite ci.yml runs on every PR. A tag push does NOT trigger ci.yml (`on: push:
+  # branches: [main]`, and a tag is not a branch), so before this the release path ran no
+  # tests whatsoever and only a human watching CI stood between a red main and a published
+  # release. `release: needs:` below makes it fail-closed instead.
+  #
+  # It costs nothing in wall clock: ~4 min of jobs running alongside binaries that take ~10.
+  tests:
+    uses: ./.github/workflows/ci.yml
+    permissions:
+      contents: read
+
   binaries:
     name: ${{ matrix.os }}-${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
@@ -31,14 +42,38 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Install patchelf (Linux standalone needs it)
+      # ccache is not on the GitHub image, and Nuitka says so itself, twice per build:
+      # "You are not using ccache, re-compilation of identical code will be slower than
+      # necessary." Nuitka's Scons backend picks it up off PATH with no flag of its own.
+      - name: Install patchelf (Linux standalone needs it) + ccache
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y patchelf
+        run: sudo apt-get update && sudo apt-get install -y patchelf ccache
+      # Measured on v0.3.23: of a 9m24s x86_64 build, 5m32s is gcc compiling the 591 C files
+      # Nuitka generates. Most of those are the frozen dependencies (pydantic, fastapi,
+      # uvicorn, starlette, httpx, stdlib), which are byte-identical between patch releases —
+      # so a warm cache skips them. The key is per-arch: x86_64 and arm64 objects never mix.
+      # `github.sha` in the key means every run writes a fresh entry; restore-keys takes the
+      # newest prefix match, which is what makes the cache roll forward instead of going stale.
+      - name: Restore the C compiler cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ccache
+          key: ccache-${{ matrix.os }}-${{ matrix.arch }}-${{ github.sha }}
+          restore-keys: ccache-${{ matrix.os }}-${{ matrix.arch }}-
       - name: Build standalone binary
+        env:
+          # Capped well under GitHub's 10 GB per-repo cache budget, and small enough that
+          # saving it costs seconds rather than eating the time the cache just saved.
+          CCACHE_MAXSIZE: 500M
         run: |
           chmod +x packaging/build_binary.sh
           GRID_BUILD_PYTHON="$(command -v python3.12)" packaging/build_binary.sh
           mv dist/grid "grid-${{ matrix.os }}-${{ matrix.arch }}"
+      # The hit rate is the whole justification for the cache above, so print it rather than
+      # assume it. A run showing ~0 hits means the cache is not working and the step should go.
+      - name: ccache statistics
+        if: always() && runner.os == 'Linux'
+        run: ccache -s
       - uses: actions/upload-artifact@v4
         with:
           name: grid-${{ matrix.os }}-${{ matrix.arch }}
@@ -46,7 +81,7 @@ jobs:
           if-no-files-found: error
 
   release:
-    needs: binaries
+    needs: [binaries, tests]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -60,6 +95,26 @@ jobs:
           python-version: "3.12"
       - name: Build universal wheel
         run: uv build --wheel
+      # v0.1.1 shipped a wheel that printed the wrong version. pyproject.toml is the only
+      # place the number lives (shared/_version.py reads it back from package metadata), so
+      # comparing the built wheel's filename to the tag is the whole check — and it belongs
+      # here rather than on the maintainer's laptop because it gates the publish: `needs:`
+      # means nothing has shipped when this exits 1, and re-tagging is free.
+      #
+      # ref_name through env, not `${{ }}` inside run: — same reason as the notes step below.
+      - name: Tag must match the wheel's version
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          built="$(basename dist/grid-*-py3-none-any.whl)"
+          built="${built#grid-}"; built="${built%-py3-none-any.whl}"
+          if [ "v$built" != "$REF_NAME" ]; then
+            echo "::error::tag is $REF_NAME but the wheel is $built."
+            echo "::error::Set pyproject.toml's version to ${REF_NAME#v}, or re-tag to match."
+            exit 1
+          fi
+          echo "tag $REF_NAME matches wheel $built"
       - uses: actions/download-artifact@v4
         with:
           path: artifacts


### PR DESCRIPTION
## What

Three commits on the release path. Each was measured on the public repo rather than reasoned about — run ids are cited throughout.

### 1. A tag push ran no tests at all (`83fa908`)

`ci.yml` triggers on `push: branches: [main]` and `pull_request`. **A tag is not a branch**, so nothing in the release path ever ran the suite — only a human watching CI stood between a red `main` and a published release.

`ci.yml` gains `workflow_call`; `release.yml` calls it and `release: needs: [binaries, tests]` it, so the gate is fail-closed.

It is free in wall clock — the suite finishes well inside the binary builds:

| job | time |
|---|---|
| `tests / lint` | 11s |
| `tests / test-windows` | 37s |
| `tests / test (3.11 / 3.12 / 3.13)` | 3m42s / 3m48s / 3m27s |
| `linux-x86_64` (the critical path) | 12m25s |

### 2. ccache, and the bug the stats step caught on its first run (`e210b2e`)

ccache was added to the Linux binary jobs, along with a `ccache -s` step whose stated purpose was "a run showing ~0 hits means the cache is not working and the step should go". It earned its place immediately — the first dry run (`32932548044`) cached **nothing**:

```
Nuitka-Scons: Compiled 590 C files using ccache.
Nuitka-Scons: Cached C files (using ccache) with result 'cache miss': 590
...
ccache -s -> Local storage: Cache size (GiB): 0.0 / 5.0 ( 0.00%)
[warning] Path Validation Error: Path(s) specified in the action for caching
          do(es) not exist, hence no cache is being saved.
```

Nuitka does use ccache, but stores it under **its own** cache directory unless the variable is already set — `nuitka/build/SconsCaching.py:167`:

```python
# Unless asked to do otherwise, store ccache files in our own directory.
if "CCACHE_DIR" not in os.environ:
    ccache_dir = getCacheDir("ccache", create=True)   # ~/.cache/Nuitka/ccache
```

So `actions/cache` was watching an empty `~/.cache/ccache`. Setting `CCACHE_DIR` through `$GITHUB_ENV` (not a job-level `env:`, where `$HOME` is not expanded) points the build step and the stats step at one directory. Measured warm, run `32934676605`:

| build | cold | warm |
|---|---|---|
| linux-x86_64 | 12m27s | **4m00s** (-68%) |
| linux-arm64 | 11m01s | **4m16s** (-61%) |

590 of 591 C files served from cache. The original estimate in the comment was 5m32s saved; the measurement is 8m27s.

### 3. The cache a release can actually inherit (`2d1e54b`)

An Actions cache is scoped to the ref that wrote it, and a release only ever runs on a fresh `refs/tags/vX.Y.Z` — so a tag run can never restore the previous tag's cache. Measured directly, not predicted: a tag run on **the same commit** whose cache already existed reported

```
Cache not found for input keys: ccache-linux-x86_64-e210b2eb…, ccache-linux-x86_64-
Hits: 0 / 591 (0.00%)
```

and then wrote its own copy under a separate scope:

| ref | key |
|---|---|
| `refs/heads/refs/tags/v0.0.0-guardtest` | `ccache-linux-x86_64-e210b2eb…` |
| `refs/heads/feat/grid-web-tool` | `ccache-linux-x86_64-e210b2eb…` |

What a tag run *can* restore is the default branch's cache, which nothing else here would write, since the binaries build on no other trigger. A weekly `schedule:` run always runs on the default branch, so it seeds one — and publishes nothing, since all three release steps are gated on `github.event_name == 'push'`.

### Also: the tag must match the wheel (`83fa908`)

v0.1.1 shipped a wheel that printed the wrong version. `pyproject.toml` is the only place the number lives, so comparing the built wheel's filename to the tag is the whole check, and it belongs in CI rather than on a maintainer's laptop because `needs:` means nothing has shipped when it exits 1.

## Test plan

Everything below has been run.

- [x] `actionlint` clean on both files — with a positive control: four injected faults (`needs:` a job that does not exist, `uses:` a missing reusable workflow, a bad expression, an unquoted var in the new `run:` block) were each reported, and exit was 1 on the broken copy
- [x] The guard's shell logic, 6 cases against a real `uv build --wheel`: match -> 0; mismatch -> 1; tag missing its `v` -> 1; no wheel present -> 1 (glob fail-closed). Two edges noted: a `v0.4.0-rc1` tag would false-fail against PEP 440's `0.4.0rc1` wheel, and a `dist/` holding two wheels silently picks the first (fresh checkout on CI, so it cannot happen there)
- [x] Three `workflow_dispatch` dry runs (`32932548044`, `32933722202`, `32934676605`): `tests` runs through `workflow_call`, and the guard, the notes step and the publish step all reported `skipped` — a dispatch cannot publish
- [x] One real tag run (`32935420962`, a deliberately mismatched **lightweight** tag so the notes step was a second fence): step 5 `failure`, steps 6-9 `skipped`, `##[error]tag is v0.0.0-guardtest but the wheel is 0.3.23.`, and **no release was created** — `v0.3.24` remained Latest. Tag and its orphaned caches have been deleted
- [x] `ruff check .` clean; `main` merged into the branch (only the v0.3.24 version bump, no conflict)

## After merging

Run once to seed the ccache on `main`, so the next release is warm instead of waiting for Monday's cron:

```
gh workflow run release.yml --repo autonomous-ai/autonomous-grid --ref main
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rj6we9PzdTy6jxk74Xh5KV