### PR TITLE
feat(media): serve Z-Image alongside Krea 2 on the one generation route

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ Grid ships a second engine, ComfyUI, for media:
 grid engine install comfyui
 
 # Download the model files for what you want to make
-grid engine pull image_generation      # also: image_editing, i2v
+grid engine pull image_generation      # also: z_image, image_editing, i2v
 
 # Join this computer as a media engine; repeat --bundle for more than one
 grid join <grid-url> --media --bundle image_generation
@@ -490,6 +490,11 @@ grid video "morning light moves across the desk" \
 
 - Each command needs `-m`: `comfyui:image_generation`, `comfyui:image_editing` or `comfyui:i2v`.
   A computer serves only the bundles it joined with.
+- Two models make images. `comfyui:image_generation` is Krea 2 Turbo, also reachable as
+  `comfyui:krea2`; `comfyui:z_image` is the lighter Z-Image Turbo. Pull and join `z_image` to serve
+  both, then pick per request — the command is the same, only `-m` changes.
+- `--steps` is optional, and better left off: each model ships with the step count it was distilled
+  for. Both of these want 4, and asking for more is slower without being better.
 - `grid edit` takes up to three `-i` images. `grid video` takes one, and `--duration` is `5s` or `8s`.
 - `--grid` is only needed on local, because the positional argument is the prompt.
 - Results are written to `~/.grid/outputs` — `-o` puts them somewhere else.

--- a/cli/_constants.py
+++ b/cli/_constants.py
@@ -1,5 +1,5 @@
 """Shared CLI constants (argument choices)."""
 
-VALID_MEDIA_BUNDLES = ("image_generation", "image_editing", "i2v")
+VALID_MEDIA_BUNDLES = ("image_generation", "z_image", "image_editing", "i2v")
 VALID_I2V_DURATIONS = ("5s", "8s")
 VALID_I2V_ASPECT_RATIOS = ("2:3", "3:2", "1:1")

--- a/cli/engine.py
+++ b/cli/engine.py
@@ -14,7 +14,7 @@ def cmd_engine_install(args: argparse.Namespace) -> int:
 
         comfyui.install()
         print("Done. Now download the model files for what you want to make:")
-        print("  grid engine pull image_generation     # also: image_editing, i2v")
+        print("  grid engine pull image_generation     # also: z_image, image_editing, i2v")
         return 0
     raise SystemExit(f"Unknown engine {args.name!r}. Choose 'llama.cpp' (text) or 'comfyui' (media).")
 

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -443,7 +443,9 @@ def _add_use(sub) -> None:
     )
     image.add_argument("--width", type=int, default=720)
     image.add_argument("--height", type=int, default=720)
-    image.add_argument("--steps", type=int, default=4)
+    # No default: the workflow the provider runs carries the step count its model was
+    # distilled for. Sending one from here would override it on every call.
+    image.add_argument("--steps", type=int, default=None)
     _add_remote_use_flags(image)
     image.set_defaults(handler=cmd_image)
 
@@ -463,7 +465,7 @@ def _add_use(sub) -> None:
         required=True,
         help="Input image path. Repeat up to three times.",
     )
-    edit.add_argument("--steps", type=int, default=4)
+    edit.add_argument("--steps", type=int, default=None)
     _add_remote_use_flags(edit)
     edit.set_defaults(handler=cmd_edit)
 

--- a/cli/request.py
+++ b/cli/request.py
@@ -152,6 +152,11 @@ def cmd_video(args: argparse.Namespace) -> int:
 
 
 def _post_media_request(args: argparse.Namespace, endpoint_path: str, payload: dict[str, Any]) -> int:
+    # An unset flag is an absent field, not a null one. `steps` is the case that matters: the
+    # provider's workflow carries the step count its model was distilled for, and it only overrides
+    # that when the request actually asks for something else. Sending `"steps": null` would be a
+    # request to set it, so the key has to go.
+    payload = {key: value for key, value in payload.items() if value is not None}
     cfg = config.select_grid(getattr(args, "grid", None))
     timeout = httpx.Timeout(float(args.timeout), read=float(args.timeout))
     url = f"{runtime.grid_url(cfg)}/v1/{endpoint_path}"

--- a/shared/media/media_gating.py
+++ b/shared/media/media_gating.py
@@ -13,6 +13,8 @@ in `engine/comfyui.py` (`--lowvram --reserve-vram 1` when max card < 32 GB):
                         threshold. Heavier than the Z-Image Turbo it replaced
                         (~12 GB UNet); if generation starts OOMing on 24 GB
                         hosts, raise this gate rather than shrinking the model.
+    z_image           - Z-Image Turbo, the lighter alternative on the same
+                        route (~12 GB UNet). A host can serve either, or both.
     image_editing     - Qwen-Image-Edit at Q4_1 + Lightning lora fits a
                         24 GB card under --lowvram (UNet partitioned to RAM).
     i2v               - Wan2.2 14B high+low noise sequential, also fits a
@@ -38,8 +40,15 @@ class MediaGate:
     min_vram_gb: float
 
 
+# `image_generation` is advertised twice on purpose. `comfyui:image_generation` names the *task* and
+# is what `ENDPOINT_MODELS` resolves a request to when it names no model — every client written
+# before there was a choice keeps working. `comfyui:krea2` names the *model*, which is what a caller
+# picking between models actually wants, and reads correctly beside `comfyui:z_image`. Same bundle,
+# same files, same workflow: two names for one thing, not two things.
 GATES: tuple[MediaGate, ...] = (
     MediaGate(bundle="image_generation", advertise_as="comfyui:image_generation", min_vram_gb=22.0),
+    MediaGate(bundle="image_generation", advertise_as="comfyui:krea2",            min_vram_gb=22.0),
+    MediaGate(bundle="z_image",          advertise_as="comfyui:z_image",          min_vram_gb=22.0),
     MediaGate(bundle="image_editing",    advertise_as="comfyui:image_editing",    min_vram_gb=22.0),
     MediaGate(bundle="i2v",              advertise_as="comfyui:i2v",              min_vram_gb=22.0),
 )

--- a/shared/media/media_handler.py
+++ b/shared/media/media_handler.py
@@ -46,6 +46,31 @@ _COMFYUI_MAX_RETRIES = 10
 _WORKFLOW_DIR = os.path.join(os.path.dirname(__file__), "workflows")
 _workflow_cache: dict[str, dict] = {}
 
+# The generation models `media/image/generate` can serve, and where each graph keeps the four
+# things a request sets. The ids are per-workflow — Krea 2 numbers its nodes 1..10, the Z-Image
+# graph carries "34:*" subgraph ids — so they belong in a table beside the file name, not inlined
+# at the call site where one model's ids would silently be used on the other's graph.
+#
+# Keys are the advertised capability names from `media_bundles.CAPABILITY_NAME`. A host serves
+# whichever it joined with; a request names one, or gets `_DEFAULT_IMAGE_GEN`.
+_DEFAULT_IMAGE_GEN = "comfyui:image_generation"
+
+_KREA2_GRAPH = {
+    "file": "image_generation_krea2_workflow.json",
+    "text": "4", "size": "6", "steps": "7", "save": "10",
+}
+
+_IMAGE_GEN_WORKFLOWS: dict[str, dict[str, str]] = {
+    # `comfyui:image_generation` (the task) and `comfyui:krea2` (the model) are the same graph —
+    # see the note on GATES in media_gating.py for why both names exist.
+    "comfyui:image_generation": _KREA2_GRAPH,
+    "comfyui:krea2": _KREA2_GRAPH,
+    "comfyui:z_image": {
+        "file": "image_generation_zimage_workflow.json",
+        "text": "34:27", "size": "34:13", "steps": "34:3", "save": "9",
+    },
+}
+
 
 def _load_workflow(name: str) -> dict:
     """Load a workflow JSON and cache it. Returns a deep copy."""
@@ -110,9 +135,18 @@ class MediaHandler:
         prompt_text = body.get("prompt", "")
         width = body.get("width", 720)
         height = body.get("height", 720)
-        steps = body.get("steps", 4)
+        # No default here: each generation workflow already carries the step count its model was
+        # distilled for (4 for both of ours), and forcing a number from this side would override a
+        # graph that knows better the moment one of them differs. Only an explicit request wins.
+        steps = body.get("steps")
         self._ensure_comfyui_running()
-        workflow = self._build_image_gen_workflow(prompt_text, width, height, steps)
+        # `model` is optional: the route already names the task, so omitting it keeps the
+        # behaviour every existing caller has. Naming one picks between the generation models
+        # this route serves — the proxy has already resolved the request to an engine that
+        # advertises it, so anything unknown here just falls back to the default.
+        workflow = self._build_image_gen_workflow(
+            prompt_text, width, height, steps, model=body.get("model")
+        )
         yield from self._submit_and_track(workflow, "image/png", "output_image")
 
     # ------------------------------------------------------------------
@@ -121,7 +155,7 @@ class MediaHandler:
 
     def _handle_image_editing(self, body: dict):
         prompt_text = body.get("prompt", "")
-        steps = body.get("steps", 4)
+        steps = body.get("steps")  # absent -> the graph keeps its own count
         input_images = body.get("input_images", [])
         if not input_images:
             yield f'data: {json.dumps({"error": "No input images provided"})}'
@@ -438,42 +472,46 @@ class MediaHandler:
     # ------------------------------------------------------------------
 
     def _build_image_gen_workflow(self, prompt: str, width: int, height: int,
-                                  steps: int) -> dict:
-        # Krea 2 Turbo. Node ids are the workflow's own and differ from the Z-Image graph this
-        # replaced (which used the "34:*" subgraph ids): 4=CLIPTextEncode, 6=EmptyLatentImage,
-        # 7=KSampler, 10=SaveImage.
-        workflow = _load_workflow("image_generation_krea2_workflow.json")
-        workflow["prompt"]["4"]["inputs"]["text"] = prompt
-        workflow["prompt"]["6"]["inputs"]["width"] = width
-        workflow["prompt"]["6"]["inputs"]["height"] = height
-        workflow["prompt"]["7"]["inputs"]["steps"] = steps
-        workflow["prompt"]["10"]["inputs"]["filename_prefix"] = "output_image"
+                                  steps: int | None = None, model: str | None = None) -> dict:
+        """Text-to-image, on whichever generation model the request named.
+
+        Both models serve the one `media/image/generate` route, so the node ids cannot be
+        hard-coded here: each graph numbers its own nodes, and the Z-Image one uses "34:*"
+        subgraph ids. An unknown (or absent) model falls back to the route's default.
+        """
+        spec = _IMAGE_GEN_WORKFLOWS.get(model or "") or _IMAGE_GEN_WORKFLOWS[_DEFAULT_IMAGE_GEN]
+        workflow = _load_workflow(spec["file"])
+        nodes = workflow["prompt"]
+        nodes[spec["text"]]["inputs"]["text"] = prompt
+        nodes[spec["size"]]["inputs"]["width"] = width
+        nodes[spec["size"]]["inputs"]["height"] = height
+        if steps is not None:
+            nodes[spec["steps"]]["inputs"]["steps"] = steps
+        nodes[spec["save"]]["inputs"]["filename_prefix"] = "output_image"
         return workflow
 
     def _build_image_edit_workflow(self, prompt: str, image_paths: list[str],
-                                   steps: int) -> dict:
+                                   steps: int | None = None) -> dict:
         num_images = len(image_paths)
         if num_images == 1:
             workflow = _load_workflow("one_image_editing_workflow.json")
-            workflow["prompt"]["111"]["inputs"]["prompt"] = prompt
-            workflow["prompt"]["3"]["inputs"]["steps"] = steps
             workflow["prompt"]["78"]["inputs"]["image"] = image_paths[0]
-            workflow["prompt"]["60"]["inputs"]["filename_prefix"] = "output_image"
         elif num_images == 2:
             workflow = _load_workflow("two_images_editing_workflow.json")
-            workflow["prompt"]["111"]["inputs"]["prompt"] = prompt
-            workflow["prompt"]["3"]["inputs"]["steps"] = steps
             workflow["prompt"]["78"]["inputs"]["image"] = image_paths[0]
             workflow["prompt"]["106"]["inputs"]["image"] = image_paths[1]
-            workflow["prompt"]["60"]["inputs"]["filename_prefix"] = "output_image"
         else:
             workflow = _load_workflow("three_images_editing_workflow.json")
-            workflow["prompt"]["111"]["inputs"]["prompt"] = prompt
-            workflow["prompt"]["3"]["inputs"]["steps"] = steps
             workflow["prompt"]["78"]["inputs"]["image"] = image_paths[0]
             workflow["prompt"]["106"]["inputs"]["image"] = image_paths[1]
             workflow["prompt"]["108"]["inputs"]["image"] = image_paths[2]
-            workflow["prompt"]["60"]["inputs"]["filename_prefix"] = "output_image"
+        # The three graphs differ only in how many images they take; the prompt, sampler and save
+        # nodes are the same ids in all of them, so setting them once is the same work without the
+        # chance of the branches drifting apart.
+        workflow["prompt"]["111"]["inputs"]["prompt"] = prompt
+        workflow["prompt"]["60"]["inputs"]["filename_prefix"] = "output_image"
+        if steps is not None:  # otherwise the graph's own count stands — see _build_image_gen_workflow
+            workflow["prompt"]["3"]["inputs"]["steps"] = steps
         return workflow
 
     def _build_i2v_workflow(self, prompt: str, image_path: str, duration: str,

--- a/shared/media/workflows/image_generation_zimage_workflow.json
+++ b/shared/media/workflows/image_generation_zimage_workflow.json
@@ -1,0 +1,129 @@
+{
+  "prompt": {
+    "9": {
+      "inputs": {
+        "filename_prefix": "output_image",
+        "images": [
+          "34:8",
+          0
+        ]
+      },
+      "class_type": "SaveImage",
+      "_meta": {
+        "title": "Save Image"
+      }
+    },
+    "34:30": {
+      "inputs": {
+        "clip_name": "qwen_3_4b.safetensors",
+        "type": "lumina2",
+        "device": "default"
+      },
+      "class_type": "CLIPLoader",
+      "_meta": {
+        "title": "Load CLIP"
+      }
+    },
+    "34:29": {
+      "inputs": {
+        "vae_name": "z_image_vae.safetensors"
+      },
+      "class_type": "VAELoader",
+      "_meta": {
+        "title": "Load VAE"
+      }
+    },
+    "34:13": {
+      "inputs": {
+        "width": 720,
+        "height": 720,
+        "batch_size": 1
+      },
+      "class_type": "EmptySD3LatentImage",
+      "_meta": {
+        "title": "EmptySD3LatentImage"
+      }
+    },
+    "34:33": {
+      "inputs": {
+        "conditioning": [
+          "34:27",
+          0
+        ]
+      },
+      "class_type": "ConditioningZeroOut",
+      "_meta": {
+        "title": "ConditioningZeroOut"
+      }
+    },
+    "34:8": {
+      "inputs": {
+        "samples": [
+          "34:3",
+          0
+        ],
+        "vae": [
+          "34:29",
+          0
+        ]
+      },
+      "class_type": "VAEDecode",
+      "_meta": {
+        "title": "VAE Decode"
+      }
+    },
+    "34:3": {
+      "inputs": {
+        "seed": 173012675742063,
+        "steps": 4,
+        "cfg": 1,
+        "sampler_name": "res_multistep",
+        "scheduler": "simple",
+        "denoise": 1,
+        "model": [
+          "34:28",
+          0
+        ],
+        "positive": [
+          "34:27",
+          0
+        ],
+        "negative": [
+          "34:33",
+          0
+        ],
+        "latent_image": [
+          "34:13",
+          0
+        ]
+      },
+      "class_type": "KSampler",
+      "_meta": {
+        "title": "KSampler"
+      }
+    },
+    "34:27": {
+      "inputs": {
+        "text": "putin kisses elon musk",
+        "clip": [
+          "34:30",
+          0
+        ]
+      },
+      "class_type": "CLIPTextEncode",
+      "_meta": {
+        "title": "CLIP Text Encode (Prompt)"
+      }
+    },
+    "34:28": {
+      "inputs": {
+        "unet_name": "z_image_turbo_bf16.safetensors",
+        "weight_dtype": "default"
+      },
+      "class_type": "UNETLoader",
+      "_meta": {
+        "title": "Load Diffusion Model"
+      }
+    }
+  }
+}

--- a/shared/models/media_bundles.py
+++ b/shared/models/media_bundles.py
@@ -63,6 +63,33 @@ IMAGE_GENERATION = (
 )
 
 
+# Z-Image Turbo — the model IMAGE_GENERATION used before Krea 2, kept as a second choice on the
+# same route rather than removed. A caller picks it with `"model": "comfyui:z_image"`; omitting
+# `model` still gets Krea 2, so nothing that worked before changes.
+#
+# It is a separate bundle, not a variant of IMAGE_GENERATION, because a host may want one and not
+# the other: together they are ~57 GB and share nothing — different UNet, different text encoder
+# (Qwen3-4B here, Qwen3-VL-4B for Krea 2), different VAE.
+IMAGE_GENERATION_ZIMAGE = (
+    FileSpec(
+        "Comfy-Org/z_image_turbo",
+        "split_files/diffusion_models/z_image_turbo_bf16.safetensors",
+        "diffusion_models",
+    ),
+    FileSpec(
+        "Comfy-Org/z_image_turbo",
+        "split_files/text_encoders/qwen_3_4b.safetensors",
+        "text_encoders",
+    ),
+    FileSpec(
+        "Comfy-Org/z_image_turbo",
+        "split_files/vae/ae.safetensors",
+        "vae",
+        target_name="z_image_vae.safetensors",
+    ),
+)
+
+
 # Image editing (Qwen-Image-Edit-2511): desktop /image-editing/models/download
 IMAGE_EDITING = (
     FileSpec(
@@ -125,6 +152,7 @@ I2V = (
 
 BUNDLES = {
     "image_generation": IMAGE_GENERATION,
+    "z_image": IMAGE_GENERATION_ZIMAGE,
     "image_editing": IMAGE_EDITING,
     "i2v": I2V,
 }
@@ -185,6 +213,7 @@ def pull_bundle(name: str, *, on_progress=None) -> list[Path]:
 # `discover_providers(model=...)` exact match.
 CAPABILITY_NAME = {
     "image_generation": "comfyui:image_generation",
+    "z_image": "comfyui:z_image",
     "image_editing": "comfyui:image_editing",
     "i2v": "comfyui:i2v",
 }

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -496,8 +496,52 @@ def test_media_pinned_engine_versions_and_bundles_are_ported():
         "comfyui_frontend_package==1.51.9",
         "comfyui_workflow_templates==0.11.48",
     )
-    assert set(media_bundles.BUNDLES) == {"image_generation", "image_editing", "i2v"}
+    assert set(media_bundles.BUNDLES) == {"image_generation", "z_image", "image_editing", "i2v"}
     assert media_bundles.CAPABILITY_NAME["image_generation"] == "comfyui:image_generation"
+    assert media_bundles.CAPABILITY_NAME["z_image"] == "comfyui:z_image"
+
+
+def test_image_gen_workflow_is_chosen_by_model():
+    """`media/image/generate` serves two models, and each graph numbers its own nodes.
+
+    The prompt landing in the right node is the whole point: Krea 2 keeps it at "4", the Z-Image
+    graph at "34:27". Picking the file without picking the ids would write the prompt into
+    whatever node happened to be called "4" — a KeyError at best, the wrong input at worst.
+    """
+    from shared.media.media_handler import MediaHandler
+
+    krea = MediaHandler._build_image_gen_workflow(None, "a crane", 1024, 1024)
+    assert krea["prompt"]["4"]["inputs"]["text"] == "a crane"
+
+    # The task name and the model name are the same graph.
+    named = MediaHandler._build_image_gen_workflow(None, "a crane", 1024, 1024, model="comfyui:krea2")
+    assert named["prompt"]["4"]["inputs"]["text"] == "a crane"
+
+    zimage = MediaHandler._build_image_gen_workflow(None, "a crane", 1024, 1024, model="comfyui:z_image")
+    assert zimage["prompt"]["34:27"]["inputs"]["text"] == "a crane"
+    assert "4" not in zimage["prompt"]  # not merely a superset — a different graph
+
+    # An unroutable name reaching the handler means the proxy already matched an engine on it, so
+    # serve the route's default rather than 500 on a lookup.
+    unknown = MediaHandler._build_image_gen_workflow(None, "a crane", 1024, 1024, model="comfyui:nope")
+    assert unknown["prompt"]["4"]["inputs"]["text"] == "a crane"
+
+
+def test_image_gen_steps_default_comes_from_the_workflow():
+    """Omitting `steps` must leave the graph's own value, not a number picked in the handler.
+
+    Both bundled models are 4-step distills, and their LoRAs are what make that work — a handler
+    that always wrote its own default would silently override a future graph tuned for something
+    else. Only an explicit request overrides.
+    """
+    from shared.media.media_handler import MediaHandler
+
+    for model, sampler_id in (("comfyui:krea2", "7"), ("comfyui:z_image", "34:3")):
+        default = MediaHandler._build_image_gen_workflow(None, "x", 1024, 1024, model=model)
+        assert default["prompt"][sampler_id]["inputs"]["steps"] == 4
+
+        asked = MediaHandler._build_image_gen_workflow(None, "x", 1024, 1024, steps=12, model=model)
+        assert asked["prompt"][sampler_id]["inputs"]["steps"] == 12
 
 
 def test_create_venv_seeds_pip_into_the_uv_venv(monkeypatch, tmp_path):
@@ -684,7 +728,9 @@ def test_prepare_media_engine_defaults_to_present_bundles(monkeypatch, tmp_path)
 
     out = media_engine.prepare_media_engine(
         media_bundles=None, comfyui_port=8188, media_port=8190, advertise_host=None)
-    assert out["models"] == ["comfyui:image_generation"]
+    # One bundle, two advertised names: the task name every existing caller uses, and the model
+    # name that reads correctly beside `comfyui:z_image`.
+    assert out["models"] == ["comfyui:image_generation", "comfyui:krea2"]
 
 
 def test_prepare_media_engine_errors_when_no_bundle_present(monkeypatch, tmp_path):


### PR DESCRIPTION
`media/image/generate` now serves two models. A request picks with `"model"`; omitting it still gets
Krea 2, so every caller written before this keeps working unchanged.

```
"model": "comfyui:krea2"     Krea 2 Turbo   (also "comfyui:image_generation")
"model": "comfyui:z_image"   Z-Image Turbo
```

Z-Image returns as its own `z_image` bundle rather than a variant of `image_generation`: the two
share nothing — different UNet, different text encoder, different VAE — and together they are ~57 GB,
so a host should be able to pull one without the other.

### Design notes

`ENDPOINT_MODELS` is deliberately untouched. It stays the route's single default, and because the
new names are not in it, `is_builtin_model` is false for them and the route guard lets them through
to engine selection — the path `doggi:*` API media models already take. Making that map one-to-many
would break the "ONE definition" invariant its own comment protects.

`image_generation` is advertised under two names: `comfyui:image_generation` names the task and is
what the route resolves to, `comfyui:krea2` names the model and reads correctly beside
`comfyui:z_image`. Same bundle, same graph.

Node ids move into a table beside the workflow filename, because the two graphs number their own
nodes — Krea 2 uses 1..10, Z-Image carries "34:*" subgraph ids.

`steps` no longer defaults in the handler or the CLI: each workflow already carries the count its
model was distilled for, and writing one from our side overrides a graph that knows better. An
explicit `--steps` still wins. Same now applies to edit.

### Testing

2059 unit tests pass, including two new ones (prompt lands in the right node per model; an omitted
`steps` leaves the graph's own value).

Verified end to end on Apple Silicon against a real grid: `grid engine pull z_image` fetches all
three files, a grid serving both advertises `comfyui:image_generation`, `comfyui:krea2` and
`comfyui:z_image`, and the same prompt through `grid image -m …` produces visibly different images.
ComfyUI's history confirms the routing rather than the eye — `z_image_turbo_bf16` with
`res_multistep` for one, `krea2_turbo_bf16` with `euler` for the other.

### Known, out of scope

The Flutter app filters chat models with a lookup table of the three known `comfyui:*` names rather
than by prefix, so the two new names would show up in its chat picker. One line on the app side; not
changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)