### PR TITLE
feat(starter-engine): ADR 0038 — the starter engine gets a meter and a clock

### DIFF
--- a/docs/adr/0038-the-starter-engine-has-a-meter-and-a-clock.md
+++ b/docs/adr/0038-the-starter-engine-has-a-meter-and-a-clock.md
@@ -1,0 +1,254 @@
+---
+status: proposed
+---
+
+# The starter engine has a meter and a clock, and neither of them lives where the money is spent
+
+A grid created from the web front end stands an engine up for itself: the control plane spawns the
+public CLI into a per-grid home and joins it with a credential the member never holds, forwarding
+every request through a passthrough the control plane owns. It shipped in public CLI v0.3.26 and it
+is live. It has no ceiling and no end — the PRD said so in as many words and deferred it:
+
+> an unbounded number of strangers can spend the operator's money on a public grid. Accepted
+> deliberately; it is the first thing a ceiling should cover.
+
+This is that ceiling, plus the thing the PRD did not name: an engine that never stops is a bill that
+never stops, even on a grid nobody has opened in a month.
+
+Five facts decided the shape, and four of them are the opposite of what the obvious implementation
+assumes.
+
+- **`auto` prefers the engine the operator pays for.** `auto_router.order_candidates`' first sort key
+  is `-free_capacity`, and `shared/run_records.effective_max_concurrency` returns
+  `API_ONLY_DEFAULT_CONCURRENCY` (4) for an identity whose every engine is an API engine — which the
+  starter engine is — against `1` for a member's llama.cpp or Ollama box. So today the paid engine
+  sorts *ahead* of the hardware a member contributed. Nothing has to be broken for the bill to grow;
+  it is the resting state.
+- **A turn is many requests.** `db.TransactionRow.conversation_id`'s own note records an agent turn
+  measured at **156 `POST /messages` in ten minutes**. A ceiling counted in HTTP requests refuses a
+  person in the middle of their first sentence.
+- **The per-turn key is chosen by the caller.** `turn_id` is the caller's `X-Request-Id`
+  (`relay._read_turn_id`), and the column is nullable. A client that sends none, and a client that
+  sends one value forever, both defeat a turn count — in opposite directions.
+- **The passthrough knows nothing about who is spending.** Every grid's starter engine presents the
+  same `GRID_OPENROUTER_PROXY_TOKEN`; the forwarded body carries a model and no identity, and no
+  ledger row is written. Meanwhile `relay.settle` marks a free network's transaction at $0 with *"no
+  charge, no report"*, so `_report_usage` never fires for exactly these grids. **The operator has no
+  record, at any granularity, of what this feature costs.**
+- **The relay cannot stop it.** The starter engine is a subprocess of the control plane;
+  `first_provider.stop_first_provider` is the only thing that can end it, and today it is called from
+  one place — deleting the grid.
+
+## Decision
+
+### D-a — The meter is enforced at the relay, keyed on the grid, and counts only what the starter engine served
+
+The relay is the only component that holds all three facts at once: who is asking, which engine
+answered, and how long ago. The passthrough holds none of them and would need a new identity on the
+wire to get any.
+
+Keyed on the **grid**, not the member: a per-member allowance multiplies the operator's cost by the
+size of the grid, which inverts the intent. Keyed on the grid, inviting people costs the operator
+nothing — a property the invitation copy has to respect, because inviting a *consumer* now makes the
+allowance run out faster rather than slower. The call to action is people with machines.
+
+Counted only against transactions the **starter engine** served (`transactions.provider_node_id`).
+Counting a member's own hardware would make the allowance a product cap rather than a cost control,
+and would make the popup's advice false: start your own engine, be refused anyway.
+
+### D-b — A turn is what a person is told; a raw request ceiling is what actually holds
+
+Two counters over the same rows in the same window:
+
+- **turns** — `COUNT(DISTINCT turn_id)`, the number a popup can say out loud;
+- **requests** — `COUNT(*)`, which no header can talk its way out of.
+
+Whichever is reached first refuses. The turn count alone is defeated by one constant `X-Request-Id`;
+the request count alone refuses an ordinary person mid-sentence. Neither is redundant, and the second
+costs one more aggregate in a query already being run.
+
+⚠️ A NULL `turn_id` counts as a turn of its own, never as one shared bucket. Every caller that sends
+no `X-Request-Id` would otherwise share a single turn forever, which is the same hole as the constant
+header with none of the intent behind it.
+
+### D-c — The starter engine is recognised by its service kind, compared for equality
+
+The relay identifies it as a node whose `meta.engine` **equals** a member of a closed set of
+grid-run service kinds — the kinds whose `ApiWhitelist.member_joinable` is false. It is not
+recognised by its display name: `meta.name` is `"Grid"`, and a member is free to name their own
+machine that.
+
+This needs no rollout at all: `cli/remote_provider` already sets `engine_label` to the kind and
+`remote/serve._meta` already sends it, on the CLI running in production today. The cost is a value
+hand-duplicated across repos, kept in lockstep by a test on both sides — the same discipline
+`SERVED_MODEL_IDS` ↔ `OPENROUTER_WHITELIST` already lives under.
+
+A control-plane route announcing the node id to the relay was considered and rejected as too
+expensive for one bit: it is a new cross-repo seam that would additionally have to survive master
+restarts and re-joins.
+
+⚠️ The failure direction is silent and it points at the operator's wallet: a second grid-run kind
+added to the CLI and not to this set serves traffic nobody counts. That is what the lockstep test is
+for, and why it is a condition of the work rather than a nicety.
+
+### D-d — Fixed five-hour windows, anchored on when the starter engine arrived
+
+`web_search.ALLOWANCE_WINDOW_SECONDS` is rolling, and its comment gives the reason: a calendar reset
+lets an account spend two allowances back to back across the boundary. That argument is much weaker
+here, because **D-f bounds the whole lifetime** — total spend is `≈5 windows × ceiling` whatever
+shape the window has, so the shape is a UX question rather than a money question.
+
+Fixed wins it on two counts. It is the only shape a countdown can be honest about ("returns at
+14:30"), where rolling hands back one turn at a time and re-opens the popup every few minutes. And
+an anchored fixed window needs **no stored state at all**: the window index is arithmetic on one
+timestamp, so the decision is one `COUNT` with a range, over a table (`transactions`) whose own
+24-hour TTL already covers every window that can be asked about.
+
+**The anchor at the relay is when the starter engine's node was first seen there**, not the grid's
+creation timestamp. The relay already holds the first, needs a new wire value to learn the second,
+and the first is anyway the semantically right one: it is when the thing being metered arrived. The
+two differ by the seconds between the grid being created and its engine joining, which is nothing at
+a five-hour granularity — and the clock in D-f, which lives where `network.created_at` is
+authoritative, uses that instead. Two timestamps, each read where it is already true, rather than
+one carried across a boundary to be re-derived on the far side.
+
+⚠️ The cost of that choice: a node row recreated at the relay moves the anchor and starts a fresh
+window. It is bounded — D-f retires the engine on the control plane's own clock regardless — and it
+is not member-reachable, because no member can rejoin a grid-run kind.
+
+### D-e — Exhaustion excludes the starter engine from selection; it refuses only when nothing else can serve
+
+The check runs **after** provider selection, not at the door. A request that `auto` would route to a
+member's engine never asks about the allowance at all. When the allowance is spent, the starter
+engine is dropped from the candidate set exactly the way `X-Allow-Self-Provider: false` already drops
+a self-provider (`relay._select_provider`), and the refusal is what falls out when nothing else is
+left.
+
+Refusing at the door would refuse a grid that has its own hardware, which is precisely the grid the
+operator is paying nothing for.
+
+The refusal carries a machine-readable `code` beside the sentence, for the reason `web_search`'s
+`ALLOWANCE_CODE` carries one: it shares its status with "the engine is busy", and the two want
+opposite actions — one lifts in seconds, the other in hours. It also carries the window's absolute
+reset time, not only a duration, because a popup can sit open for minutes.
+
+### D-f — The starter engine retires 24 hours after the grid is created, and the control plane owns the clock
+
+A periodic sweep in the control plane stops every starter engine whose grid is older than 24 hours.
+Not a timer armed at creation: a timer dies with the process that holds it, and a control-plane
+restart would leave engines running forever with nothing to say so — fail-open, silent, on the
+spending path. A sweep re-derives the answer from `network.created_at` every pass, so a restart costs
+nothing and a failed stop is retried by the next pass rather than lost. **Idempotence and retry are
+acceptance criteria, not implementation detail.**
+
+The stop must also make the engine leave the grid, not merely die. A stopped process leaves its node
+row at the relay until the heartbeat ages out, and `auto` can still pick it in that gap and fail the
+request. `stop_first_provider` already runs `grid --remote leave` before removing the home on the
+delete path, for a neighbouring reason; this is the second caller of the same sequence.
+
+Retirement is one-way. A grid whose member later removes their own engine does not get the starter
+engine back — that is the product's answer to "why would I ever contribute hardware".
+
+⚠️ Retiring on a fixed 24 hours rather than on inactivity is deliberate and it is the expensive
+direction for the *member*: a grid in active daily use loses its engine at the same hour as a grid
+nobody opened. The alternative — extend while in use — makes the operator's cost per grid unbounded
+again, which is the thing this ADR exists to stop.
+
+### D-g — The relay answers the meter; the app derives the clock
+
+The relay serves one new read for the allowance (`used`, `ceiling`, `reset_at`, and the request-count
+pair). It is a **new route**, so a relay that does not have it answers a bare 404 and the app knows
+immediately. Adding the keys to an existing read instead would make "this relay is too old" and
+"you have allowance left" indistinguishable, which is the failure this repo has already paid for
+more than once.
+
+The relay is deliberately **not** told about the 24-hour clock. After retirement the starter engine's
+node is gone, so the relay could not distinguish "retired" from "never had one" without being handed
+a lifetime it otherwise has no use for. The app can already tell: it holds the grid's creation time
+and its machine list, and *older than 24 hours with no machines* is the whole of the derivation.
+
+### D-h — The display may fail open; the enforcement may not
+
+A failed read of the allowance means the app shows no popup and the person keeps chatting — the
+relay is still refusing at the right point, so nothing was spent that should not have been. The
+inverse — blocking a person because a `GET` failed — protects no money and breaks a working grid.
+
+### D-i — `auto` ranks grid-run models last, through a key that is a constant for everyone else
+
+A new leading sort key in `order_candidates`, ahead of `-free_capacity`, worth `0` for every
+candidate and `1` for a model served only by a grid-run kind. A pool containing no such model
+therefore orders byte-for-byte as it does today, which is the property that keeps every existing
+routing test and the routing ledger meaningful.
+
+It ranks last rather than being filtered out: when a member's engine is busy, `auto`'s free-first
+walk still reaches the starter engine instead of making the person wait, and that request costs money
+and is counted. Floor, not default.
+
+⚠️ Two things this does not do, both of which will look like bugs to somebody:
+`order_candidates` is also what cuts the Advisor's shortlist (`[:ADVISOR_CANDIDATES_MAX]`, 50), so on
+a grid with more than fifty candidate models the grid-run ones stop being *considered* rather than
+merely ranked — an effect stronger than the word "prefer" suggests. And a member who picks a
+grid-run model **by name** in the picker still reaches it; ordering has nothing to say about a
+request that named its model.
+
+### D-j — The nudge is per member; the ceiling is per grid
+
+The prompt to contribute an engine or invite people appears on a member's own fifth turn, once. The
+ceiling stays per grid (D-a). Two counters over one table with two different `WHERE` clauses, and
+they are keyed differently on purpose: a ceiling is about the operator's money, an invitation is
+about one person's experience of the product. Keyed on the grid, the nudge would greet every invited
+member with a request for help on their very first message.
+
+### D-k — A request already handed to the starter engine counts, whatever happens next
+
+The count is of transaction rows assigned to the starter engine, ignoring `status`. An assignment
+means the vendor was called, so the money is gone whether the stream completed, timed out, or the
+client hung up. Only a request refused before assignment costs nothing and is not counted.
+
+### D-l — The passthrough records what it spent, or every number in this ADR is permanently a guess
+
+Each forwarded call logs the model and the `usage` block the vendor returned. No identity, no
+`network_id`, no new wire value — an aggregate, because the question it has to answer is *what does
+this feature cost per day*, which is the question that sets every ceiling below.
+
+Without it the operator's only artefact is an undifferentiated vendor invoice, and there is no path
+from "the ceiling is 50" to "the ceiling should be 30", ever. Per-grid attribution would require an
+identity on a wire that deliberately has none, and is not proposed.
+
+### D-m — The numbers are starting values read from the environment
+
+Fifth turn for the nudge; **50 turns and 1,000 requests per five-hour window**; twenty-four hours to
+retirement. All read at call time from the environment, on the model of `web_search.daily_allowance`,
+so the number an operator most wants to move is not the one that needs a release to move.
+
+They are chosen, not measured — and D-l is what will eventually replace them with measurements.
+50 turns per five hours is about ten an hour, and with retirement it caps a grid's entire life at
+roughly 240 turns.
+
+## Consequences
+
+- **Creating a second grid buys a second allowance.** There is no cross-grid ceiling per account; the
+  relay has no cross-grid view and adding one is a control-plane feature of its own. What bounds it
+  instead is that each grid only spends for its first 24 hours, and that unbounded grid creation
+  already fails louder elsewhere — the dev VM exhausts memory at roughly sixteen grids.
+- **Non-app clients get a request-counted tier, not a turn-counted one.** An agent CLI pointed at a
+  grid sends no `X-Request-Id`, so by D-b every call is its own turn and the ceiling arrives inside
+  the first agent turn. This tier is for chat in the app; that is a product decision, and it is
+  visible here rather than discovered later.
+- **A grid can go quiet at hour 24 with nothing wrong with it.** Everything the member sees at that
+  point comes from the app deriving retirement (D-g). If the app does not do that work, the grid
+  simply answers *no providers available* — which is exactly the state the starter engine was built
+  to remove, arriving a day later with no explanation.
+- **The vocabulary and the code disagree on purpose.** Product surfaces, glossary and this ADR say
+  **starter engine**; the shipped modules keep saying `first_provider`. Renaming live code is a
+  separate change with its own risk, and mixing it into this one would bury the review.
+
+## Rollout order
+
+- **Relay before app.** The app's allowance read is a new route; without it the app shows nothing and
+  the grid still works (D-h).
+- **No order for the recognition rule.** `meta.engine` already arrives from the CLI in production
+  (D-c).
+- **No order for the sweep.** It is control-plane-internal and touches no wire value (D-f).
+- **The passthrough's usage log is independent** and should land first, because it is the only thing
+  that can tell anyone whether D-m's numbers were right.

--- a/docs/adr/0038-the-starter-engine-has-a-meter-and-a-clock.md
+++ b/docs/adr/0038-the-starter-engine-has-a-meter-and-a-clock.md
@@ -191,6 +191,12 @@ merely ranked — an effect stronger than the word "prefer" suggests. And a memb
 grid-run model **by name** in the picker still reaches it; ordering has nothing to say about a
 request that named its model.
 
+**Amended by D-n.** That second caveat was written as a limit and turned out to be the larger half of
+the bill: this key is keyed on a MODEL's providers, so it is silent both for a named request and for
+a model a member's engine merely serves *too*. D-n adds the same key one tier down, where those two
+cases are decided. What survives here unchanged is the shortlist caveat, which is genuinely about
+this tier.
+
 ### D-j — The nudge is per member; the ceiling is per grid
 
 The prompt to contribute an engine or invite people appears on a member's own fifth turn, once. The
@@ -225,6 +231,46 @@ They are chosen, not measured — and D-l is what will eventually replace them w
 50 turns per five hours is about ten an hour, and with retirement it caps a grid's entire life at
 roughly 240 turns.
 
+### D-n — Node selection prefers the engine the operator does not pay for, ahead of speed and price
+
+A leading key on `relay._selection_sort_key`, spelled exactly as D-i's: `1` for a node
+`starter_engine.is_starter_engine` recognises, `0` for everyone else, so a grid running no engine of
+its own sorts byte-for-byte as it did before. It is the node-level twin of D-i, and it exists because
+D-i cannot reach the two cases that actually move the bill.
+
+D-i's key is keyed on a **model's** providers (`all(...)`). So it says nothing when a member's engine
+serves the same model — the candidate keys `0` and is never demoted — and nothing at all about a
+request that **named** its model, which never reaches the model tier. Both fall through to
+`_select_provider`, which ranked on measured speed and spare slots and never on who pays. Measured on
+the dev grid: an outside Ollama box and the starter engine both advertising `qwen/qwen3.8-27b`, both
+healthy, and the starter engine served every request. Nothing had to break for the bill to grow.
+
+**It leads `cost` as well.** `cost` is the price the *consumer* is charged (`price_score`, present in
+the key only while `grid_pricing_enabled` is on); this key is about what the *operator* pays. Two
+different questions, and `order_candidates` already puts the same key ahead of `price_score`, so the
+two tiers now say one thing rather than two.
+
+⚠️ **It also outranks `perf`, including `perf`'s unmeasured guard, and that is the trade rather than
+an oversight.** `perf` sorts an unmeasured (node, model) pairing last on purpose — a cold start on the
+reference grid was 57s against 0.67s warm — so from here on `perf` separates member boxes from each
+other and starter engines from each other, never a member box from a starter engine. A member box
+that measures nine times slower still takes the request, and an unproven one takes it before it has
+been measured at all; `_schedule_warm` then measures the winner at the relay's expense. Ranking the
+two on speed instead is precisely the resting state that grew the bill.
+
+**Floor, not default, exactly as D-i is.** The sort runs over `available_providers` — already filtered
+to nodes with a free slot — and the caller walks the sorted list, so the starter engine is still
+reached the moment no member box has room. Nobody waits for one. The queueable path deliberately
+keeps `fill` ahead of this whole tuple (`busy_sort_key`): when every engine is full the choice is
+which *queue* to join, and sending a person to a longer one to save money is the thing D-i refused.
+
+A three-way key preserving the cold-start guard — measured member, then starter engine, then
+unmeasured member — was designed and **rejected**: `_schedule_warm` returns early unless
+`endpoint_path == "chat/completions"`, so on `/responses` and the Anthropic `/messages` wire an
+unmeasured member box would never be warmed *and* never receive real traffic, and would sit behind
+the starter engine permanently. A self-perpetuating, silent cost leak is a worse failure than a slow
+first request.
+
 ## Consequences
 
 - **Creating a second grid buys a second allowance.** There is no cross-grid ceiling per account; the
@@ -249,6 +295,9 @@ roughly 240 turns.
   the grid still works (D-h).
 - **No order for the recognition rule.** `meta.engine` already arrives from the CLI in production
   (D-c).
+- **No order for the node-level preference** (D-n). It is relay-internal, reads a value the CLI
+  already sends, and adds no wire value in either direction — a relay without it simply keeps
+  spending, which is today's behaviour.
 - **No order for the sweep.** It is control-plane-internal and touches no wire value (D-f).
 - **The passthrough's usage log is independent** and should land first, because it is the only thing
   that can tell anyone whether D-m's numbers were right.

--- a/tests/test_starter_engine_lockstep.py
+++ b/tests/test_starter_engine_lockstep.py
@@ -1,0 +1,144 @@
+"""The set of grid-run service kinds, pinned across the repo boundary (ADR 0038 D-c).
+
+A grid created from the web front end gets a **starter engine** stood up for it: the control plane
+spawns this CLI into a per-grid home and joins it with a credential the member never holds. The
+relay has to know which node that is — it ranks its models last (D-i) and counts its traffic against
+the grid's allowance (D-a) — and it recognises it by the service kind the node advertises, compared
+for equality against a closed set it holds its own copy of.
+
+This CLI is where the authority lives: `ApiWhitelist.member_joinable` is the field that decides who
+may join a kind, and a kind the grid stands up on a member's behalf is exactly one nobody can join.
+There is no import path between the two repositories, so the copies are kept in lockstep by editing
+both sides — and by this test.
+
+⚠️ **It is the only thing that can catch D-c's failure, and that failure is SILENT.** A second
+grid-run kind added here and not to the relay is not an error anywhere: the node registers, serves,
+ranks first on free capacity, and is counted against nothing. The invoice is where it shows up.
+
+⚠️ Per this repository's rule for every cross-repo assertion, this **skips unless the grid-src
+worktree sits beside this one** — i.e. it skips in CI, and a green CI proves nothing about it. Run
+it locally, on a machine that has both.
+
+Its own module rather than more of `tests/test_task_lease.py`, which carries the task plane's
+lockstep checks and is already this repository's second-largest suite. Nothing here is about tasks,
+and its grid-src resolver is different: that file names one worktree by absolute path, which is why
+its checks skip in every *other* worktree. This one derives the sibling from its own location.
+"""
+
+import os
+import pathlib
+
+import pytest
+
+# The grid-src module holding the relay's copy, and the name of the copy inside it.
+_RELAY_MODULE = "starter_engine.py"
+_RELAY_CONSTANT = "GRID_RUN_ENGINE_KINDS"
+
+
+def _grid_src_private_server():
+    """grid-src's `private_server` package, or ``None`` when this machine does not have it.
+
+    Derived from THIS file's location rather than written out, so the check runs in whichever
+    worktree it is checked out into instead of skipping everywhere but one. The convention is
+    `<repo>-feats/<slug>` beside `<repo>`, so a worktree of `autonomous-grid` at
+    `…/autonomous-grid-feats/<slug>` looks for `…/grid-src-feats/<slug>` first and falls back to the
+    main `…/grid-src` checkout.
+
+    `GRID_SRC_REPO` — the cross-repo E2E's own override — wins over both, so a machine that lays the
+    repositories out differently can still run this.
+    """
+    override = os.environ.get("GRID_SRC_REPO")
+    if override:
+        return pathlib.Path(override) / "grid_cli" / "private_server"
+
+    here = pathlib.Path(__file__).resolve().parent.parent  # the autonomous-grid checkout
+    projects = here.parent
+    candidates = []
+    if projects.name == "autonomous-grid-feats":
+        candidates.append(projects.parent / "grid-src-feats" / here.name)
+        candidates.append(projects.parent / "grid-src")
+    else:
+        candidates.append(projects / "grid-src")
+    for candidate in candidates:
+        if (candidate / "grid_cli" / "private_server").is_dir():
+            return candidate / "grid_cli" / "private_server"
+    return None
+
+
+def _relay_grid_run_kinds():
+    """The relay's copy of the set, parsed out of grid-src rather than imported.
+
+    The two repositories are separate installs with no import path between them. Parsed with `ast`,
+    and every shape this helper does not understand is an assertion rather than a shrug — a check
+    that silently returns something plausible is worse than no check, because the thing it guards
+    fails silently too.
+    """
+    import ast
+
+    package = _grid_src_private_server()
+    if package is None:
+        pytest.skip("grid-src worktree is not beside this one; the lockstep cannot be checked here")
+    source = package / _RELAY_MODULE
+    if not source.exists():
+        pytest.skip("grid-src worktree is not beside this one; the lockstep cannot be checked here")
+
+    for node in ast.parse(source.read_text()).body:
+        targets = (
+            node.targets if isinstance(node, ast.Assign)
+            else [node.target] if isinstance(node, ast.AnnAssign) and node.value is not None
+            else []
+        )
+        if not any(getattr(t, "id", None) == _RELAY_CONSTANT for t in targets):
+            continue
+        value = node.value
+        # `frozenset({...})` / `set([...])` — the collection is the call's single argument.
+        if isinstance(value, ast.Call) and len(value.args) == 1:
+            value = value.args[0]
+        assert isinstance(value, (ast.Set, ast.Tuple, ast.List)), (
+            f"grid-src's {_RELAY_CONSTANT} is no longer a literal collection, so this lockstep "
+            f"check cannot read it — teach this helper the new shape rather than deleting the check")
+        members = []
+        for element in value.elts:
+            assert isinstance(element, ast.Constant) and isinstance(element.value, str), (
+                f"grid-src's {_RELAY_CONSTANT} holds something that is not a plain string literal, "
+                f"so this check would compare a set it has only partly read")
+            members.append(element.value)
+        assert members, (
+            f"grid-src's {_RELAY_CONSTANT} is empty, so the relay recognises no starter engine at "
+            f"all — every grid's engine would serve traffic nobody counts")
+        return frozenset(members)
+
+    raise AssertionError(
+        f"{_RELAY_CONSTANT} is no longer defined in grid-src's {_RELAY_MODULE} — it was renamed or "
+        f"moved, so teach this check where it went rather than deleting it")
+
+
+def _cli_grid_run_kinds():
+    """The kinds this CLI says nobody may join — the authority the relay's copy must match."""
+    from shared.models.api_catalog import WHITELISTS
+
+    return frozenset(kind for kind, entry in WHITELISTS.items() if not entry.member_joinable)
+
+
+def test_this_cli_still_has_a_kind_no_member_may_join():
+    """The control, and it does NOT need grid-src.
+
+    Without it the comparison below is satisfied by two empty sets: `member_joinable` defaulting to
+    True everywhere, and a relay recognising nothing, agree perfectly and mean the feature is gone.
+    """
+    assert _cli_grid_run_kinds(), (
+        "no ApiWhitelist sets member_joinable=False any more, so this CLI describes no engine the "
+        "grid stands up on a member's behalf — ADR 0038 D-c has nothing left to recognise")
+
+
+def test_the_relay_recognises_exactly_the_kinds_no_member_may_join():
+    """The lockstep itself. Both directions of drift are a real failure, in opposite ways.
+
+    A kind marked `member_joinable=False` here and missing from the relay's set is the silent one:
+    that grid's starter engine ranks FIRST on free capacity and its traffic is counted against
+    nothing. A kind in the relay's set that members CAN join is the mirror: somebody's own API key,
+    paid for out of their own pocket, is ranked last and metered as if the operator bought it.
+    """
+    assert _relay_grid_run_kinds() == _cli_grid_run_kinds(), (
+        "grid-src's starter_engine.GRID_RUN_ENGINE_KINDS and this CLI's member_joinable=False rows "
+        "have drifted; edit BOTH sides, and read ADR 0038 D-c before choosing which is right")


### PR DESCRIPTION
The decision record for ADR 0038, plus the one half of it that lives in this repository.

## What is here

- **`docs/adr/0038-the-starter-engine-has-a-meter-and-a-clock.md`** — the committed authority for the whole feature, including D-n (node selection stops preferring the starter engine).
- **`tests/test_starter_engine_lockstep.py`** — pins the set of grid-run service kinds against the relay's own copy.

Almost all of the code lands in the sibling repos; this repo is the cross-repo hub, so the ADR and the lockstep test belong here.

## Why the lockstep test exists

`ApiWhitelist.member_joinable` is the field that decides who may join a service kind, and a kind the grid stands up on a member's behalf is exactly one nobody can join. There is no import path between this CLI and the relay, so the two copies are kept in step by editing both sides — and by this test.

It is the only thing that can catch ADR 0038 D-c's failure, and that failure is **silent**: a second grid-run kind added here and not to the relay is an error nowhere. The node registers, serves, ranks first on free capacity, and is counted against nothing. The invoice is where it shows up.

**Two tests, not one.** The comparison alone is satisfied by two empty sets — `member_joinable` defaulting to `True` everywhere and a relay recognising nothing agree perfectly and mean the feature is gone — so the control asserts this CLI still HAS such a kind, and it deliberately does not need the sibling repo. With that repo absent the result is `1 passed, 1 skipped` rather than a clean sweep of skips.

## Test plan

- [x] `tests/test_starter_engine_lockstep.py` — passes; with the sibling repo present it compares both sides, without it the control still runs
- [x] Mutation-checked: pointing the relay's set at a non-matching value turns the comparison red with a real set diff
- [x] The feature's behaviour is verified live on the dev VM from the sibling repos (allowance counting, refusal, read route, retirement, node preference)
- [ ] Live verification of the app-facing half — needs `autonomous-grid-app`, tracked separately

## Rollout

Roll the **relay out before the app**. Nothing in this PR is on the request path; it is the ADR and a lockstep guard.