### PR TITLE
feat(relay): connect to operator-hosted relays

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,8 @@ grid use <grid-name>
   other commands have nothing to talk to. `grid start <grid-name>` on a new grid still needs it too.
 - Requests pass through our relay, which local mode never does. We forward and keep nothing — no
   stored prompts, no training on your traffic.
+- A Grid can instead use an owner-operated relay. Pair it with `grid relay connect`; no Autonomous
+  login or SSH is required. See [Self-hosted relays](docs/self-hosted-relay.md).
 
 Three commands change. `chat`, `models`, `info` and your apps are identical.
 

--- a/cli/auth.py
+++ b/cli/auth.py
@@ -47,6 +47,7 @@ def cmd_login(args: argparse.Namespace) -> int:
     # drops every prior grid's bundle while its serve child keeps polling, and afterwards there is
     # nothing left to diff against (ADR 0023).
     previous_networks = list(credentials.load_credentials().get("networks") or [])
+    self_hosted = [n for n in previous_networks if isinstance(n, dict) and n.get("self_hosted")]
 
     started = control_plane.start_device_login(api_url)
     url = _device_login_url(started)
@@ -71,11 +72,13 @@ def cmd_login(args: argparse.Namespace) -> int:
         "session_token": session_token,
         "api_url": api_url,
         "user": user,
-        "networks": networks,
+        # A hosted account cannot authoritatively delete a Grid owned by somebody else's relay.
+        # Pairing records therefore survive login and are refreshed only by another pairing bundle.
+        "networks": [*networks, *self_hosted],
     })
-    signout.warn_stranded(previous_networks, networks)
+    signout.warn_stranded(previous_networks, [*networks, *self_hosted])
     # Deliberately no `state.set_active("remote", …)` here — login never auto-selects a grid.
-    return _report_login(user.get("email", ""), networks, as_json=as_json)
+    return _report_login(user.get("email", ""), [*networks, *self_hosted], as_json=as_json)
 
 
 def _await_approval(started: dict[str, Any], api_url: str) -> dict[str, Any]:
@@ -372,7 +375,19 @@ def cmd_sync(args: argparse.Namespace) -> int:
     session_token = data.get("session_token")
     if not session_token:
         raise SystemExit("You're not signed in. Run `grid login` to sign in.")
-    prev_count = len(data.get("networks") or [])
+    self_hosted = [
+        item for item in (data.get("networks") or [])
+        if isinstance(item, dict) and item.get("self_hosted")
+    ]
+    hosted_before = [
+        item for item in (data.get("networks") or [])
+        if isinstance(item, dict) and not item.get("self_hosted")
+    ]
+    if str(session_token).startswith("self-hosted:"):
+        # A standalone relay has no account-level control plane to sync against. Its credential is
+        # replaced by `grid relay connect`; reporting the preserved records is the complete sync.
+        return _report_sync(self_hosted, as_json=as_json)
+    prev_count = len(hosted_before)
     device_id = credentials.device_id()
     api_url = credentials.api_url()
     try:
@@ -391,11 +406,12 @@ def cmd_sync(args: argparse.Namespace) -> int:
     networks = _validated(raw)
     # Authoritative overwrite of the stored grid list; session_token / api_url / user are preserved.
     # Immutable update — a fresh dict, never the loaded one mutated in place. state.json is untouched.
-    credentials.save_credentials({**data, "networks": networks})
+    combined = [*networks, *self_hosted]
+    credentials.save_credentials({**data, "networks": combined})
     # A grid that just dropped out takes its token with it while its serve child keeps polling — the
     # same unreachable state a logout produces, one grid at a time (ADR 0023). Sync does not tear it
     # down; it names it and the verb that still reaches it.
-    signout.warn_stranded(list(data.get("networks") or []), networks)
+    signout.warn_stranded(list(data.get("networks") or []), combined)
     if prev_count and not networks:
         # The overwrite just cleared every grid. Make the wipe visible so a transient backend hiccup
         # isn't mistaken for a silent loss of all credentials.
@@ -404,7 +420,7 @@ def cmd_sync(args: argparse.Namespace) -> int:
             "were cleared locally. Re-run `grid sync` if this may be transient.",
             file=sys.stderr,
         )
-    return _report_sync(networks, as_json=as_json)
+    return _report_sync(combined, as_json=as_json)
 
 
 def _report_sync(networks: list[dict[str, Any]], *, as_json: bool) -> int:

--- a/cli/dispatch.py
+++ b/cli/dispatch.py
@@ -51,6 +51,10 @@ AGNOSTIC = frozenset({
     # `stt` hits the account-level control plane — there's no "this grid" for it to route
     # through, so it is mode-blind too.
     "stt",
+    # Host lifecycle is delegated to the separately installed `grid-relay` runtime, while
+    # `connect` changes this CLI into remote mode itself. `relay info` performs its own remote-mode
+    # gate. Classifying the group as one agnostic command keeps those three surfaces coherent.
+    "relay",
 })
 
 # Mode-gated commands: real local behaviour today; a clear stub in remote mode until later slices
@@ -139,9 +143,6 @@ REMOTE_ONLY: dict[str, str | None] = {
     # (ADR 0032). A local grid has neither, so this is sign-in-gated like the rest.
     "task": None,
     "goal": None,
-    # Relay ownership is remote metadata: Goal -> Grid -> Relay. The command reads the Grid
-    # records already fetched at login and never adds a second relay pointer to a Goal.
-    "relay": None,
     # A project and its members are rows in the RELAY's own database (ADR 0033 D-a) — deliberately
     # not the control plane's — and the repository they name is served by the relay's git plane. A
     # local grid has none of it.

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -557,7 +557,7 @@ def _add_state(sub) -> None:
 def _add_relay(sub) -> None:
     relay = sub.add_parser(
         "relay",
-        help="Show a relay and the Grids that use it (remote)",
+        help="Connect to, inspect, or host a Grid relay",
     )
     actions = relay.add_subparsers(dest="subcommand", required=True)
     info = actions.add_parser(
@@ -573,6 +573,41 @@ def _add_relay(sub) -> None:
     )
     info.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
     info.set_defaults(handler=cmd_remote_relay)
+
+    connect = actions.add_parser(
+        "connect",
+        help="Connect this machine to a self-hosted relay using a pairing bundle",
+    )
+    connect.add_argument("--bundle", default=None, help="Pairing bundle (visible in shell history).")
+    connect.add_argument("--bundle-file", default=None, help="Owner-only file containing the bundle.")
+    connect.set_defaults(handler=cmd_remote_relay)
+
+    disconnect = actions.add_parser(
+        "disconnect",
+        help="Forget one self-hosted relay/Grid on this machine without stopping it",
+    )
+    disconnect.add_argument("relay", help="Relay id, Grid id, or Grid name.")
+    disconnect.set_defaults(handler=cmd_remote_relay)
+
+    host_help = {
+        "list": "List relay instances hosted on this machine",
+        "up": "Create or start a relay on this machine",
+        "down": "Stop a relay on this machine",
+        "restart": "Restart a relay on this machine",
+        "status": "Inspect relay host health",
+        "invite": "Create a member pairing bundle",
+        "revoke": "Revoke one member's relay credentials",
+        "set-url": "Verify and publish a relay URL",
+        "backup": "Back up relay configuration and PostgreSQL",
+        "restore": "Restore an absent relay from a backup",
+        "destroy": "Permanently remove a relay and its database",
+        "supervise": "Run relay supervision in the foreground",
+        "service": "Manage relay auto-start with launchd or systemd",
+    }
+    for command, help_text in host_help.items():
+        host = actions.add_parser(command, help=help_text, add_help=False)
+        host.add_argument("host_args", nargs=argparse.REMAINDER)
+        host.set_defaults(handler=cmd_remote_relay)
 
 
 def _add_auth(sub) -> None:

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -606,6 +606,13 @@ def _add_relay(sub) -> None:
     }
     for command, help_text in host_help.items():
         host = actions.add_parser(command, help=help_text, add_help=False)
+        # A REMAINDER positional starts only after argparse has consumed a positional token.  Host
+        # commands whose selector is optional (notably `list`, and `status` with its default relay)
+        # therefore rejected `--json` when it was the first forwarded argument.  Recognize the one
+        # shared Grid flag here; `_host` puts it back on the separate runtime's argv.  Flags after a
+        # selector continue to travel verbatim in `host_args`.
+        host.add_argument("--json", dest="host_json", action="store_true",
+                          help="Emit machine-readable JSON.")
         host.add_argument("host_args", nargs=argparse.REMAINDER)
         host.set_defaults(handler=cmd_remote_relay)
 

--- a/cli/remote_relay.py
+++ b/cli/remote_relay.py
@@ -343,5 +343,9 @@ def _host(args: argparse.Namespace) -> int:
             "The relay host runtime is not installed. Install the `grid-relay` package on this "
             "machine, then retry. Client-only machines need only `grid relay connect`."
         )
-    forwarded = [str(executable), args.subcommand, *list(args.host_args or [])]
+    host_args = list(args.host_args or [])
+    wants_json = getattr(args, "json", False) or getattr(args, "host_json", False)
+    if wants_json and "--json" not in host_args:
+        host_args.append("--json")
+    forwarded = [str(executable), args.subcommand, *host_args]
     return subprocess.run(forwarded, check=False).returncode

--- a/cli/remote_relay.py
+++ b/cli/remote_relay.py
@@ -11,11 +11,28 @@ identity.  Supporting both makes ``grid relay info`` useful during a rolling upg
 from __future__ import annotations
 
 import argparse
+import base64
+import getpass
 import json
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
+import httpx
+
 from shared import state
+
+
+PAIRING_VERSION = 1
+MAX_PAIRING_BYTES = 32 * 1024
+_HOST_COMMANDS = frozenset({
+    "list", "up", "down", "restart", "status", "invite", "revoke", "set-url", "backup",
+    "restore", "destroy", "supervise", "service",
+})
 
 
 def _networks() -> list[dict[str, Any]]:
@@ -131,9 +148,17 @@ def _target(networks: list[dict[str, Any]], selector: str | None) -> dict[str, A
 def cmd_remote_relay(args: argparse.Namespace) -> int:
     from remote import credentials
 
-    credentials.require_session()
+    if args.subcommand == "connect":
+        return _connect(args)
+    if args.subcommand == "disconnect":
+        return _disconnect(args)
+    if args.subcommand in _HOST_COMMANDS:
+        return _host(args)
     if args.subcommand != "info":
         raise SystemExit(f"Unknown relay subcommand: {args.subcommand!r}")
+    if getattr(args, "mode", None) != "remote":
+        raise SystemExit("`grid relay info` reads remote Grid records. Pass `--remote` or switch modes.")
+    credentials.require_session()
 
     networks = _networks()
     target = _target(networks, args.relay)
@@ -174,3 +199,149 @@ def cmd_remote_relay(args: argparse.Namespace) -> int:
     for grid in grids:
         print(f"  {grid['grid']}\t{grid['id']}")
     return 0
+
+
+def _decode_bundle(raw: str) -> dict[str, Any]:
+    compact = "".join(str(raw or "").split())
+    if not compact or len(compact) > MAX_PAIRING_BYTES:
+        raise SystemExit("Pairing bundle is missing or unexpectedly large.")
+    try:
+        decoded = base64.urlsafe_b64decode(compact + "=" * (-len(compact) % 4))
+        value = json.loads(decoded)
+    except (ValueError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise SystemExit("Pairing bundle is not valid base64url JSON.") from exc
+    if not isinstance(value, dict) or value.get("version") != PAIRING_VERSION:
+        raise SystemExit(f"Pairing bundle must use version {PAIRING_VERSION}.")
+    return value
+
+
+def _root_url(value: object) -> str:
+    raw = str(value or "").strip().rstrip("/")
+    parsed = urlsplit(raw)
+    if parsed.scheme not in ("http", "https") or not parsed.hostname:
+        raise SystemExit("Pairing bundle has no valid HTTP relay URL.")
+    if parsed.username or parsed.password or parsed.query or parsed.fragment or parsed.path not in ("", "/"):
+        raise SystemExit("Pairing bundle relay URL must be a credential-free root URL.")
+    try:
+        parsed.port
+    except ValueError as exc:
+        raise SystemExit("Pairing bundle relay URL has an invalid port.") from exc
+    return raw
+
+
+def _bundle_value(args: argparse.Namespace) -> str:
+    if args.bundle and args.bundle_file:
+        raise SystemExit("Use either --bundle or --bundle-file, not both.")
+    if args.bundle_file:
+        path = Path(args.bundle_file).expanduser()
+        try:
+            return path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise SystemExit(f"Cannot read pairing bundle {path}: {exc}") from None
+    if args.bundle:
+        return args.bundle
+    return getpass.getpass("Paste relay pairing bundle (input hidden): ")
+
+
+def _connect(args: argparse.Namespace) -> int:
+    from remote import credentials
+
+    value = _decode_bundle(_bundle_value(args))
+    relay_url = _root_url(value.get("relay_url"))
+    required = (
+        "relay_id", "server_id", "network_id", "network_name", "network_type", "access_token",
+        "node_id",
+    )
+    missing = [key for key in required if not str(value.get(key) or "").strip()]
+    if missing:
+        raise SystemExit(f"Pairing bundle is missing: {', '.join(missing)}.")
+    claims = credentials.claims_from_token(value["access_token"])
+    signed_identity = {
+        "relay_id", "relay_url", "server_id", "network_id", "network_name", "network_type",
+        "node_id",
+    }
+    if any(claims.get(key) != value.get(key) for key in signed_identity):
+        raise SystemExit("Pairing bundle identity does not match its signed credential.")
+    expires_at = value.get("expires_at")
+    if not isinstance(expires_at, int) or isinstance(expires_at, bool) or expires_at <= int(time.time()):
+        raise SystemExit("Pairing bundle credential is expired or has no valid expiry.")
+    try:
+        response = httpx.get(f"{relay_url}/server/info", timeout=10)
+        response.raise_for_status()
+        server = response.json()
+    except (httpx.HTTPError, ValueError) as exc:
+        raise SystemExit(f"Relay is not reachable at {relay_url}: {exc}") from None
+    if not isinstance(server, dict) or not server.get("server_id"):
+        raise SystemExit(f"{relay_url} answered, but it is not a Grid relay.")
+    if str(server["server_id"]) != str(value["server_id"]):
+        raise SystemExit("Pairing bundle points at a different Grid relay; refusing to connect.")
+
+    current = credentials.load_credentials()
+    record = {
+        "network_id": str(value["network_id"]),
+        "name": str(value["network_name"]),
+        "network_type": str(value["network_type"]),
+        "relay_id": str(value["relay_id"]),
+        "signaling_url": relay_url,
+        "lan_signaling_url": relay_url,
+        "access_token": str(value["access_token"]),
+        "node_id": str(value["node_id"]),
+        "email": str(value.get("email") or ""),
+        "roles": list(value.get("roles") or []),
+        "scopes": list(value.get("scopes") or []),
+        "expires_at": expires_at,
+        "self_hosted": True,
+    }
+    networks = [
+        item for item in (current.get("networks") or [])
+        if isinstance(item, dict) and item.get("network_id") != record["network_id"]
+    ]
+    networks.append(record)
+    credentials.save_credentials({
+        **current,
+        "session_token": current.get("session_token") or f"self-hosted:{record['relay_id']}",
+        "user": current.get("user") or {"email": record["email"]},
+        "networks": networks,
+    })
+    state.set_mode("remote")
+    state.set_active("remote", record["network_id"])
+    print(f"Connected to self-hosted Grid {record['name']} through relay {record['relay_id']}.")
+    print(f"relay_url={relay_url}")
+    print(f"node={record['node_id']}")
+    return 0
+
+
+def _disconnect(args: argparse.Namespace) -> int:
+    from remote import credentials
+
+    data = credentials.load_credentials()
+    selector = args.relay
+    removed = [item for item in (data.get("networks") or []) if isinstance(item, dict) and (
+        item.get("self_hosted") and selector in {
+            item.get("network_id"), item.get("name"), item.get("relay_id"),
+        }
+    )]
+    if not removed:
+        raise SystemExit(f"Self-hosted relay/Grid not found locally: {selector!r}.")
+    remove_ids = {item.get("network_id") for item in removed}
+    networks = [
+        item for item in (data.get("networks") or [])
+        if not isinstance(item, dict) or item.get("network_id") not in remove_ids
+    ]
+    credentials.save_credentials({**data, "networks": networks})
+    active = state.get_active("remote")
+    if active in remove_ids:
+        state.set_active("remote", None)
+    print(f"Disconnected {len(removed)} self-hosted Grid(s). The relay was not stopped.")
+    return 0
+
+
+def _host(args: argparse.Namespace) -> int:
+    executable = os.getenv("GRID_RELAY_BIN") or shutil.which("grid-relay")
+    if not executable:
+        raise SystemExit(
+            "The relay host runtime is not installed. Install the `grid-relay` package on this "
+            "machine, then retry. Client-only machines need only `grid relay connect`."
+        )
+    forwarded = [str(executable), args.subcommand, *list(args.host_args or [])]
+    return subprocess.run(forwarded, check=False).returncode

--- a/docs/self-hosted-relay-physical-test.md
+++ b/docs/self-hosted-relay-physical-test.md
@@ -1,0 +1,40 @@
+# Self-hosted relay physical acceptance
+
+Status: **in progress**. The relay PR remains draft until Machine B and the forced three-machine
+Goal handoff pass.
+
+Test date: 2026-09-01
+
+## Revisions and topology
+
+- Public member CLI/Goal worker: `grid-relay` at `c0dee9c`
+- Separate relay/server runtime: `grid-relay` at `4bcfefd`
+- Fresh isolated Grid: `relay-physical-3`
+- Machine A: macOS arm64, Codex task worker
+- Machine C: Linux, two NVIDIA RTX 4090 D GPUs, Codex task worker and local
+  `qwen3.6-27b` inference provider
+- Machine B: pending its physical join
+
+## Passed checks
+
+- A -> self-hosted relay -> C inference returned `RELAY_C_OK`.
+- `grid relay info`, `grid relay status` delegation, `grid engines`, `grid goal list`, pairing by
+  file, disconnect, revocation, and credential reissue behaved as specified.
+- Goal `fd4a7477-c53c-4fb4-bcb6-0e7743dede61` completed in two durable Codex turns using 80,607
+  local-model tokens. Relay evaluation scored the exact final commit `1.0` and accepted it.
+- Evidence verification passed with required inference and exact clean worker revision `c0dee9c`.
+- The completed artifact was readable from the relay-owned project repository and the Goal cleared
+  from the active list.
+- A live relay restart preserved Goal/eval history; A and C re-registered automatically and
+  post-restart inference returned `RESTART_RECOVERY_OK`.
+- Public exact-head suite: `3399 passed, 57 skipped, 7 deselected`.
+- Public relay/process focused suite: `37 passed`.
+- The public sdist and wheel built, installed into a fresh disposable environment, and exposed the
+  expected `grid relay` command surface.
+
+## Remaining gates
+
+- Join physical Machine B and prove all three hardware identities.
+- Force and verify a B -> A -> C Goal continuation with worker loss.
+- Run a full relay down/up recovery cycle.
+- Update this record with the final evidence before marking the PR ready.

--- a/docs/self-hosted-relay-physical-test.md
+++ b/docs/self-hosted-relay-physical-test.md
@@ -1,40 +1,41 @@
 # Self-hosted relay physical acceptance
 
-Status: **in progress**. The relay PR remains draft until Machine B and the forced three-machine
-Goal handoff pass.
-
-Test date: 2026-09-01
+Status: **passed** on 2026-09-02.
 
 ## Revisions and topology
 
-- Public member CLI/Goal worker: `grid-relay` at `c0dee9c`
-- Separate relay/server runtime: `grid-relay` at `4bcfefd`
-- Fresh isolated Grid: `relay-physical-3`
-- Machine A: macOS arm64, Codex task worker
-- Machine C: Linux, two NVIDIA RTX 4090 D GPUs, Codex task worker and local
-  `qwen3.6-27b` inference provider
-- Machine B: pending its physical join
+- Public member CLI/workers: `grid-relay` at `4feb975`
+- Goal verifier: `grid-goal-distributed` at `bdf3e52`
+- Separate relay/server package: `autonomous-grid-cli` `grid-relay` at `4f33900`
+- Isolated Grid `relay-physical-4` (`grid-relay-physical-4-bfc35758`)
+- Relay `relay-01d1ed2cc8fd4a0f8298342bc7789838`
+- Machine A: Apple M2 Max, relay host and Codex task worker
+- Machine C: Linux, two NVIDIA RTX 4090 D GPUs, `qwen3.6-27b` inference and Codex tasks
+- Machine D: Linux, one NVIDIA RTX 4090 D GPU, Codex tasks
 
 ## Passed checks
 
-- A -> self-hosted relay -> C inference returned `RELAY_C_OK`.
-- `grid relay info`, `grid relay status` delegation, `grid engines`, `grid goal list`, pairing by
-  file, disconnect, revocation, and credential reissue behaved as specified.
-- Goal `fd4a7477-c53c-4fb4-bcb6-0e7743dede61` completed in two durable Codex turns using 80,607
-  local-model tokens. Relay evaluation scored the exact final commit `1.0` and accepted it.
-- Evidence verification passed with required inference and exact clean worker revision `c0dee9c`.
-- The completed artifact was readable from the relay-owned project repository and the Goal cleared
-  from the active list.
-- A live relay restart preserved Goal/eval history; A and C re-registered automatically and
-  post-restart inference returned `RESTART_RECOVERY_OK`.
-- Public exact-head suite: `3399 passed, 57 skipped, 7 deselected`.
-- Public relay/process focused suite: `37 passed`.
-- The public sdist and wheel built, installed into a fresh disposable environment, and exposed the
-  expected `grid relay` command surface.
-
-## Remaining gates
-
-- Join physical Machine B and prove all three hardware identities.
-- Force and verify a B -> A -> C Goal continuation with worker loss.
-- Run a full relay down/up recovery cycle.
-- Update this record with the final evidence before marking the PR ready.
+- Pairing, node join/rejoin, relay info/status/list JSON, inference, member revocation/reissue, and
+  automatic worker recovery passed without copying Grid homes or task roots.
+- Individual Goals ran successfully on A, C, and D with independent eval score `1.0` and strict
+  evidence verification.
+- Forced handoff Goal `a475278a-58d1-4342-ab4f-347fb47005d1` continued A -> D -> C after two
+  deliberate worker losses. It recorded four ordered Codex attempts across three execution nodes,
+  used 2,261,947 local-model tokens through Grid inference, repaired an initial failed eval, passed
+  all seven final evals, and produced commit `8ac063f72ea2ff43e3364fb32a31f7aff07197a3`.
+- Strict evidence required three execution nodes, Grid inference, the exact clean worker revision,
+  and ordered agent sequence. The completed Goal cleared from the active queue.
+- A full relay/PostgreSQL down/up cycle preserved identity and history. A post-restart Goal ran on D
+  with inference on C, used 41,496 tokens, scored `1.0`, and passed strict revision evidence.
+- A real disaster restore deleted the test relay's dedicated PostgreSQL container and volume, then
+  restored solely from a mode-`0600` backup. Relay/Grid/server ids, all five members, node
+  credentials, Goal/eval history, usage, and all seven Git project repositories survived. C and D
+  reconnected automatically, inference returned `RESTORE_OK`, strict historical evidence passed,
+  and the restored game cloned at the exact evaluated commit and passed all seven behavior tests.
+- The recovery drill found and fixed the old backup's missing Git plane. Backup v2 uses checksummed
+  Git bundles, restores all refs, runs `git fsck`, streams large members, rejects malformed
+  archives, and isolates project storage per relay on every OS.
+- Public exact-head suite: `3405 passed, 57 skipped, 7 deselected`; lint, Python
+  3.11/3.12/3.13, and Windows CI passed.
+- Public and private sdists/wheels built and installed in fresh environments. `grid relay`,
+  `grid goal`, and `grid-relay` entry points passed their package smoke tests.

--- a/docs/self-hosted-relay-physical-test.md
+++ b/docs/self-hosted-relay-physical-test.md
@@ -32,6 +32,9 @@ Status: **passed** on 2026-09-02.
   credentials, Goal/eval history, usage, and all seven Git project repositories survived. C and D
   reconnected automatically, inference returned `RESTORE_OK`, strict historical evidence passed,
   and the restored game cloned at the exact evaluated commit and passed all seven behavior tests.
+- A fresh post-restore Goal then wrote a new project on Machine D using Machine C inference. It used
+  41,842 tokens, scored `1.0`, passed strict worker/inference evidence, cloned its exact evaluated
+  commit through the recovered Git plane, and cleared from the active queue.
 - The recovery drill found and fixed the old backup's missing Git plane. Backup v2 uses checksummed
   Git bundles, restores all refs, runs `git fsck`, streams large members, rejects malformed
   archives, and isolates project storage per relay on every OS.

--- a/docs/self-hosted-relay.md
+++ b/docs/self-hosted-relay.md
@@ -1,0 +1,47 @@
+# Connect to or operate a self-hosted relay
+
+A Grid may use an Autonomous-hosted relay or a relay run by its owner. Goals and tasks still belong
+to the Grid; they do not store a second relay id. The Grid's local credential record determines
+which relay every inference, task, Git, and Goal request uses.
+
+## Join an owner-operated Grid
+
+Ask the relay owner for a pairing bundle, transferred through a secure channel, then run:
+
+```bash
+grid relay connect --bundle-file /secure/path/worker.pairing
+grid use <grid-name>
+grid relay info <grid-name>
+```
+
+For an interactive paste, omit both bundle flags; input is hidden. `--bundle` exists for automation
+but exposes the credential in shell history. Connecting switches this machine to remote mode and
+selects the paired Grid. It does not require an Autonomous account or hosted control plane.
+
+`grid login` and `grid sync` preserve self-hosted Grid records. A new pairing bundle refreshes or
+replaces the credential for the same Grid. To forget it locally without stopping the relay:
+
+```bash
+grid relay disconnect <grid-name>
+```
+
+## Host commands
+
+Relay hosting is a separate runtime because most Grid machines should be clients/workers, not
+authorities. Install the `grid-relay` package on the host. These public CLI commands delegate to
+that executable without a shell:
+
+```bash
+grid relay up ...
+grid relay list --health
+grid relay status ...
+grid relay invite ...
+grid relay revoke ...
+grid relay set-url ...
+grid relay backup ...
+grid relay restore ...
+grid relay service install ...
+```
+
+The operator runbook, including TLS, auto-start, restore, and destructive teardown, ships with the
+relay/server repository. Client-only nodes need only `grid relay connect`.

--- a/tests/test_relay_cli.py
+++ b/tests/test_relay_cli.py
@@ -211,6 +211,35 @@ def test_host_command_delegates_to_separate_runtime(monkeypatch, tmp_path):
     }
 
 
+@pytest.mark.parametrize("argv", [
+    pytest.param(["relay", "list", "--json"], id="after-list"),
+    pytest.param(["--json", "relay", "list"], id="global"),
+    pytest.param(["relay", "status", "--json"], id="status-with-default-selector"),
+])
+def test_host_json_without_selector_reaches_separate_runtime(monkeypatch, tmp_path, argv):
+    from cli import remote_relay
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    monkeypatch.setenv("GRID_RELAY_BIN", "/opt/grid/bin/grid-relay")
+    seen = {}
+
+    class Result:
+        returncode = 0
+
+    def run(command, check):
+        seen["argv"] = command
+        seen["check"] = check
+        return Result()
+
+    monkeypatch.setattr(remote_relay.subprocess, "run", run)
+    assert cli.main(argv) == 0
+    command = "status" if "status" in argv else "list"
+    assert seen == {
+        "argv": ["/opt/grid/bin/grid-relay", command, "--json"],
+        "check": False,
+    }
+
+
 def test_disconnect_removes_only_selected_self_hosted_grid(monkeypatch, tmp_path):
     _remote_home(monkeypatch, tmp_path, [
         {"network_id": "hosted", "name": "Hosted", "signaling_url": "https://hosted.example"},

--- a/tests/test_relay_cli.py
+++ b/tests/test_relay_cli.py
@@ -135,6 +135,118 @@ def test_relay_info_requires_remote_mode(monkeypatch, tmp_path):
     with pytest.raises(SystemExit) as exc:
         cli.main(["relay", "info"])
     assert str(exc.value) == (
-        "`grid relay` is a remote-mode command. "
-        "Run `grid mode remote` (or pass --remote) to sign in."
+        "`grid relay info` reads remote Grid records. Pass `--remote` or switch modes."
     )
+
+
+def _pairing_bundle(**updates):
+    import base64
+    import time
+
+    def enc(value):
+        return base64.urlsafe_b64encode(value).rstrip(b"=").decode()
+
+    claims = {
+        "relay_id": "relay-self", "relay_url": "https://relay.example",
+        "server_id": "server-self", "network_id": "grid-self", "network_name": "Self",
+        "network_type": "permissioned", "node_id": "node-self",
+        "exp": int(time.time()) + 3600,
+    }
+    token = ".".join((enc(b'{"alg":"RS256"}'), enc(json.dumps(claims).encode()), enc(b"sig")))
+    value = {
+        "version": 1, "relay_id": "relay-self", "server_id": "server-self",
+        "relay_url": "https://relay.example",
+        "network_id": "grid-self", "network_name": "Self", "network_type": "permissioned",
+        "access_token": token, "node_id": "node-self", "email": "a@example.com",
+        "roles": ["both"], "scopes": ["inference:create"], "expires_at": claims["exp"],
+    }
+    value.update(updates)
+    return enc(json.dumps(value).encode())
+
+
+def test_connect_saves_self_hosted_grid_and_switches_to_remote(monkeypatch, tmp_path, capsys):
+    from cli import remote_relay
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+
+    class Response:
+        status_code = 200
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"server_id": "server-self"}
+
+    monkeypatch.setattr(remote_relay.httpx, "get", lambda *a, **k: Response())
+    assert cli.main(["relay", "connect", "--bundle", _pairing_bundle()]) == 0
+    data = credentials.load_credentials()
+    assert data["networks"][0]["self_hosted"] is True
+    assert data["networks"][0]["relay_id"] == "relay-self"
+    assert state.get_mode() == "remote"
+    assert state.get_active("remote") == "grid-self"
+    assert "Connected to self-hosted Grid Self" in capsys.readouterr().out
+
+
+def test_host_command_delegates_to_separate_runtime(monkeypatch, tmp_path):
+    from cli import remote_relay
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    monkeypatch.setenv("GRID_RELAY_BIN", "/opt/grid/bin/grid-relay")
+    seen = {}
+
+    class Result:
+        returncode = 7
+
+    def run(argv, check):
+        seen["argv"] = argv
+        seen["check"] = check
+        return Result()
+
+    monkeypatch.setattr(remote_relay.subprocess, "run", run)
+    assert cli.main(["relay", "status", "forge", "--json"]) == 7
+    assert seen == {
+        "argv": ["/opt/grid/bin/grid-relay", "status", "forge", "--json"],
+        "check": False,
+    }
+
+
+def test_disconnect_removes_only_selected_self_hosted_grid(monkeypatch, tmp_path):
+    _remote_home(monkeypatch, tmp_path, [
+        {"network_id": "hosted", "name": "Hosted", "signaling_url": "https://hosted.example"},
+        {"network_id": "self", "name": "Self", "relay_id": "relay-self",
+         "signaling_url": "https://self.example", "self_hosted": True},
+    ], active="self")
+    assert cli.main(["relay", "disconnect", "relay-self"]) == 0
+    assert [item["network_id"] for item in credentials.load_credentials()["networks"]] == ["hosted"]
+    assert state.get_active("remote") is None
+
+
+def test_sync_without_hosted_account_keeps_self_hosted_grid(monkeypatch, tmp_path, capsys):
+    _remote_home(monkeypatch, tmp_path, [
+        {"network_id": "self", "name": "Self", "relay_id": "relay-self",
+         "signaling_url": "https://self.example", "self_hosted": True},
+    ])
+    data = credentials.load_credentials()
+    credentials.save_credentials({**data, "session_token": "self-hosted:relay-self"})
+    assert cli.main(["sync"]) == 0
+    assert [item["network_id"] for item in credentials.load_credentials()["networks"]] == ["self"]
+    assert capsys.readouterr().out == "Synced 1 grid(s): Self.\n"
+
+
+def test_hosted_sync_merges_self_hosted_grid(monkeypatch, tmp_path, capsys):
+    from remote import control_plane
+
+    _remote_home(monkeypatch, tmp_path, [
+        {"network_id": "old", "name": "Old", "signaling_url": "https://hosted.example"},
+        {"network_id": "self", "name": "Self", "relay_id": "relay-self",
+         "signaling_url": "https://self.example", "self_hosted": True},
+    ])
+    monkeypatch.setattr(control_plane, "fetch_tokens", lambda *args: [
+        {"network_id": "new", "name": "New", "signaling_url": "https://new.example"},
+    ])
+    assert cli.main(["sync"]) == 0
+    assert {item["network_id"] for item in credentials.load_credentials()["networks"]} == {
+        "new", "self",
+    }
+    assert capsys.readouterr().out == "Synced 2 grid(s): New, Self.\n"


### PR DESCRIPTION
## Summary

- connect the public Grid CLI to an operator-owned relay with a portable pairing bundle; no hosted login or SSH
- preserve self-hosted Grid records across hosted login/sync and expose relay-to-Grid ownership with `grid relay info`
- delegate host lifecycle to the separately installed `grid-relay` runtime without invoking a shell
- document client pairing, disconnect, hosting commands, and the stacked rollout

## Verification

- 15 focused relay CLI tests pass
- Ruff passes on every changed Python file
- full public suite: 3,399 passed, 57 skipped, 7 deselected
- real disposable relay: pair client, resolve relay ownership, authenticate to protected relay API
- real stacked Goal relay: `/server/info` advertised `goals/v1` and `grid goal list` succeeded through the paired self-hosted relay

## Merge order

Stacked on #69. Merge #69 first, then retarget this PR to `main` (or merge this PR into `grid-goal-distributed` before #69).
