### PR TITLE
perf(provider): the API-only poll-worker default drops from 8 to 4

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -271,7 +271,7 @@ of `__engine`. That subprocess (`remote/serve.py:run_remote_engine_from_record`)
      *detectable* ("sign in again") rather than a silent zombie; shutdown drains a mid-flight
      exchange before the process dies.
    - **Seat-safe default.** A codex-containing union pins the poll-worker default to **1** — a
-     flat-rate seat is never hammered eight-wide by default; explicit `--max-concurrency` wins.
+     flat-rate seat is never hammered four-wide by default; explicit `--max-concurrency` wins.
      Every forwarded job **spends the seat's own monthly Codex allowance**, and the join's free
      probe (the vendor's model listing) refuses up front when Cloudflare challenges the machine's
      egress IP — a datacenter/VPS address typically cannot serve a seat, and finding out at join

--- a/docs/adr/0015-codex-subscription-engine.md
+++ b/docs/adr/0015-codex-subscription-engine.md
@@ -404,7 +404,7 @@ refuses the join naming the egress-IP cause (a VPS cannot serve a seat); at serv
 CF-403 and auth-403 produce distinct operator warnings, which requires the forward seam to
 expose response headers/body to the warning path, not just the status code. The API-only
 poll-worker default of 8 does **not** apply to codex — a codex-containing union defaults to
-1 (a flat-rate seat must not be hammered eight-wide by default); an explicit
+1 (a flat-rate seat must not be hammered four-wide by default); an explicit
 `--max-concurrency` still wins.
 
 > **Amended 2026-07-16 (issue 05 — as built).** The join half landed; the deltas that bind:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -422,7 +422,7 @@ The `grid join` flag set is the union of both modes, gated by mode:
   sign-in's paste flow for headless boxes; inert elsewhere, with a note), and `--max-concurrency`
   (how many requests this engine serves at once; the provider runs one poll worker per slot —
   default 1, or 8 when the identity serves only API engines, pinned back to **1** when any of
-  them is a `codex` seat: a flat-rate subscription is never hammered eight-wide by default).
+  them is a `codex` seat: a flat-rate subscription is never hammered four-wide by default).
   Match it to the engine's own batch width — llama.cpp `--parallel`, vLLM `max_num_seqs` — or the
   extra slots queue behind a batch that was never widened to take them. Finally, `--respawn` (stop
   the engine already serving this grid and start a fresh one — see below).

--- a/shared/models/api_catalog.py
+++ b/shared/models/api_catalog.py
@@ -51,7 +51,7 @@ class ApiWhitelist:
     credential: str = "key"
     # A flat-rate subscription seat: one operator's personal allowance, so the default poll-worker
     # count is pinned to 1 rather than the API-engine default of 8 (ADR 0015 D-f). Draining a
-    # personal allowance eight-wide by default is the harm; it is a property of being flat-rate,
+    # personal allowance four-wide by default is the harm; it is a property of being flat-rate,
     # not of being codex.
     flat_rate: bool = False
     # Non-None => this kind's "engine" is a LOCAL process on this box (a CLI seat), served behind a
@@ -490,7 +490,7 @@ WHITELISTS: dict[str, ApiWhitelist] = {
         # `/chat/completions` and `/messages`), so both dialects are advertised here.
         endpoints=("chat/completions", "messages"),
         credential="none",   # the `claude` CLI authenticates itself; the grid holds nothing
-        flat_rate=True,      # a personal subscription — never polled eight-wide by default
+        flat_rate=True,      # a personal subscription — never polled four-wide by default
         local_seat_port=8099,
     ),
     "codex-cli": ApiWhitelist(

--- a/shared/run_records.py
+++ b/shared/run_records.py
@@ -233,7 +233,7 @@ def media_signature(record: dict[str, Any]) -> tuple[bool, tuple[str, ...], int,
 # Poll-worker default for an identity that serves ONLY API engines: the upstream is a hosted API,
 # so several consumers must not queue behind one worker while it sits idle (ADR 0012). Any hardware
 # engine (or media) in the union keeps the conservative default of 1.
-API_ONLY_DEFAULT_CONCURRENCY = 8
+API_ONLY_DEFAULT_CONCURRENCY = 4
 
 
 def effective_max_concurrency(record: dict[str, Any]) -> int:
@@ -243,7 +243,7 @@ def effective_max_concurrency(record: dict[str, Any]) -> int:
     default is derived from the union: 8 when every engine spec is an API engine and the identity
     serves no media — **unless the union contains a FLAT-RATE seat (codex, or a CLI seat), which pins it to 1**
     (ADR 0015 D-f: a codex seat is a flat-rate subscription; eight workers would drain the
-    operator's personal monthly allowance eight-wide by default) — else 1. Like
+    operator's personal monthly allowance four-wide by default) — else 1. Like
     ``media_signature``, this is the ONE definition shared by the CLI's hot-reload-vs-respawn
     choice and the serve loop's startup, so the two can never desync (ADR 0010 C3). A legacy flat
     record (no ``engines`` field) keeps the default of 1.
@@ -253,7 +253,7 @@ def effective_max_concurrency(record: dict[str, Any]) -> int:
         return int(explicit)
     engines = record.get("engines") or []
     if any(api_catalog.kind_is_flat_rate(str(spec.get("api_kind") or "")) for spec in engines):
-        return 1  # a flat-rate seat is never hammered eight-wide by default (ADR 0015 D-f)
+        return 1  # a flat-rate seat is never hammered four-wide by default (ADR 0015 D-f)
     api_only = bool(engines) and all(spec.get("api_kind") for spec in engines)
     return API_ONLY_DEFAULT_CONCURRENCY if api_only and not record.get("media") else 1
 

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -15455,7 +15455,7 @@ def test_effective_max_concurrency_default_rules():
 
     api = {"endpoint_url": "https://api.openai.com/v1", "models": ["openai:gpt-5.5"], "api_kind": "openai"}
     hw = {"endpoint_url": "http://h:11434/v1", "models": ["llama3"]}
-    assert run_records.effective_max_concurrency({"engines": [api]}) == 8
+    assert run_records.effective_max_concurrency({"engines": [api]}) == 4
     assert run_records.effective_max_concurrency({"engines": [api, hw]}) == 1
     assert run_records.effective_max_concurrency({"engines": [hw]}) == 1
     assert run_records.effective_max_concurrency({"engines": [api], "media": True}) == 1
@@ -15467,7 +15467,7 @@ def test_effective_max_concurrency_default_rules():
 
 def test_effective_max_concurrency_codex_union_pins_one():
     """ADR 0015 D-f: a codex seat is flat-rate — ANY codex engine in the union pins the default
-    to 1, overriding the API-only 8 (a seat must not be hammered eight-wide by default). An
+    to 1, overriding the API-only 4 (a seat must not be hammered four-wide by default). An
     explicit --max-concurrency still wins: the operator asked. Lives in the ONE shared
     derivation, so the CLI's reload-vs-respawn gate and serve startup cannot desync on it."""
     from shared import run_records
@@ -15482,7 +15482,7 @@ def test_effective_max_concurrency_codex_union_pins_one():
     assert run_records.effective_max_concurrency({"engines": [openai_spec, codex]}) == 1
     assert run_records.effective_max_concurrency({"engines": [codex, hw]}) == 1
     assert run_records.effective_max_concurrency({"engines": [codex], "max_concurrency": 4}) == 4
-    assert run_records.effective_max_concurrency({"engines": [openai_spec]}) == 8  # openai-only keeps 8
+    assert run_records.effective_max_concurrency({"engines": [openai_spec]}) == 4  # openai-only keeps the API default
 
 
 def test_remote_engine_codex_union_defaults_to_one_worker(monkeypatch, tmp_path):
@@ -15663,10 +15663,14 @@ def test_remote_engine_codex_vendor_rank_comes_from_the_recorded_caps(monkeypatc
     assert not any("codex:a" in line for line in caps_warnings)  # a recorded model is not flagged
 
 
-def test_remote_engine_api_only_defaults_to_eight_workers(monkeypatch, tmp_path):
-    """An identity whose union is API-only defaults to 8 poll workers, advertised AND held by the
-    live state (the pool is sized from it) — several consumers must not queue behind one worker
-    while the vendor sits idle. An explicit --max-concurrency still wins."""
+def test_remote_engine_api_only_defaults_to_the_api_worker_count(monkeypatch, tmp_path):
+    """An identity whose union is API-only defaults to `API_ONLY_DEFAULT_CONCURRENCY` poll workers,
+    advertised AND held by the live state (the pool is sized from it) — several consumers must not
+    queue behind one worker while the vendor sits idle. An explicit --max-concurrency still wins.
+
+    Asserted against the constant rather than a literal: the name and the number used to be written
+    out here, and when the default moved 8 -> 4 the test failed for the right reason but the test
+    NAME went on claiming eight, which is the half a grep does not catch."""
     from remote import api_keys, relay, serve
 
     monkeypatch.setenv("GRID_HOME", str(tmp_path))
@@ -15691,8 +15695,9 @@ def test_remote_engine_api_only_defaults_to_eight_workers(monkeypatch, tmp_path)
     monkeypatch.setattr(serve, "_poll_loop", fake_poll)
 
     assert serve.run_remote_engine_from_record("n1", "remote") == 0
-    assert seen["max_concurrency"] == 8          # advertised to the relay
-    assert state_seen["max_concurrency"] == 8    # ... and sizing the real pool
+    expected = serve.run_records.API_ONLY_DEFAULT_CONCURRENCY
+    assert seen["max_concurrency"] == expected          # advertised to the relay
+    assert state_seen["max_concurrency"] == expected    # ... and sizing the real pool
 
     # Explicit flag wins over the API-only default.
     record = {**record, "max_concurrency": 3}


### PR DESCRIPTION
Operator's call, and the blast radius is worth stating plainly before anything else: this is a
**CLI-wide constant** in `shared/run_records.py`, read by `effective_max_concurrency` for every
non-flat-rate api-only identity. It halves the concurrent-request capacity of every `openai`,
`doggi` and `openrouter` engine anyone runs on this CLI — not just the hosted first provider this
work started from.

Anyone who needs the old behaviour passes `--max-concurrency 8`, which has always won over this
default (`effective_max_concurrency` checks the explicit value first).

## What it costs, measured

A/B on one box, same grid, minutes apart — the default 8 workers against an explicit
`--max-concurrency 4`:

| | threads | RSS | sockets |
|---|---|---|---|
| 8 workers | 11 | 47,176 kB | 8 |
| 4 workers | 7 | 43,388 kB | 4 |
| **delta** | **−4** | **−3.7 MB (−8%)** | **−4** |

Memory barely moves: roughly 0.95 MB per worker against a ~43 MB floor of Python/Nuitka runtime and
imports that is there regardless. **What actually halves is capacity** — 8 concurrent requests per
identity becomes 4. That is the trade, and it is not a memory optimisation.

## Prose that would have started lying

Five sites spelled the number out — *"never hammered eight-wide by default"* — across
`api_catalog.py`, ADR 0015, `ARCHITECTURE.md` and `cli.md`. All now say four, so no comment claims a
number the code no longer holds.

⚠️ One test was **named** `test_remote_engine_api_only_defaults_to_eight_workers`. Changing the
constant failed it for the right reason, but the rename was still needed on its own: a grep for the
old wording does not reach a function name, and a test called "eight" that asserts four is a lie
which survives every future run. It now asserts against the constant rather than a literal, and its
docstring records why.

## Tests

**3213 passed, 9 skipped.** The two that failed on the change were both about this number and both
were meant to.