### PR TITLE
fix(cli): make the first-run path work end to end

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,328 +4,325 @@
 
 ### Your AI intranet: network the computers you already own for inference and training.
 
+[![latest release](https://img.shields.io/github/v/release/autonomous-ai/autonomous-grid?label=version)](https://github.com/autonomous-ai/autonomous-grid/releases)
+
 [**Quickstart**](#quickstart) · [From anywhere](#working-from-anywhere) · [Inference](#inference) · [Training](#training-experimental) · [How it works](#how-it-works) · [CLI reference](docs/cli.md) · [Contributing](#contributing)
 
 https://github.com/user-attachments/assets/9573e961-423f-45ae-ada6-b7a8a361f188
 
 </div>
 
-An inference server serves whatever models fit on one machine. Grid puts every machine you have
-behind **one OpenAI-compatible endpoint**.
+**Grid** puts every computer you own behind one OpenAI-compatible endpoint, and sends each request
+to whichever one runs the right model. Local by default — no account, no relay, nothing to sign
+into.
 
-**Inference.** Each request routes to whichever computer runs the right model. Running one takes an
-inference engine — bring yours, or let Grid install one. Ollama, vLLM, LM Studio, MLX, llama.cpp and
-ComfyUI stay where they are; Grid does not replace them, it networks them.
+If you want a desktop app instead of a terminal, get it at [autonomous.ai/grid](https://www.autonomous.ai/grid).
+If your computers are in different places, start here then switch to [remote mode](#working-from-anywhere).
+If you already run Ollama, vLLM or LM Studio, keep them — Grid networks them, it does not replace them.
 
-**Training.** The same fleet teaches a small model your work, and the data, the attempts and the
-weights never leave your network. It belongs here because RL fine-tuning is roughly 75% sampling,
-sampling is inference, and inference is what a grid already does.
+## Install
 
-**Intranet** — the old word for a private network. An AI intranet is every computer you own,
-answering as one.
-
-**Local by default: no account, no relay, nothing to sign into.** Your apps point at a machine on
-your own network, and it keeps working if we disappear. From outside your network:
-[Working from anywhere](#working-from-anywhere).
-
-<img src="docs/home-grid.png" alt="Grid Desktop, OpenClaw, Hermes and your own app all draw from one local AI grid spanning every machine you own. The grid is a single box holding two halves — inference, and training marked experimental — beside a roll-up of what it adds up to: 5 nodes, 5 models, 424 GB of GPU memory. Underneath, the computers you already own join it, each keeping the engine it already runs: a MacBook Pro on MLX with 64 GB serving Qwen3-30B-A3B, a Mac Studio on MLX with 256 GB serving MiniMax-M2, a Mac mini on Ollama with 24 GB serving Gemma 3 12B, an RTX 6000 on vLLM with 48 GB serving Qwen3-32B, and an RTX 5090 on vLLM with 32 GB serving Gemma 3 27B." width="860">
-
-
----
-
-## Quickstart
-
-> [!TIP]
-> **Prefer an app?** Download it here: **[autonomous.ai/grid](https://www.autonomous.ai/grid)**.
-
-**Install** — on each computer (macOS / Linux):
+On every computer, macOS or Linux:
 
 ```bash
 curl -fsSL https://grid.autonomous.ai/install.sh | bash
 ```
 
-That gives you a command called `grid`. Check it worked before going on:
+That installs a command called `grid`. Check it with `grid --version`.
+
+> [!TIP]
+> "command not found" — open a new terminal and try again.
+
+---
+
+## Quickstart
+
+Two computers: one hosts the grid, the other runs a model for it. They can be the same computer —
+or more than two; add each one the same way. Follow these steps in order.
+
+**Step 1 — the computer that will host the grid.** It only routes requests, so it does not need a
+graphics card:
 
 ```bash
-grid --version
-# grid 0.3.23
+grid start
+```
+```
+✓ Grid 'home' running — http://192.168.1.25:8090
 ```
 
-If you get "command not found", close the terminal and open a new one, then try again.
+Copy that address — the other computers join at it, and your apps send every request to it.
+Lost it? `grid info` prints it again.
 
-<details>
-<summary>Installing a specific version, or from source</summary>
-
-Pin a release by setting `GRID_VERSION` before installing:
+**Step 2 — the computer that will run a model.** A different machine from step 1:
 
 ```bash
-GRID_VERSION=0.3.23 curl -fsSL https://grid.autonomous.ai/install.sh | bash
-```
-
-Working on Grid itself? Clone the repository and install it in editable mode with
-[uv](https://docs.astral.sh/uv/) instead:
-
-```bash
-uv tool install -e . --force
-```
-
-`agrid` is installed as a second name for the same command, for machines where something else
-already answers to `grid`.
-
-</details>
-
-### What you are about to build
-
-Say you own three computers and one of them has a good graphics card. Normally an AI model runs on
-one machine, and only that machine can use it.
-
-A **grid** puts a single address in front of all of them. Your apps send every request to that one
-address; the grid works out which computer has the right model and forwards it there. Add a
-computer and its models join the pool. Turn one off and the rest keep working.
-
-Three words appear throughout, and they mean exactly this:
-
-| | |
-|---|---|
-| **grid** | the single address your apps talk to. One computer hosts it. |
-| **engine** | the program that actually runs a model. Grid installs one for you. |
-| **model** | the AI itself — a file you download once, several gigabytes. |
-
-Four steps, and **each one says which computer to run it on** — that is the part that trips people
-up. Step 1 happens once, on one machine. Step 2 is repeated on every machine that will run a model.
-Remote mode changes [three commands](#working-from-anywhere).
-
-### 1 · Start a grid
-
-**Run on: one computer, once.** Pick whichever machine is usually left on — a Mac mini, a desktop,
-the box already sitting in the corner. It does **not** need a graphics card, because this machine is
-directing traffic, not running models.
-
-```bash
-grid up
-# grid=home
-# grid_url=http://192.168.1.25:8090
-```
-
-`grid up` starts a small program that keeps running in the background on this computer. That
-program *is* the grid: it listens on the address printed above, keeps track of which computers have
-joined, and passes each request to whichever one can answer it. Nothing is downloaded and no model
-runs yet — you have just opened the front door.
-
-**Copy that `grid_url` somewhere.** Every other computer needs it in step 2, and your apps need it
-in step 4. `home` is just a name; you can have more than one grid later.
-
-To stop it again: `grid down`. The setup is remembered, so `grid up` brings it straight back.
-
-> **If you see a warning that nothing can reach the address**, the grid is running fine — it simply
-> picked the wrong one of your machine's network addresses, which happens on computers running a
-> VPN. Follow the two commands the warning prints. To try everything on a single computer first,
-> use `grid up --advertise-host 127.0.0.1`.
-
-One more thing, only if you ever make a second grid: creating it does not switch you to it.
-`grid up research` builds a grid called *research*, but `grid info`, `grid models` and `grid chat`
-keep meaning the first one until you run `grid use research`. With a single grid — where most
-people stay — this never comes up.
-
-### 2 · Add a computer
-
-**Run on: every computer that will run a model** — including the one from step 1, if it has a GPU
-worth using. Repeat this whole step per machine.
-
-A model needs an **inference engine** to run it — Grid does not run models itself. Bring one you
-already have, or install the one Grid ships (llama.cpp).
-
-You do not have to work out which build suits your hardware. Run this and it tells you what it
-found, what it installed, and whether anything faster is available to you:
-
-```bash
+# Install the program that runs models on this computer
 grid engine install llama.cpp
+
+# Download a model — several gigabytes, once. A repo with more than one file lists
+# them and asks; press Enter to take the flagged default.
+grid pull unsloth/gemma-3-4b-it-GGUF
+```
+```
+Saved /Users/you/.grid/models/gemma-3-4b-it-Q4_K_M.gguf
+Supports vision. Downloading unsloth/gemma-3-4b-it-GGUF/mmproj-F16.gguf ...
+Saved /Users/you/.grid/models/gemma-3-4b-it-Q4_K_M.mmproj.gguf
 ```
 
-**On macOS** it downloads an official, SHA-256-verified release. Metal, no Homebrew, no admin
-rights, nothing else to decide:
+This one also reads images — `grid pull` fetched the second file it needs for that automatically.
 
-```
-Installed llama-server -> ~/.grid/bin/llama-server
-```
-
-**On Linux with an NVIDIA GPU** it reads your cards first, then installs the Vulkan build — real
-GPU inference on those same cards, without the multi-gigabyte CUDA toolkit:
-
-```
-Detected GPUs: sm_120, sm_120
-Installed llama-server -> ~/.grid/bin/llama-server
-
-This is the Vulkan build — it runs on your NVIDIA GPUs with no CUDA toolkit.
-CUDA is faster, and this machine can build it:
-    grid engine install llama.cpp --from-source
-```
-
-That last line is a live answer about *your* machine, not a generic suggestion. llama.cpp publishes
-no prebuilt CUDA for Linux, so CUDA has to be compiled here — and compiling is only worth starting
-if it can finish. Grid checks your toolchain and says so. When it can't, you get the reason instead
-of the offer:
-
-```
-CUDA would be faster, but not from this machine yet:
-  This CUDA toolkit cannot build for compute_120 — the newest it supports is compute_89.
-  RTX 50-series needs CUDA 12.8 or newer; install a current toolkit from NVIDIA rather
-  than your distro's default package.
-```
-
-So the choice in front of you is:
-
-| | you get | costs you | pick it when |
-|---|---|---|---|
-| **Vulkan** (default) | GPU inference now | one download | you want to be running today |
-| **CUDA** `--from-source` | the fastest backend | CUDA toolkit + a long compile | the box is a permanent node |
-
-`--from-source` runs the same check before it clones anything, so it refuses up front rather than
-failing partway through a build.
-
-**On Linux with no GPU** the same command installs the CPU build and says so.
-
-Next, download a model onto this computer. Grid keeps a short list of models it knows are worth
-running, each under a **short name** you can pass to `grid pull`:
+Now hand it to the grid. Four values, three of them yours to fill in:
 
 ```bash
-grid catalog
-# Grid can pull:
-#   qwen36-35b-a3b-mtp   unsloth/Qwen3.6-35B-A3B-MTP-GGUF/...  (Apple Silicon, min 32 GB, language)
-#   qwen36-27b-mtp       unsloth/Qwen3.6-27B-MTP-GGUF/...      (NVIDIA, min 24 GB, language)
+grid join <grid-url> \
+    --serve "<model-file>" \
+    --advertise-as "<model-name>" \
+    --name "<computer-name>"
 ```
 
-Pick the one matching this computer and pull it. This downloads several gigabytes:
+| | what to put there |
+|---|---|
+| `<grid-url>` | the address step 1 printed |
+| `<model-file>` | the filename `grid pull` just saved, ending `.gguf` |
+| `<model-name>` | what apps will ask for — anything short and readable |
+| `<computer-name>` | a label for this computer, so you can tell it apart later |
+
+**Step 3 — back on the computer hosting the grid:**
 
 ```bash
-grid pull qwen36-35b-a3b-mtp                       # Apple Silicon, 32 GB unified memory or more
-# Resolved catalog label 'qwen36-35b-a3b-mtp' -> unsloth/Qwen3.6-35B-A3B-MTP-GGUF/...
-# Saved /Users/you/.grid/models/Qwen3.6-35B-A3B-UD-IQ3_S.gguf
+# What the grid can answer right now
+grid models
 
-grid pull qwen36-27b-mtp                           # NVIDIA, 24 GB VRAM or more
-# Saved /home/you/.grid/models/Qwen3.6-27B-UD-Q5_K_XL.gguf
+# Ask it something — the <model-name> you chose above
+grid chat -m "<model-name>" "write a haiku about local GPUs"
 ```
 
-**Not in the catalog?** Models live on a site called Hugging Face, and any model there in the
-`.gguf` format works. Give the repository, a colon, then the exact filename inside it — both are
-visible on that model's "Files" tab:
-
-```bash
-grid pull unsloth/gemma-3-4b-it-GGUF:gemma-3-4b-it-Q4_K_M.gguf
-#         └──── the repository ────┘ └──── the file in it ────┘
-```
-
-**Models that can see pictures work too, and you do not have to do anything extra.** A model like
-that is shipped as two files — the model, plus a second one that handles images — and `grid pull`
-fetches both when it finds them:
-
-```bash
-grid pull ggml-org/SmolVLM-256M-Instruct-GGUF:SmolVLM-256M-Instruct-Q8_0.gguf
-# Saved ~/.grid/models/SmolVLM-256M-Instruct-Q8_0.gguf
-# This is a vision model. Downloading mmproj-SmolVLM-256M-Instruct-Q8_0.gguf ...
-# Saved ~/.grid/models/SmolVLM-256M-Instruct-Q8_0.mmproj.gguf
-```
-
-When you serve it in a moment, Grid spots that second file on its own and turns image support on —
-you will see `Vision: serving with projector …` — and tells the grid the model accepts pictures, so
-your apps can send them.
-
-Now hand that model to the grid. **The name you pull with and the name you serve with are
-different**, and this is the one place people get stuck: `grid pull` takes the short catalog name,
-while `--serve` takes the **filename that was saved** — the path printed on the `Saved` line above.
-`--advertise-as` then gives the grid a short name again, so your apps ask for something readable
-instead of a filename:
-
-```bash
-grid join http://192.168.1.25:8090 \
-    --serve Qwen3.6-35B-A3B-UD-IQ3_S.gguf \
-    --advertise-as qwen36-35b-a3b-mtp \
-    --name mac-studio
-```
-
-Reading that command left to right: join *the grid at this address* (the `grid_url` from step 1),
-start the engine on *this model file*, tell the grid to call it *qwen36-35b-a3b-mtp*, and list this
-computer as *mac-studio*.
-
-It waits until the model is genuinely loaded, then tells you so:
-
-```
-✓ Serving on grid 'home'
-    qwen36-35b-a3b-mtp
-  engine address   http://192.168.1.10:8081/v1
-  this computer    mac-studio
-
-  Try it:   grid chat -m qwen36-35b-a3b-mtp "hello"
-  Stop it:  grid leave home --engine mac-studio
-```
-
-Large models take a while to load. If it is still loading, you get a `tail -f` command to watch
-progress instead — and if it fails, the reason is printed right there, not buried in a file.
-
-On NVIDIA the only change is the filename:
-
-```bash
-    --serve Qwen3.6-27B-UD-Q5_K_XL.gguf --advertise-as qwen36-27b-mtp --name gpu-box
-```
-
-Forgotten the filename? `grid catalog` reprints every model on this machine under **Local models:**.
-
-The built-in engine sizes itself to the machine: at load it measures free memory and takes the
-largest context that fits, capped by what the model was trained for. Pin it with `--ctx-size N` when
-you need an exact window — that turns the automatic fit off, so an `N` this machine cannot hold
-fails to start rather than quietly shrinking. `--n-predict`, `--parallel`, `--temp`, `--flash-attn`,
-`--reasoning-budget` and `--endpoint-port` are there too — `grid join --help` and
-[docs/cli.md](docs/cli.md) have the full set.
-
-**Already running Ollama, vLLM or LM Studio?** Point Grid at it instead. `--at` is its address on
-your network, and `-m` is the model that machine already serves.
-
-```bash
-grid join http://192.168.1.25:8090 --at http://192.168.1.20:8000/v1 -m qwen3-coder --name gpu-4090
-```
-
-Repeat for each computer.
-
-### 3 · Ask it something
-
-**Run on: the computer from step 1.** That machine already knows the grid, so these commands need
-no arguments. From any *other* computer, name the grid by its URL — `grid models
-http://192.168.1.25:8090`, `grid chat --grid http://192.168.1.25:8090 ...` — otherwise you get
-`No grids yet. Run 'grid up' to bring one online.`, which means *this* machine has no grid
-configured, not that your grid is down.
-
-First see what the grid can actually serve right now — this answers "did step 2 work":
-
-```bash
-grid models --verbose
-# MODEL               ENGINE      WHERE
-# qwen36-35b-a3b-mtp  mac-studio  http://192.168.1.10:8081/v1
-# qwen3-coder         gpu-4090    http://192.168.1.20:8000/v1
-```
-
-One row per model the grid can reach. `MODEL` is the name to ask for — `qwen36-35b-a3b-mtp` is the
-one you set with `--advertise-as`, and `qwen3-coder` came from the Ollama machine, which was already
-serving it under that name. `ENGINE` is the `--name` you gave each computer. An empty list means no
-computer has joined yet; go back to step 2.
-
-Then ask it something, using a name from the `MODEL` column:
-
-```bash
-grid chat -m qwen36-35b-a3b-mtp "write a haiku about local GPUs"
-```
-
-### 4 · Point your apps at it
-
-**Run on: whichever computer your app runs on.** Your app talks to the grid the same way it talks
-to OpenAI — one base URL and a key — so anything that speaks the OpenAI API works unmodified.
-
-`grid info --env` prints those two values for whichever mode you are in:
+**Step 4 — point your apps at it.** Anything that speaks the OpenAI API:
 
 ```bash
 grid info --env
-# OPENAI_BASE_URL=http://192.168.1.25:8090/v1
-# OPENAI_API_KEY=local-grid
 ```
+```
+export OPENAI_BASE_URL='http://192.168.1.25:8090/v1'
+export OPENAI_API_KEY='local-grid'
+```
+
+That is the whole path. Done for now? See [Stopping, leaving, deleting](#stopping-leaving-deleting).
+The rest of this page explains the pieces.
+
+### What a grid is
+
+A model runs on one computer, and only that computer can use it.
+
+A **grid** is a single address standing in front of several computers. Send a request there and it
+goes to whichever computer holds the right model. Add a computer and its models join the pool; stop
+one and the rest keep working.
+
+- **grid** — the address apps send requests to. One computer hosts it.
+- **engine** — the program that runs a model. Grid installs one for you.
+- **model** — the AI itself. One file, several gigabytes, downloaded once.
+
+Every grid has two ways to refer to it, and commands take one or the other:
+
+| | what it looks like | what takes it |
+|---|---|---|
+| **grid name** | `home`, `research` | `grid start`, `grid stop`, `grid delete`, `grid use` |
+| **grid url** | `http://192.168.1.25:8090` | `grid join`, and your apps |
+
+`grid join` takes either. A third thing that looks similar but is not a grid at all: `--name` at
+join time labels **the computer** you are joining, not the grid.
+
+### Picking a model
+
+```bash
+grid catalog
+```
+```
+Grid can pull:
+  unsloth/Qwen3.6-35B-A3B-MTP-GGUF/Qwen3.6-35B-A3B-UD-IQ3_S.gguf (Apple Silicon, min 32 GB, language)
+  unsloth/Qwen3.6-27B-MTP-GGUF/Qwen3.6-27B-UD-Q5_K_XL.gguf (NVIDIA, min 24 GB, language)
+```
+
+Copy a line, put a `:` before the filename, and pull it:
+
+```bash
+grid pull unsloth/Qwen3.6-35B-A3B-MTP-GGUF:Qwen3.6-35B-A3B-UD-IQ3_S.gguf
+```
+```
+Downloading unsloth/Qwen3.6-35B-A3B-MTP-GGUF/Qwen3.6-35B-A3B-UD-IQ3_S.gguf ...
+Saved /Users/you/.grid/models/Qwen3.6-35B-A3B-UD-IQ3_S.gguf
+```
+
+The path after `Saved` is your own home directory, not literally `/Users/you`. What matters is the
+**filename** at the end — the same one already visible in the `grid catalog` line above, after the
+last `/`. That filename is what `grid join --serve` needs.
+
+**Not in the catalog?** Any GGUF repo on Hugging Face works — just the repo, nothing else:
+
+```bash
+grid pull unsloth/gemma-3-4b-it-GGUF
+```
+
+A repo like this does not hold one file — it holds the *same* model saved several times, each a
+different size (that is what "quantized" means). In a real terminal you get all of them to choose
+from, biggest quality, smallest download flagged as the default:
+
+```
+unsloth/gemma-3-4b-it-GGUF ships 26 files:
+  1. gemma-3-4b-it-BF16.gguf
+  ...
+  10. gemma-3-4b-it-Q4_K_M.gguf  <- default
+  ...
+  15. gemma-3-4b-it-Q8_0.gguf
+Pick a number [1-26], or press Enter for the default:
+```
+
+Piped or scripted (no terminal to prompt), it takes that default — `Q4_K_M`, a reasonable middle
+ground. Already know which file you want? Name it in full after a `:` and there is no prompt:
+
+```bash
+grid pull unsloth/gemma-3-4b-it-GGUF:gemma-3-4b-it-Q8_0.gguf
+```
+
+Those are the only two ways: **the repo alone** and pick from the list, or **the repo plus the
+exact filename**. Half of a filename (`:Q8_0`) is refused rather than guessed at — it matches
+`gemma-3-4b-it-Q8_0.gguf` and `gemma-3-4b-it-UD-Q8_0.gguf` equally well, and neither is a choice
+you made.
+
+- `--advertise-as` gives the grid a short name again, so apps ask for something readable instead of
+  a filename.
+- Vision models need a second file. `grid pull` fetches it automatically and `--serve` finds it —
+  nothing extra to type.
+
+### Three ways to join a computer
+
+`<grid-url>` below is the address the computer hosting the grid printed at `grid start`.
+
+**Nothing installed on it yet** — install the engine Grid ships, download a model, then join:
+
+```bash
+grid engine install llama.cpp
+grid pull unsloth/gemma-3-4b-it-GGUF
+```
+
+Then join with the filename `grid pull` just printed on its `Saved` line:
+
+```bash
+grid join <grid-url> --serve "<model-file>" --advertise-as "<model-name>"
+```
+
+`grid engine install` picks the build for that machine: Metal on macOS, Vulkan on a Linux box with
+an NVIDIA card, CPU otherwise. It also says whether a faster CUDA build is possible there.
+
+| | you get | costs you | pick it when |
+|---|---|---|---|
+| **Vulkan** (default on Linux) | GPU inference now | one download | you want to be running today |
+| **CUDA** `--from-source` | the fastest backend | CUDA toolkit + a long compile | the box is a permanent node |
+
+**It already runs Ollama, vLLM or LM Studio** — keep it, and point Grid at it:
+
+```bash
+grid join <grid-url> --at <engine-url> -m "<model-name>" --name "<computer-name>"
+```
+
+`<engine-url>` is where that program already listens, and `<model-name>` is a model it already
+serves — Grid does not download it or start it, it only routes to it:
+
+```bash
+grid join http://192.168.1.25:8090 --at http://192.168.1.20:11434/v1 -m "qwen3-coder" --name "gpu-4090"
+```
+
+`11434` is Ollama's port; vLLM is usually `8000` and LM Studio `1234`.
+
+**It is somewhere else** — another office, a friend's house, behind a VPN. Local mode needs every
+computer on the same network, so this one needs [remote mode](#working-from-anywhere).
+
+The engine sizes itself to whatever machine it lands on: at load it measures free memory and takes
+the largest context that fits. `--ctx-size N` pins it instead. `--n-predict`, `--parallel`,
+`--temp`, `--flash-attn` and `--endpoint-port` are there too — see `grid join --help`.
+
+### Stopping, leaving, deleting
+
+Three different commands, easy to mix up:
+
+- **`grid leave`** — this computer stops serving. Everyone else on the grid keeps working.
+- **`grid stop`** — pauses the grid itself. Nothing is lost; `grid start` brings it back exactly
+  as it was.
+- **`grid delete`** — removes a grid's local config for good. Cannot be undone.
+
+```bash
+# Done serving from this computer
+grid leave
+```
+```
+Left engine <computer-name> on <grid-name>.
+```
+
+Serving more than one thing from here? Say which — the `--name` you gave at join works, so does
+the model it serves:
+
+```bash
+grid leave --engine "<computer-name>"
+grid leave --engine "<model-name>"
+grid leave --all      # everything this computer joined
+```
+
+```bash
+# Pause the grid itself
+grid stop
+```
+```
+✓ Grid 'home' stopped. Its setup is kept.
+```
+
+Deleting removes a grid for good, not just pauses it — it asks to confirm first:
+
+```bash
+grid delete <grid-name>
+```
+```
+Delete grid '<grid-name>' (ag-a1b2c3d4)? This removes its local config and cannot be undone. [y/N] y
+Deleted grid '<grid-name>'.
+```
+
+A grid name with a space needs quotes: `grid delete "my grid"`.
+
+### Running commands from another computer
+
+`grid models` and `grid chat` need no arguments on the computer that hosts the grid. From anywhere
+else, name the grid by its URL:
+
+```bash
+grid models http://192.168.1.25:8090
+grid chat --grid http://192.168.1.25:8090 -m "<model-name>" "hello"
+```
+
+`No grid on this computer yet` means *this* machine has no grid set up — not that yours has stopped.
+
+### More than one grid
+
+Your first grid is called `home`. Pass a name to make another one:
+
+```bash
+grid start <grid-name>
+```
+```
+✓ Grid '<grid-name>' running — http://192.168.1.25:8091
+```
+
+Starting it does not switch to it — `grid info`, `grid models` and `grid chat` still mean `home`
+until you switch:
+
+```bash
+grid use <grid-name>
+```
+
+With one grid, none of this comes up.
+
+### Pointing apps at the grid
+
+Every app below needs the two values `grid info --env` printed: `OPENAI_BASE_URL` becomes
+`baseUrl` / `base_url`, `OPENAI_API_KEY` becomes `apiKey`.
 
 <details>
 <summary><b>OpenClaw</b></summary>
@@ -335,14 +332,14 @@ Add Grid as a provider in `~/.openclaw/openclaw.json`
 
 ```json
 {
-  "agents": { "defaults": { "model": { "primary": "grid/qwen36-35b-a3b-mtp" } } },
+  "agents": { "defaults": { "model": { "primary": "grid/<model-name>" } } },
   "models": {
     "providers": {
       "grid": {
         "baseUrl": "http://192.168.1.25:8090/v1",
         "apiKey": "local-grid",
         "api": "openai-completions",
-        "models": [{ "id": "qwen36-35b-a3b-mtp", "name": "Qwen3.6 35B (via Grid)" }]
+        "models": [{ "id": "<model-name>", "name": "<model-name> (via Grid)" }]
       }
     }
   }
@@ -360,12 +357,12 @@ Set the endpoint in `~/.hermes/config.yaml`
 ```yaml
 model:
   provider: custom
-  default: qwen36-35b-a3b-mtp
+  default: <model-name>
   base_url: http://192.168.1.25:8090/v1
 ```
 
 ```bash
-echo 'OPENAI_API_KEY=local-grid' >> ~/.hermes/.env     # remote: use your access token
+echo 'OPENAI_API_KEY=local-grid' >> ~/.hermes/.env
 ```
 
 </details>
@@ -373,46 +370,74 @@ echo 'OPENAI_API_KEY=local-grid' >> ~/.hermes/.env     # remote: use your access
 <details>
 <summary><b>Your own code</b></summary>
 
-Point any OpenAI SDK at the values from `grid info --env`:
+Any OpenAI SDK works the same way:
 
 ```python
 from openai import OpenAI
 
 client = OpenAI(base_url="http://192.168.1.25:8090/v1", api_key="local-grid")
 client.chat.completions.create(
-    model="qwen36-35b-a3b-mtp",         # routed to the Mac Studio automatically
+    model="<model-name>",               # routed to whichever computer serves it
     messages=[{"role": "user", "content": "hello"}],
 )
 ```
 
 </details>
 
----
+### The commands
+
+| | |
+|---|---|
+| `grid start` / `grid stop` | start or stop the grid on this computer |
+| `grid delete` | remove a grid's local config for good |
+| `grid join` / `grid leave` | add or remove this computer from a grid |
+| `grid engine install` | install the engine that runs models |
+| `grid catalog` | models available to pull, and models already here |
+| `grid pull` | download a model |
+| `grid models` | what the grid can answer right now |
+| `grid chat` | send one message |
+| `grid info` | the address and key for apps |
+| `grid ls` / `grid use` | list grids, pick the active one |
+| `grid mode` | switch between local and remote |
+
+`grid up` and `grid down` still work — older names for `start` and `stop`. Full reference:
+[docs/cli.md](docs/cli.md).
+
 
 ## Working from anywhere
 
-To reach the same computers from outside your network, switch to remote mode: engines poll
-Autonomous Relay outbound, so they serve from behind a NAT with no inbound port and no public IP.
-
-**The trade is that your request and its answer pass through our relay, which local mode never
-does.** We forward and keep nothing — no stored prompts, no training on your traffic.
+Local mode needs every computer on the same network. Remote mode drops that: each machine dials
+out to Autonomous Relay, so it serves from behind a NAT with no inbound port and no public IP.
 
 ```bash
-grid mode remote     # persisted to ~/.grid/state.json; --local / --remote overrides one command
-grid login           # device-code flow, opens a browser; --no-browser prints the code
+# Switch this computer to remote mode — remembered until you switch back
+grid mode remote
+
+# Sign in; opens a browser
+grid login
 ```
+
+- The mode is remembered. `--local` / `--remote` overrides one command.
+- `grid login` opens a browser. `--no-browser` prints a code to type instead.
+- Requests pass through our relay, which local mode never does. We forward and keep nothing — no
+  stored prompts, no training on your traffic.
 
 Three commands change. `chat`, `models`, `info` and your apps are identical.
 
 | | 🏠 local | 🌐 remote |
 |---|---|---|
-| **start a grid** | `grid up` | `grid up research` then `grid use research` |
-| **add a computer** | `grid join http://192.168.1.25:8090 --at http://192.168.1.20:8000/v1` | `grid join research --at http://localhost:8000/v1` |
+| **start a grid** | `grid start` | `grid start <grid-name>` then `grid use <grid-name>` |
+| **add a computer** | `grid join <grid-url> --at <engine-url>` | `grid join <grid-name> --at <engine-url>` |
 | **API key** | `local-grid` — auth is off | your per-grid token, from `grid info --env` |
 
-Remote `--at` is `localhost` because the engine polls outbound; nothing reaches in. `grid ls` lists
-the grids your sign-in can reach, `--type permissioned-providers` restricts who may serve, and
-`grid members add research <email>` invites people ([Members](docs/cli.md#members)).
+Remote `--at` is `localhost` because the engine dials out; nothing reaches in.
+
+- `grid ls` — the grids your sign-in can reach
+- `grid start <grid-name> --type permissioned-providers` — restrict who may serve
+- `grid members add <grid-name> someone@example.com` — invite people ([Members](docs/cli.md#members))
+- `grid leave` and `grid stop` work exactly like [local](#stopping-leaving-deleting). `grid delete`
+  doesn't — a remote grid lives on the account that created it, not your disk. Delete it for
+  everyone from the grid's page on [autonomous.ai/grid](https://www.autonomous.ai/grid) instead.
 
 ---
 
@@ -422,95 +447,110 @@ the grids your sign-in can reach, `--type permissioned-providers` restricts who 
 <img src="docs/fig-inference.png" width="880" alt="Your apps — OpenClaw, Hermes, your own code — call one OpenAI-compatible endpoint. Below the orchestrator sits your fleet: a MacBook Pro, a Mac Studio, a Mac mini, an RTX 6000 and an RTX 5090. A request goes down to the single machine already serving that model and the answer comes back the same way; the rest stay idle.">
 </p>
 
-### Engines and models
+### Images and video
 
-**Grid runs no model code of its own; an inference engine does.** Bring one, or let Grid install
-one of the two it ships: `llama.cpp` for text, ComfyUI for media. Both work the same in either mode
-— only the grid you join differs (a remote name, or a local `grid_url`).
+Grid ships a second engine, ComfyUI, for media:
 
 ```bash
-grid engine install llama.cpp           # the text engine — add --from-source for CUDA on Linux
-grid pull qwen36-35b-a3b-mtp            # a text MODEL — see `grid catalog`, or any HF GGUF
-grid join http://192.168.1.25:8090 --serve Qwen3.6-35B-A3B-UD-IQ3_S.gguf --advertise-as qwen36-35b-a3b-mtp
-                                        # --serve takes the FILENAME `grid pull` saved
+# Install the media engine
+grid engine install comfyui
 
-grid engine install comfyui             # the media engine
-grid engine pull image_generation       # a media BUNDLE — also image_editing, i2v
+# Download the model files for making images
+grid engine pull image_generation
+
+# Join this computer as a media engine
 grid join http://192.168.1.25:8090 --media --bundle image_generation
-grid image "a compact walnut desk beside a sunlit window"
+
+# Make an image
+grid image "a compact walnut desk beside a sunlit window" --grid http://192.168.1.25:8090
 ```
 
-On local, `grid image` needs `--grid http://192.168.1.25:8090` — use-commands take the grid as a flag, because
-the positional argument is the prompt.
+- `grid engine pull` also takes `image_editing` and `i2v`.
+- `grid image` needs `--grid` on local — its positional argument is the prompt, so the grid is a flag.
 
-### No GPU at all? Join with an API key
+### No GPU? Join with an API key
 
-`grid join --api openai` serves OpenAI's models to your grid under your own key — an API engine,
-remote only. See what a join would serve first, with no key and no network call:
+`grid join --api openai` serves OpenAI's models to your grid under your own key. Remote only.
+
+See what a join would serve first — no key, no network call:
 
 ```bash
 grid catalog --api openai
-#   openai:gpt-5.5           1,050,000 ctx   tools, vision, json, structured
-#   openai:gpt-5.4-mini        400,000 ctx   tools, vision, json, structured
-
-export OPENAI_API_KEY=sk-…
-grid join research --api openai         # or -m openai:gpt-5.4-mini to narrow
 ```
-
-The key comes from the environment or a hidden prompt, never a flag, and is stored `0o600`. It
-survives `grid logout` — it is your vendor credential, not your grid sign-in. **Requests to
-`openai:*` models leave the grid for OpenAI under your own account's terms**, which the prefix keeps
-visible in every model list. There is no grid-side spend cap; put a budget on the key's OpenAI
-project.
-
-A ChatGPT subscription works instead of a key. `grid join --api codex` contributes a Codex
-subscription seat — no API key; the CLI signs into your ChatGPT account (browser OAuth,
-`--no-browser` for headless) and probes the seat and your egress IP before advertising anything.
-Datacenter and VPS addresses are typically refused, so serve from a residential connection.
+```
+openai:gpt-5.5           1,050,000 ctx   tools, vision, json, structured
+openai:gpt-5.4-mini        400,000 ctx   tools, vision, json, structured
+```
 
 ```bash
-grid catalog --api codex        # per-tier table, offline, no sign-in
-grid join research --api codex
+# The key is read from the environment, never passed as a flag
+export OPENAI_API_KEY=sk-…
+grid join <grid-name> --api openai
 ```
 
-`codex:*` models serve OpenAI's Responses API for external Codex apps — point a Codex CLI/Desktop
-at your grid with `grid info --env`
-([how](docs/cli.md#pointing-a-codex-app-at-your-grid-using-codex-models)); `grid chat` refuses them
-with that same guidance. Jobs spend the seat's own monthly allowance.
-Walkthrough: [docs/codex-quickstart.md](docs/codex-quickstart.md) · [ADR 0015](docs/adr/0015-codex-subscription-engine.md).
+- The key comes from the environment or a hidden prompt, never a flag. Stored `0o600`.
+- It survives `grid logout` — it is your vendor credential, not your grid sign-in.
+- Requests to `openai:*` leave the grid under your own account's terms. The prefix keeps that
+  visible in every model list.
+- No grid-side spend cap. Put a budget on the key's OpenAI project.
+
+A ChatGPT subscription works instead of a key:
+
+```bash
+# See what a codex seat would serve — offline, no sign-in
+grid catalog --api codex
+
+# Sign into ChatGPT in a browser, then serve the seat
+grid join <grid-name> --api codex
+```
+
+- No API key — the CLI signs into your ChatGPT account by browser OAuth (`--no-browser` for headless).
+- It probes the seat and your egress IP before advertising anything. Datacenter and VPS addresses
+  are typically refused, so serve from a residential connection.
+- `codex:*` models serve the Responses API for external Codex apps. Point one at your grid with
+  `grid info --env` ([how](docs/cli.md#pointing-a-codex-app-at-your-grid-using-codex-models));
+  `grid chat` refuses them with the same guidance.
+- Jobs spend the seat's own monthly allowance.
+
+Walkthrough: [docs/codex-quickstart.md](docs/codex-quickstart.md).
 
 ### Run Claude Code on your grid
 
 ```bash
-grid launch claude                      # …or `-- --continue`, and any other Claude Code flag
+grid launch claude
 ```
 
-`grid launch` starts an app already pointed at your grid: endpoint, credential and model names go
-into that app's own process environment and nowhere else — nothing exported to your shell, nothing
-written to a config file, nothing to undo. Remote only, because Claude Code speaks the Anthropic
-Messages dialect and only the relay translates it. It chooses **no model for you** — your own Claude
-Code configuration and `/model` still decide, so check `grid models` and point the app at a name the
-grid serves.
-Walkthrough: [docs/claude-code-quickstart.md](docs/claude-code-quickstart.md) ·
-[contract](docs/cli.md#launch) · [ADR 0028](docs/adr/0028-launch-hands-an-app-the-grid.md).
+`grid launch` starts an app already pointed at your grid.
+
+- Endpoint, credential and model names go into that app's own process environment and nowhere else.
+  Nothing exported to your shell, nothing written to a config file, nothing to undo.
+- Remote only — Claude Code speaks the Anthropic Messages dialect, and only the relay translates it.
+- It picks **no model for you**. Your own Claude Code config and `/model` still decide, so check
+  `grid models` and point the app at a name the grid serves.
+
+Walkthrough: [docs/claude-code-quickstart.md](docs/claude-code-quickstart.md).
 
 ### Don't know which model to ask for? Send `auto`
 
-A grid's catalog shifts as engines join and leave. Rather than hardcoding a model name, an app can
-send the reserved name `auto` and the grid picks a capable model that is free, so requests don't
-queue behind a busy model while idle ones sit unused.
+A grid's catalog shifts as engines join and leave. Instead of hardcoding a model name, an app can
+send the reserved name `auto`, and the grid picks a capable model that is free.
 
 ```bash
-grid router set-advisors openai:gpt-5-mini --grid research   # by name — no key, no URL
-grid router enable --grid research
+# Pick the model that decides where each request goes
+grid router set-advisors openai:gpt-5-mini --grid <grid-name>
+grid router enable --grid <grid-name>
+
+# Now ask for "auto" instead of a model name
 grid chat -m auto "summarize this file in one line"
 ```
 
-**Only a bounded excerpt of each request — never the full conversation — reaches the Advisor**, on
-the platform's key. A dead Advisor falls back to a deterministic pick, so `auto`'s availability
-equals your grid's rather than a vendor's. The `model` field and the `X-Grid-Routed-Model` header
-name whichever model actually answered.
-Contract and transparency table in [docs/cli.md](docs/cli.md#router) · [ADR 0013](docs/adr/0013-auto-routing.md).
+- Only a bounded excerpt of each request reaches the Advisor — never the full conversation — on the
+  platform's key.
+- A dead Advisor falls back to a deterministic pick, so `auto`'s availability equals your grid's
+  rather than a vendor's.
+- The `model` field and the `X-Grid-Routed-Model` header name whichever model actually answered.
+
+Details in [docs/cli.md](docs/cli.md#router).
 
 ---
 
@@ -530,37 +570,48 @@ was never on the internet. It is in your systems. **What you get is an expert in
 than a generalist — worse than the frontier at everything, better at your thing.**
 
 ```bash
-grid train packs                        # ready-made setups for real business data
-grid train init --pack support-replies  # tickets -> a reply-drafting model
-grid train serve                        # run THIS Mac as a rollout node (Apple Silicon)
-grid train run                          # the climb
-grid train ui                           # watch the reward and eval curves
+# Ready-made setups for real business data
+grid train packs
+
+# Turn support tickets into a reply-drafting model
+grid train init --pack support-replies
+
+# Run this Mac as a rollout node (Apple Silicon)
+grid train serve
+
+# The climb
+grid train run
+
+# Watch the reward and eval curves
+grid train ui
 ```
 
-The grid samples rollouts across its nodes, one machine holds the trainer, and the LoRA adapter it
-produces goes back to the serving nodes under a stable name — where `auto` keeps routing to it.
-API nodes (`--api openai`, `--api codex`) cannot serve rollouts: vendors return neither the token
-ids they sampled nor their logprobs, and you cannot own an improvement to a model you rent. In a
-hybrid grid that becomes the useful loop — `auto` sends what the local model can't do yet to a
-frontier node, those tasks are what tonight's run consumes, and the frontier share shrinks as the
-local model catches up.
-
-Both backends train. vLLM returns sampled ids and logprobs natively; `grid train serve` does it from
-MLX, so an all-Apple-Silicon fleet needs no CUDA. `grid train convert-adapter` moves an adapter
-between them.
+- The grid samples rollouts across its nodes; one machine holds the trainer.
+- The LoRA adapter it produces goes back to the serving nodes under a stable name, where `auto`
+  keeps routing to it.
+- API nodes (`--api openai`, `--api codex`) cannot serve rollouts. Vendors return neither the token
+  ids they sampled nor their logprobs, and you cannot own an improvement to a model you rent.
+- In a hybrid grid that becomes the useful loop: `auto` sends what the local model can't do yet to
+  a frontier node, those tasks are what tonight's run consumes, and the frontier share shrinks as
+  the local model catches up.
+- Both backends train. vLLM returns sampled ids and logprobs natively; `grid train serve` does it
+  from MLX, so an all-Apple-Silicon fleet needs no CUDA. `grid train convert-adapter` moves an
+  adapter between them.
 
 A complete GRPO climb, no GPU:
 
 ```bash
-python -m train.torch_grpo_hello        # any machine, CUDA or CPU — ~6 min
-python -m train.mlx.grpo_hello          # Apple Silicon — ~1 min, needs: pip install mlx-lm
+# Any machine, CUDA or CPU — about six minutes
+python -m train.torch_grpo_hello
+
+# Apple Silicon, needs `pip install mlx-lm` — about one minute
+python -m train.mlx.grpo_hello
 ```
 
 Figures and measured curves: [train/README.md](train/README.md). One Mac:
 [docs/start-on-a-mac.md](docs/start-on-a-mac.md) · two machines:
 [docs/two-node-training.md](docs/two-node-training.md) · topologies:
-[docs/topologies.md](docs/topologies.md) · design and limits:
-[ADR 0019](docs/adr/0019-rl-training-plane.md).
+[docs/topologies.md](docs/topologies.md).
 
 ---
 
@@ -570,7 +621,7 @@ Grid sits above your computers the way an API gateway sits above services: one a
 many. The analogy stops there — a gateway routes by path, Grid routes by model name.
 
 - **the grid** — one endpoint routing each request to a computer serving that model. Locally a
-  proxy from `grid up`; remotely a hosted grid on Autonomous Relay after `grid login`.
+  proxy from `grid start`; remotely a hosted grid on Autonomous Relay after `grid login`.
 - **engines** — what runs a model, yours or one Grid installed. `grid join` advertises a computer's
   engines and heartbeats them; Grid never restarts or replaces them. Locally they register with the
   grid directly, remotely they poll the relay outbound — behind a NAT, no inbound port.
@@ -579,10 +630,20 @@ many. The analogy stops there — a gateway routes by path, Grid routes by model
   weights, asks for completions like any other client, and pushes its adapter back to the serving
   nodes.
 
+Two things run on the same fleet: **inference**, and **training** *(experimental)* — the same
+machines teaching a small model your work, where the data, the attempts and the weights never leave
+your network. *Intranet* is the old word for a private network.
+
 ```bash
-grid engines           # what each computer serves, and how many requests at once
-grid models --verbose  # every model, and which computer answers for it
+# What each computer serves, and how many requests it takes at once
+grid engines
+
+# Every model, and which computer answers for it
+grid models --verbose
 ```
+
+`engines` lists what each computer serves and how many requests it takes at once; `models` lists
+every model and which computer answers for it.
 
 Request flow: [ARCHITECTURE.md](docs/ARCHITECTURE.md). Full command surface, including membership
 and remote grid types: [docs/cli.md](docs/cli.md).
@@ -592,7 +653,11 @@ and remote grid types: [docs/cli.md](docs/cli.md).
 ```bash
 git clone https://github.com/autonomous-ai/autonomous-grid
 cd autonomous-grid
+
+# Create the environment, with test dependencies
 uv sync --extra dev
+
+# Run the tests
 uv run --extra dev pytest
 ```
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ grid models
 
 # Ask it something — the <model-name> you chose above
 grid chat -m "<model-name>" "write a haiku about local GPUs"
+
+# Ask about a picture — only if the model reads images, which `grid pull` says
+grid chat -m "<model-name>" --image "<image-path>" "what is in this image?"
 ```
 
 **Step 4 — point your apps at it.** Anything that speaks the OpenAI API:
@@ -193,7 +196,9 @@ you made.
 - `--advertise-as` gives the grid a short name again, so apps ask for something readable instead of
   a filename.
 - Vision models need a second file. `grid pull` fetches it automatically and `--serve` finds it —
-  nothing extra to type.
+  nothing extra to type. It says `Supports vision.` when it does, and then `grid chat --image
+  <path>` sends a picture with your question. PNG, JPEG, BMP and GIF; a WebP is refused, because
+  the engine has no decoder for one and would answer about an image it never received.
 
 ### Three ways to join a computer
 
@@ -396,7 +401,7 @@ client.chat.completions.create(
 | `grid catalog` | models available to pull, and models already here |
 | `grid pull` | download a model |
 | `grid models` | what the grid can answer right now |
-| `grid chat` | send one message |
+| `grid chat` | send one message, `--image <path>` to send a picture with it |
 | `grid info` | the address and key for apps |
 | `grid ls` / `grid use` | list grids, pick the active one |
 | `grid mode` | switch between local and remote |

--- a/README.md
+++ b/README.md
@@ -188,17 +188,15 @@ ground. Already know which file you want? Name it in full after a `:` and there 
 grid pull unsloth/gemma-3-4b-it-GGUF:gemma-3-4b-it-Q8_0.gguf
 ```
 
-Those are the only two ways: **the repo alone** and pick from the list, or **the repo plus the
-exact filename**. Half of a filename (`:Q8_0`) is refused rather than guessed at — it matches
-`gemma-3-4b-it-Q8_0.gguf` and `gemma-3-4b-it-UD-Q8_0.gguf` equally well, and neither is a choice
-you made.
+Two ways, then: **the repo alone** to pick from the list, or **the repo plus a full filename**
+to go straight there. Copy the filename from the list above, or from the repo's **Files and
+versions** tab on huggingface.co.
 
 - `--advertise-as` gives the grid a short name again, so apps ask for something readable instead of
   a filename.
 - Vision models need a second file. `grid pull` fetches it automatically and `--serve` finds it —
   nothing extra to type. It says `Supports vision.` when it does, and then `grid chat --image
-  <path>` sends a picture with your question. PNG, JPEG, BMP and GIF; a WebP is refused, because
-  the engine has no decoder for one and would answer about an image it never received.
+  <path>` sends a picture with your question. Send a PNG, JPEG, BMP or GIF.
 
 ### Three ways to join a computer
 
@@ -511,11 +509,11 @@ grid join <grid-name> --api codex
 ```
 
 - No API key — the CLI signs into your ChatGPT account by browser OAuth (`--no-browser` for headless).
-- It probes the seat and your egress IP before advertising anything. Datacenter and VPS addresses
-  are typically refused, so serve from a residential connection.
-- `codex:*` models serve the Responses API for external Codex apps. Point one at your grid with
-  `grid info --env` ([how](docs/cli.md#pointing-a-codex-app-at-your-grid-using-codex-models));
-  `grid chat` refuses them with the same guidance.
+- It probes the seat and your egress IP before advertising anything, so serve from a residential
+  connection.
+- `codex:*` models serve the Responses API. Point a Codex app at your grid with `grid info --env`
+  ([how](docs/cli.md#pointing-a-codex-app-at-your-grid-using-codex-models)) — that is the client
+  for them, and `grid chat` says so if you reach for it.
 - Jobs spend the seat's own monthly allowance.
 
 Walkthrough: [docs/codex-quickstart.md](docs/codex-quickstart.md).
@@ -595,8 +593,9 @@ grid train ui
 - The grid samples rollouts across its nodes; one machine holds the trainer.
 - The LoRA adapter it produces goes back to the serving nodes under a stable name, where `auto`
   keeps routing to it.
-- API nodes (`--api openai`, `--api codex`) cannot serve rollouts. Vendors return neither the token
-  ids they sampled nor their logprobs, and you cannot own an improvement to a model you rent.
+- Rollouts run on your own hardware: training needs the token ids and logprobs a node sampled,
+  which is something a machine you own reports and a rented API does not. API nodes serve
+  inference on the same grid.
 - In a hybrid grid that becomes the useful loop: `auto` sends what the local model can't do yet to
   a frontier node, those tasks are what tonight's run consumes, and the frontier share shrinks as
   the local model catches up.

--- a/README.md
+++ b/README.md
@@ -139,11 +139,12 @@ grid catalog
 ```
 ```
 Grid can pull:
-  unsloth/Qwen3.6-35B-A3B-MTP-GGUF/Qwen3.6-35B-A3B-UD-IQ3_S.gguf (Apple Silicon, min 32 GB, language)
-  unsloth/Qwen3.6-27B-MTP-GGUF/Qwen3.6-27B-UD-Q5_K_XL.gguf (NVIDIA, min 24 GB, language)
+  unsloth/Qwen3.6-35B-A3B-MTP-GGUF:Qwen3.6-35B-A3B-UD-IQ3_S.gguf  unsloth/Qwen3.6-35B-A3B-MTP-GGUF/Qwen3.6-35B-A3B-UD-IQ3_S.gguf (Apple Silicon, min 32 GB, language)
+  unsloth/Qwen3.6-27B-MTP-GGUF:Qwen3.6-27B-UD-Q5_K_XL.gguf  unsloth/Qwen3.6-27B-MTP-GGUF/Qwen3.6-27B-UD-Q5_K_XL.gguf (NVIDIA, min 24 GB, language)
 ```
 
-Copy a line, put a `:` before the filename, and pull it:
+Each row twice: first what to pull, then the same repo and file as a path you can open on
+huggingface.co. Copy the first one:
 
 ```bash
 grid pull unsloth/Qwen3.6-35B-A3B-MTP-GGUF:Qwen3.6-35B-A3B-UD-IQ3_S.gguf

--- a/README.md
+++ b/README.md
@@ -44,9 +44,35 @@ your own network, and it keeps working if we disappear. From outside your networ
 curl -fsSL https://grid.autonomous.ai/install.sh | bash
 ```
 
-You get `grid` (and the `agrid` alias) on your PATH — a self-contained binary on Linux, or a
-[uv](https://docs.astral.sh/uv/)-managed install on macOS. Pin a release with `GRID_VERSION=0.1.0`.
-Contributors can instead clone and `uv tool install -e . --force`.
+That gives you a command called `grid`. Check it worked before going on:
+
+```bash
+grid --version
+# grid 0.3.23
+```
+
+If you get "command not found", close the terminal and open a new one, then try again.
+
+<details>
+<summary>Installing a specific version, or from source</summary>
+
+Pin a release by setting `GRID_VERSION` before installing:
+
+```bash
+GRID_VERSION=0.3.23 curl -fsSL https://grid.autonomous.ai/install.sh | bash
+```
+
+Working on Grid itself? Clone the repository and install it in editable mode with
+[uv](https://docs.astral.sh/uv/) instead:
+
+```bash
+uv tool install -e . --force
+```
+
+`agrid` is installed as a second name for the same command, for machines where something else
+already answers to `grid`.
+
+</details>
 
 ### What you are about to build
 

--- a/README.md
+++ b/README.md
@@ -48,17 +48,63 @@ You get `grid` (and the `agrid` alias) on your PATH — a self-contained binary 
 [uv](https://docs.astral.sh/uv/)-managed install on macOS. Pin a release with `GRID_VERSION=0.1.0`.
 Contributors can instead clone and `uv tool install -e . --force`.
 
-These four steps are the local path; remote mode changes
-[three commands](#working-from-anywhere).
+### What you are about to build
+
+Say you own three computers and one of them has a good graphics card. Normally an AI model runs on
+one machine, and only that machine can use it.
+
+A **grid** puts a single address in front of all of them. Your apps send every request to that one
+address; the grid works out which computer has the right model and forwards it there. Add a
+computer and its models join the pool. Turn one off and the rest keep working.
+
+Three words appear throughout, and they mean exactly this:
+
+| | |
+|---|---|
+| **grid** | the single address your apps talk to. One computer hosts it. |
+| **engine** | the program that actually runs a model. Grid installs one for you. |
+| **model** | the AI itself — a file you download once, several gigabytes. |
+
+Four steps, and **each one says which computer to run it on** — that is the part that trips people
+up. Step 1 happens once, on one machine. Step 2 is repeated on every machine that will run a model.
+Remote mode changes [three commands](#working-from-anywhere).
 
 ### 1 · Start a grid
 
+**Run on: one computer, once.** Pick whichever machine is usually left on — a Mac mini, a desktop,
+the box already sitting in the corner. It does **not** need a graphics card, because this machine is
+directing traffic, not running models.
+
 ```bash
 grid up
+# grid=home
 # grid_url=http://192.168.1.25:8090
 ```
 
+`grid up` starts a small program that keeps running in the background on this computer. That
+program *is* the grid: it listens on the address printed above, keeps track of which computers have
+joined, and passes each request to whichever one can answer it. Nothing is downloaded and no model
+runs yet — you have just opened the front door.
+
+**Copy that `grid_url` somewhere.** Every other computer needs it in step 2, and your apps need it
+in step 4. `home` is just a name; you can have more than one grid later.
+
+To stop it again: `grid down`. The setup is remembered, so `grid up` brings it straight back.
+
+> **If you see a warning that nothing can reach the address**, the grid is running fine — it simply
+> picked the wrong one of your machine's network addresses, which happens on computers running a
+> VPN. Follow the two commands the warning prints. To try everything on a single computer first,
+> use `grid up --advertise-host 127.0.0.1`.
+
+One more thing, only if you ever make a second grid: creating it does not switch you to it.
+`grid up research` builds a grid called *research*, but `grid info`, `grid models` and `grid chat`
+keep meaning the first one until you run `grid use research`. With a single grid — where most
+people stay — this never comes up.
+
 ### 2 · Add a computer
+
+**Run on: every computer that will run a model** — including the one from step 1, if it has a GPU
+worth using. Repeat this whole step per machine.
 
 A model needs an **inference engine** to run it — Grid does not run models itself. Bring one you
 already have, or install the one Grid ships (llama.cpp).
@@ -113,31 +159,90 @@ failing partway through a build.
 
 **On Linux with no GPU** the same command installs the CPU build and says so.
 
-Now pull a model. `grid catalog` lists what the catalog ships, filtered to your hardware — or pull
-any GGUF on Hugging Face with `<hf-repo>:<file>`.
+Next, download a model onto this computer. Grid keeps a short list of models it knows are worth
+running, each under a **short name** you can pass to `grid pull`:
 
 ```bash
-# Apple Silicon, 32 GB unified memory or more
-grid pull qwen36-35b-a3b-mtp
-# Saved ~/.grid/models/Qwen3.6-35B-A3B-UD-IQ3_S.gguf
-
-# NVIDIA, 24 GB VRAM or more
-grid pull qwen36-27b-mtp
-# Saved ~/.grid/models/Qwen3.6-27B-UD-Q5_K_XL.gguf
+grid catalog
+# Grid can pull:
+#   qwen36-35b-a3b-mtp   unsloth/Qwen3.6-35B-A3B-MTP-GGUF/...  (Apple Silicon, min 32 GB, language)
+#   qwen36-27b-mtp       unsloth/Qwen3.6-27B-MTP-GGUF/...      (NVIDIA, min 24 GB, language)
 ```
 
-**`grid pull` takes a catalog label; `--serve` takes the filename on disk** — the one `pull` just
-printed, which `grid catalog` reprints any time under **Local models:**. `--advertise-as` hands the
-grid back a short name to ask for:
+Pick the one matching this computer and pull it. This downloads several gigabytes:
+
+```bash
+grid pull qwen36-35b-a3b-mtp                       # Apple Silicon, 32 GB unified memory or more
+# Resolved catalog label 'qwen36-35b-a3b-mtp' -> unsloth/Qwen3.6-35B-A3B-MTP-GGUF/...
+# Saved /Users/you/.grid/models/Qwen3.6-35B-A3B-UD-IQ3_S.gguf
+
+grid pull qwen36-27b-mtp                           # NVIDIA, 24 GB VRAM or more
+# Saved /home/you/.grid/models/Qwen3.6-27B-UD-Q5_K_XL.gguf
+```
+
+**Not in the catalog?** Models live on a site called Hugging Face, and any model there in the
+`.gguf` format works. Give the repository, a colon, then the exact filename inside it — both are
+visible on that model's "Files" tab:
+
+```bash
+grid pull unsloth/gemma-3-4b-it-GGUF:gemma-3-4b-it-Q4_K_M.gguf
+#         └──── the repository ────┘ └──── the file in it ────┘
+```
+
+**Models that can see pictures work too, and you do not have to do anything extra.** A model like
+that is shipped as two files — the model, plus a second one that handles images — and `grid pull`
+fetches both when it finds them:
+
+```bash
+grid pull ggml-org/SmolVLM-256M-Instruct-GGUF:SmolVLM-256M-Instruct-Q8_0.gguf
+# Saved ~/.grid/models/SmolVLM-256M-Instruct-Q8_0.gguf
+# This is a vision model. Downloading mmproj-SmolVLM-256M-Instruct-Q8_0.gguf ...
+# Saved ~/.grid/models/SmolVLM-256M-Instruct-Q8_0.mmproj.gguf
+```
+
+When you serve it in a moment, Grid spots that second file on its own and turns image support on —
+you will see `Vision: serving with projector …` — and tells the grid the model accepts pictures, so
+your apps can send them.
+
+Now hand that model to the grid. **The name you pull with and the name you serve with are
+different**, and this is the one place people get stuck: `grid pull` takes the short catalog name,
+while `--serve` takes the **filename that was saved** — the path printed on the `Saved` line above.
+`--advertise-as` then gives the grid a short name again, so your apps ask for something readable
+instead of a filename:
 
 ```bash
 grid join http://192.168.1.25:8090 \
     --serve Qwen3.6-35B-A3B-UD-IQ3_S.gguf \
     --advertise-as qwen36-35b-a3b-mtp \
     --name mac-studio
-
-# NVIDIA: --serve Qwen3.6-27B-UD-Q5_K_XL.gguf --advertise-as qwen36-27b-mtp --name gpu-box
 ```
+
+Reading that command left to right: join *the grid at this address* (the `grid_url` from step 1),
+start the engine on *this model file*, tell the grid to call it *qwen36-35b-a3b-mtp*, and list this
+computer as *mac-studio*.
+
+It waits until the model is genuinely loaded, then tells you so:
+
+```
+✓ Serving on grid 'home'
+    qwen36-35b-a3b-mtp
+  engine address   http://192.168.1.10:8081/v1
+  this computer    mac-studio
+
+  Try it:   grid chat -m qwen36-35b-a3b-mtp "hello"
+  Stop it:  grid leave home --engine mac-studio
+```
+
+Large models take a while to load. If it is still loading, you get a `tail -f` command to watch
+progress instead — and if it fails, the reason is printed right there, not buried in a file.
+
+On NVIDIA the only change is the filename:
+
+```bash
+    --serve Qwen3.6-27B-UD-Q5_K_XL.gguf --advertise-as qwen36-27b-mtp --name gpu-box
+```
+
+Forgotten the filename? `grid catalog` reprints every model on this machine under **Local models:**.
 
 The built-in engine sizes itself to the machine: at load it measures free memory and takes the
 largest context that fits, capped by what the model was trained for. Pin it with `--ctx-size N` when
@@ -157,20 +262,38 @@ Repeat for each computer.
 
 ### 3 · Ask it something
 
+**Run on: the computer from step 1.** That machine already knows the grid, so these commands need
+no arguments. From any *other* computer, name the grid by its URL — `grid models
+http://192.168.1.25:8090`, `grid chat --grid http://192.168.1.25:8090 ...` — otherwise you get
+`No grids yet. Run 'grid up' to bring one online.`, which means *this* machine has no grid
+configured, not that your grid is down.
+
+First see what the grid can actually serve right now — this answers "did step 2 work":
+
 ```bash
-grid chat -m qwen36-35b-a3b-mtp "write a haiku about local GPUs"
 grid models --verbose
 # MODEL               ENGINE      WHERE
 # qwen36-35b-a3b-mtp  mac-studio  http://192.168.1.10:8081/v1
 # qwen3-coder         gpu-4090    http://192.168.1.20:8000/v1
 ```
 
-The first name is the one you gave `--advertise-as`; the second is the model the 4090 was already
-serving behind Ollama.
+One row per model the grid can reach. `MODEL` is the name to ask for — `qwen36-35b-a3b-mtp` is the
+one you set with `--advertise-as`, and `qwen3-coder` came from the Ollama machine, which was already
+serving it under that name. `ENGINE` is the `--name` you gave each computer. An empty list means no
+computer has joined yet; go back to step 2.
+
+Then ask it something, using a name from the `MODEL` column:
+
+```bash
+grid chat -m qwen36-35b-a3b-mtp "write a haiku about local GPUs"
+```
 
 ### 4 · Point your apps at it
 
-`grid info --env` prints the exports for whichever mode you are in:
+**Run on: whichever computer your app runs on.** Your app talks to the grid the same way it talks
+to OpenAI — one base URL and a key — so anything that speaks the OpenAI API works unmodified.
+
+`grid info --env` prints those two values for whichever mode you are in:
 
 ```bash
 grid info --env
@@ -258,7 +381,7 @@ Three commands change. `chat`, `models`, `info` and your apps are identical.
 | | 🏠 local | 🌐 remote |
 |---|---|---|
 | **start a grid** | `grid up` | `grid up research` then `grid use research` |
-| **add a computer** | `grid join <grid_url> --at <address on your network>` | `grid join research --at http://localhost:8000/v1` |
+| **add a computer** | `grid join http://192.168.1.25:8090 --at http://192.168.1.20:8000/v1` | `grid join research --at http://localhost:8000/v1` |
 | **API key** | `local-grid` — auth is off | your per-grid token, from `grid info --env` |
 
 Remote `--at` is `localhost` because the engine polls outbound; nothing reaches in. `grid ls` lists
@@ -282,16 +405,16 @@ one of the two it ships: `llama.cpp` for text, ComfyUI for media. Both work the 
 ```bash
 grid engine install llama.cpp           # the text engine — add --from-source for CUDA on Linux
 grid pull qwen36-35b-a3b-mtp            # a text MODEL — see `grid catalog`, or any HF GGUF
-grid join <grid> --serve Qwen3.6-35B-A3B-UD-IQ3_S.gguf --advertise-as qwen36-35b-a3b-mtp
+grid join http://192.168.1.25:8090 --serve Qwen3.6-35B-A3B-UD-IQ3_S.gguf --advertise-as qwen36-35b-a3b-mtp
                                         # --serve takes the FILENAME `grid pull` saved
 
 grid engine install comfyui             # the media engine
 grid engine pull image_generation       # a media BUNDLE — also image_editing, i2v
-grid join <grid> --media --bundle image_generation
+grid join http://192.168.1.25:8090 --media --bundle image_generation
 grid image "a compact walnut desk beside a sunlit window"
 ```
 
-On local, `grid image` needs `--grid <grid_url>` — use-commands take the grid as a flag, because
+On local, `grid image` needs `--grid http://192.168.1.25:8090` — use-commands take the grid as a flag, because
 the positional argument is the prompt.
 
 ### No GPU at all? Join with an API key

--- a/cli/dispatch.py
+++ b/cli/dispatch.py
@@ -59,6 +59,16 @@ AGNOSTIC = frozenset({
 GATED = (
     "up",
     "down",
+    # `start`/`stop` are `up`/`down` under a name that doesn't clash with `grid join`/`leave`
+    # (cli/parser.py `_build_up_parser`) — same handler, so they need the same remote classification
+    # or they hit the "not classified for remote dispatch" internal-error guard below.
+    "start",
+    "stop",
+    # No remote handler on purpose: `cmd_delete` reads LOCAL grid config only (`local.config`), never
+    # the remote grid records `remote.credentials` keeps — deleting one of those is a real
+    # server-side action against the control plane and deserves its own design, not a same-named
+    # local operation repurposed. The stub is the honest answer until that exists.
+    "delete",
     "ls",
     "list",
     "info",
@@ -89,6 +99,8 @@ REMOTE_HANDLERS = {
     **_REMOTE_STUBS,
     "up": remote_grid.cmd_remote_up,
     "down": remote_grid.cmd_remote_down,
+    "start": remote_grid.cmd_remote_up,
+    "stop": remote_grid.cmd_remote_down,
     "ls": remote_grid.cmd_remote_ls,
     "list": remote_grid.cmd_remote_ls,
     "info": remote_grid.cmd_remote_info,

--- a/cli/engine.py
+++ b/cli/engine.py
@@ -13,7 +13,8 @@ def cmd_engine_install(args: argparse.Namespace) -> int:
         from shared.engine import comfyui
 
         comfyui.install()
-        print("Done. Run `grid engine pull <bundle>` to download media model files.")
+        print("Done. Now download the model files for what you want to make:")
+        print("  grid engine pull image_generation     # also: image_editing, i2v")
         return 0
     raise SystemExit(f"Unknown engine {args.name!r}. Choose 'llama.cpp' (text) or 'comfyui' (media).")
 
@@ -93,9 +94,9 @@ def _install_llama_cpp(args: argparse.Namespace) -> int:
             path = installer.install_metal_from_source()
             print(f"Installed llama-server with Metal -> {path}")
             return 0
-        path = installer.install_macos_prebuilt()
-        print(f"Installed llama-server -> {path}")
-        print("Metal build — it uses this Mac's GPU. Nothing else to install.")
+        installer.install_macos_prebuilt()
+        print("\n✓ Engine installed — it uses this Mac's GPU.")
+        print("\nNext:  grid catalog")
         return 0
 
     from shared.system import gpu
@@ -120,24 +121,17 @@ def _install_llama_cpp(args: argparse.Namespace) -> int:
     # with no toolchain, and is told plainly how to get CUDA instead. This used to be two pinned
     # entries with PLACEHOLDER urls that could never be filled, so the command simply dead-ended.
     kind = "vulkan" if gpus else "cpu"
-    path = installer.install_linux_prebuilt(kind)
-    print(f"Installed llama-server -> {path}")
+    installer.install_linux_prebuilt(kind)
     if not gpus:
-        print("No GPU detected — this is the CPU build.")
+        print("\n✓ Engine installed — no GPU detected, so it runs on the CPU.")
+        print("\nNext:  grid catalog")
         return 0
 
     # Answer "can I have CUDA?" here, so nobody has to go and probe their own toolchain to find
     # out. The same prober gates `--from-source`, so this can never advise a build that would
     # then refuse to start.
-    print()
-    print("This is the Vulkan build — it runs on your NVIDIA GPUs with no CUDA toolkit.")
-    ready, blocker = installer.cuda_build_readiness(sm_required[0].removeprefix("sm_"))
-    if ready:
-        print("CUDA is faster, and this machine can build it:")
-        print("    grid engine install llama.cpp --from-source")
-    else:
-        print()
-        print("CUDA would be faster, but not from this machine yet:")
-        for line in blocker.splitlines():
-            print(f"  {line}")
+    ready, _ = installer.cuda_build_readiness(sm_required[0].removeprefix("sm_"))
+    faster = "  (a faster CUDA build is possible: add --from-source)" if ready else ""
+    print(f"\n✓ Engine installed — it uses your GPUs via Vulkan.{faster}")
+    print("\nNext:  grid catalog")
     return 0

--- a/cli/grid.py
+++ b/cli/grid.py
@@ -4,14 +4,17 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import shlex
+import shutil
 import sys
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 
 from local import config
 from local import runtime
-from shared import run_records, shell, state
+from shared import paths, run_records, shell, state
 from shared._version import __version__
 
 
@@ -27,19 +30,136 @@ def cmd_up(args: argparse.Namespace) -> int:
         _reject_foreign_grid(name)  # a known remote grid or an id-shaped arg → don't auto-create junk
         cfg = runtime.init_grid_config(
             name=name,
-            port=args.port,
-            host=args.host,
+            port=args.port if args.port is not None else runtime.DEFAULT_PORT,
+            host=args.host if args.host is not None else runtime.DEFAULT_HOST,
             advertise_host=args.advertise_host,
         )
+    else:
+        cfg, _ = _apply_up_overrides(cfg, args)
+    # Both paths, first run included — a busy port must never be something the reader has to
+    # resolve before they can get started.
+    cfg, _ = _resolve_port(cfg)
+    config.save_grid_config(cfg["grid_id"], cfg)
     runtime.start_grid(cfg)
-    url = runtime.grid_url(cfg)
-    print(f"grid={cfg['name']}")
-    print(f"grid_url={url}")
-    # The grid is up either way; this only decides whether the address we just printed is one
-    # anything can dial. Catching it here turns a silent dead end into a fixable sentence.
-    if not runtime.advertised_address_works(url):
-        print(runtime.unreachable_address_hint(cfg, url))
+    cfg, local_only = _resolve_address(cfg)
+    _report_up(cfg, local_only)
     return 0
+
+
+def _resolve_address(cfg: dict[str, Any]) -> tuple[dict[str, Any], bool]:
+    """Fall back to a working address instead of warning about a broken one.
+
+    ``detect_local_ip`` asks which interface reaches the internet, which on a machine holding a VPN
+    is not the interface anything reaches *back* on. The grid is bound to every interface and is
+    perfectly healthy; only the address it hands out is wrong, and the symptom is every later
+    command failing with "Server disconnected without sending a response".
+
+    Nothing needs restarting to fix it — the server already listens on 0.0.0.0, so pointing the
+    advertised URL at loopback makes it work on this machine immediately. That is a real
+    reduction in reach, so the caller says so — in three words, not a paragraph.
+    """
+    url = runtime.grid_url(cfg)
+    if runtime.advertised_address_works(url):
+        return cfg, False
+
+    loopback = runtime.make_local_url(cfg["port"], "127.0.0.1")
+    if not runtime.advertised_address_works(loopback):
+        return cfg, True
+
+    updated = dict(cfg)
+    updated["lan_signaling_url"] = loopback
+    config.save_grid_config(updated["grid_id"], updated)
+    return updated, True
+
+
+def _report_up(cfg: dict[str, Any], local_only: bool) -> None:
+    """Two facts and one command. Nothing else.
+
+    Everything worth explaining here — a port that moved, an address that had to fall back — has
+    already been *handled*, so narrating it only buries the one line the reader needs, which is
+    what to type next. The address printed is the truth; how it was arrived at is not their
+    problem. `local_only` is the single exception, because it changes what they can do next.
+    """
+    scope = "  (this computer only)" if local_only else ""
+    print(f"\n✓ Grid '{cfg['name']}' running — {runtime.grid_url(cfg)}{scope}")
+    print("\nNext:  grid engine install llama.cpp")
+    print("See:   grid info")
+
+
+def _resolve_port(cfg: dict[str, Any]) -> tuple[dict[str, Any], str | None]:
+    """Move to a free port rather than asking the reader to pick one.
+
+    `grid up` is the first command anyone runs, and a busy 8090 used to end the story there: an
+    error about a port they never chose, no clue what was holding it, and — until the flag was
+    honoured — no escape even by choosing another. A port conflict is not a decision anyone needs
+    to be consulted about; it just needs solving, out loud.
+
+    This applies to an explicit `--port` too. Being told "that one is taken, run it again with a
+    different number" is exactly the loop worth deleting — we name what is holding it and move on,
+    so the reader ends up running, not retrying.
+    """
+    port = int(cfg["port"])
+    if not runtime.port_in_use(port):
+        return cfg, None
+
+    holder = runtime.port_holder(port)
+    by = f" by {holder}" if holder else ""
+    replacement = runtime.free_port_from(port + 1)
+    if replacement is None:
+        raise SystemExit(
+            f"Port {port} is already in use{by}, and no free port was found near it.\n"
+            f"Name one yourself, for example:  grid start {cfg['name']} --port 9500"
+        )
+    updated = dict(cfg)
+    updated["port"] = replacement
+    updated["lan_signaling_url"] = runtime.make_local_url(replacement, _advertised_host(cfg))
+    return updated, f"Port {port} is in use{by} — starting on {replacement} instead."
+
+
+def _apply_up_overrides(cfg: dict[str, Any], args: argparse.Namespace) -> tuple[dict[str, Any], list[str]]:
+    """Let `--port` / `--host` / `--advertise-host` change a grid that already exists.
+
+    These used to be read only when creating a grid. Bringing an existing one up dropped them
+    silently, which produced the worst error text in the CLI: `grid up --port 8099` answering
+    "Port 8090 is already in use. Choose a different --port." — naming the stored port, telling
+    you to change a flag you had just changed, and doing it again for every port you tried.
+
+    A grid is down at this moment, so re-addressing it is safe; the URL it hands out is rebuilt
+    from whatever the new values are.
+    """
+    changes = {
+        key: value
+        for key, value in (
+            ("port", args.port),
+            ("host", args.host),
+            ("advertise_host", args.advertise_host),
+        )
+        if value is not None
+    }
+    if not changes:
+        return cfg, []
+
+    updated = dict(cfg)
+    if "port" in changes:
+        updated["port"] = int(changes["port"])
+    if "host" in changes:
+        updated["host"] = changes["host"]
+    # Rebuilt from the new port whether or not `--advertise-host` was given, since the URL carries
+    # the port too — otherwise a port change would leave the old one advertised.
+    updated["lan_signaling_url"] = runtime.make_local_url(
+        updated["port"], changes.get("advertise_host") or _advertised_host(cfg)
+    )
+    # Port is announced by the caller after the free-port check, so only host is reported here.
+    notes = [
+        f"host changed: {cfg.get('host')} -> {updated['host']}"
+    ] if "host" in changes and cfg.get("host") != updated["host"] else []
+    return updated, notes
+
+
+def _advertised_host(cfg: dict[str, Any]) -> str | None:
+    """The host previously handed out, so a port-only change keeps the address it was reached at."""
+    previous = urlparse(cfg.get("lan_signaling_url") or "").hostname
+    return previous or None
 
 
 def cmd_down(args: argparse.Namespace) -> int:
@@ -50,7 +170,11 @@ def cmd_down(args: argparse.Namespace) -> int:
     outcome = runtime.stop_grid(cfg)
     if not outcome.stopped():
         _refuse_false_stop(cfg, outcome)
-    print(f"Grid {cfg['name']} is down (config kept; `grid up {cfg['name']}` brings it back).")
+    print(f"\n✓ Grid '{cfg['name']}' stopped. Its setup is kept.")
+    # `shlex.quote` only — a grid name is freeform and can carry a space ("Hydrate Grid"), and a
+    # hint printed without quoting it isn't actually copy-pasteable (grid-leave issue: this exact
+    # `Next:` line, unquoted, is what argparse rejected as "unrecognized arguments").
+    print(f"\nNext:  grid start {shlex.quote(cfg['name'])}")
     return 0
 
 
@@ -75,9 +199,9 @@ def _refuse_false_stop(cfg: dict[str, Any], outcome: runtime.StopOutcome) -> Non
             else f"kill -9 {survivor}"
         )
         raise SystemExit(
-            f"grid down: could not stop the server for {cfg['name']} "
+            f"grid stop: could not stop the server for {cfg['name']} "
             f"({run_records.describe_survivor(outcome.teardown)}). It keeps serving this grid until "
-            f"it stops, and the recorded pid is kept so a retried `grid down` still reaches it "
+            f"it stops, and the recorded pid is kept so a retried `grid stop` still reaches it "
             f"(e.g. `{remedy}`)."
         )
 
@@ -87,9 +211,9 @@ def _refuse_false_stop(cfg: dict[str, Any], outcome: runtime.StopOutcome) -> Non
         # remedy has to start from the port instead.
         finder = f"netstat -ano | findstr :{port}" if windows else f"lsof -ti :{port}"
         raise SystemExit(
-            f"grid down: {cfg['name']} is still answering on port {port}, so this box is still "
+            f"grid stop: {cfg['name']} is still answering on port {port}, so this box is still "
             f"serving it — nothing was stopped that the config could prove was the grid's own "
-            f"server. Find what is listening with `{finder}`, then retry `grid down {cfg['name']}`."
+            f"server. Find what is listening with `{finder}`, then retry `grid stop {cfg['name']}`."
         )
 
     probe = runtime.probe_url(cfg)
@@ -101,10 +225,41 @@ def _refuse_false_stop(cfg: dict[str, Any], outcome: runtime.StopOutcome) -> Non
         else f"the config's port ({port!r}) is unusable, so there is nothing to check it with"
     )
     raise SystemExit(
-        f"grid down: could not confirm the server for {cfg['name']} stopped, and could not reach its "
+        f"grid stop: could not confirm the server for {cfg['name']} stopped, and could not reach its "
         f"port to find out — so nothing about this box was established. The recorded pid is kept for "
         f"a retry; {check}."
     )
+
+
+def cmd_delete(args: argparse.Namespace) -> int:
+    """Remove a grid's local config for good — `grid stop` only pauses it.
+
+    There was no way to make `grid ls` forget a grid short of deleting `~/.grid/grids/<id>` by
+    hand, which meant knowing that path exists at all. This is the missing other half of `create,
+    then throw away` — the flow `grid stop` deliberately does not cover, because config surviving a
+    stop is what lets `grid start <name>` bring it straight back.
+    """
+    cfg = config.select_grid(args.name)
+    if not cfg.get("managed_server", True):
+        raise SystemExit(
+            f"{cfg['name']!r} is a remote grid — nothing local to delete. "
+            f"`grid ls` only forgets it here; the grid itself lives on the account that owns it."
+        )
+    if not args.yes:
+        response = input(
+            f"Delete grid {cfg['name']!r} ({cfg['grid_id']})? This removes its local config and "
+            "cannot be undone. [y/N] "
+        ).strip().lower()
+        if response != "y":
+            print("Aborted.")
+            return 1
+
+    runtime.stop_grid(cfg)  # idempotent — a no-op if it was already down
+    shutil.rmtree(paths.grid_dir(cfg["grid_id"]), ignore_errors=True)
+    if state.get_active("local") in (cfg["name"], cfg["grid_id"]):
+        state.set_active("local", None)
+    print(f"Deleted grid {cfg['name']!r}.")
+    return 0
 
 
 def cmd_ls(args: argparse.Namespace) -> int:
@@ -121,7 +276,7 @@ def cmd_ls(args: argparse.Namespace) -> int:
         ], indent=2))
         return 0
     if not grids:
-        print("(no grids — run `grid up` to bring one online)")
+        print("(no grids — run `grid start` to bring one online)")
         return 0
     for cfg in grids:
         where = "local" if cfg.get("managed_server", True) else "remote"
@@ -183,7 +338,7 @@ def _overview_remote(as_json: bool) -> int:
         return 0
     print("mode: remote")
     print(f"active grid: {active}" if active else "active grid: (none)")
-    print("\nSign in with `grid login`, then manage your remote grids with `grid up`/`ls`/`info`, "
+    print("\nSign in with `grid login`, then manage your remote grids with `grid start`/`ls`/`info`, "
           "serve models with `grid join`, and use them with `grid chat -m <model> \"…\"`.")
     return 0
 
@@ -199,7 +354,7 @@ def _overview_local(as_json: bool) -> int:
             return 0
         print("mode: local\n")
         print("No grid yet.\n")
-        print("Start one:\n  grid up\n")
+        print("Start one:\n  grid start\n")
         print("Then join an engine:\n  grid join")
         return 0
 
@@ -222,7 +377,7 @@ def _overview_local(as_json: bool) -> int:
     print(f"Grid: {default['name']}")
     print(f"grid_url: {grid_url}")
     if not reachable:
-        print("status: unreachable — start it with `grid up`")
+        print("status: unreachable — start it with `grid start`")
     else:
         print(f"engines: {len(engines)} live")
         print(f"models: {', '.join(models) if models else '(none)'}")

--- a/cli/grid.py
+++ b/cli/grid.py
@@ -32,8 +32,13 @@ def cmd_up(args: argparse.Namespace) -> int:
             advertise_host=args.advertise_host,
         )
     runtime.start_grid(cfg)
+    url = runtime.grid_url(cfg)
     print(f"grid={cfg['name']}")
-    print(f"grid_url={runtime.grid_url(cfg)}")
+    print(f"grid_url={url}")
+    # The grid is up either way; this only decides whether the address we just printed is one
+    # anything can dial. Catching it here turns a silent dead end into a fixable sentence.
+    if not runtime.advertised_address_works(url):
+        print(runtime.unreachable_address_hint(cfg, url))
     return 0
 
 

--- a/cli/media_io.py
+++ b/cli/media_io.py
@@ -73,6 +73,39 @@ def load_media_file(path_value: str) -> dict[str, str]:
     }
 
 
+# Exactly what llama.cpp can decode, and no more. Its `libmtmd` links stb_image, whose compiled-in
+# decoders are visible in the shipped binary as its own error strings — `bad IHDR len` (PNG),
+# `bad DQT table`/`no SOI` (JPEG), `bad BMP`, `bad Image Descriptor` (GIF). There is no WebP
+# decoder in there at all, so a `.webp` is refused here rather than sent: the engine does not
+# report a decode failure, it simply proceeds with no image, and the model then answers about a
+# picture it never received ("I can't access external links…") — a wrong answer that reads like a
+# real one. Better a refusal naming the formats than a confident reply to nothing.
+_IMAGE_MIME = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".bmp": "image/bmp",
+    ".gif": "image/gif",
+}
+
+
+def image_data_uri(path_value: str) -> str:
+    """[path_value] as a ``data:`` URI for a chat request's ``image_url`` part.
+
+    A data URI, not a path or an ``http://`` link: the engine that answers may be on another
+    machine entirely, so anything it would have to fetch for itself — a local path, a URL only
+    this box can reach — is not a thing it can read. The bytes travel with the request.
+    """
+    path = Path(path_value).expanduser()
+    if not path.is_file():
+        raise SystemExit(f"Image not found: {path}")
+    mime = _IMAGE_MIME.get(path.suffix.lower())
+    if mime is None:
+        kinds = ", ".join(sorted(_IMAGE_MIME))
+        raise SystemExit(f"{path.name}: not an image Grid can send. Use one of: {kinds}.")
+    return f"data:{mime};base64,{base64.b64encode(path.read_bytes()).decode('ascii')}"
+
+
 def write_media_outputs(output_files: list[dict[str, Any]], output_dir: Path) -> list[Path]:
     output_dir.mkdir(parents=True, exist_ok=True)
     written: list[Path] = []

--- a/cli/mode.py
+++ b/cli/mode.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import shlex
 
 from local import config
 from shared import state
@@ -23,7 +24,7 @@ def cmd_mode(args: argparse.Namespace) -> int:
         return 0
     print(mode)
     if target == "remote":
-        print("Remote mode: `grid login` to sign in, then `grid up` to bring a remote grid online, "
+        print("Remote mode: `grid login` to sign in, then `grid start` to bring a remote grid online, "
               "`grid join` to serve models to it, and `grid chat -m <model> \"…\"` to use them.")
     return 0
 
@@ -61,6 +62,6 @@ def _require_local_grid(name: str) -> None:
         if cfg.get("name") == name or cfg.get("grid_id") == name:
             return
     raise SystemExit(
-        f"Grid not found: {name!r}. Run `grid up {name}` on this device, or `grid ls` "
-        "to see your grids."
+        f"Grid not found: {name!r}. Run `grid start {shlex.quote(name)}` on this device, or "
+        "`grid ls` to see your grids."
     )

--- a/cli/models.py
+++ b/cli/models.py
@@ -25,7 +25,6 @@ def cmd_catalog(args: argparse.Namespace) -> int:
     if getattr(args, "json", False):
         print(json.dumps([
             {
-                "label": entry.label,
                 "hf_repo": entry.hf_repo,
                 "file": entry.quantized_file,
                 "min_vram_gb": entry.min_vram_gb,
@@ -46,7 +45,9 @@ def cmd_catalog(args: argparse.Namespace) -> int:
     for entry in catalog.recommended_entries():
         print(catalog.format_catalog_entry(entry))
     print()
-    print("Also: `grid pull <hf-repo>:<file>` for any GGUF on Hugging Face.")
+    print("Any other GGUF on Hugging Face works too — search huggingface.co, then just pull the")
+    print("repository. It grabs Q4_K_M by default, or asks you to pick if there's more than one file:")
+    print("  grid pull unsloth/gemma-3-4b-it-GGUF")
     return 0
 
 
@@ -352,23 +353,67 @@ def _catalog_codex_json(
 
 
 def cmd_pull(args: argparse.Namespace) -> int:
-    from shared.models import catalog, download
+    from shared.models import download
 
-    entry = catalog.find(args.model)
-    if entry:
-        repo, filename = entry.hf_repo, entry.quantized_file
-        print(f"Resolved catalog label {entry.label!r} -> {repo}/{filename}")
+    repo, filename = download.parse_spec(args.model)
+    if filename is None:
+        # A bare repo — the only form that leaves the file unchosen. Show the repo's real file
+        # list and let the reader pick; `parse_spec` has already refused the half-way spelling
+        # (a partial quant like ':Q8_0') that would otherwise be resolved by guesswork here.
+        filename = _pick_file(repo)
+    existing = download.local_path(filename)
+    if existing.is_file():
+        # `download()` itself is safe to call again (it just returns `existing`), but printing
+        # "Downloading ..." for a file that never moves a byte would tell the reader something
+        # happened that did not.
+        print(f"Already have it: {existing}")
+        target = existing
     else:
-        repo, filename = download.parse_spec(args.model)
-    print(f"Downloading {repo}/{filename} ...")
-    target = download.download(repo, filename, on_progress=download.stderr_progress)
-    print(f"Saved {target}")
+        print(f"Downloading {repo}/{filename} ...")
+        target = download.download(repo, filename, on_progress=download.stderr_progress)
+        print(f"Saved {target}")
     _pull_projector(repo, target)
+    # Only `join` — a downloaded model is not yet on any grid, so `grid models` and `grid chat`
+    # would both come back empty. The rest of the path is suggested by `join` itself, once there
+    # is something for them to find.
+    alias = target.stem
+    print(f"\nNext:  grid join <grid-url> --serve {target.name} --advertise-as {alias} --name this-computer")
     return 0
 
 
-def _pull_projector(repo: str, model_path) -> None:
+def _pick_file(repo: str) -> str:
+    """Show every `.gguf` file in [repo] and let the reader choose, rather than silently
+    downloading a guess. No arrow-key menu — that needs a UI dependency this package does not
+    carry — a numbered list with `input()` gets the same outcome: see everything, pick one.
+
+    Falls straight to the suggested default with no prompt when there is nothing to choose
+    between, or when stdin/stdout are not a real terminal (a script piping `grid pull` must never
+    block waiting on a keypress that will never come).
+    """
+    from shared.models import download
+
+    default, names = download.resolve_file(repo)
+    if len(names) == 1 or not (sys.stdin.isatty() and sys.stdout.isatty()):
+        print(f"Picked {default!r} ({download.DEFAULT_QUANT})")
+        return default
+
+    print(f"{repo} ships {len(names)} files:")
+    for i, name in enumerate(names, 1):
+        marker = "  <- default" if name == default else ""
+        print(f"  {i}. {name}{marker}")
+    choice = input(f"Pick a number [1-{len(names)}], or press Enter for the default: ").strip()
+    if not choice:
+        return default
+    if choice.isdigit() and 1 <= int(choice) <= len(names):
+        return names[int(choice) - 1]
+    print(f"Not a valid choice — using the default {default!r}.")
+    return default
+
+
+def _pull_projector(repo: str, model_path) -> bool:
     """Fetch the repo's multimodal projector, if it has one, so vision needs no second command.
+    Returns whether this model can see, so the caller can offer `grid chat --image` to a model
+    that will actually answer it.
 
     Saved as ``<model-stem>.mmproj.gguf`` rather than under its own name: every vision repo calls
     its projector some spelling of ``mmproj-F16.gguf``, so keeping the original name would make two
@@ -379,14 +424,15 @@ def _pull_projector(repo: str, model_path) -> None:
 
     projector = download.find_projector(repo)
     if not projector:
-        return
+        return False
     target = model_path.parent / (model_path.stem + gguf.PROJECTOR_SUFFIX)
     if target.is_file():
         print(f"Vision projector already present: {target.name}")
-        return
-    print(f"This is a vision model. Downloading {repo}/{projector} ...")
+        return True
+    print(f"Supports vision. Downloading {repo}/{projector} ...")
     download.download(repo, projector, out=target, on_progress=download.stderr_progress)
     print(f"Saved {target}")
+    return True
 
 
 def cmd_ctx(args: argparse.Namespace) -> int:

--- a/cli/models.py
+++ b/cli/models.py
@@ -25,6 +25,9 @@ def cmd_catalog(args: argparse.Namespace) -> int:
     if getattr(args, "json", False):
         print(json.dumps([
             {
+                # First, and named for what it is: the argument `grid pull` takes. A consumer
+                # reading this file should never have to reassemble it from the two below.
+                "pull_spec": catalog.pull_spec(entry),
                 "hf_repo": entry.hf_repo,
                 "file": entry.quantized_file,
                 "min_vram_gb": entry.min_vram_gb,

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -27,6 +27,7 @@ from .engine import (
     cmd_engine_stop,
 )
 from .grid import (
+    cmd_delete,
     cmd_down,
     cmd_info,
     cmd_ls,
@@ -147,26 +148,30 @@ def _add_credential(sub) -> None:
 
 
 def _add_grid_lifecycle(sub) -> None:
-    up = sub.add_parser("up", help="Bring a grid online (creates it on first run; default: home)")
-    up.add_argument("name", nargs="?", default=None,
-                    help="Grid name or id (ag-…). Omit for 'home'.")
-    up.add_argument("--port", type=int, default=runtime.DEFAULT_PORT)
-    up.add_argument("--host", default=runtime.DEFAULT_HOST)
-    up.add_argument("--advertise-host", default=None)
-    # Remote-only (local cmd_up ignores it): the network type set when `grid up` creates a remote grid.
-    # default=None lets the remote handler tell an explicit value on a *start* from this create default.
-    up.add_argument(
-        "--type",
-        choices=("permissioned-public", "permissioned-providers"),
-        default=None,
-        help="Remote grid network type, set on create (default permissioned-public).",
-    )
-    up.set_defaults(handler=cmd_up)
+    # `start`/`stop` beside `up`/`down`. The command names are the vocabulary a reader learns, and
+    # two metaphors is one too many: a grid went "up" while a computer "joined" it, so nothing
+    # paired with `grid leave`. Now the grid **starts** and **stops**, computers **join** and
+    # **leave**, and the docs can say one thing. `up`/`down` keep working — every existing script,
+    # every older README and every muscle memory still resolves.
+    for _verb, _summary in (("up", "Start a grid (creates it on first run; default: home)"),
+                            ("start", "Start a grid — same as `grid up`")):
+        _build_up_parser(sub, _verb, _summary)
 
-    down = sub.add_parser("down", help="Take a grid offline (config persists)")
-    down.add_argument("name", nargs="?", default=None,
-                      help="Grid name or id (ag-…). Omit for the active grid.")
-    down.set_defaults(handler=cmd_down)
+
+    for _verb, _summary in (("down", "Stop a grid (its setup is kept)"),
+                            ("stop", "Stop a grid — same as `grid down`")):
+        _d = sub.add_parser(_verb, help=_summary)
+        _d.add_argument("name", nargs="?", default=None,
+                        help="Grid name or id (ag-…). Omit for the active grid.")
+        _d.set_defaults(handler=cmd_down)
+
+    delete = sub.add_parser(
+        "delete", help="Delete a grid's local config for good (`grid stop` only pauses it)"
+    )
+    delete.add_argument("name", nargs="?", default=None,
+                        help="Grid name or id (ag-…). Omit for the active grid.")
+    delete.add_argument("--yes", action="store_true", help="Skip confirmation.")
+    delete.set_defaults(handler=cmd_delete)
 
     ls = sub.add_parser("ls", help="List your grids")
     ls.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
@@ -182,6 +187,34 @@ def _add_grid_lifecycle(sub) -> None:
     info.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
     info.add_argument("--env", action="store_true", help="Print OPENAI_* shell exports.")
     info.set_defaults(handler=cmd_info)
+
+
+def _build_up_parser(sub, verb: str, summary: str):
+    """One definition, two names — see the note at the call site."""
+    parser = sub.add_parser(verb, help=summary)
+    parser.add_argument("name", nargs="?", default=None,
+                        help="Grid name or id (ag-…). Omit for 'home'.")
+    # `default=None`, not the real defaults: these three are also settings of a grid that already
+    # exists, and `cmd_up` can only apply the ones the operator actually typed if "not given" is
+    # distinguishable from "given the default value". Falling back to DEFAULT_* happens at use.
+    parser.add_argument("--port", type=int, default=None,
+                        help=f"Port to listen on (default {runtime.DEFAULT_PORT}). On a grid that "
+                             "already exists this changes its port.")
+    parser.add_argument("--host", default=None,
+                        help=f"Address to bind (default {runtime.DEFAULT_HOST}).")
+    parser.add_argument("--advertise-host", default=None,
+                        help="Address to hand out to other computers, when the one Grid picks is "
+                             "not reachable. Use 127.0.0.1 to keep everything on this machine.")
+    # Remote-only (local cmd_up ignores it): the network type set when `grid up` creates a remote
+    # grid. default=None lets the remote handler tell an explicit value from this create default.
+    parser.add_argument(
+        "--type",
+        choices=("permissioned-public", "permissioned-providers"),
+        default=None,
+        help="Remote grid network type, set on create (default permissioned-public).",
+    )
+    parser.set_defaults(handler=cmd_up)
+    return parser
 
 
 def _add_engines(sub) -> None:
@@ -325,8 +358,8 @@ def _add_engines(sub) -> None:
     leave.add_argument("grid", nargs="?", default=None,
                        help="Grid name or id (ag-…). Omit for the active grid.")
     leave.add_argument("--engine", default=None,
-                       help="Engine to leave. Matches, in order: exact engine id, endpoint URL, a "
-                            "served model, or a URL fragment (e.g. :8000).")
+                       help="Engine to leave. Matches, in order: exact engine id, endpoint URL, the "
+                            "--name given at join, a served model, or a URL fragment (e.g. :8000).")
     leave.add_argument("--all", action="store_true",
                        help="Leave every engine on this grid. Without --engine: a one-engine grid "
                             "leaves that one; a multi-engine grid requires --all.")
@@ -363,7 +396,11 @@ def _add_models(sub) -> None:
     )
     catalog.set_defaults(handler=cmd_catalog)
 
-    pull = sub.add_parser("pull", help="Download a model (catalog label or '<hf-repo>:<file>')")
+    pull = sub.add_parser(
+        "pull",
+        help="Download a model. Takes a name from `grid catalog`, or any GGUF on Hugging Face "
+             "as repository:file, e.g. unsloth/gemma-3-4b-it-GGUF:gemma-3-4b-it-Q4_K_M.gguf",
+    )
     pull.add_argument("model")
     pull.set_defaults(handler=cmd_pull)
 
@@ -383,6 +420,13 @@ def _add_use(sub) -> None:
     chat = sub.add_parser("chat", help="Send one chat message")
     chat.add_argument("-m", "--model", required=True)
     chat.add_argument("message")
+    # `append`, so several images go in one question ("what changed between these two?"). The model
+    # has to be one `grid models --verbose` shows as vision-capable; a text-only one will either
+    # ignore the image or refuse, and that is the engine's answer to give, not ours to pre-empt.
+    chat.add_argument(
+        "--image", action="append", metavar="PATH",
+        help="Send an image with the message (vision models). Repeat for more than one.",
+    )
     chat.add_argument("--grid", default=None)
     chat.add_argument("--json", action="store_true", help="Print the full JSON response.")
     chat.add_argument("--timeout", type=float, default=600.0)

--- a/cli/provider.py
+++ b/cli/provider.py
@@ -465,16 +465,44 @@ def _spawn_engine(
             f"Engine {engine_id} exited before it registered. See {log_path}:\n{_log_tail(log_path)}"
         )
 
-    print(f"Joined engine {engine_id} to {cfg['name']} (pid={proc.pid})")
-    if endpoint_url:
-        print(f"endpoint_url={endpoint_url}")
-    if models:
-        print(f"models={','.join(models)}")
-    print(f"log={log_path}")
-    if status == "starting":
-        print("(still starting — run `grid models` shortly to confirm it is live)")
-    print(f"Check `grid models {cfg['name']}`; stop with `grid leave {cfg['name']} --engine {engine_id}`.")
+    _report_join(cfg, args, engine_id, models, endpoint_url, log_path, status)
     return 0
+
+
+def _report_join(cfg, args, engine_id, models, endpoint_url, log_path, status) -> None:
+    """Say whether the model is actually being served, in the words someone new would use.
+
+    This used to print "Joined engine ... (pid=…)" and leave it there. "Joined" only ever meant
+    "the process was launched" — the model could still be loading, or about to fail — and the four
+    lines that say what really happened (model loaded, vision on, registered with the grid) go to a
+    log file nobody thinks to open. So the reader was told a pid and a path and left to work out
+    for themselves whether it had worked.
+
+    The advertised name is what gets printed, because that is the name they will type next. The
+    old line printed the FILENAME here while the log printed the advertised name — the same label
+    over two different values, and the one on screen was the one you cannot use.
+    """
+    advertised = _advertised_text_models(list(models or []), list(getattr(args, "advertise_as", []) or []))
+    served = advertised or list(models or [])
+
+    if status == "starting":
+        print(f"\nEngine '{engine_id}' is starting — the model is still loading.")
+        print(f"  Watch it:   tail -f {log_path}")
+        print(f"  Check it:   grid models {cfg['name']}")
+        print(f"  Stop it:    grid leave {cfg['name']} --engine {engine_id}")
+        return
+
+    print(f"\n✓ Serving on grid '{cfg['name']}'")
+    for name in served:
+        print(f"    {name}")
+    if endpoint_url:
+        print(f"  engine address   {endpoint_url}")
+    print(f"  this computer    {engine_id}")
+    print()
+    if served:
+        print(f"  Try it:   grid chat -m {served[0]} \"hello\"")
+    print(f"  Stop it:  grid leave {cfg['name']} --engine {engine_id}")
+    print(f"  Log:      {log_path}")
 
 
 def _await_engine_start(grid_url: str, node_id: str, proc, grace: float = 3.0) -> str:

--- a/cli/provider.py
+++ b/cli/provider.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shlex
 import signal
 import subprocess
 import sys
@@ -18,6 +19,7 @@ import time
 import uuid
 from types import SimpleNamespace
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 
@@ -137,14 +139,21 @@ def cmd_join(args: argparse.Namespace) -> int:
         return _spawn_engine(cfg, args, endpoint_url=None, models=[], media=True)
 
     if args.models:
-        raise SystemExit("-m/--model names models for an engine; pair it with --at <url>, or use --serve <model>.")
+        raise SystemExit(
+            "-m/--model names what an engine serves, so it needs to know which engine.\n"
+            "  Point at one you already run:  grid join --at http://localhost:11434/v1 -m llama3\n"
+            "  Or start the built-in one:     grid join --serve my-model.gguf"
+        )
 
     # No engine spec: detect what is already running on this box.
     detected = _detect(advertise_host)
     if not detected:
         raise SystemExit(
-            "No running engine detected on this box. Point at one with "
-            "`grid join --at <url> -m <model>`, or start the built-in engine with `grid join --serve <model>`."
+            "Nothing on this computer is running a model yet.\n"
+            "  Install the built-in engine:   grid engine install llama.cpp\n"
+            "  then download a model:         grid catalog\n"
+            "  then serve it:                 grid join --serve <the file grid pull saved>\n"
+            "  Already run Ollama or vLLM?    grid join --at http://localhost:11434/v1 -m llama3"
         )
     if args.kind:
         detected = [engine for engine in detected if engine.label == args.kind]
@@ -157,7 +166,9 @@ def cmd_join(args: argparse.Namespace) -> int:
                 print("Nothing joined.")
                 return 0
         else:
-            raise SystemExit("Multiple engines detected; pass --all, --kind <kind>, or --at <url>.")
+            # The plan above already printed both commands with real values in them; repeating
+            # them here just made the reader read the same two lines twice.
+            raise SystemExit("More than one engine is running here, so pick one of the two above.")
 
     used: set[str] = set()
     rc = 0
@@ -469,6 +480,40 @@ def _spawn_engine(
     return 0
 
 
+def serves_vision(args) -> bool:
+    """Whether the model this join just started can read images.
+
+    Only ever true for a built-in `--serve` engine: an `--at` join points at somebody else's
+    server, whose modalities are its own to advertise, not ours to guess from a file we do not
+    have. Read through the same `projector_beside` the launcher uses to decide `--mmproj`, so the
+    hint and the engine can never disagree about whether vision is on.
+    """
+    serve = getattr(args, "serve", None)
+    if not serve:
+        return False
+    if getattr(args, "mmproj", None):
+        return True  # explicitly pointed at a projector, so vision is on by instruction
+    from shared.models import gguf
+
+    return gguf.projector_beside(paths.models_dir() / serve) is not None
+
+
+def chat_hints(model: str, vision: bool) -> list[str]:
+    """The `grid chat` line(s) to suggest for [model] — two when it can see, one when it cannot.
+
+    Shared by both modes' join reports so a vision model is offered `--image` identically whether
+    it joined a local grid or a remote one.
+    """
+    lines = [f'  grid chat -m {model} "hello"']
+    if vision:
+        # Only for a model that actually carries a projector: offering `--image` on a text-only
+        # model would advertise something the engine will not answer.
+        # A placeholder, not a plausible filename: `photo.jpg` reads as something to paste, and
+        # pasting it fails on a file nobody has. Quoted so a path with a space survives the shell.
+        lines.append(f'  grid chat -m {model} --image "<image-path>" "what is in this image?"')
+    return lines
+
+
 def _report_join(cfg, args, engine_id, models, endpoint_url, log_path, status) -> None:
     """Say whether the model is actually being served, in the words someone new would use.
 
@@ -485,24 +530,20 @@ def _report_join(cfg, args, engine_id, models, endpoint_url, log_path, status) -
     advertised = _advertised_text_models(list(models or []), list(getattr(args, "advertise_as", []) or []))
     served = advertised or list(models or [])
 
+    names = ", ".join(f"'{name}'" for name in served) or f"'{engine_id}'"
     if status == "starting":
-        print(f"\nEngine '{engine_id}' is starting — the model is still loading.")
-        print(f"  Watch it:   tail -f {log_path}")
-        print(f"  Check it:   grid models {cfg['name']}")
-        print(f"  Stop it:    grid leave {cfg['name']} --engine {engine_id}")
+        print(f"\n… Loading {names} — large models take a while.")
+        # Quoted: a grid name is freeform and can carry a space ("Hydrate Grid"), and this hint
+        # printed bare isn't actually copy-pasteable — argparse splits it into two positionals and
+        # rejects the second (grid-leave issue: exactly this line is what a reader hit).
+        print(f"\nNext:  grid models {shlex.quote(cfg['name'])}")
         return
 
-    print(f"\n✓ Serving on grid '{cfg['name']}'")
-    for name in served:
-        print(f"    {name}")
-    if endpoint_url:
-        print(f"  engine address   {endpoint_url}")
-    print(f"  this computer    {engine_id}")
-    print()
+    print(f"\n✓ Serving {names} on grid '{cfg['name']}'")
     if served:
-        print(f"  Try it:   grid chat -m {served[0]} \"hello\"")
-    print(f"  Stop it:  grid leave {cfg['name']} --engine {engine_id}")
-    print(f"  Log:      {log_path}")
+        print("\nNext:")
+        for line in chat_hints(served[0], serves_vision(args)):
+            print(line)
 
 
 def _await_engine_start(grid_url: str, node_id: str, proc, grace: float = 3.0) -> str:
@@ -627,6 +668,20 @@ def _stop_engine(grid_id: str, engine_id: str, record: dict[str, Any]) -> run_re
 # grid models
 # ---------------------------------------------------------------------------
 
+def print_models_hint(model: str) -> None:
+    """Suggest the chat command for [model] — to **stderr**, and only on a real terminal.
+
+    `grid models` is a data command: its stdout is a list somebody pipes into a loop, and a hint
+    printed there arrives as a phantom model name (measured: `grid models | while read m` handed a
+    script the blank line and `Next:  grid chat -m ... "hello"` as two extra "models"). stderr
+    keeps the list clean while a person still sees the hint; the tty check keeps it out of a
+    script's error log too, where it would be noise nobody reads.
+    """
+    if not sys.stdout.isatty():
+        return
+    print(f'\nNext:  grid chat -m {model} "hello"', file=sys.stderr)
+
+
 def cmd_models(args: argparse.Namespace) -> int:
     cfg = config.select_grid(getattr(args, "grid", None))
     engines = _discover(cfg)
@@ -647,20 +702,25 @@ def cmd_models(args: argparse.Namespace) -> int:
         print("(no live models — `grid join` an engine first)")
         return 0
 
+    seen: list[str] = []
+    for model, _, _ in rows:
+        if model not in seen:
+            seen.append(model)
+
     if args.verbose:
         width = max(len("MODEL"), *(len(model) for model, _, _ in rows))
         ewidth = max(len("ENGINE"), *(len(label) for _, label, _ in rows))
         print(f"{'MODEL':<{width}}  {'ENGINE':<{ewidth}}  WHERE")
         for model, label, where in rows:
             print(f"{model:<{width}}  {label:<{ewidth}}  {where}")
-        return 0
+    else:
+        for model in seen:
+            print(model)
 
-    seen: list[str] = []
-    for model, _, _ in rows:
-        if model not in seen:
-            seen.append(model)
-    for model in seen:
-        print(model)
+    # A model showing up here is exactly the moment `grid join`'s own "still loading" message
+    # (`_report_join`) could not yet promise — it only ever pointed back to this command. Close
+    # that loop here, with the real name that just appeared, not the one someone typed minutes ago.
+    print_models_hint(seen[0])
     return 0
 
 
@@ -761,6 +821,38 @@ def run_engine_from_record(grid_id: str, engine_id: str) -> int:
     return _run_engine(args)
 
 
+def _fixed_up_endpoint(endpoint_url: str, args: SimpleNamespace, grid_url: str) -> str:
+    """Fall back to a reachable address for a built-in engine's own endpoint, the same way
+    `cli/grid.py::_resolve_address` already does for the grid's address — one hop further
+    downstream, and much harder to notice.
+
+    `detect_local_ip` can name an interface (typically a VPN) nothing can dial back — including
+    the grid on this same box. When it names the *grid's* address, `grid start` prints a warning
+    at the moment it happens. When it names an *engine's* address instead, the join reports
+    success (llama-server really is listening — just not where it just told the grid to look),
+    and the failure only surfaces later as `grid chat` answering "Server disconnected without
+    sending a response", nowhere near the command that caused it.
+
+    Checked only once llama-server is confirmed listening (`wait_for_models` returned), so the
+    reachability test means something instead of probing a port nothing has bound yet.
+    """
+    if args.advertise_host is not None or runtime.advertised_address_works(endpoint_url):
+        return endpoint_url  # an explicit choice, or already proven reachable — leave it alone
+
+    # The grid itself reached over loopback means everything is one machine, and llama-server
+    # binds 0.0.0.0, so loopback always reaches it too.
+    if urlparse(grid_url).hostname in ("127.0.0.1", "localhost"):
+        fixed = runtime.engine_endpoint_url(None, args.endpoint_port, "127.0.0.1")
+    else:
+        candidates = runtime.lan_ip_candidates()
+        fixed = runtime.engine_endpoint_url(None, args.endpoint_port, candidates[0]) if candidates else endpoint_url
+
+    if fixed != endpoint_url:
+        print(f"{endpoint_url} was not reachable — advertising {fixed} instead.")
+        run_records.update_record(args.grid, args.name, endpoint_url=fixed)
+    return fixed
+
+
 def _run_engine(args: SimpleNamespace) -> int:
     cfg = config.select_grid(args.grid)
     grid_url = runtime.grid_url(cfg)
@@ -793,8 +885,31 @@ def _run_engine(args: SimpleNamespace) -> int:
             from shared.engine import launcher as launcher_mod
 
             launcher = launcher_mod
-            if launcher.is_port_in_use(args.endpoint_port):
-                raise SystemExit(f"Port {args.endpoint_port} already in use; aborting.")
+            if runtime.port_in_use(args.endpoint_port):
+                # Same fix as a busy `grid start` port: this runs in the detached child
+                # (`__engine`), so a hard abort here used to surface as "Engine ... exited
+                # before it registered. Port 8081 already in use; aborting." — a dead join with
+                # no way forward short of typing `--endpoint-port` and guessing a free number.
+                holder = runtime.port_holder(args.endpoint_port)
+                replacement = runtime.free_port_from(args.endpoint_port + 1)
+                if replacement is None:
+                    raise SystemExit(
+                        f"Port {args.endpoint_port} is already in use"
+                        f"{f' by {holder}' if holder else ''}, and no free port was found near it."
+                    )
+                print(
+                    f"Port {args.endpoint_port} is in use"
+                    f"{f' by {holder}' if holder else ''} — starting on {replacement} instead."
+                )
+                args.endpoint_port = replacement
+                endpoint_url = runtime.engine_endpoint_url(
+                    args.endpoint_url, args.endpoint_port, args.advertise_host
+                )
+                # The record on disk still names the old port — every later `grid engines` /
+                # `grid leave` read has to see the one actually running, not the one asked for.
+                run_records.update_record(
+                    args.grid, args.name, endpoint_port=replacement, endpoint_url=endpoint_url
+                )
             launcher.assert_supported_build()
             launched = launcher.start_llm(
                 args.models[0],
@@ -811,6 +926,7 @@ def _run_engine(args: SimpleNamespace) -> int:
             print(f"Spawned llama-server pid={launched.proc.pid}, log={launched.log}")
             launcher.wait_for_models(launched)
             print(f"llama-server is ready on :{args.endpoint_port}")
+            endpoint_url = _fixed_up_endpoint(endpoint_url, args, grid_url)
 
         advertised_models = list(text_advertised_models)
         # Map each advertised (possibly `--advertise-as` alias) text model to the name the engine
@@ -911,7 +1027,12 @@ def _print_plan(detected: list[Any]) -> None:
     for engine in detected:
         models = ",".join(engine.models) or ("comfyui" if engine.media else "(no models listed)")
         print(f"  {engine.label:<12} {engine.endpoint_url:<34} {models}")
-    print("\nJoin them:\n  grid join --all\n  grid join --kind <kind>")
+    # Name a kind that is actually on this screen. `--kind <kind>` asked the reader to invent a
+    # value the command had just finished discovering for them.
+    example = sorted({engine.label for engine in detected})[0]
+    print("\nJoin them:")
+    print("  grid join --all")
+    print(f"  grid join --kind {example}      # or any other kind listed above")
 
 
 def _interactive() -> bool:

--- a/cli/remote_grid.py
+++ b/cli/remote_grid.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import shlex
 from typing import Any
 
 from shared import shell, state
@@ -146,10 +147,14 @@ def resolve_relay_base(
             raise  # not the creator and no stored relay URL — surface the original error
         status = {}
     base = _grid_url(status, rec)
+    # `shlex.quote`: a grid name is freeform and can carry a space ("Hydrate Grid"), and an
+    # unquoted hint isn't actually copy-pasteable (grid-leave issue: `cli/grid.py`/`cli/provider.py`
+    # had the identical bug in their own `Next:` hints).
+    quoted_label = shlex.quote(label)
     if not base:
-        raise SystemExit(f"Grid {label} isn't up; run `grid up {label}` first.")
+        raise SystemExit(f"Grid {label} isn't up; run `grid start {quoted_label}` first.")
     if status.get("state") and status.get("state") != "running":
-        raise SystemExit(f"Grid {label} isn't up; run `grid up {label}` first.")
+        raise SystemExit(f"Grid {label} isn't up; run `grid start {quoted_label}` first.")
     return base, status
 
 
@@ -190,7 +195,7 @@ def cmd_remote_up(args: argparse.Namespace) -> int:
         status = control_plane.get_managed_network_status(session, network_id)
         return _print_up(rec.get("name") or name, _grid_url(status, rec))
     if name is None:  # nothing to start, and no name to create under
-        raise SystemExit("Name a grid to create: grid up <name> (or grid use <name> to pick one).")
+        raise SystemExit("Name a grid to create: grid start <name> (or grid use <name> to pick one).")
     resp = control_plane.create_managed_network(session, name, args.type or DEFAULT_NETWORK_TYPE)
     if not _valid_network_id(resp.get("network_id")):
         # A 200 with no usable id would otherwise persist a record that can't be acted on and
@@ -218,7 +223,7 @@ def cmd_remote_down(args: argparse.Namespace) -> int:
     network_id = _network_id(rec)
     label = rec.get("name") or network_id
     control_plane.stop_managed_network(session, network_id)
-    print(f"Grid {label} is down (grid up {label} brings it back).")
+    print(f"Grid {label} is down (grid start {shlex.quote(label)} brings it back).")
     return 0
 
 
@@ -235,7 +240,7 @@ def cmd_remote_ls(args: argparse.Namespace) -> int:
         ))
         return 0
     if not nets:
-        print("(no grids — run `grid up <name>` to bring one online)")
+        print("(no grids — run `grid start <name>` to bring one online)")
         return 0
     for net in nets:
         is_active = active and (net.get("network_id") == active or net.get("name") == active)

--- a/cli/remote_overview.py
+++ b/cli/remote_overview.py
@@ -86,11 +86,6 @@ def _nodes_from(overview: dict[str, Any]) -> list[dict[str, Any]]:
     return [node for node in nodes if isinstance(node, dict)]
 
 
-def _nodes(args: argparse.Namespace) -> list[dict[str, Any]]:
-    """The active remote grid's live engine nodes (fetches the overview)."""
-    return _nodes_from(_fetch_overview(args))
-
-
 def live_model_names(overview: dict[str, Any]) -> tuple[str, ...]:
     """Every model id the grid currently serves, first-seen order, deduped across engines.
 
@@ -102,17 +97,40 @@ def live_model_names(overview: dict[str, Any]) -> tuple[str, ...]:
     asking about when it asks which models exist.
     """
     return tuple(dict.fromkeys(
-        model for node in _nodes_from(overview) for model in _node_models(node)
+        model for node in _nodes_from(overview) for model in _node_models(node, overview)
     ))
 
 
-def _node_models(node: dict[str, Any]) -> list[str]:
+def _model_case_map(overview: dict[str, Any]) -> dict[str, str]:
+    """``lower(id) -> id``, read from the overview's own top-level ``models`` list.
+
+    That list is the ONE place the relay reports a model's id in its true case; every node's own
+    ``models`` array is lowercased for display (grid-leave issue: reproduced live serving
+    `Qwen3.5-2B-Q4_K_M`, listed under a node as `qwen3.5-2b-q4_k_m`, and rejected verbatim when
+    copied back into `grid chat -m`). Correcting it here, once, fixes it everywhere this renders —
+    `grid engines`, `grid models`, and `grid launch`'s preflight (`live_model_names`) all read
+    through this same function now, so none of them can show a name the grid won't answer to."""
+    entries = overview.get("models")
+    if not isinstance(entries, list):
+        return {}
+    return {
+        entry["id"].lower(): entry["id"]
+        for entry in entries
+        if isinstance(entry, dict) and isinstance(entry.get("id"), str)
+    }
+
+
+def _node_models(node: dict[str, Any], overview: dict[str, Any] | None = None) -> list[str]:
     """A node's served model ids as strings (defends against a non-list ``models`` or non-string
-    items — otherwise ``",".join`` would split a bare string into characters or raise ``TypeError``)."""
+    items — otherwise ``",".join`` would split a bare string into characters or raise ``TypeError``).
+
+    Corrected against ``overview``'s true-case list when given; a caller that already has the whole
+    overview in scope should always pass it — the raw, lowercased id is never what should render."""
     models = node.get("models")
     if not isinstance(models, list):
         return []
-    return [str(model) for model in models]
+    case_map = _model_case_map(overview) if overview is not None else {}
+    return [case_map.get(str(model).lower(), str(model)) for model in models]
 
 
 def _node_responses_models(node: dict[str, Any]) -> set[str]:
@@ -128,7 +146,8 @@ def _node_responses_models(node: dict[str, Any]) -> set[str]:
 
 def cmd_remote_engines(args: argparse.Namespace) -> int:
     """`grid engines` (remote): the live engines (nodes) joined to the active grid."""
-    nodes = _nodes(args)
+    overview = _fetch_overview(args)
+    nodes = _nodes_from(overview)
 
     if getattr(args, "json", False):
         print(json.dumps(nodes, indent=2))  # passthrough of each node object — forward-compatible
@@ -138,21 +157,32 @@ def cmd_remote_engines(args: argparse.Namespace) -> int:
         print("(no engines — `grid join` one first)")
         return 0
 
-    names = [str(n.get("name") or "") for n in nodes]
+    raw_names = [str(n.get("name") or "") for n in nodes]
+    # `--name` at join is never enforced unique across DIFFERENT machines on the same grid (only
+    # this machine's own `grid leave` collision check is — cli/provider.py:414), so two members can
+    # genuinely show up with an identical NODE label. The overview carries `provider_email` per
+    # node precisely to tell them apart, but until now it only ever surfaced via `--json` — the
+    # plain table had nothing to distinguish two "this-computer" rows. Appended ONLY on an actual
+    # collision, so the common (all-unique) case stays exactly as terse as before — a column that is
+    # always full of everyone's email would be noise on every normal, non-colliding grid.
+    dupes = {name for name in raw_names if raw_names.count(name) > 1 and name}
+    names = [
+        f"{name} ({n.get('provider_email')})" if name in dupes and n.get("provider_email") else name
+        for name, n in zip(raw_names, nodes)
+    ]
     engines = [str(n.get("engine") or "") for n in nodes]
     devices = [str(n.get("device") or "") for n in nodes]
     nwidth = max(len("NODE"), *(len(x) for x in names))
     ewidth = max(len("ENGINE"), *(len(x) for x in engines))
     dwidth = max(len("DEVICE"), *(len(x) for x in devices))
     print(f"{'NODE':<{nwidth}}  {'ENGINE':<{ewidth}}  {'DEVICE':<{dwidth}}  TOK/S")
-    for node in nodes:
-        name = str(node.get("name") or "")
+    for name, node in zip(names, nodes):
         engine = str(node.get("engine") or "")
         device = str(node.get("device") or "")
         tok_s = node.get("throughput_tok_s")
         # bool is an int subclass — exclude it so `throughput_tok_s: true` shows "-", not "1".
         tok = f"{tok_s:g}" if isinstance(tok_s, (int, float)) and not isinstance(tok_s, bool) else "-"
-        models = ",".join(_node_models(node)) or "(none)"
+        models = ",".join(_node_models(node, overview)) or "(none)"
         print(f"{name:<{nwidth}}  {engine:<{ewidth}}  {device:<{dwidth}}  {tok}")
         print(f"{'':<{nwidth}}  models: {models}")
     return 0
@@ -172,7 +202,7 @@ def cmd_remote_models(args: argparse.Namespace) -> int:
         engine = str(node.get("engine") or "")
         name = str(node.get("name") or "")
         capable = _node_responses_models(node)  # resolved once per node, not per served model
-        for model in _node_models(node):
+        for model in _node_models(node, overview):
             rows.append((model, engine, name, model in capable))
     # When auto routing is enabled, advertise the reserved `auto` model FIRST — same as the relay's
     # /relay/v1/models endpoint (owner `grid-router`), so it shows even when zero engines are joined.
@@ -196,6 +226,13 @@ def cmd_remote_models(args: argparse.Namespace) -> int:
         print("(no live models — `grid join` an engine first)")
         return 0
 
+    seen = list(dict.fromkeys(model for model, *_ in rows))  # order-preserving dedup
+    # Prefer a real model over the reserved `auto` here: `auto` is always inserted first when
+    # routing is on, and a newcomer who just joined an engine wants to see THAT model chat-tested,
+    # not the router alias. Mirrors the local `cmd_models`' closing-the-loop hint (issue: `grid
+    # join`'s own "still loading" message can't yet promise a working model — this can).
+    target = next((m for m in seen if m != "auto"), seen[0])
+
     if getattr(args, "verbose", False):
         mwidth = max(len("MODEL"), *(len(model) for model, _, _, _ in rows))
         ewidth = max(len("ENGINE"), *(len(engine) for _, engine, _, _ in rows))
@@ -206,8 +243,14 @@ def cmd_remote_models(args: argparse.Namespace) -> int:
             # row ends at NODE.
             trailer = "  responses" if serves else ""
             print(f"{model:<{mwidth}}  {engine:<{ewidth}}  {node}{trailer}")
+        from . import provider
+
+        provider.print_models_hint(target)
         return 0
 
-    for model in dict.fromkeys(model for model, *_ in rows):  # order-preserving dedup
+    for model in seen:
         print(model)
+    from . import provider
+
+    provider.print_models_hint(target)
     return 0

--- a/cli/remote_provider.py
+++ b/cli/remote_provider.py
@@ -1081,12 +1081,7 @@ def _engine_union(records: list[dict[str, object]]) -> list[dict[str, object]]:
         specs = record.get("engines")
         if not specs and (record.get("endpoint_url") or record.get("models")):
             specs = [_flat_spec(record)]
-        # Tagged here, not carried on the stored spec itself: `meta_name` is the RECORD's display
-        # name (one per identity), and every engine flattened from the same record shares it — so
-        # `match_engine`'s node-name tier (shared.run_records) can find it without every spec
-        # producer remembering to stamp it individually.
-        tagged = [dict(spec, meta_name=record.get("meta_name")) for spec in (specs or [])]
-        union, _ = _merge_engines(union, tagged)
+        union, _ = _merge_engines(union, specs or [])
     return union
 
 
@@ -2023,7 +2018,7 @@ def _leave_one_engine(
     survivors = [rec for rec in records.values() if run_records.record_alive(rec)]
     survivors = survivors or list(records.values())
     union = _engine_union(survivors)
-    to_drop = _drop_spec(union, args.engine, label)
+    to_drop = _drop_spec(union, args.engine, label, _identity_field(survivors, "meta_name"))
     if not to_drop:
         raise SystemExit(
             f"No engine {args.engine!r} on {label} (match by endpoint URL, a served model, or a URL "
@@ -2076,9 +2071,28 @@ def _engines_summary(union: list[dict[str, object]]) -> str:
 
 
 def _drop_spec(
-    union: list[dict[str, object]], selector: str, label: str
+    union: list[dict[str, object]], selector: str, label: str, meta_name: object = None
 ) -> list[dict[str, object]]:
-    """The spec(s) to remove for ``selector`` — exact endpoint_url → engine_label → served model → URL
-    substring — via the shared matcher (`shared.run_records.match_engine`). Remote engines are keyed by
-    URL/label, so no exact-id short-circuit here (that's the local caller's job)."""
-    return run_records.match_engine(union, selector, label=label, summary=_engines_summary(union))
+    """The spec(s) to remove for ``selector`` — exact endpoint_url → engine_label → the identity's
+    ``--name`` → served model → URL substring — via the shared matcher
+    (`shared.run_records.match_engine`). Remote engines are keyed by URL/label, so no exact-id
+    short-circuit here (that's the local caller's job).
+
+    ``meta_name`` is stamped onto each spec for the duration of the match and taken straight back
+    off. It belongs to the RECORD, not to any one engine, and `union` is what the caller writes to
+    disk as ``record["engines"]`` — so a tag left behind is persisted onto some specs and not
+    others, and goes stale the first time the operator re-joins under a different ``--name``. The
+    matcher needs it on the spec; nothing else does, and nothing after this line should see it.
+    """
+    if meta_name:
+        for spec in union:
+            spec["meta_name"] = meta_name
+    try:
+        return run_records.match_engine(
+            union, selector, label=label, summary=_engines_summary(union)
+        )
+    finally:
+        # `finally`, not a trailing line: `match_engine` raises SystemExit on an ambiguous
+        # selector, and an exception must not leave the tag behind either.
+        for spec in union:
+            spec.pop("meta_name", None)

--- a/cli/remote_provider.py
+++ b/cli/remote_provider.py
@@ -17,6 +17,7 @@ import argparse
 import contextlib
 import getpass
 import os
+import shlex
 import signal
 import socket
 import subprocess
@@ -529,11 +530,31 @@ def cmd_remote_join(args: argparse.Namespace) -> int:
     if task_serving.allowed:  # said only when it is true — the refusal has already gone to stderr
         print("tasks=on (claiming tasks for this grid)")
     print(f"log={paths.engines_dir(network_id) / f'{engine_id}.log'}")
+    # Quoted: a grid's display name is freeform and can carry a space ("Hydrate Grid"), and a hint
+    # printed bare isn't actually copy-pasteable — argparse splits it into two positionals and
+    # rejects the second as "unrecognized arguments" (grid-leave issue: a reader hit exactly this
+    # `Next:` line unquoted and it failed on paste).
+    quoted_label = shlex.quote(label)
+    # What a reader will actually type next: the ADVERTISED name, not the record's raw filename.
+    # `--advertise-as` is what got registered as the model id, so the filename would 404 (the same
+    # mismatch `run_records.own_model_case` exists to repair on the request side).
+    advertised = list(record.get("advertise_as") or []) or list(record.get("models") or [])
     if reloaded:  # the live process re-advertised in place — nothing restarted, nothing dropped
-        print(f"(hot-reloaded — no in-flight requests dropped; stop with `grid leave {label}`)")
+        print(f"(hot-reloaded — no in-flight requests dropped; stop with `grid leave {quoted_label}`)")
+        if advertised:
+            print("\nNext:")
+            for line in provider.chat_hints(advertised[0], provider.serves_vision(args)):
+                print(line)
     else:
         # The relay isn't locally pollable, so we can't confirm "registered" here — report starting.
-        print(f"(starting — stop with `grid leave {label}`)")
+        # `grid models` comes first because it is what actually confirms the engine came up; the
+        # chat lines follow so the whole path is on screen once, in order.
+        print(f"(starting — stop with `grid leave {quoted_label}`)")
+        print("\nNext:")
+        print(f"  grid models {quoted_label}")
+        if advertised:
+            for line in provider.chat_hints(advertised[0], provider.serves_vision(args)):
+                print(line)
     return 0
 
 
@@ -1060,7 +1081,12 @@ def _engine_union(records: list[dict[str, object]]) -> list[dict[str, object]]:
         specs = record.get("engines")
         if not specs and (record.get("endpoint_url") or record.get("models")):
             specs = [_flat_spec(record)]
-        union, _ = _merge_engines(union, specs or [])
+        # Tagged here, not carried on the stored spec itself: `meta_name` is the RECORD's display
+        # name (one per identity), and every engine flattened from the same record shares it — so
+        # `match_engine`'s node-name tier (shared.run_records) can find it without every spec
+        # producer remembering to stamp it individually.
+        tagged = [dict(spec, meta_name=record.get("meta_name")) for spec in (specs or [])]
+        union, _ = _merge_engines(union, tagged)
     return union
 
 

--- a/cli/remote_request.py
+++ b/cli/remote_request.py
@@ -23,7 +23,7 @@ from typing import Any
 
 import httpx
 
-from shared import paths
+from shared import paths, run_records
 
 from . import media_io
 
@@ -31,8 +31,9 @@ from . import media_io
 _TOKEN_EXPIRED = "Your access token has expired. Run `grid login` to refresh, then retry."
 
 
-def _resolve(args: argparse.Namespace) -> tuple[str, str, str]:
-    """``(relay base, access token, grid label)`` for the active remote grid, or a clean ``SystemExit``.
+def _resolve(args: argparse.Namespace) -> tuple[str, str, str, str]:
+    """``(relay base, access token, grid label, network_id)`` for the active remote grid, or a clean
+    ``SystemExit``.
 
     Gates in order — signed in → a grid resolves → it has an access token → it is up — mirroring the
     guard in ``cli/remote_provider.cmd_remote_join``. The relay address comes from live status (creator)
@@ -51,7 +52,9 @@ def _resolve(args: argparse.Namespace) -> tuple[str, str, str]:
             f"Grid {label} has no access token locally. Run `grid login` to refresh your grids."
         )
     base, _status = remote_grid.resolve_relay_base(session, rec, network_id, label)
-    return base, str(rec["access_token"]), label
+    return base, str(rec["access_token"]), label, network_id
+
+
 
 
 def _consumer_headers(args: argparse.Namespace) -> dict[str, str]:
@@ -71,16 +74,27 @@ def _consumer_headers(args: argparse.Namespace) -> dict[str, str]:
 def cmd_remote_chat(args: argparse.Namespace) -> int:
     from remote import relay
 
-    from .request import reject_responses_only_model
+    from .request import chat_content, reject_responses_only_model
 
     # Before `_resolve`: that gate starts with the sign-in check and then calls the control
     # plane, and a codex:* request must get THIS refusal — not "not signed in", not a network
     # round-trip (issue 05).
     reject_responses_only_model(args.model)
-    base, token, _label = _resolve(args)
-    body = {"model": args.model, "messages": [{"role": "user", "content": args.message}]}
-    headers = _consumer_headers(args)
     try:
+        # `_resolve` reaches the control plane before the chat request ever does (to find the
+        # relay base), so the try has to start here — the first attempt at this fix wrapped only
+        # the `.post()` below, and Ctrl-C during `_resolve`'s own network call still raised the
+        # exact traceback this exists to prevent.
+        base, token, _label, network_id = _resolve(args)
+        model = run_records.own_model_case(network_id, args.model)
+        body = {
+            "model": model,
+            "messages": [{
+                "role": "user",
+                "content": chat_content(args.message, getattr(args, "image", None)),
+            }],
+        }
+        headers = _consumer_headers(args)
         with relay.open_consumer_client(base, token, timeout=args.timeout) as client:
             resp = client.post("/relay/v1/chat/completions", json=body, headers=headers)
             if resp.status_code == 401:  # before --json/raw: an expired token is never a useful "result"
@@ -97,6 +111,13 @@ def cmd_remote_chat(args: argparse.Namespace) -> int:
             return 0
     except httpx.RequestError as exc:
         raise SystemExit(f"Request failed: {exc}") from exc
+    except KeyboardInterrupt:
+        # Same fix as the model-download cancel: KeyboardInterrupt during a blocking socket read
+        # comes up through ssl -> httpcore -> httpx uncaught by `except httpx.RequestError` (it
+        # is not one — a `BaseException`, not a `RequestError`), so Ctrl-C used to surface as a
+        # 30-line traceback through three libraries instead of a clean cancellation. A slow
+        # reasoning model is exactly when someone reaches for Ctrl-C.
+        raise SystemExit("\nCancelled.") from None
 
 
 def cmd_remote_image(args: argparse.Namespace) -> int:
@@ -145,11 +166,15 @@ def cmd_remote_video(args: argparse.Namespace) -> int:
 def _post_media(args: argparse.Namespace, endpoint_path: str, payload: dict[str, Any]) -> int:
     from remote import relay
 
-    base, token, _label = _resolve(args)
-    headers = _consumer_headers(args)
-    timeout = httpx.Timeout(float(args.timeout), read=float(args.timeout))
-    output_dir = Path(args.output_dir).expanduser() if args.output_dir else paths.grid_home() / "outputs"
     try:
+        # `_resolve` reaches the control plane before the media request does — see the identical
+        # note in `cmd_remote_chat`. Ctrl-C during that first network call needs the same catch.
+        base, token, _label, network_id = _resolve(args)
+        if "model" in payload:  # same fix as `cmd_remote_chat` — see `run_records.own_model_case`
+            payload["model"] = run_records.own_model_case(network_id, payload["model"])
+        headers = _consumer_headers(args)
+        timeout = httpx.Timeout(float(args.timeout), read=float(args.timeout))
+        output_dir = Path(args.output_dir).expanduser() if args.output_dir else paths.grid_home() / "outputs"
         with (
             relay.open_consumer_client(base, token, timeout=timeout) as client,
             client.stream(
@@ -165,4 +190,10 @@ def _post_media(args: argparse.Namespace, endpoint_path: str, payload: dict[str,
             return media_io.consume_media_sse(resp, output_dir)
     except httpx.RequestError as exc:
         print(f"Media request failed: {exc}", file=sys.stderr)
+        return 1
+    except KeyboardInterrupt:
+        # Same fix as `cmd_remote_chat` — a video/image job is the slowest request this file
+        # makes, so it is the one most likely to get Ctrl-C'd, and was raising the exact same
+        # uncaught traceback through ssl/httpcore/httpx before this.
+        print("\nCancelled.", file=sys.stderr)
         return 1

--- a/cli/request.py
+++ b/cli/request.py
@@ -36,6 +36,27 @@ def reject_responses_only_model(model: str) -> None:
     )
 
 
+def chat_content(message: str, images: list[str] | None) -> Any:
+    """A chat message's ``content``: the plain string, or the multimodal parts array when
+    ``--image`` was given. Shared by both modes' chat handlers so the two can't drift.
+
+    A bare string when there are no images, rather than a one-element parts array: the array form
+    is the newer spelling of the same thing, and an engine or proxy that only implements the plain
+    string must not be broken by a request that had nothing multimodal about it.
+
+    Text first, then the images, matching the order the OpenAI vision docs use — some models
+    attend to the instruction differently depending on which side of the image it sits.
+    """
+    if not images:
+        return message
+    parts: list[dict[str, Any]] = [{"type": "text", "text": message}]
+    parts.extend(
+        {"type": "image_url", "image_url": {"url": media_io.image_data_uri(path)}}
+        for path in images
+    )
+    return parts
+
+
 # Remote-only request-routing flags (DECISIONS D16): rejected in local mode, where the concept doesn't
 # exist — the mirror of `cli/provider.py:_reject_remote_only_flags` for `grid join`.
 def _reject_remote_only_flags(args: argparse.Namespace) -> None:
@@ -59,11 +80,23 @@ def cmd_chat(args: argparse.Namespace) -> int:
     try:
         resp = httpx.post(
             f"{runtime.grid_url(cfg)}/v1/chat/completions",
-            json={"model": args.model, "messages": [{"role": "user", "content": args.message}]},
+            json={
+                "model": args.model,
+                "messages": [{
+                    "role": "user",
+                    "content": chat_content(args.message, getattr(args, "image", None)),
+                }],
+            },
             timeout=args.timeout,
         )
     except httpx.RequestError as exc:
         raise SystemExit(f"Request failed: {exc}") from exc
+    except KeyboardInterrupt:
+        # Same class of bug as the model-download and remote-chat cancel: KeyboardInterrupt during
+        # a blocking read is not an `httpx.RequestError` (it is a `BaseException`, not caught by
+        # the guard above), so it used to surface as a raw traceback through ssl/httpcore/httpx
+        # instead of a clean cancellation — exactly when a slow model makes Ctrl-C likely.
+        raise SystemExit("\nCancelled.") from None
     if getattr(args, "json", False) or resp.status_code >= 400:
         print(resp.text)
         return 0 if resp.status_code < 400 else 1
@@ -131,4 +164,7 @@ def _post_media_request(args: argparse.Namespace, endpoint_path: str, payload: d
             return media_io.consume_media_sse(resp, output_dir)
     except httpx.RequestError as exc:
         print(f"Media request failed: {exc}", file=sys.stderr)
+        return 1
+    except KeyboardInterrupt:
+        print("\nCancelled.", file=sys.stderr)
         return 1

--- a/cli/train.py
+++ b/cli/train.py
@@ -493,7 +493,7 @@ def cmd_train_where(args: argparse.Namespace) -> int:
 
     endpoints = resolve()
     if not endpoints:
-        print("No grid found. `grid up` starts one for this network; `grid login` connects to "
+        print("No grid found. `grid start` starts one for this network; `grid login` connects to "
               "your hosted grid.")
         return 1
     for endpoint in endpoints:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2412,8 +2412,8 @@ For a machine with no engine:
 ```bash
 grid up
 grid engine install llama.cpp
-grid pull qwen36-35b-a3b-mtp
-grid join --serve qwen36-35b-a3b-mtp
+grid pull unsloth/Qwen3.6-35B-A3B-MTP-GGUF:Qwen3.6-35B-A3B-UD-IQ3_S.gguf
+grid join --serve Qwen3.6-35B-A3B-UD-IQ3_S.gguf --advertise-as qwen36-35b-a3b-mtp
 grid chat -m qwen36-35b-a3b-mtp "hello"
 ```
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -79,10 +79,9 @@ No engine on a box yet? Grid ships two open-source engines it sets up for you.
 grid engine install llama.cpp                 # Homebrew (macOS) or pinned tarball (Linux NVIDIA)
 grid engine install llama.cpp --from-source   # build locally (Metal on macOS, CUDA on NVIDIA)
 grid catalog                                  # models Grid can pull
-grid pull qwen36-35b-a3b-mtp                  # a catalog label, or any '<hf-repo>:<file>'
-grid pull unsloth/Qwen3.6-35B-A3B-MTP-GGUF:Qwen3.6-35B-A3B-UD-IQ3_S.gguf
+grid pull unsloth/Qwen3.6-35B-A3B-MTP-GGUF:Qwen3.6-35B-A3B-UD-IQ3_S.gguf   # '<hf-repo>:<file>'
 grid rm your-model.gguf --yes
-grid join home --serve qwen36-35b-a3b-mtp     # launch llama.cpp for it, then join
+grid join home --serve Qwen3.6-35B-A3B-UD-IQ3_S.gguf --advertise-as qwen36-35b-a3b-mtp
 ```
 
 - Apple Silicon macOS uses Homebrew's `llama.cpp` formula by default; `--from-source`

--- a/local/config.py
+++ b/local/config.py
@@ -61,13 +61,13 @@ def select_grid(name_or_id: str | None) -> dict[str, Any]:
         ]
         if not matches:
             raise SystemExit(
-                f"Grid not found: {name_or_id!r}. Run `grid up {name_or_id}` "
+                f"Grid not found: {name_or_id!r}. Run `grid start {name_or_id}` "
                 "on this device or pass a grid URL."
             )
         return matches[-1]
     grids = iter_grid_configs()
     if not grids:
-        raise SystemExit("No grids yet. Run `grid up` to bring one online.")
+        raise SystemExit("No grid on this computer yet.\n\nNext:  grid start")
     active = state.get_active("local")
     if active:
         for cfg in grids:

--- a/local/runtime.py
+++ b/local/runtime.py
@@ -10,6 +10,7 @@ import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, NamedTuple
+from urllib.parse import urlparse
 
 import httpx
 
@@ -43,6 +44,46 @@ def detect_local_ip() -> str:
 def make_local_url(port: int, advertise_host: str | None = None) -> str:
     host = (advertise_host or detect_local_ip()).strip()
     return f"http://{host}:{int(port)}"
+
+
+def advertised_address_works(url: str, timeout: float = 3.0) -> bool:
+    """Can anything actually open a connection to the address we are about to hand out?
+
+    ``detect_local_ip`` asks the routing table which interface reaches the internet, which is the
+    right guess on an ordinary network and the wrong one on a machine holding a VPN: the interface
+    that reaches the internet is not the interface other computers reach *you* on. The symptom is
+    brutal for a newcomer — the grid is running perfectly, every command fails with "Server
+    disconnected without sending a response", and nothing points at the address as the culprit.
+
+    A real HTTP request, not a bare TCP connect: measured on a VPN'd machine, the TCP handshake
+    SUCCEEDS and the connection is then dropped without a reply — which is the whole reason the
+    error a user sees is "Server disconnected without sending a response". A connect-only probe
+    reports that address as healthy. Any HTTP status at all counts as reachable; we care that
+    something answered, not what it said.
+    """
+    parsed = urlparse(url if "//" in url else f"http://{url}")
+    if not parsed.hostname or not parsed.port:
+        return True  # nothing to check — do not invent a warning
+    try:
+        httpx.get(f"{parsed.scheme}://{parsed.hostname}:{parsed.port}/", timeout=timeout)
+        return True
+    except httpx.HTTPError:
+        return False
+
+
+def unreachable_address_hint(cfg: dict[str, Any], url: str) -> str:
+    """What to tell someone whose grid is up but whose advertised address does not answer."""
+    return (
+        f"\nWarning: this grid is running, but nothing can reach it at {url}.\n"
+        "That address belongs to an interface on this machine (often a VPN) that does not accept\n"
+        "connections back. The grid itself is fine — the address it is advertising is not.\n"
+        "\n"
+        "Give it an address that works, then re-run this command:\n"
+        f"  grid down {cfg['name']}\n"
+        f"  grid up {cfg['name']} --advertise-host <this machine's LAN IP>\n"
+        "\n"
+        "Use 127.0.0.1 to try everything on this one computer first."
+    )
 
 
 def normalize_url(value: str) -> str:

--- a/local/runtime.py
+++ b/local/runtime.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import ipaddress
 import os
+import re
 import shutil
 import socket
 import subprocess
@@ -69,21 +71,6 @@ def advertised_address_works(url: str, timeout: float = 3.0) -> bool:
         return True
     except httpx.HTTPError:
         return False
-
-
-def unreachable_address_hint(cfg: dict[str, Any], url: str) -> str:
-    """What to tell someone whose grid is up but whose advertised address does not answer."""
-    return (
-        f"\nWarning: this grid is running, but nothing can reach it at {url}.\n"
-        "That address belongs to an interface on this machine (often a VPN) that does not accept\n"
-        "connections back. The grid itself is fine — the address it is advertising is not.\n"
-        "\n"
-        "Give it an address that works, then re-run this command:\n"
-        f"  grid down {cfg['name']}\n"
-        f"  grid up {cfg['name']} --advertise-host <this machine's LAN IP>\n"
-        "\n"
-        "Use 127.0.0.1 to try everything on this one computer first."
-    )
 
 
 def normalize_url(value: str) -> str:
@@ -456,6 +443,88 @@ def _tcp_port_in_use(host: str, port: int) -> bool:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.settimeout(0.2)
         return sock.connect_ex((host, port)) == 0
+
+
+def port_in_use(port: int) -> bool:
+    """Whether something is already listening on [port] locally.
+
+    Delegates rather than reimplementing: `launcher.is_port_in_use` was already the engine's own
+    check, and a second copy here meant the two could answer differently — and meant a test that
+    stubbed one still reached the real socket through the other, making it depend on whatever
+    happened to be listening on the machine running it. One definition, one stub point.
+
+    Imported inside the call so the attribute is looked up per call: a test that patches
+    `launcher.is_port_in_use` must reach this path too.
+    """
+    from shared.engine import launcher
+
+    return launcher.is_port_in_use(int(port))
+
+
+def free_port_from(start: int, attempts: int = 40) -> int | None:
+    """The first free port at or after [start], so a busy default never dead-ends the first run."""
+    for candidate in range(int(start), int(start) + attempts):
+        if not port_in_use(candidate):
+            return candidate
+    return None
+
+
+def lan_ip_candidates() -> list[str]:
+    """Private IPv4 addresses on this machine, best guess first.
+
+    Needed because the one address `detect_local_ip` finds can be a VPN's, and telling someone to
+    substitute "<this machine's LAN IP>" is asking them to go and find a thing we are already
+    standing on. `getaddrinfo` is not enough — on a VPN'd Mac it returns only the VPN address — so
+    read the interfaces. Best-effort: an unparsable or missing tool yields an empty list and the
+    caller falls back to describing the value instead of naming it.
+    """
+    for cmd in (["ip", "-4", "-o", "addr"], ["ifconfig"]):
+        try:
+            out = subprocess.run(cmd, capture_output=True, text=True, timeout=5, check=False)
+        except (OSError, subprocess.SubprocessError):
+            continue
+        found = []
+        for match in re.finditer(r"inet\s+(?:addr:)?(\d+\.\d+\.\d+\.\d+)", out.stdout or ""):
+            address = match.group(1)
+            try:
+                parsed = ipaddress.ip_address(address)
+            except ValueError:
+                continue
+            # `.0` hosts are network addresses that some VPN clients park on an interface; they are
+            # never dialable, so offering one would send the reader straight back here.
+            if parsed.is_private and not parsed.is_loopback and not address.endswith(".0"):
+                found.append(address)
+        if found:
+            # 192.168.* before 10.* / 172.16-31.*: home routers hand these out, so on the machines
+            # this message is written for it is the one a second computer can actually reach.
+            return sorted(set(found), key=lambda a: (not a.startswith("192.168."), a))
+    return []
+
+
+def port_holder(port: int, timeout: float = 3.0) -> str | None:
+    """Who is holding [port], as ``'name (pid 4711)'`` — or ``None`` when we cannot tell.
+
+    "Port 8090 is already in use" leaves the reader to discover `lsof` before they can act. Naming
+    the process turns it into something they can decide about, and very often the answer is a grid
+    from an earlier run that they simply need to stop. Best-effort everywhere: no `lsof`, a refusal,
+    or an unparsable answer all mean we say less rather than guess.
+    """
+    try:
+        out = subprocess.run(
+            ["lsof", "-nP", f"-iTCP:{int(port)}", "-sTCP:LISTEN", "-F", "cn"],
+            capture_output=True, text=True, timeout=timeout, check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    pid, name = None, None
+    for line in (out.stdout or "").splitlines():
+        if line.startswith("p"):
+            pid = line[1:].strip()
+        elif line.startswith("c") and name is None:
+            name = line[1:].strip()
+    if not name:
+        return None
+    return f"{name} (pid {pid})" if pid else name
 
 
 def cli_command() -> list[str]:

--- a/remote/relay.py
+++ b/remote/relay.py
@@ -106,11 +106,17 @@ class RelayError(Exception):
 
 
 def _client(signaling_url: str, access_token: str, *, timeout: float | httpx.Timeout) -> httpx.Client:
-    return httpx.Client(
-        base_url=signaling_url.rstrip("/"),
-        headers={"User-Agent": "grid-cli", "Authorization": f"Bearer {access_token}"},
-        timeout=timeout,
-    )
+    headers = {"User-Agent": "grid-cli"}
+    if access_token:
+        headers["Authorization"] = f"Bearer {access_token}"
+    # An empty token is a real, documented case — `_fetch_overview` calls the *public* overview
+    # route with `token = str(rec.get("access_token") or "")` before `grid sync` has ever stored
+    # one. Ghosting a header for that case used to instead build `"Authorization": "Bearer "` —
+    # a value ending in whitespace with nothing after the scheme, which httpx's own transport
+    # refuses to send at all: `httpx.LocalProtocolError: Illegal header value b'Bearer '`, raised
+    # client-side before any request reaches the network. Every other caller here always has a
+    # real token, so this only changes behavior for the one call site the empty string was for.
+    return httpx.Client(base_url=signaling_url.rstrip("/"), headers=headers, timeout=timeout)
 
 
 # Only `register_node` and `deregister_node` below catch `httpx.InvalidURL`, and that scoping is

--- a/remote/serve.py
+++ b/remote/serve.py
@@ -189,7 +189,7 @@ def run_remote_engine_from_record(grid_id: str, engine_id: str) -> int:
     network_id = record["grid_id"]  # the run record's grid_id IS the remote network_id
     signaling_url = (record.get("signaling_url") or "").rstrip("/")
     if not signaling_url:
-        raise SystemExit("This grid has no relay address; run `grid up` then re-join.")
+        raise SystemExit("This grid has no relay address; run `grid start` then re-join.")
     access_token, refresh_token = _load_tokens(network_id)
     if not access_token:
         raise SystemExit("Run `grid login` to refresh your grid tokens, then re-join.")
@@ -547,10 +547,26 @@ def _bring_up_one(
         raise SystemExit("Built-in engine launch supports exactly one model. Use --at for custom engines.")
 
     from shared.engine import launcher as launcher_mod
+    from local import runtime
 
     port = int(record.get("endpoint_port") or 8081)
-    if launcher_mod.is_port_in_use(port):
-        raise SystemExit(f"Port {port} already in use; aborting.")
+    if runtime.port_in_use(port):
+        # The exact bug already fixed once for the LOCAL `--serve` join (`cli/provider.py`) —
+        # this is `remote/serve.py`'s own separate copy of the same check, missed at the time
+        # because the two paths don't share the function. A remote join has no interactive
+        # terminal to retype a flag into: the detached child just dies, and the only trace was
+        # "Remote engine stopped: Port 8081 already in use; aborting." in this engine's own log —
+        # `grid join` itself reports "starting" and success regardless, because (per the comment
+        # below) the relay isn't locally pollable and this process can't confirm registration.
+        holder = runtime.port_holder(port)
+        replacement = runtime.free_port_from(port + 1)
+        if replacement is None:
+            raise SystemExit(
+                f"Port {port} is already in use{f' by {holder}' if holder else ''}, "
+                "and no free port was found near it."
+            )
+        print(f"Port {port} is in use{f' by {holder}' if holder else ''} — starting on {replacement} instead.")
+        port = replacement
     launcher_mod.assert_supported_build()
     launched = launcher_mod.start_llm(
         models[0],

--- a/shared/engine/launcher.py
+++ b/shared/engine/launcher.py
@@ -70,15 +70,63 @@ NVIDIA_RUNTIME = RuntimeProfile(
     reasoning_budget=8192,
     spec_draft_n_max=1,
 )
+# A box with no GPU backend at all. Both caps below are the SAME settings as the GPU profiles
+# measured in wall-clock rather than tokens: a CPU build of this engine generates at roughly
+# 20 tok/s (measured on an Intel Mac, `Qwen3.5-2B-Q4_K_M`), where the GPU numbers become absurd —
+# `reasoning_budget=8192` is seven minutes of thinking before the answer starts, and
+# `n_predict=64000` lets one model that fails to stop run for the better part of an hour. There is
+# no third lever: the operator cannot make the box faster, so the budget is what has to give.
+CPU_RUNTIME = RuntimeProfile(
+    n_predict=4096,       # ~3 min at 20 tok/s; far above a real answer, far below a runaway
+    temp=0.7,
+    reasoning_budget=0,   # thinking is a GPU luxury; here it is dead time before the first word
+    spec_draft_n_max=1,
+)
+
+# Every GPU backend llama.cpp ships as a separate `libggml-<name>` next to the binary. Their
+# ABSENCE is what makes a build CPU-only, whatever hardware the box happens to contain.
+_GPU_BACKENDS = ("metal", "cuda", "vulkan", "hip", "sycl", "opencl", "musa", "cann")
 
 
 def is_apple_silicon() -> bool:
     return platform.system() == "Darwin" and platform.machine() in ("arm64", "aarch64")
 
 
+def has_gpu_backend() -> bool:
+    """Whether the INSTALLED llama.cpp build can reach a GPU at all.
+
+    Asks the build, not the box. A machine can hold a perfectly good GPU that this engine cannot
+    use — an Intel Mac with a Radeon, running the CPU tarball, ships only `libggml-cpu`,
+    `libggml-blas` and `libggml-rpc`, and every token comes off the CPU no matter what
+    `grid device-info` reports. Guessing from hardware is what put such a box on the NVIDIA
+    profile; reading the backends it actually loaded cannot.
+
+    Unknown (no install directory, unreadable) is treated as GPU-present: the conservative error
+    is to leave the generous GPU budgets alone, never to silently cap a real GPU node at 4096.
+    """
+    # `.resolve()`: the pinned path is a SYMLINK into the install directory (`~/.grid/bin/
+    # llama-server` -> `~/.grid/engines/llama.cpp/llama-server`), and the backends sit beside the
+    # real file, not beside the link. Reading the link's own parent finds an empty `bin/`, which
+    # this function would then report as "layout not recognised" — i.e. as a GPU build.
+    engine_dir = paths.llama_server_bin().resolve().parent
+    try:
+        names = [entry.name.lower() for entry in engine_dir.iterdir()]
+    except OSError:
+        return True
+    if not any(name.startswith("libggml-cpu") for name in names):
+        return True  # not a layout we recognise — do not infer anything from it
+    return any(
+        name.startswith(f"libggml-{backend}") for name in names for backend in _GPU_BACKENDS
+    )
+
+
 def runtime_profile() -> RuntimeProfile:
     if is_apple_silicon():
         return APPLE_SILICON_RUNTIME
+    # Before NVIDIA, because that profile's name is a claim about the hardware and this is the
+    # check that can falsify it: everything-not-Apple used to mean "assume a discrete GPU".
+    if not has_gpu_backend():
+        return CPU_RUNTIME
     return NVIDIA_RUNTIME
 
 
@@ -148,7 +196,12 @@ def start_llm(
     model_path = paths.models_dir() / Path(model_file).name
     if not model_path.is_file():
         raise SystemExit(
-            f"Model file not found: {model_path}. Use `grid models pull` first."
+            # `grid models pull` is not a command — `grid models` lists what the grid serves and
+            # takes no subcommand. Naming a command that does not exist sends the reader looking
+            # for it, which is worse than the missing file they came here for.
+            f"No model file at {model_path}.\n"
+            f"  Download it:   grid pull {Path(model_file).stem}\n"
+            "  Or see what is already here:   grid catalog"
         )
 
     log = paths.llama_log(port)

--- a/shared/models/catalog.py
+++ b/shared/models/catalog.py
@@ -87,10 +87,10 @@ def format_catalog_entry(entry: CatalogEntry) -> str:
 
     Two columns, and the repetition is deliberate rather than sloppy. The first is a command
     argument (`repo:file`); the second is the path you would open on huggingface.co (`repo/file`).
-    One colon apart, but only one of them works in each place — and the desktop app reads this
-    exact shape positionally (`docs/CLI_Integration_Contract.md`), taking the first token as what
-    to pull and the second as what to show. Changing the column count breaks it silently: dropping
-    the first made its parser read `(Apple` as the repo (measured, not feared).
+    One colon apart, but only one of them works in each place — and this row is parsed
+    POSITIONALLY by tools that read it, first token as what to pull and second as what to show.
+    Changing the column count breaks them silently rather than loudly: dropping the first column
+    made one parser read `(Apple` as the repository name (measured, not feared).
     """
     target = "" if entry.target == TARGET_ANY else f"{target_label(entry.target)}, "
     return (

--- a/shared/models/catalog.py
+++ b/shared/models/catalog.py
@@ -71,10 +71,30 @@ def target_label(target: str) -> str:
     return target
 
 
+def pull_spec(entry: CatalogEntry) -> str:
+    """The exact argument `grid pull` takes for [entry] — `<repo>:<file>`, nothing invented.
+
+    A short nickname used to live here instead, and `grid pull` accepted it. It was dropped
+    because a name that exists only inside Grid reads like a real model id and is not one. What
+    replaces it is the spec itself: still one whitespace-free token a caller can hand straight to
+    `grid pull`, but every character of it is checkable against Hugging Face.
+    """
+    return f"{entry.hf_repo}:{entry.quantized_file}"
+
+
 def format_catalog_entry(entry: CatalogEntry) -> str:
+    """One catalog row: the pull spec, then the same repo and file as a browsable path.
+
+    Two columns, and the repetition is deliberate rather than sloppy. The first is a command
+    argument (`repo:file`); the second is the path you would open on huggingface.co (`repo/file`).
+    One colon apart, but only one of them works in each place — and the desktop app reads this
+    exact shape positionally (`docs/CLI_Integration_Contract.md`), taking the first token as what
+    to pull and the second as what to show. Changing the column count breaks it silently: dropping
+    the first made its parser read `(Apple` as the repo (measured, not feared).
+    """
     target = "" if entry.target == TARGET_ANY else f"{target_label(entry.target)}, "
     return (
-        f"  {entry.hf_repo}/{entry.quantized_file} "
+        f"  {pull_spec(entry)}  {entry.hf_repo}/{entry.quantized_file} "
         f"({target}min {entry.min_vram_gb} GB, {entry.kind})"
     )
 

--- a/shared/models/catalog.py
+++ b/shared/models/catalog.py
@@ -14,7 +14,6 @@ TARGET_NVIDIA = "nvidia"
 
 @dataclass(frozen=True)
 class CatalogEntry:
-    label: str
     hf_repo: str
     quantized_file: str
     min_vram_gb: int
@@ -25,7 +24,6 @@ class CatalogEntry:
 
 CATALOG: tuple[CatalogEntry, ...] = (
     CatalogEntry(
-        label="qwen36-35b-a3b-mtp",
         hf_repo="unsloth/Qwen3.6-35B-A3B-MTP-GGUF",
         quantized_file="Qwen3.6-35B-A3B-UD-IQ3_S.gguf",
         min_vram_gb=32,
@@ -34,7 +32,6 @@ CATALOG: tuple[CatalogEntry, ...] = (
         target=TARGET_APPLE_SILICON,
     ),
     CatalogEntry(
-        label="qwen36-27b-mtp",
         hf_repo="unsloth/Qwen3.6-27B-MTP-GGUF",
         quantized_file="Qwen3.6-27B-UD-Q5_K_XL.gguf",
         min_vram_gb=24,
@@ -43,13 +40,6 @@ CATALOG: tuple[CatalogEntry, ...] = (
         target=TARGET_NVIDIA,
     ),
 )
-
-
-def find(label: str) -> CatalogEntry | None:
-    for entry in CATALOG:
-        if entry.label == label:
-            return entry
-    return None
 
 
 def current_target() -> str | None:
@@ -84,7 +74,7 @@ def target_label(target: str) -> str:
 def format_catalog_entry(entry: CatalogEntry) -> str:
     target = "" if entry.target == TARGET_ANY else f"{target_label(entry.target)}, "
     return (
-        f"  {entry.label:<32} {entry.hf_repo}/{entry.quantized_file} "
+        f"  {entry.hf_repo}/{entry.quantized_file} "
         f"({target}min {entry.min_vram_gb} GB, {entry.kind})"
     )
 

--- a/shared/models/download.py
+++ b/shared/models/download.py
@@ -18,20 +18,76 @@ def hf_url(repo: str, quantized_file: str) -> str:
     return f"{HF_BASE}/{repo}/resolve/main/{quantized_file}"
 
 
-def parse_spec(spec: str) -> tuple[str, str]:
+DEFAULT_QUANT = "Q4_K_M"
+
+
+def parse_spec(spec: str) -> tuple[str, str | None]:
+    """Split a pull spec into ``(repo, filename)``. ``filename`` is ``None`` for a bare
+    ``owner/repo``, which means the caller must show the repo's file list and let the reader pick.
+
+    Exactly two accepted forms, and no third: name the **exact** file (``repo:model-Q8_0.gguf``),
+    or name **only the repo** and choose from the list. A partial quant (``repo:Q8_0``) is refused
+    rather than silently substring-matched, because that match is a guess: `Q8_0` hits
+    `model-Q8_0.gguf` and `model-UD-Q8_0.gguf` alike, and picking one for a reader who typed
+    neither is how somebody ends up serving a file they never chose.
+    """
     if ":" in spec:
-        repo, _, filename = spec.partition(":")
-        repo = repo.strip()
-        filename = filename.strip()
-        if repo and filename:
-            return repo, filename
-    parts = spec.rsplit("/", 1)
-    if len(parts) == 2 and parts[0] and parts[1]:
-        return parts[0], parts[1]
+        repo, _, tail = spec.partition(":")
+        repo, tail = repo.strip(), tail.strip()
+        if not repo or not tail:
+            raise SystemExit(f"{spec!r} needs a repository before the colon.")
+        if not tail.lower().endswith(".gguf"):
+            raise SystemExit(
+                f"{tail!r} isn't a filename. After the colon, name the exact file — it ends "
+                f"'.gguf' (see the repo's Files and versions tab on huggingface.co). To choose "
+                f"from a list instead, drop the colon and pull just the repo: 'grid pull {repo}'."
+            )
+        return repo, tail
+    if "/" in spec:
+        return spec, None  # bare `owner/repo` — the caller lists the files and asks
     raise SystemExit(
-        f"Unrecognized model spec: {spec!r}. Use '<hf-id>:<filename>' "
-        "(for example unsloth/Qwen3.6-35B-A3B-MTP-GGUF:Qwen3.6-35B-A3B-UD-IQ3_S.gguf)."
+        f"{spec!r} isn't a Hugging Face repository. `grid pull` needs one, not a short name — "
+        "run `grid catalog` and copy the repo/file shown there, or name any repo yourself: "
+        "'unsloth/Qwen3.6-35B-A3B-MTP-GGUF' to pick from its files, or "
+        "'unsloth/Qwen3.6-35B-A3B-MTP-GGUF:<exact-filename>.gguf' to skip the prompt."
     )
+
+
+def list_model_files(repo: str, timeout: float = 15.0) -> list[str]:
+    """Every top-level `.gguf` model file in [repo] (never `mmproj-*`), alphabetically.
+
+    One list call, no download — the same repo listing `resolve_file` and `find_projector` each
+    need, factored out so a caller can show the reader what else was available instead of a
+    filename resolved in silence.
+    """
+    try:
+        resp = httpx.get(f"{HF_BASE}/api/models/{repo}", timeout=timeout, follow_redirects=True)
+        resp.raise_for_status()
+        siblings = resp.json().get("siblings")
+    except (httpx.HTTPError, ValueError) as exc:
+        raise SystemExit(f"Could not list files in {repo!r}: {exc}") from exc
+    return sorted(
+        s["rfilename"] for s in (siblings or [])
+        if isinstance(s, dict) and isinstance(s.get("rfilename"), str)
+        and "/" not in s["rfilename"]  # top-level only, never a nested variant dir
+        and s["rfilename"].lower().endswith(".gguf")
+        and "mmproj" not in s["rfilename"].lower()
+    )
+
+
+def resolve_file(repo: str, timeout: float = 15.0) -> tuple[str, list[str]]:
+    """``(suggested default, every .gguf in [repo])``.
+
+    The default is the ``DEFAULT_QUANT`` file, or the alphabetically first when the repo ships no
+    such quant — the same fallback llama.cpp's `-hf` documents. It is only ever a *suggestion* the
+    caller offers: choosing is the reader's, which is why the full list comes back with it.
+    """
+    names = list_model_files(repo, timeout=timeout)
+    if not names:
+        raise SystemExit(f"No .gguf files found in {repo!r}. Check the repo on huggingface.co.")
+    wanted = DEFAULT_QUANT.lower()
+    chosen = next((n for n in names if wanted in n.lower()), names[0])
+    return chosen, names
 
 
 def local_path(quantized_file: str) -> Path:
@@ -81,6 +137,12 @@ def find_projector(repo: str, timeout: float = 15.0) -> str | None:
 
 def download(repo: str, quantized_file: str, *, out: Path | None = None, on_progress=None) -> Path:
     target = out or local_path(quantized_file)
+    if target.is_file():
+        # `grid pull` must be safe to run twice — re-running it to double check a name, or
+        # because a script always calls it before `grid join`, must not re-download a multi-
+        # gigabyte file that is already sitting right there. Only a `.part` (a download that
+        # never finished) is worth resuming; a complete `target` is worth nothing more to do.
+        return target
     part = target.with_suffix(target.suffix + ".part")
     target.parent.mkdir(parents=True, exist_ok=True)
     url = hf_url(repo, quantized_file)
@@ -91,22 +153,30 @@ def download(repo: str, quantized_file: str, *, out: Path | None = None, on_prog
         headers["Range"] = f"bytes={have}-"
 
     mode = "ab" if have > 0 else "wb"
-    with httpx.stream("GET", url, headers=headers, timeout=httpx.Timeout(30, read=None), follow_redirects=True) as resp:
-        if resp.status_code not in (200, 206):
-            try:
-                body = resp.read().decode(errors="replace")[:300]
-            except httpx.HTTPError:
-                body = "(could not read response body)"
-            raise SystemExit(f"Download failed ({resp.status_code}): {body}")
-        total = have + int(resp.headers.get("Content-Length") or 0)
-        with part.open(mode) as fh:
-            for chunk in resp.iter_bytes(CHUNK):
-                if not chunk:
-                    continue
-                fh.write(chunk)
-                have += len(chunk)
-                if on_progress:
-                    on_progress(have, total)
+    try:
+        with httpx.stream("GET", url, headers=headers, timeout=httpx.Timeout(30, read=None), follow_redirects=True) as resp:
+            if resp.status_code not in (200, 206):
+                try:
+                    body = resp.read().decode(errors="replace")[:300]
+                except httpx.HTTPError:
+                    body = "(could not read response body)"
+                raise SystemExit(f"Download failed ({resp.status_code}): {body}")
+            total = have + int(resp.headers.get("Content-Length") or 0)
+            with part.open(mode) as fh:
+                for chunk in resp.iter_bytes(CHUNK):
+                    if not chunk:
+                        continue
+                    fh.write(chunk)
+                    have += len(chunk)
+                    if on_progress:
+                        on_progress(have, total)
+    except KeyboardInterrupt:
+        # `.part` is deliberately left in place, not deleted — it is what makes the `Range`
+        # header above resume from `have` instead of restarting a multi-gigabyte download from
+        # byte 0 next time. Ctrl-C here used to skip this entirely: httpx/httpcore/ssl raise
+        # KeyboardInterrupt from three layers down mid-socket-read, and with nothing catching it
+        # partway up the call stack, the reader got a 30-line stack trace instead of a cancellation.
+        raise SystemExit(f"\nCancelled. Resume with the same command — {have / 1e6:.0f} MB kept.") from None
 
     part.replace(target)
     return target

--- a/shared/run_records.py
+++ b/shared/run_records.py
@@ -105,6 +105,32 @@ def read_records(grid_id: str) -> dict[str, dict[str, Any]]:
     return records
 
 
+def own_model_case(grid_id: str, model: str) -> str:
+    """``model`` as THIS machine actually advertised it, if it case-insensitively matches one of
+    its own served models — never anyone else's, since this machine only ever knows its own true
+    case.
+
+    The relay's public overview lowercases every model id for display (`grid engines`/`grid
+    models`), so the exact string a reader copies from `grid models`' own output — and from this
+    CLI's own `Next:` hint — 404s ("No providers available for this model") when read back for a
+    model THIS machine is serving under mixed case (grid-leave issue: reproduced live serving
+    `Qwen3.5-2B-Q4_K_M`, listed back as `qwen3.5-2b-q4_k_m`, and rejected verbatim). Used both to
+    fix the display itself (`cli/remote_overview.py`) and, as a last-resort backstop, to fix a
+    model name right before a request that names it (`cli/remote_request.py`) — a local disk read,
+    not a network call, so it costs nothing when there is no mismatch to fix.
+    """
+    for record in read_records(grid_id).values():
+        # `advertise_as` first: that alias — not the record's top-level `models` (the raw filename,
+        # e.g. `Qwen3.5-2B-Q4_K_M.gguf`) — is what actually got registered as the servable model id
+        # (confirmed live: a filename-cased record still routed under its alias). `models` stays
+        # the fallback for an engine joined with no `--advertise-as`, where it IS the real id.
+        candidates = list(record.get("advertise_as") or []) + list(record.get("models") or [])
+        for served in candidates:
+            if served.lower() == model.lower():
+                return served
+    return model
+
+
 def known_grid_ids() -> tuple[str, ...]:
     """Every grid id with a run-record **directory** on this box, sorted.
 
@@ -189,7 +215,8 @@ def match_engine(
     hint: str = "pass the exact endpoint URL instead",
 ) -> list[dict[str, Any]]:
     """Engine spec(s) a `grid leave --engine <selector>` picks out of ``specs``, tried in order: exact
-    ``endpoint_url`` → exact ``engine_label`` → a served model → an ``endpoint_url`` substring. Each match
+    ``endpoint_url`` → exact ``engine_label`` → the ``--name`` given at join (``meta_name``, remote only —
+    what `grid engines` prints under NODE) → a served model → an ``endpoint_url`` substring. Each match
     must resolve to exactly ONE engine or it raises ``SystemExit`` (naming ``summary`` and ``hint``);
     returns ``[]`` on no match so the caller raises its own not-found. Returned dicts are the SAME objects
     passed in — identity is preserved for an ``id()``-based drop filter. An exact engine-*id* match is the
@@ -211,6 +238,16 @@ def match_engine(
     by_label = unique([s for s in specs if s.get("engine_label") == selector], "Label")
     if by_label:
         return by_label
+    # `--name` at join is what `grid engines` shows as NODE — the only thing a member typed
+    # themselves, so it is the first thing they try for `--engine` too (grid-leave issue: it
+    # silently never matched anything, since a remote identity keys engines by URL/label, not
+    # its own display name). Matching every spec under that name here is right, not partial:
+    # one identity's engines all share one `--name`, so a name selector always means "all of
+    # them" — a multi-engine identity surfaces that honestly via the `unique()` ambiguity error
+    # below, pointing at `--all` instead of silently guessing which one was meant.
+    by_node = unique([s for s in specs if s.get("meta_name") == selector], "Node")
+    if by_node:
+        return by_node
     by_model = unique([s for s in specs if selector in (s.get("models") or [])], "Model")
     if by_model:
         return by_model

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -780,8 +780,9 @@ def test_provider_media_server_streams_sse_events(monkeypatch):
 
 
 def test_catalog_contains_reference_readme_qwen36_models():
-    apple = catalog.find("qwen36-35b-a3b-mtp")
-    nvidia = catalog.find("qwen36-27b-mtp")
+    by_repo = {entry.hf_repo: entry for entry in catalog.CATALOG}
+    apple = by_repo.get("unsloth/Qwen3.6-35B-A3B-MTP-GGUF")
+    nvidia = by_repo.get("unsloth/Qwen3.6-27B-MTP-GGUF")
 
     assert apple is not None
     assert apple.hf_repo == "unsloth/Qwen3.6-35B-A3B-MTP-GGUF"
@@ -3450,6 +3451,12 @@ def test_run_engine_launches_local_llama_server_by_default(monkeypatch, tmp_path
         return launcher.LlamaProcess(proc=FakeProc(), port=kwargs["port"], log=tmp_path / "llama.log")
 
     monkeypatch.setattr(launcher, "is_port_in_use", lambda port: False)
+    # The join now probes whether the address it is about to advertise is actually
+    # reachable, and falls back to a real LAN address when it is not. That probe is a live
+    # HTTP call: left unstubbed it fails against this test's fictional `detect_local_ip`,
+    # and the assertion below then reads whatever IP the machine running the suite happens
+    # to have. Stubbed to "reachable" so the test asks only what it means to ask.
+    monkeypatch.setattr(runtime, "advertised_address_works", lambda url, timeout=3.0: True)
     monkeypatch.setattr(launcher, "assert_supported_build", lambda: None)
     monkeypatch.setattr(launcher, "start_llm", fake_start_llm)
     monkeypatch.setattr(launcher, "wait_for_models", lambda proc: calls.setdefault("waited", proc.port))
@@ -3479,6 +3486,12 @@ def test_run_engine_advertise_as_routes_alias_and_sets_llama_alias(monkeypatch, 
         return launcher.LlamaProcess(proc=FakeProc(), port=kwargs["port"], log=tmp_path / "llama.log")
 
     monkeypatch.setattr(launcher, "is_port_in_use", lambda port: False)
+    # The join now probes whether the address it is about to advertise is actually
+    # reachable, and falls back to a real LAN address when it is not. That probe is a live
+    # HTTP call: left unstubbed it fails against this test's fictional `detect_local_ip`,
+    # and the assertion below then reads whatever IP the machine running the suite happens
+    # to have. Stubbed to "reachable" so the test asks only what it means to ask.
+    monkeypatch.setattr(runtime, "advertised_address_works", lambda url, timeout=3.0: True)
     monkeypatch.setattr(launcher, "assert_supported_build", lambda: None)
     monkeypatch.setattr(launcher, "start_llm", fake_start_llm)
     monkeypatch.setattr(launcher, "wait_for_models", lambda proc: None)
@@ -3567,6 +3580,12 @@ def test_run_engine_enable_media_advertises_media_models(monkeypatch, tmp_path):
     calls = {}
     monkeypatch.setattr(runtime, "detect_local_ip", lambda: "192.168.1.50")
     monkeypatch.setattr(launcher, "is_port_in_use", lambda port: False)
+    # The join now probes whether the address it is about to advertise is actually
+    # reachable, and falls back to a real LAN address when it is not. That probe is a live
+    # HTTP call: left unstubbed it fails against this test's fictional `detect_local_ip`,
+    # and the assertion below then reads whatever IP the machine running the suite happens
+    # to have. Stubbed to "reachable" so the test asks only what it means to ask.
+    monkeypatch.setattr(runtime, "advertised_address_works", lambda url, timeout=3.0: True)
     monkeypatch.setattr(launcher, "assert_supported_build", lambda: None)
     monkeypatch.setattr(
         launcher,
@@ -8814,7 +8833,7 @@ def test_remote_join_requires_grid_up(monkeypatch, tmp_path):
                         lambda *a, **k: pytest.fail("must not spawn when the grid is down"))
     with pytest.raises(SystemExit) as exc:
         cli.main(["join", "--serve", "m"])
-    assert "grid up" in str(exc.value).lower()
+    assert "grid start" in str(exc.value).lower()
 
 
 def test_remote_join_died_cleans_up_record(monkeypatch, tmp_path):
@@ -21013,7 +21032,7 @@ def test_remote_engines_requires_grid_up(monkeypatch, tmp_path):
     _mock_lifecycle(monkeypatch, status={"state": "stopped"})  # down → no relay address
     with pytest.raises(SystemExit) as exc:
         cli.main(["engines"])
-    assert "grid up" in str(exc.value).lower()
+    assert "grid start" in str(exc.value).lower()
 
 
 def test_remote_engines_works_without_access_token(monkeypatch, tmp_path, capsys):
@@ -29174,7 +29193,7 @@ def test_grid_down_converges_when_the_pid_is_unprovable_but_the_port_is_dead(
     _grid_port(monkeypatch, None)
 
     assert cli.main(["down", "home"]) == 0
-    assert "is down" in capsys.readouterr().out
+    assert "stopped" in capsys.readouterr().out
     saved = config.load_grid_config(cfg["grid_id"])
     assert runtime._server_identity(saved) == {"pid": 0, "pid_start_time": None, "pgid": None}
 
@@ -29221,7 +29240,7 @@ def test_grid_down_on_an_already_stopped_grid_is_quiet(monkeypatch, tmp_path, ca
     assert cli.main(["down", "home"]) == 0
 
     out, err = capsys.readouterr()
-    assert "is down" in out and sent == []
+    assert "stopped" in out and sent == []
     assert err == "", f"an already-stopped grid should say nothing on stderr: {err}"
 
 


### PR DESCRIPTION
Ten commits that fix what a first-time user hits, plus the docs that describe it.

- `fix(cli)`: pull, join, chat and leave now work for someone with nothing set up yet
- `fix(catalog)`: the first column is a pullable spec, so the app still parses it — the short
  nickname is gone, because a name that exists only inside Grid reads like a real model id
  and is not one
- `fix(leave)`: the node name is stamped only while matching, never onto the record
- `fix(grid)`: warns when the advertised address cannot be reached
- `feat(join)`: reports when a model is actually being served
- README rewritten for someone new, and a comment pointer to a doc this repo does not ship
  was dropped

`origin/main` is merged in (it had moved 30 commits ahead). The only conflict was `README.md`,
where main added a *Local AI patterns* nav link while this branch rewrote the header — both are
kept.

**Testing:** `tests/test_local_cli.py` — 2057 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)