### PR TITLE
feat(openrouter): serve the Responses dialect, and stop naming the supplier

### DIFF
--- a/cli/models.py
+++ b/cli/models.py
@@ -60,8 +60,14 @@ def _catalog_api(args: argparse.Namespace) -> int:
     # proxy, which held only while every row had some; a credential-only row (ADR 0015 D-c: codex
     # ships its credential path before issue 05's per-tier model table) made the proxy disagree with
     # the real predicate and print "Unknown API kind 'codex'. Supported: codex, openai".
-    if whitelist is None:
-        supported = ", ".join(api_catalog.supported_kinds())
+    # A kind nobody can join has no catalog to show: this command answers "what would `grid join
+    # --api <kind>` serve me?", and for a grid-run kind the answer is "you cannot run that join".
+    # Refused as UNKNOWN rather than with a reason of its own — a distinct refusal would confirm the
+    # kind exists, which is the one thing `member_joinable=False` is there to avoid.
+    if whitelist is None or not whitelist.member_joinable:
+        # `joinable_kinds`, not `supported_kinds`: this line answers "which did you mean?",
+        # and a kind nobody can join is not one of the answers (see ApiWhitelist).
+        supported = ", ".join(api_catalog.joinable_kinds())
         raise SystemExit(f"Unknown API kind {kind!r}. Supported: {supported}")
 
     # A tier-keyed kind prints per tier — its flat `entries` (the tier union) exists for the

--- a/cli/remote_provider.py
+++ b/cli/remote_provider.py
@@ -118,7 +118,10 @@ def _reject_api_conflicts(args: argparse.Namespace) -> None:
     optional: omitted, the join serves the whole whitelist the key can see (zero-config default)."""
     kind = args.api
     if kind not in api_catalog.WHITELISTS:
-        supported = ", ".join(api_catalog.supported_kinds())
+        # See `_catalog_api` in cli/models.py: the OFFER is `joinable_kinds`, while the membership
+        # test above stays the WHOLE table — `grid join --api openrouter` is what the control plane
+        # runs for every grid it creates, and narrowing this line would refuse it.
+        supported = ", ".join(api_catalog.joinable_kinds())
         raise SystemExit(f"Unknown API kind {kind!r}. Supported: {supported}")
     conflicts = (
         ("serve", "--serve"),

--- a/shared/models/api_catalog.py
+++ b/shared/models/api_catalog.py
@@ -58,6 +58,23 @@ class ApiWhitelist:
     # loopback server on this default port. Also what makes the kind joinable in local mode. Each
     # seat needs a DIFFERENT default so two seats can run on one box without colliding.
     local_seat_port: int | None = None
+    # Whether a person can join with this kind at all. False for a kind the GRID stands up on a
+    # member's behalf, holding a credential the member never sees — only `openrouter` today.
+    #
+    # ONE field because two surfaces turn on the same fact and must not drift apart:
+    #
+    #   * `joinable_kinds` — what `--api` offers when somebody names a kind that doesn't exist. A
+    #     kind nobody can join is not an answer to "which did you mean?".
+    #   * `advertised_name` — a joinable kind's models are namespaced `<kind>:<vendor>`; this one's
+    #     are advertised BARE. The prefix would print the name of a supplier the member has no
+    #     relationship with on every surface carrying a model id: the picker, `GET /v1/models`, and
+    #     the client config they copy out of the app — which must carry the wire id verbatim and so
+    #     cannot be relabelled by any display layer.
+    #
+    # Bare ids are safe *because* of the first fact and not otherwise: a bare id can collide with a
+    # hardware engine's model name, and only a kind whose model set the grid itself chooses can
+    # promise it doesn't.
+    member_joinable: bool = True
 
 # Verified against https://platform.openai.com/docs/models (which 301-redirects to
 # https://developers.openai.com/api/docs/models) on 2026-07-08.
@@ -517,10 +534,24 @@ WHITELISTS: dict[str, ApiWhitelist] = {
         # visible filter both work unchanged — that is what makes a retired vendor id a loud
         # refusal at join time instead of a 404 on the first real request.
         supports_model_listing=True,
-        # Chat only. Left at the default rather than spelled out to make the point that this kind
-        # adds no lockstep row: grid-src's `provider_supports` reads `chat/completions` for a kind
-        # it has never heard of, which is the fail-closed answer we want.
-        endpoints=("chat/completions",),
+        # BOTH dialects. The vendor serves a Responses route beside its chat one (probed
+        # 2026-08-27: `POST /api/v1/responses` answers 401 — the route exists and wants a key —
+        # where an invented path answers a 404 HTML page), and the control plane's passthrough
+        # mounts a `responses` half beside its `chat/completions` one. Chat alone is what made a
+        # hosted grid answer *no* to Codex: the relay folds `advertises_responses` from the
+        # per-model `endpoints` capability, so a grid whose only provider was this one told the app
+        # it served no dialect Codex speaks.
+        #
+        # ⚠️ This is a LOCKSTEP row, and it did not used to be one. `responses` here means the
+        # provider will POST `{--at}/responses`; absent on the passthrough that is a bare 404 on
+        # every Codex turn. **Roll the control plane out BEFORE this provider release.** The
+        # opposite order is free: a passthrough serving a route nobody asks for costs nothing.
+        endpoints=("chat/completions", "responses"),
+        # Nobody joins with this kind: the grid stands the provider up itself, on a passthrough
+        # token no member holds. So it is absent from `joinable_kinds` and its models are
+        # advertised BARE — `deepseek/deepseek-v4-flash-0731`, never `openrouter:deepseek/…`. See
+        # `ApiWhitelist.member_joinable` for why the two are one field.
+        member_joinable=False,
     ),
     "doggi": ApiWhitelist(
         last_verified=DOGGI_LAST_VERIFIED,
@@ -533,7 +564,23 @@ WHITELISTS: dict[str, ApiWhitelist] = {
 
 
 def supported_kinds() -> tuple[str, ...]:
+    """Every kind this build knows, joinable or not — the set `--api` VALIDATES against.
+
+    Deliberately the whole table: narrowing this is how `--api openrouter` would start being
+    refused for the one caller that has a token for it. What a person is OFFERED is
+    `joinable_kinds`, and the two are different questions.
+    """
     return tuple(sorted(WHITELISTS))
+
+
+def joinable_kinds() -> tuple[str, ...]:
+    """The kinds a person can name on `--api` — what an unknown-kind refusal lists.
+
+    See `ApiWhitelist.member_joinable`: a kind the grid stands up on a member's behalf is not an
+    answer to "which did you mean?", and naming it there tells every member who mistypes a flag
+    which upstream service their grid buys from.
+    """
+    return tuple(sorted(k for k, w in WHITELISTS.items() if w.member_joinable))
 
 
 def advertised_name(kind: str, entry: ApiModelEntry) -> str:
@@ -544,7 +591,16 @@ def advertised_name(kind: str, entry: ApiModelEntry) -> str:
     prefix. Nothing in its catalog changes that (`tool_mode`, `use_responses_lite` and
     `multi_agent_version` were all patched in its own cache, still 0), so the prefix is the only
     thing that keeps those models usable at all.
+
+    A kind whose row sets ``member_joinable=False`` is advertised BARE, and that is the one case
+    where the reasoning above does not apply: nothing on the far end recognises the id, and the
+    prefix's only remaining effect is to name the upstream service to every member of every grid.
+    An unknown kind namespaces — the fail-safe direction, since a bare id can collide with a
+    hardware engine's model name while a namespaced one cannot.
     """
+    whitelist = WHITELISTS.get(kind)
+    if whitelist is not None and not whitelist.member_joinable:
+        return entry.vendor_name
     return f"{kind}:{entry.vendor_name}"
 
 
@@ -660,7 +716,10 @@ def _discovered_codex_cli_entries() -> tuple[ApiModelEntry, ...]:
 def find_advertised(kind: str, advertised: str) -> ApiModelEntry | None:
     """The whitelist entry advertised under ``advertised`` (e.g. ``openai:gpt-5.5``), or None.
 
-    Only the namespaced form resolves — a bare vendor name is not an advertised name.
+    Only this kind's OWN advertised spelling resolves: the namespaced form for a namespaced kind,
+    the bare vendor name for one whose row sets ``namespaced=False``. It compares what
+    ``advertised_name`` produces rather than re-deriving the shape, so the two cannot disagree —
+    and a bare vendor name is still not an advertised name for a namespaced kind.
     """
     whitelist = WHITELISTS.get(kind)
     if whitelist is None:

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -886,7 +886,13 @@ def test_api_whitelist_integrity():
             if whitelist.supports_model_listing and kind != api_catalog.CODEX_KIND:
                 assert entry.context_window > 0
             assert entry.context_window >= 0
-            assert api_catalog.advertised_name(kind, entry) == f"{kind}:{entry.vendor_name}"
+            # Namespaced for every kind a person can join; BARE for a kind the grid stands up
+            # itself. Keyed on the row's own flag rather than on the kind's name, so a second
+            # grid-run kind inherits the rule instead of tripping this assertion.
+            expected = (
+                f"{kind}:{entry.vendor_name}" if whitelist.member_joinable else entry.vendor_name
+            )
+            assert api_catalog.advertised_name(kind, entry) == expected
         date.fromisoformat(whitelist.last_verified)  # dated, ISO format
         # APIs with base_url=None require --at (e.g. Doggi); others must have a valid HTTPS URL.
         if whitelist.base_url is not None:
@@ -1135,26 +1141,110 @@ def test_openrouter_has_no_base_url_so_the_join_cannot_reach_the_vendor_directly
 
 
 def test_openrouter_vendor_names_survive_the_advertised_name_round_trip():
-    """`serve.py` recovers the upstream id with `advertised_model.partition(":")[2]`, so a vendor
-    id containing its own colon (ollama's `qwen3:8b` shape) would be truncated at that colon and
-    forwarded as a model the vendor has never heard of — a 404 on the first real request, long
-    after the join reported success. Slashes are fine and already precedented (`Wan-AI/…`); colons
-    are not.
+    """`serve.py` recovers the upstream id with `advertised_model.partition(":")[2] or advertised`,
+    so a vendor id containing its own colon (ollama's `qwen3:8b` shape) would be truncated at that
+    colon and forwarded as a model the vendor has never heard of — a 404 on the first real request,
+    long after the join reported success. Slashes are fine and already precedented (`Wan-AI/…`);
+    colons are not.
+
+    ⚠️ The colon ban got MORE load-bearing when this kind went bare, not less. Namespaced, the
+    `partition` split at the kind's own colon and a vendor colon merely truncated the tail; bare,
+    the split lands INSIDE the vendor name and the recovered id is its tail alone.
     """
     for entry in api_catalog.entries_for("openrouter"):
         advertised = api_catalog.advertised_name("openrouter", entry)
         assert ":" not in entry.vendor_name, f"{entry.vendor_name} would be truncated by serve.py"
-        assert advertised.partition(":")[2] == entry.vendor_name
+        # serve.py's own expression, verbatim — the thing that must round-trip.
+        assert (advertised.partition(":")[2] or advertised) == entry.vendor_name
+        assert api_catalog.find_advertised("openrouter", advertised) is entry
 
 
-def test_openrouter_is_chat_only_so_an_unknown_kind_fails_closed_on_the_relay():
-    """Chat-only, and therefore adding no lockstep row. grid-src's `provider_supports` answers
-    `chat/completions` for a kind it has never heard of, so this kind needs no hand-duplicated half
-    there — but only while the tuple stays exactly this. Declaring `responses` here would make the
-    relay and the CLI disagree in silence until a Responses request reached a seat that 400s it.
+def test_openrouter_models_are_advertised_bare():
+    """No `openrouter:` prefix on the wire, and this is the ONLY place that can be true.
+
+    The id reaches a member in three forms no display layer can rewrite: `GET /v1/models`, the
+    Hermes/OpenClaw/Codex config the app hands them to paste, and the relay's own routing. Hiding
+    the vendor's name in the app alone would leave it in all three.
     """
-    assert api_catalog.WHITELISTS["openrouter"].endpoints == ("chat/completions",)
+    advertised = [
+        api_catalog.advertised_name("openrouter", entry)
+        for entry in api_catalog.entries_for("openrouter")
+    ]
+    assert advertised == ["deepseek/deepseek-v4-flash-0731", "qwen/qwen3.8-27b"]
+    assert not any(name.startswith("openrouter") for name in advertised)
+
+
+def test_openrouter_is_not_offered_as_a_kind_anyone_can_join():
+    """Absent from every surface that NAMES the kinds, present in the one that validates them.
+
+    A member who mistypes `--api` gets the list of kinds they could have meant, and this one is not
+    among them; the control plane's own `grid join --api openrouter` still resolves, because the
+    membership test stayed the whole table.
+    """
+    assert "openrouter" in api_catalog.supported_kinds()
+    assert "openrouter" not in api_catalog.joinable_kinds()
+    assert set(api_catalog.joinable_kinds()) < set(api_catalog.supported_kinds())
+    # Every other kind is joinable — this is a one-row exception, not a new default.
+    assert set(api_catalog.supported_kinds()) - set(api_catalog.joinable_kinds()) == {"openrouter"}
+
+
+def test_catalog_refuses_a_grid_run_kind_without_confirming_it_exists(capsys):
+    """`grid catalog --api openrouter` reads as an unknown kind — the same refusal a typo gets.
+
+    A refusal of its own ("that kind isn't yours to join") would confirm the kind exists, which is
+    the one thing the flag is for. The listed alternatives must not name it either.
+    """
+    with pytest.raises(SystemExit) as exc:
+        cli.cmd_catalog(argparse.Namespace(api="openrouter", json=False))
+
+    message = str(exc.value)
+    assert "Unknown API kind 'openrouter'" in message
+    # The message names the kind the caller typed — that is their own word back. What must never
+    # appear is the kind in the SUPPORTED list, where the app would be volunteering it.
+    assert "Supported:" in message
+    assert "openrouter" not in message.split("Supported:", 1)[1]
+
+
+def test_the_join_still_accepts_the_kind_the_control_plane_starts():
+    """The narrowing must not reach VALIDATION — this is the property the whole change rests on.
+
+    `grid join --api openrouter` is what the control plane runs for every grid it creates. Made to
+    read `joinable_kinds` too, the refusal above would take every hosted grid's provider with it and
+    the create path would report it as "not started" once per grid, forever.
+    """
+    from cli import remote_provider
+
+    args = argparse.Namespace(
+        api="openrouter", serve=None, advertise_as=None, media=None, bundles=None,
+    )
+    remote_provider._reject_api_conflicts(args)  # no SystemExit == accepted
+
+    with pytest.raises(SystemExit) as exc:
+        remote_provider._reject_api_conflicts(
+            argparse.Namespace(
+                api="not-a-kind", serve=None, advertise_as=None, media=None, bundles=None,
+            )
+        )
+    assert "openrouter" not in str(exc.value)
+
+
+def test_openrouter_serves_both_dialects_so_codex_runs_on_a_hosted_grid():
+    """The lockstep row this kind gained (2026-08-27).
+
+    Chat-only was what made the app tell a member *Codex is not available on this grid*: the relay
+    folds `advertises_responses` from the per-model `endpoints` capability, so a grid whose only
+    provider was this one advertised no dialect Codex speaks. The vendor serves a Responses route
+    (probed: `POST /api/v1/responses` → 401, an invented path → 404), and the control plane's
+    passthrough mounts a `responses` half beside its chat one.
+
+    ⚠️ **Roll the control plane out BEFORE this provider release** — `responses` here means the
+    provider will POST `{--at}/responses`, and against a passthrough without that route every Codex
+    turn is a bare 404. The other order costs nothing.
+    """
+    assert api_catalog.WHITELISTS["openrouter"].endpoints == ("chat/completions", "responses")
+    # Not responses-ONLY: `grid chat` must keep working against these models.
     assert api_catalog.responses_only_kind("openrouter:qwen/qwen3.8-27b") is None
+    assert api_catalog.responses_only_kind("qwen/qwen3.8-27b") is None
     assert api_catalog.kind_is_stream_only("openrouter") is False
 
 


### PR DESCRIPTION
## What

- `openrouter` gains `responses` in its `endpoints` tuple.
- New `ApiWhitelist.member_joinable`, False only for `openrouter` — the one kind nobody joins, because the grid stands it up on a passthrough token no member holds. One field, two surfaces:
  - `joinable_kinds()` — what an unknown-`--api` refusal offers, and what `grid catalog --api` answers for at all;
  - `advertised_name` — these models are advertised **bare**: `deepseek/deepseek-v4-flash-0731`, never `openrouter:deepseek/…`.

## Why

Chat-only is what made the app say *Codex is not available on this grid*: the relay folds `advertises_responses` from the per-model endpoint capability.

The bare id is the only place the second decision can be made. The id reaches a member through `GET /v1/models`, through the Hermes/OpenClaw/Codex config the app hands them to paste, and through the relay's routing — no display layer can rewrite those.

`supported_kinds()` deliberately still returns the whole table: it is what `--api` validates against, and narrowing it is how the control plane's own `grid join --api openrouter` would start being refused. A test pins exactly that.

## ⚠️ Rollout order

**The control plane ships FIRST** (autonomous-grid-be#2). `responses` here means the provider POSTs `{--at}/responses`; against a passthrough without that route it is a bare 404 on every Codex turn.

## Test plan

- [x] Full suite: 3217 passed, 9 skipped
- [x] `ruff check` clean on every changed file
- [x] Mutation check: flipping `member_joinable`, and narrowing the `--api` validation, each turn the right tests red
- [x] Vendor probed live — both models serve `/responses` in all three shapes
- [x] Deployed to dev and re-joined both provider homes: overview flips to `advertises_responses: true`, node `Grid`, bare ids
- [x] Real Responses inference through the relay, parsed clean by the official `openai` SDK
- [ ] Codex CLI itself — not installed on either box, still unproven