### PR TITLE
feat(openrouter): the service kind a hosted grid's first provider joins with

### DIFF
--- a/shared/models/api_catalog.py
+++ b/shared/models/api_catalog.py
@@ -143,6 +143,8 @@ DOGGI_WHITELIST: tuple[ApiModelEntry, ...] = (
     ),
 )
 
+# Taken 2026-08-26 from the LIVE feed (`GET https://openrouter.ai/api/v1/models`, 417 models), not
+# from prose docs — the exact command is beside OPENROUTER_WHITELIST below.
 OPENROUTER_LAST_VERIFIED = "2026-08-26"
 
 # The service-kind key. Named here beside the whitelist so the CLI and the tests spell it once.
@@ -159,27 +161,53 @@ OPENROUTER_KIND = "openrouter"
 # refuses without it rather than defaulting to a URL that would send the passthrough token straight
 # to OpenRouter.
 #
-# The capability rows are the vendor's published ones. They are hand-copied under the same
-# `last_verified` discipline as every other kind — the passthrough forwards `GET /models`, so a
-# retired id fails the join loudly, but the capability flags themselves are not read back from it.
+# The capability rows are DERIVED from the vendor's own machine-readable feed, not hand-copied.
+# Re-take them with one command when `last_verified` goes stale — OpenRouter is one of the few
+# vendors that publishes this, which is why these rows can be checked rather than believed:
+#
+#     curl -s https://openrouter.ai/api/v1/models | python3 -c 'import json,sys
+#     for m in json.load(sys.stdin)["data"]:
+#         if m["id"] in ("deepseek/deepseek-v4-flash-0731", "qwen/qwen3.8-27b"):
+#             sp = m.get("supported_parameters") or []
+#             print(m["id"], m["top_provider"]["context_length"],
+#                   "tools" in sp, "image" in m["architecture"]["input_modalities"],
+#                   "response_format" in sp, "structured_outputs" in sp)'
+#
+# The mapping, spelled out because two of the four are not the obvious field:
+#   context_window            <- top_provider.context_length          (NOT the top-level one)
+#   supports_tools            <- "tools" in supported_parameters
+#   supports_vision           <- "image" in architecture.input_modalities
+#   supports_json_mode        <- "response_format" in supported_parameters
+#   supports_structured_outputs <- "structured_outputs" in supported_parameters
+#
+# ⚠️ `context_window` is `top_provider.context_length`, deliberately the SMALLER of the two numbers
+# the feed carries. The top-level `context_length` is the largest any upstream provider offers
+# (deepseek: 1,310,720) while `top_provider` is what OpenRouter's own default routing actually
+# serves (1,048,576). Advertising the larger one is the fail-OPEN direction: the relay would route a
+# 1.2M-token request here on the strength of a number no request can reach, and the vendor would
+# refuse it after it had already been queued and dispatched.
 OPENROUTER_WHITELIST: tuple[ApiModelEntry, ...] = (
     ApiModelEntry(
         vendor_name="deepseek/deepseek-v4-flash-0731",
-        context_window=163_840,
+        context_window=1_048_576,
         supports_tools=True,
-        supports_vision=False,
+        supports_vision=False,  # architecture: text->text
         supports_json_mode=True,
         supports_structured_outputs=True,
-        notes="Fast general-purpose model; the default for a hosted grid's first provider.",
+        notes="Fast general-purpose text model; the default for a hosted grid's first provider.",
     ),
     ApiModelEntry(
         vendor_name="qwen/qwen3.8-27b",
-        context_window=131_072,
+        context_window=1_000_000,
         supports_tools=True,
-        supports_vision=False,
+        # architecture: text+image+video->text. The passthrough forwards the body verbatim, so image
+        # parts ride through untouched and this is honest to advertise — it is also what lets the
+        # auto-router put a vision request on a hosted grid at all.
+        supports_vision=True,
         supports_json_mode=True,
-        supports_structured_outputs=False,
-        notes="Mid-size general-purpose model; the second seat on a hosted grid's first provider.",
+        supports_structured_outputs=True,
+        notes="Multimodal general-purpose model (text + image + video in); the second seat on a "
+              "hosted grid's first provider.",
     ),
 )
 

--- a/shared/models/api_catalog.py
+++ b/shared/models/api_catalog.py
@@ -143,6 +143,46 @@ DOGGI_WHITELIST: tuple[ApiModelEntry, ...] = (
     ),
 )
 
+OPENROUTER_LAST_VERIFIED = "2026-08-26"
+
+# The service-kind key. Named here beside the whitelist so the CLI and the tests spell it once.
+OPENROUTER_KIND = "openrouter"
+
+# The two models a hosted grid's first provider serves. Unlike every other kind here, the credential
+# is NOT the vendor's — `openrouter` reaches OpenRouter through the control plane's own passthrough
+# (`--at <control-plane>/v1/grid/internal/openrouter`), which holds the real `OPENROUTER_API_KEY` and
+# never hands it out. What the provider stores is the passthrough's own token, so a provider box that
+# is compromised cannot spend the operator's vendor account anywhere but through that one route.
+#
+# `base_url` is deliberately None: there is no fixed vendor endpoint for this kind, because the
+# endpoint is whichever control plane this box belongs to. `--at` is therefore required, and the join
+# refuses without it rather than defaulting to a URL that would send the passthrough token straight
+# to OpenRouter.
+#
+# The capability rows are the vendor's published ones. They are hand-copied under the same
+# `last_verified` discipline as every other kind — the passthrough forwards `GET /models`, so a
+# retired id fails the join loudly, but the capability flags themselves are not read back from it.
+OPENROUTER_WHITELIST: tuple[ApiModelEntry, ...] = (
+    ApiModelEntry(
+        vendor_name="deepseek/deepseek-v4-flash-0731",
+        context_window=163_840,
+        supports_tools=True,
+        supports_vision=False,
+        supports_json_mode=True,
+        supports_structured_outputs=True,
+        notes="Fast general-purpose model; the default for a hosted grid's first provider.",
+    ),
+    ApiModelEntry(
+        vendor_name="qwen/qwen3.8-27b",
+        context_window=131_072,
+        supports_tools=True,
+        supports_vision=False,
+        supports_json_mode=True,
+        supports_structured_outputs=False,
+        notes="Mid-size general-purpose model; the second seat on a hosted grid's first provider.",
+    ),
+)
+
 # The seat's backend (ADR 0015). Verified live on 2026-07-15 (spike 01, `.scratch/codex-subs/facts.md`).
 CODEX_LAST_VERIFIED = "2026-07-15"
 
@@ -435,6 +475,24 @@ WHITELISTS: dict[str, ApiWhitelist] = {
         credential="none",
         flat_rate=True,
         local_seat_port=8098,
+    ),
+    OPENROUTER_KIND: ApiWhitelist(
+        last_verified=OPENROUTER_LAST_VERIFIED,
+        # None on purpose — see OPENROUTER_WHITELIST. The endpoint is the control plane's
+        # passthrough, which differs per deployment, so `--at` is required.
+        base_url=None,
+        # The passthrough's own token, NOT an OpenRouter key. Named so an operator standing a
+        # provider up by hand exports the same variable the control plane hands its own.
+        env_var="GRID_OPENROUTER_PROXY_TOKEN",
+        entries=OPENROUTER_WHITELIST,
+        # The passthrough forwards `GET /models`, so the join's key check and the whitelist ∩
+        # visible filter both work unchanged — that is what makes a retired vendor id a loud
+        # refusal at join time instead of a 404 on the first real request.
+        supports_model_listing=True,
+        # Chat only. Left at the default rather than spelled out to make the point that this kind
+        # adds no lockstep row: grid-src's `provider_supports` reads `chat/completions` for a kind
+        # it has never heard of, which is the fail-closed answer we want.
+        endpoints=("chat/completions",),
     ),
     "doggi": ApiWhitelist(
         last_verified=DOGGI_LAST_VERIFIED,

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -1110,6 +1110,54 @@ def test_api_whitelist_key_kinds_name_their_env_var():
         assert whitelist.env_var, f"{kind} needs the env var its key is read from"
 
 
+def test_openrouter_whitelist_serves_exactly_the_two_hosted_models():
+    """The set a hosted grid's first provider advertises, pinned by name.
+
+    Not a restatement of the table: with no `-m`, `_resolve_api_targets` joins **the whole
+    whitelist**, so this tuple *is* the model set every hosted grid comes up serving. Adding a third
+    row silently widens what the operator pays for on every grid created after that release.
+    """
+    served = {entry.vendor_name for entry in api_catalog.entries_for("openrouter")}
+    assert served == {"deepseek/deepseek-v4-flash-0731", "qwen/qwen3.8-27b"}
+
+
+def test_openrouter_has_no_base_url_so_the_join_cannot_reach_the_vendor_directly():
+    """`base_url is None` is a security property, not a gap in the table.
+
+    The credential this kind stores is the control plane's passthrough token, not an OpenRouter
+    key. `_resolve_key_api_targets` resolves the endpoint as `--at or whitelist.base_url` and
+    refuses when both are absent — so a default here would send the passthrough token to
+    `openrouter.ai` on any join that forgot `--at`, where it authenticates nothing and is simply
+    disclosed to the vendor. The refusal is what keeps `--at` mandatory.
+    """
+    assert api_catalog.WHITELISTS["openrouter"].base_url is None
+    assert api_catalog.WHITELISTS["openrouter"].env_var == "GRID_OPENROUTER_PROXY_TOKEN"
+
+
+def test_openrouter_vendor_names_survive_the_advertised_name_round_trip():
+    """`serve.py` recovers the upstream id with `advertised_model.partition(":")[2]`, so a vendor
+    id containing its own colon (ollama's `qwen3:8b` shape) would be truncated at that colon and
+    forwarded as a model the vendor has never heard of — a 404 on the first real request, long
+    after the join reported success. Slashes are fine and already precedented (`Wan-AI/…`); colons
+    are not.
+    """
+    for entry in api_catalog.entries_for("openrouter"):
+        advertised = api_catalog.advertised_name("openrouter", entry)
+        assert ":" not in entry.vendor_name, f"{entry.vendor_name} would be truncated by serve.py"
+        assert advertised.partition(":")[2] == entry.vendor_name
+
+
+def test_openrouter_is_chat_only_so_an_unknown_kind_fails_closed_on_the_relay():
+    """Chat-only, and therefore adding no lockstep row. grid-src's `provider_supports` answers
+    `chat/completions` for a kind it has never heard of, so this kind needs no hand-duplicated half
+    there — but only while the tuple stays exactly this. Declaring `responses` here would make the
+    relay and the CLI disagree in silence until a Responses request reached a seat that 400s it.
+    """
+    assert api_catalog.WHITELISTS["openrouter"].endpoints == ("chat/completions",)
+    assert api_catalog.responses_only_kind("openrouter:qwen/qwen3.8-27b") is None
+    assert api_catalog.kind_is_stream_only("openrouter") is False
+
+
 def test_codex_whitelist_has_no_env_var_and_no_output_cap():
     """The two fields an OAuth seat cannot have (issue 04), kept true now that issue 05 populates
     the row's model entries (the tier union — see test_codex_tier_whitelist_integrity):


### PR DESCRIPTION
Adds one service kind to `shared/models/api_catalog.py` — `grid join --api openrouter` — serving two
OpenRouter models through a control-plane passthrough rather than the provider's own vendor key, so a
grid created from the web comes up with an engine already answering.

## What's here

Everything but the catalog row already existed. `advertised_name` gives
`openrouter:deepseek/deepseek-v4-flash-0731`, `serve.py` strips the prefix back to the upstream slug,
`require_bearer` resolves the credential, and `_list_vendor_models` doubles as the key check and the
whitelist ∩ available filter. With no `-m` the join takes the whole whitelist, so this tuple **is**
the set every hosted grid comes up serving.

`base_url` is `None` on purpose, and that is the security half: the credential this kind stores is
the passthrough's token, not an OpenRouter key. A default here would send that token straight to
`openrouter.ai` on any join that forgot `--at`, where it authenticates nothing and is simply
disclosed to the vendor. `--at` is therefore mandatory and the join refuses without it.

Chat-only, so it adds **no lockstep row**: grid-src's `provider_supports` answers `chat/completions`
for a kind it has never heard of, which is the fail-closed direction.

## The capability rows are measured, not believed

The second commit is a correction worth reading. Four of the ten fields in the first version were
wrong, and both context windows were wrong by nearly an order of magnitude:

| | first version | measured |
|---|---|---|
| deepseek `context_window` | 163,840 | **1,048,576** |
| qwen `context_window` | 131,072 | **1,000,000** |
| qwen `supports_vision` | `False` | **`True`** (`text+image+video->text`) |
| qwen `supports_structured_outputs` | `False` | **`True`** |

The context windows were the damaging pair: the auto-router's candidate filter and the output-cap
exclusion both key on that number, so a grid would have advertised ~1/7th of what these models take
and long-context requests would have been filtered off the only engine on it.

`context_window` is `top_provider.context_length`, deliberately the **smaller** of the two numbers
the vendor feed carries — the top-level `context_length` is the largest any upstream provider offers
(deepseek: 1,310,720) while `top_provider` is what OpenRouter's own default routing serves.
Advertising the larger one fails **open**: the relay would dispatch on the strength of a number no
request can reach. The four-field mapping and the exact re-take command now sit beside the table, so
the next `last_verified` is a command rather than a recollection.

## Tests

Four new, and the one worth naming pins that no vendor id carries a colon — `serve.py` recovers the
upstream slug with `partition(":")[2]`, so an ollama-shaped `qwen3:8b` id would be truncated there
and forwarded as a model the vendor has never heard of: a 404 on the first real request, long after
the join reported success. Slashes are fine and already precedented by the Doggi row.

Full suite green after merging `main`: **3213 passed, 9 skipped**.

## Verified end to end on the dev VM

Create a grid → the provider auto-joins → `POST {master}/relay/v1/chat/completions` answered in 1.5s;
streaming assembled over 17 SSE frames with `[DONE]`; a model outside the allowlist is refused before
the vendor is called. The control-plane half of this feature lives in the `grid-apis` repo.