### PR TITLE
[Allocator 3/5 — after #71] Qualify physical engine lifecycles with real inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,6 +622,22 @@ grid --local allocator status --grid allocator-control
 grid --local allocator mode automatic --grid allocator-control
 ```
 
+Before granting a new physical runtime production lifecycle authority, qualify it on that machine
+with actual inference. The command writes an owner-only evidence report and always attempts to stop
+what it warmed; it never deletes a pre-existing artifact:
+
+```bash
+grid --local allocator qualify ollama <model> --artifact-sha256 <digest>
+grid --local allocator qualify comfyui comfyui:image_generation \
+  --endpoint http://127.0.0.1:8188
+grid --local allocator qualify vllm <served-model> \
+  --artifact-source hf://owner/repo@<commit> \
+  --artifact-sha256 <snapshot-identity> --artifact-size-mb <bound>
+```
+
+See [physical runtime qualification](docs/allocator-runtime-qualification.md) for canary cleanup,
+failure interpretation, and the evidence captured on Forge.
+
 Allocator enrollment verifies the managed llama.cpp runtime and installs Grid's version- and
 SHA-256-pinned build when it is absent. It also waits briefly for a just-started provider identity
 to become visible at the relay, so the two fresh-node commands above are safe to run back to back.

--- a/cli/allocator_qualification.py
+++ b/cli/allocator_qualification.py
@@ -26,6 +26,8 @@ def cmd_allocator_qualify(args: argparse.Namespace) -> int:
         raise SystemExit("tensor parallel size and max tokens must be positive")
     if not 0.0 < args.gpu_memory_utilization <= 1.0:
         raise SystemExit("--gpu-memory-utilization must be in (0, 1]")
+    if args.max_model_len < 0:
+        raise SystemExit("--max-model-len must be non-negative")
     if args.image_size < 64 or args.steps < 1:
         raise SystemExit("ComfyUI image size must be at least 64 and steps must be positive")
     backend = _backend(args)
@@ -70,6 +72,8 @@ def _backend(args: argparse.Namespace) -> Any:
         cache,
         tensor_parallel_size=args.tensor_parallel_size,
         gpu_memory_utilization=args.gpu_memory_utilization,
+        max_model_len=args.max_model_len,
+        enforce_eager=args.enforce_eager,
         readiness_timeout=args.timeout,
     )
 

--- a/cli/allocator_qualification.py
+++ b/cli/allocator_qualification.py
@@ -74,6 +74,7 @@ def _backend(args: argparse.Namespace) -> Any:
         gpu_memory_utilization=args.gpu_memory_utilization,
         max_model_len=args.max_model_len,
         enforce_eager=args.enforce_eager,
+        use_flashinfer_sampler=(False if args.disable_flashinfer_sampler else None),
         readiness_timeout=args.timeout,
     )
 

--- a/cli/allocator_qualification.py
+++ b/cli/allocator_qualification.py
@@ -24,6 +24,8 @@ def cmd_allocator_qualify(args: argparse.Namespace) -> int:
         raise SystemExit("--timeout must be positive and --artifact-size-mb must be non-negative")
     if args.tensor_parallel_size < 1 or args.max_tokens < 1:
         raise SystemExit("tensor parallel size and max tokens must be positive")
+    if not 0.0 < args.gpu_memory_utilization <= 1.0:
+        raise SystemExit("--gpu-memory-utilization must be in (0, 1]")
     if args.image_size < 64 or args.steps < 1:
         raise SystemExit("ComfyUI image size must be at least 64 and steps must be positive")
     backend = _backend(args)
@@ -67,6 +69,7 @@ def _backend(args: argparse.Namespace) -> Any:
     return VllmBackend(
         cache,
         tensor_parallel_size=args.tensor_parallel_size,
+        gpu_memory_utilization=args.gpu_memory_utilization,
         readiness_timeout=args.timeout,
     )
 

--- a/cli/allocator_qualification.py
+++ b/cli/allocator_qualification.py
@@ -1,0 +1,153 @@
+"""Physical runtime lifecycle qualification command."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from shared import paths
+from shared.allocator.orchestrator import ComfyUIBackend, OllamaBackend, VllmBackend
+from shared.allocator.qualification import qualify_runtime, save_report
+from shared.media.media_handler import MediaHandler
+
+
+def cmd_allocator_qualify(args: argparse.Namespace) -> int:
+    if not 1 <= args.port <= 65_535:
+        raise SystemExit("--port must be in [1, 65535]")
+    if args.timeout <= 0 or args.artifact_size_mb < 0:
+        raise SystemExit("--timeout must be positive and --artifact-size-mb must be non-negative")
+    if args.tensor_parallel_size < 1 or args.max_tokens < 1:
+        raise SystemExit("tensor parallel size and max tokens must be positive")
+    if args.image_size < 64 or args.steps < 1:
+        raise SystemExit("ComfyUI image size must be at least 64 and steps must be positive")
+    backend = _backend(args)
+    report = qualify_runtime(
+        runtime=args.runtime,
+        backend=backend,
+        model_id=args.model,
+        port=args.port,
+        inference=_inference(args),
+        artifact_source=args.artifact_source,
+        artifact_sha256=args.artifact_sha256,
+        artifact_size_mb=args.artifact_size_mb,
+        cleanup_artifact=args.cleanup_artifact,
+    )
+    report_path = _report_path(args, report.started_at)
+    save_report(report_path, report)
+    if args.json:
+        print(json.dumps({**report.to_dict(), "report_path": str(report_path)}, indent=2))
+    else:
+        verdict = "PASS" if report.passed else "FAIL"
+        print(f"Runtime qualification {verdict}: {report.runtime} · {report.model_id}")
+        for item in report.steps:
+            marker = "✓" if item.passed else "✗"
+            print(f"  {marker} {item.name:<20} {item.duration_seconds:7.2f}s  {item.detail}")
+        print(f"  report  {report_path}")
+    return 0 if report.passed else 1
+
+
+def _backend(args: argparse.Namespace) -> Any:
+    endpoint = _endpoint(args)
+    if args.runtime == "ollama":
+        return OllamaBackend(endpoint, timeout=args.timeout)
+    if args.runtime == "comfyui":
+        bundle = args.model.removeprefix("comfyui:")
+        return ComfyUIBackend(endpoint, bundles=(bundle,))
+    cache = (
+        Path(args.cache_dir).expanduser()
+        if args.cache_dir
+        else paths.grid_home() / "allocator-qualification" / "vllm"
+    )
+    return VllmBackend(
+        cache,
+        tensor_parallel_size=args.tensor_parallel_size,
+        readiness_timeout=args.timeout,
+    )
+
+
+def _inference(args: argparse.Namespace):
+    endpoint = _endpoint(args)
+    if args.runtime == "ollama":
+
+        def ollama(_handle):
+            with httpx.Client(timeout=args.timeout, trust_env=False) as client:
+                response = client.post(
+                    f"{endpoint}/api/generate",
+                    json={
+                        "model": args.model,
+                        "prompt": args.prompt,
+                        "stream": False,
+                        "keep_alive": -1,
+                    },
+                )
+            response.raise_for_status()
+            text = str(response.json().get("response") or "")
+            return len(text), "Ollama /api/generate"
+
+        return ollama
+    if args.runtime == "vllm":
+
+        def vllm(handle):
+            with httpx.Client(timeout=args.timeout, trust_env=False) as client:
+                response = client.post(
+                    f"http://127.0.0.1:{handle.port}/v1/chat/completions",
+                    json={
+                        "model": args.model,
+                        "messages": [{"role": "user", "content": args.prompt}],
+                        "max_tokens": args.max_tokens,
+                    },
+                )
+            response.raise_for_status()
+            text = str(response.json()["choices"][0]["message"]["content"])
+            return len(text), "vLLM OpenAI-compatible chat"
+
+        return vllm
+
+    def comfyui(_handle):
+        if args.model not in (
+            "comfyui:image_generation",
+            "comfyui:krea2",
+            "comfyui:z_image",
+        ):
+            raise RuntimeError(
+                "physical ComfyUI qualification currently requires an image-generation bundle"
+            )
+        handler = MediaHandler(comfyui_url=endpoint)
+        output_units = 0
+        for line in handler.handle_request(
+            "media/image/generate",
+            {
+                "model": args.model,
+                "prompt": args.prompt,
+                "width": args.image_size,
+                "height": args.image_size,
+                "steps": args.steps,
+            },
+        ):
+            terminal = str(line)
+            if '"error"' in terminal:
+                raise RuntimeError(terminal[:500])
+            output_units += len(terminal)
+        return output_units, "ComfyUI completed workflow output"
+
+    return comfyui
+
+
+def _endpoint(args: argparse.Namespace) -> str:
+    if args.endpoint:
+        return str(args.endpoint).rstrip("/")
+    return "http://127.0.0.1:11434" if args.runtime == "ollama" else "http://127.0.0.1:8188"
+
+
+def _report_path(args: argparse.Namespace, started_at: float) -> Path:
+    if args.report:
+        return Path(args.report).expanduser()
+    scope = hashlib.sha256(f"{args.runtime}\0{args.model}".encode()).hexdigest()[:16]
+    stamp = time.strftime("%Y%m%d-%H%M%S", time.gmtime(started_at))
+    return paths.grid_home() / "allocator-qualification" / "reports" / f"{stamp}-{scope}.json"

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -646,6 +646,17 @@ def _add_allocator(sub) -> None:
         default=0.90,
         help="Fraction of each visible GPU vLLM may reserve (default: 0.90).",
     )
+    qualify.add_argument(
+        "--max-model-len",
+        type=int,
+        default=0,
+        help="Override vLLM context length; zero keeps the model default.",
+    )
+    qualify.add_argument(
+        "--enforce-eager",
+        action="store_true",
+        help="Disable CUDA graph compilation for a lower-impact shared-node qualification.",
+    )
     qualify.add_argument("--cache-dir", default=None)
     qualify.add_argument("--prompt", default="Reply with exactly GRID.")
     qualify.add_argument("--max-tokens", type=int, default=32)

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -30,6 +30,7 @@ from .allocator import (
     cmd_allocator_tick,
     cmd_allocator_token_write,
 )
+from .allocator_qualification import cmd_allocator_qualify
 from shared.allocator.scenario import SCENARIO_STRATEGIES
 
 from .allocator_scenario import (
@@ -622,6 +623,33 @@ def _add_allocator(sub) -> None:
     _add_allocator_grid(tick, token=True)
     tick.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
     tick.set_defaults(handler=cmd_allocator_tick)
+
+    qualify = allocator_sub.add_parser(
+        "qualify",
+        help="Prove a physical engine's full managed lifecycle with real inference",
+    )
+    qualify.add_argument("runtime", choices=("ollama", "comfyui", "vllm"))
+    qualify.add_argument("model")
+    qualify.add_argument(
+        "--endpoint",
+        default="",
+        help="Native engine base URL (defaults by runtime).",
+    )
+    qualify.add_argument("--artifact-source", default="")
+    qualify.add_argument("--artifact-sha256", default="")
+    qualify.add_argument("--artifact-size-mb", type=int, default=0)
+    qualify.add_argument("--port", type=int, default=28901)
+    qualify.add_argument("--tensor-parallel-size", type=int, default=1)
+    qualify.add_argument("--cache-dir", default=None)
+    qualify.add_argument("--prompt", default="Reply with exactly GRID.")
+    qualify.add_argument("--max-tokens", type=int, default=32)
+    qualify.add_argument("--image-size", type=int, default=256)
+    qualify.add_argument("--steps", type=int, default=1)
+    qualify.add_argument("--timeout", type=float, default=900.0)
+    qualify.add_argument("--cleanup-artifact", action="store_true")
+    qualify.add_argument("--report", default=None)
+    qualify.add_argument("--json", action="store_true")
+    qualify.set_defaults(handler=cmd_allocator_qualify)
 
     token = allocator_sub.add_parser("token", help="Provision the node control capability")
     token_sub = token.add_subparsers(dest="allocator_token_command", required=True)

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -657,6 +657,11 @@ def _add_allocator(sub) -> None:
         action="store_true",
         help="Disable CUDA graph compilation for a lower-impact shared-node qualification.",
     )
+    qualify.add_argument(
+        "--disable-flashinfer-sampler",
+        action="store_true",
+        help="Use vLLM's native sampler when FlashInfer JIT is unavailable or incompatible.",
+    )
     qualify.add_argument("--cache-dir", default=None)
     qualify.add_argument("--prompt", default="Reply with exactly GRID.")
     qualify.add_argument("--max-tokens", type=int, default=32)

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -640,6 +640,12 @@ def _add_allocator(sub) -> None:
     qualify.add_argument("--artifact-size-mb", type=int, default=0)
     qualify.add_argument("--port", type=int, default=28901)
     qualify.add_argument("--tensor-parallel-size", type=int, default=1)
+    qualify.add_argument(
+        "--gpu-memory-utilization",
+        type=float,
+        default=0.90,
+        help="Fraction of each visible GPU vLLM may reserve (default: 0.90).",
+    )
     qualify.add_argument("--cache-dir", default=None)
     qualify.add_argument("--prompt", default="Reply with exactly GRID.")
     qualify.add_argument("--max-tokens", type=int, default=32)

--- a/docs/allocator-runtime-qualification.md
+++ b/docs/allocator-runtime-qualification.md
@@ -76,6 +76,10 @@ the OpenAI-compatible chat API, observed zero active requests, stopped the child
 canary artifact. The run also established that fresh Ubuntu needs Python development headers for
 Triton.
 
-ComfyUI must be run on a host where its canary assets are installed. A report is not transferable
-between machines: the engine version, accelerator, driver, and artifacts are part of what the
-physical run is testing.
+Machine A physically passed ComfyUI 0.34.0 with the installed Z-Image bundle on MPS. The run proved
+inventory and artifact identity, loaded the text encoder, diffusion model, and VAE, completed a real
+256-by-256 image workflow, collected the exact output from ComfyUI history, observed an empty queue,
+and released model memory through `/free`.
+
+A report is not transferable between machines: the engine version, accelerator, driver, and
+artifacts are part of what the physical run is testing.

--- a/docs/allocator-runtime-qualification.md
+++ b/docs/allocator-runtime-qualification.md
@@ -1,0 +1,68 @@
+# Physical runtime qualification
+
+Grid does not treat adapter unit tests or an open TCP port as proof that it can manage an engine on
+real hardware. `grid --local allocator qualify` executes the same native lifecycle boundary used by
+the allocator and writes an owner-only JSON report below
+`~/.grid/allocator-qualification/reports/`.
+
+Every successful report proves, in order:
+
+1. Native cached-model inventory and exact artifact identity.
+2. Artifact fetch with a digest and size bound when it was not already cached.
+3. Warm/load through the engine's native API.
+4. Process/model ownership and native readiness.
+5. A real generated response or completed ComfyUI workflow.
+6. The runtime activity probe used during drain.
+7. Native drain/stop or model-memory unload.
+
+Teardown is attempted even after a failed inference. `--cleanup-artifact` removes only an artifact
+fetched by that same qualification run; a model already present at the inventory step is never
+deleted. Without that flag all artifacts remain cached.
+
+## Commands
+
+Ollama uses its registry digest and does not stop the shared daemon:
+
+```bash
+grid --local allocator qualify ollama smollm2:135m \
+  --artifact-sha256 <digest> --timeout 300
+```
+
+ComfyUI qualification requires an installed image-generation bundle. It submits the real bundled
+workflow at 256×256 and one step by default, waits for an output, checks the queue, then calls the
+native `/free` memory-unload API:
+
+```bash
+grid --local allocator qualify comfyui comfyui:image_generation \
+  --endpoint http://127.0.0.1:8188 --timeout 900
+```
+
+vLLM qualification pins a full Hugging Face commit. Its `artifact_sha256` is the allocator's
+deterministic identity for that exact repository snapshot, not a mutable branch name:
+
+```bash
+grid --local allocator qualify vllm Qwen/example \
+  --artifact-source hf://Qwen/example@<40-hex-commit> \
+  --artifact-sha256 <snapshot-identity> \
+  --artifact-size-mb <maximum-download-mb> \
+  --tensor-parallel-size 2 --timeout 1800
+```
+
+The command downloads into Grid's isolated qualification cache, starts a Grid-owned vLLM child,
+proves it through `/v1/models`, runs an OpenAI-compatible chat completion, and reaps the child.
+
+## Forge evidence, 2026-09-02
+
+Machine A physically passed the full Ollama lifecycle with `smollm2:135m`: exact digest inventory,
+warm, ownership, readiness, a real `/api/generate` response, activity probe, and unload. The warm
+took 0.81 seconds and inference 2.13 seconds after the artifact was cached. The disposable 270 MB
+canary was removed after the report; only the pre-existing model remained.
+
+The same run found a model-specific failure for the pre-existing `gpt-oss:20b`: Ollama returned
+`tensor "blk.0.ffn_down_exps.weight" size overflow` during warm. Grid correctly withheld readiness
+and did not attempt inference or delete the artifact. That is a failed artifact/runtime
+qualification, not evidence that the Ollama lifecycle adapter is healthy for that model.
+
+ComfyUI and vLLM must be run on a host where those engines and canary assets are installed. A report
+is not transferable between machines: the engine version, accelerator, driver, and artifacts are
+part of what the physical run is testing.

--- a/docs/allocator-runtime-qualification.md
+++ b/docs/allocator-runtime-qualification.md
@@ -48,6 +48,12 @@ grid --local allocator qualify vllm Qwen/example \
   --tensor-parallel-size 2 --timeout 1800
 ```
 
+On a shared GPU, bound the canary and shorten its compilation window with
+`--gpu-memory-utilization`, `--max-model-len`, and `--enforce-eager`. If the installed vLLM and
+FlashInfer wheels have incompatible JIT toolchains, `--disable-flashinfer-sampler` selects vLLM's
+native sampler. Grid activates sibling vLLM build tools and a wheel-packaged CUDA compiler when the
+host has only an NVIDIA driver; a source-build path still requires Python development headers.
+
 The command downloads into Grid's isolated qualification cache, starts a Grid-owned vLLM child,
 proves it through `/v1/models`, runs an OpenAI-compatible chat completion, and reaps the child.
 
@@ -63,6 +69,13 @@ The same run found a model-specific failure for the pre-existing `gpt-oss:20b`: 
 and did not attempt inference or delete the artifact. That is a failed artifact/runtime
 qualification, not evidence that the Ollama lifecycle adapter is healthy for that model.
 
-ComfyUI and vLLM must be run on a host where those engines and canary assets are installed. A report
-is not transferable between machines: the engine version, accelerator, driver, and artifacts are
-part of what the physical run is testing.
+Machine D physically passed vLLM 0.28 with Qwen2.5-Coder-0.5B-Instruct at an immutable commit. The
+run used 35% GPU utilization, a 2,048-token context, eager mode, and the native sampler. It fetched
+the bounded snapshot, proved process ownership and `/v1/models` readiness, returned `GRID` through
+the OpenAI-compatible chat API, observed zero active requests, stopped the child, and cleaned the
+canary artifact. The run also established that fresh Ubuntu needs Python development headers for
+Triton.
+
+ComfyUI must be run on a host where its canary assets are installed. A report is not transferable
+between machines: the engine version, accelerator, driver, and artifacts are part of what the
+physical run is testing.

--- a/docs/allocator.md
+++ b/docs/allocator.md
@@ -889,6 +889,20 @@ grid --remote models <grid>
 grid --remote chat -m <model.gguf> "hello"
 ```
 
+Before enabling a newly installed engine adapter on a physical provider, run its real lifecycle
+qualification locally on that host. It validates inventory, immutable identity, warm, ownership,
+native readiness, real inference, activity, and drain/stop, then writes durable evidence:
+
+```bash
+grid --local allocator qualify ollama <model> --artifact-sha256 <digest>
+grid --local allocator qualify comfyui comfyui:image_generation
+grid --local allocator qualify vllm <model> \
+  --artifact-source hf://owner/repo@<commit> \
+  --artifact-sha256 <snapshot-identity> --artifact-size-mb <bound>
+```
+
+See [physical runtime qualification](allocator-runtime-qualification.md) for exact behavior.
+
 On a remote provider enrolled with `--dedicated`, the node uses Grid's multi-engine lifecycle
 orchestrator. It manages installed `llama.cpp`, Ollama, ComfyUI, and vLLM runtimes through one
 `LOAD → WARM → READY → DRAIN → UNLOAD` contract while the existing provider remains the only relay
@@ -1396,20 +1410,20 @@ The design follows several primary systems results while preserving Grid's alloc
 - Remote allocator nodes require a relay with the authenticated allocator sidecar and enrollment
   bridge enabled. Policy administration remains controller-only; remote providers may enroll only
   their own already-live identity.
-- The first managed process boundary is Grid-owned llama.cpp model runtimes. ComfyUI, external
-  Ollama/vLLM/LM Studio, API, and manually started engines are inventory and routing sources, not
-  processes the allocator may stop. The mixed-framework logical fixture starts and stops its own
-  ComfyUI process as test-fixture setup/cleanup; allocator actions do not masquerade as ComfyUI
-  model lifecycle mutations.
+- Dedicated allocator providers have lifecycle adapters for Grid-owned llama.cpp and vLLM children,
+  plus model-memory control for loopback Ollama and ComfyUI services. External/manual processes
+  remain inventory and routing sources until explicitly enrolled; lifecycle authority never follows
+  from protocol detection alone. LM Studio and generic API engines remain routing-only.
 - The current autonomous.ai NVIDIA engines are vLLM/CUDA even though live discovery labels their
   ownership class `external`. Framework identity and lifecycle ownership are independent: those
   engines participate in routing and placement evidence, but discovery alone does not grant Grid
   permission to start, drain, or stop them. Local auto-discovery publishes the detected runtime;
   when pointing at an engine explicitly, use `grid join --at <url> -m <model> --kind vllm` (or the
   corresponding kind) so runtime-constrained profiles can use the inventory.
-- Managed llama.cpp can autonomously fetch an exact, size-bounded, SHA-256-pinned Hugging Face GGUF.
-  ComfyUI bundles and externally owned vLLM artifacts still require their runtime-specific install
-  paths; the generic action fields are present, but those lifecycle adapters are not yet claimed.
+- Managed llama.cpp and vLLM can autonomously fetch exact, size-bounded immutable artifacts. Ollama
+  verifies the native registry digest and refuses to overwrite a pre-existing tag with another
+  digest. ComfyUI workflow assets still require their runtime-specific installation path and are
+  unloaded from accelerator memory rather than deleted.
 - Capacity is refreshed by the node as stable physical capacity plus dynamic non-Grid reserve.
   Device count and per-device VRAM are preserved, and profiles may fail closed with
   `min_gpu_count` and `min_gpu_memory_mb` constraints. This covers basic tensor-parallel

--- a/shared/allocator/orchestrator.py
+++ b/shared/allocator/orchestrator.py
@@ -460,6 +460,7 @@ class VllmBackend:
         cache_dir: Path,
         *,
         tensor_parallel_size: int = 1,
+        gpu_memory_utilization: float = 0.90,
         readiness_timeout: float = 600.0,
         bind_host: str = "127.0.0.1",
         endpoint_host: str | None = None,
@@ -468,6 +469,9 @@ class VllmBackend:
         self.cache_dir.mkdir(parents=True, exist_ok=True)
         self.metadata_path = self.cache_dir / "artifacts.json"
         self.tensor_parallel_size = max(1, int(tensor_parallel_size))
+        if not 0.0 < gpu_memory_utilization <= 1.0:
+            raise ValueError("gpu_memory_utilization must be in (0, 1]")
+        self.gpu_memory_utilization = float(gpu_memory_utilization)
         self.readiness_timeout = readiness_timeout
         self.bind_host = bind_host
         self.endpoint_host = endpoint_host or bind_host
@@ -542,6 +546,8 @@ class VllmBackend:
             model_id,
             "--tensor-parallel-size",
             str(self.tensor_parallel_size),
+            "--gpu-memory-utilization",
+            str(self.gpu_memory_utilization),
         ]
         log_path = self.cache_dir / f"{hashlib.sha256(model_id.encode()).hexdigest()[:16]}.log"
         log = log_path.open("ab")

--- a/shared/allocator/orchestrator.py
+++ b/shared/allocator/orchestrator.py
@@ -13,6 +13,7 @@ import os
 import shutil
 import signal
 import subprocess
+import sys
 import threading
 import time
 from collections.abc import Callable, Mapping
@@ -538,6 +539,10 @@ class VllmBackend:
             raise RuntimeError(f"vLLM snapshot is not cached: {model_id!r}")
         binary = shutil.which("vllm")
         if not binary:
+            sibling = Path(sys.executable).with_name("vllm")
+            if sibling.is_file():
+                binary = str(sibling)
+        if not binary:
             raise RuntimeError("vLLM is not installed on this node")
         model_path = str(Path(str(item["path"])).resolve())
         command = [
@@ -563,10 +568,11 @@ class VllmBackend:
         log = log_path.open("ab")
         try:
             process = subprocess.Popen(
-                command,
-                stdout=log,
-                stderr=subprocess.STDOUT,
-                start_new_session=True,
+            command,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            env=_vllm_process_env(Path(binary)),
+            start_new_session=True,
             )
         finally:
             log.close()
@@ -656,6 +662,24 @@ class VllmBackend:
                 except ValueError:
                     return None
         return int(total) if found and total.is_integer() else None
+
+
+def _vllm_process_env(binary: Path) -> dict[str, str]:
+    """Activate a wheel-packaged CUDA compiler when the host has drivers only."""
+
+    env = os.environ.copy()
+    if env.get("CUDA_HOME") or shutil.which("nvcc", path=env.get("PATH")):
+        return env
+    venv_root = binary.resolve().parent.parent
+    candidates = sorted(
+        venv_root.glob("lib/python*/site-packages/nvidia/cu*/bin/nvcc"), reverse=True
+    )
+    if not candidates:
+        return env
+    cuda_bin = candidates[0].parent
+    env["CUDA_HOME"] = str(cuda_bin.parent)
+    env["PATH"] = f"{cuda_bin}{os.pathsep}{env.get('PATH', '')}"
+    return env
 
 
 def build_engine_orchestrator(

--- a/shared/allocator/orchestrator.py
+++ b/shared/allocator/orchestrator.py
@@ -255,13 +255,19 @@ class OllamaBackend:
         source_model = unquote(f"{parsed.netloc}{parsed.path}").lstrip("/")
         if source_model != model_id:
             raise RuntimeError("Ollama source model does not match the placement model")
+        expected = canonical_sha256(expected_sha256)
+        if model_id in self.cached_models():
+            existing = self.artifact_sha256(model_id)
+            if existing != expected:
+                raise RuntimeError("refusing to replace an existing Ollama tag with another digest")
+            return existing
         response = self.client.post(
             f"{self.base_url}/api/pull",
             json={"model": model_id, "stream": False},
         )
-        response.raise_for_status()
+        _raise_engine_error(response, "Ollama pull")
         digest = self.artifact_sha256(model_id)
-        if digest != canonical_sha256(expected_sha256):
+        if digest != expected:
             self.evict_artifact(model_id, digest)
             raise RuntimeError("pulled Ollama model digest does not match the pinned artifact")
         for item in self._json("GET", "/api/tags").get("models", []):
@@ -278,7 +284,7 @@ class OllamaBackend:
         response = self.client.request(
             "DELETE", f"{self.base_url}/api/delete", json={"model": model_id}
         )
-        response.raise_for_status()
+        _raise_engine_error(response, "Ollama delete")
 
     def start(self, model_id: str, port: int) -> RuntimeHandle:
         del port
@@ -286,7 +292,7 @@ class OllamaBackend:
             f"{self.base_url}/api/generate",
             json={"model": model_id, "prompt": "", "stream": False, "keep_alive": -1},
         )
-        response.raise_for_status()
+        _raise_engine_error(response, "Ollama warm")
         handle = RuntimeHandle(
             pid=os.getpid(),
             port=self.port,
@@ -329,7 +335,15 @@ class OllamaBackend:
             f"{self.base_url}/api/generate",
             json={"model": model_id, "prompt": "", "stream": False, "keep_alive": 0},
         )
-        response.raise_for_status()
+        _raise_engine_error(response, "Ollama unload")
+        deadline = time.monotonic() + 30.0
+        while self.ready(handle, model_id) and time.monotonic() < deadline:
+            time.sleep(0.1)
+        if self.ready(handle, model_id):
+            raise RuntimeError(f"Ollama did not unload {model_id!r} within 30 seconds")
+
+    def close(self) -> None:
+        self.client.close()
 
     def active_requests(self, handle: RuntimeHandle, model_id: str) -> int | None:
         del handle, model_id
@@ -422,6 +436,9 @@ class ComfyUIBackend:
             return len(running) if isinstance(running, list) else None
         except (httpx.HTTPError, ValueError):
             return None
+
+    def close(self) -> None:
+        self.client.close()
 
     def _healthy(self) -> bool:
         try:
@@ -558,6 +575,10 @@ class VllmBackend:
         raise RuntimeError(f"vLLM readiness timed out; see {log_path}")
 
     def alive(self, handle: RuntimeHandle) -> bool:
+        with self._lock:
+            process = self._spawned.get(handle.pid)
+        if process is not None:
+            return process.poll() is None
         try:
             os.kill(handle.pid, 0)
             return True
@@ -598,6 +619,10 @@ class VllmBackend:
             time.sleep(0.1)
         if self.alive(handle):
             raise RuntimeError("vLLM did not drain and stop within 30 seconds")
+        with self._lock:
+            process = self._spawned.pop(handle.pid, None)
+        if process is not None:
+            process.wait(timeout=1.0)
 
     def active_requests(self, handle: RuntimeHandle, model_id: str) -> int | None:
         del model_id
@@ -655,6 +680,21 @@ def _ollama_digest(value: Any) -> str:
     if digest.startswith("sha256:"):
         digest = digest.removeprefix("sha256:")
     return canonical_sha256(digest, "Ollama model digest")
+
+
+def _raise_engine_error(response: httpx.Response, operation: str) -> None:
+    """Preserve a native engine's bounded error text instead of hiding it behind status only."""
+
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        try:
+            payload = response.json()
+            detail = str(payload.get("error") or payload.get("detail") or "")
+        except (ValueError, AttributeError):
+            detail = response.text[:500]
+        suffix = f": {detail[:500]}" if detail else ""
+        raise RuntimeError(f"{operation} failed with HTTP {response.status_code}{suffix}") from exc
 
 
 def _handle_with_runtime(handle: RuntimeHandle, runtime: str) -> RuntimeHandle:

--- a/shared/allocator/orchestrator.py
+++ b/shared/allocator/orchestrator.py
@@ -668,9 +668,11 @@ def _vllm_process_env(binary: Path) -> dict[str, str]:
     """Activate a wheel-packaged CUDA compiler when the host has drivers only."""
 
     env = os.environ.copy()
+    binary_dir = binary.resolve().parent
+    env["PATH"] = f"{binary_dir}{os.pathsep}{env.get('PATH', '')}"
     if env.get("CUDA_HOME") or shutil.which("nvcc", path=env.get("PATH")):
         return env
-    venv_root = binary.resolve().parent.parent
+    venv_root = binary_dir.parent
     candidates = sorted(
         venv_root.glob("lib/python*/site-packages/nvidia/cu*/bin/nvcc"), reverse=True
     )
@@ -678,7 +680,7 @@ def _vllm_process_env(binary: Path) -> dict[str, str]:
         return env
     cuda_bin = candidates[0].parent
     env["CUDA_HOME"] = str(cuda_bin.parent)
-    env["PATH"] = f"{cuda_bin}{os.pathsep}{env.get('PATH', '')}"
+    env["PATH"] = f"{cuda_bin}{os.pathsep}{env['PATH']}"
     return env
 
 

--- a/shared/allocator/orchestrator.py
+++ b/shared/allocator/orchestrator.py
@@ -464,6 +464,7 @@ class VllmBackend:
         gpu_memory_utilization: float = 0.90,
         max_model_len: int = 0,
         enforce_eager: bool = False,
+        use_flashinfer_sampler: bool | None = None,
         readiness_timeout: float = 600.0,
         bind_host: str = "127.0.0.1",
         endpoint_host: str | None = None,
@@ -479,6 +480,7 @@ class VllmBackend:
             raise ValueError("max_model_len must be non-negative")
         self.max_model_len = int(max_model_len)
         self.enforce_eager = bool(enforce_eager)
+        self.use_flashinfer_sampler = use_flashinfer_sampler
         self.readiness_timeout = readiness_timeout
         self.bind_host = bind_host
         self.endpoint_host = endpoint_host or bind_host
@@ -571,7 +573,9 @@ class VllmBackend:
             command,
             stdout=log,
             stderr=subprocess.STDOUT,
-            env=_vllm_process_env(Path(binary)),
+            env=_vllm_process_env(
+                Path(binary), use_flashinfer_sampler=self.use_flashinfer_sampler
+            ),
             start_new_session=True,
             )
         finally:
@@ -664,12 +668,16 @@ class VllmBackend:
         return int(total) if found and total.is_integer() else None
 
 
-def _vllm_process_env(binary: Path) -> dict[str, str]:
+def _vllm_process_env(
+    binary: Path, *, use_flashinfer_sampler: bool | None = None
+) -> dict[str, str]:
     """Activate a wheel-packaged CUDA compiler when the host has drivers only."""
 
     env = os.environ.copy()
     binary_dir = binary.resolve().parent
     env["PATH"] = f"{binary_dir}{os.pathsep}{env.get('PATH', '')}"
+    if use_flashinfer_sampler is not None:
+        env["VLLM_USE_FLASHINFER_SAMPLER"] = "1" if use_flashinfer_sampler else "0"
     if env.get("CUDA_HOME") or shutil.which("nvcc", path=env.get("PATH")):
         return env
     venv_root = binary_dir.parent

--- a/shared/allocator/orchestrator.py
+++ b/shared/allocator/orchestrator.py
@@ -461,6 +461,8 @@ class VllmBackend:
         *,
         tensor_parallel_size: int = 1,
         gpu_memory_utilization: float = 0.90,
+        max_model_len: int = 0,
+        enforce_eager: bool = False,
         readiness_timeout: float = 600.0,
         bind_host: str = "127.0.0.1",
         endpoint_host: str | None = None,
@@ -472,6 +474,10 @@ class VllmBackend:
         if not 0.0 < gpu_memory_utilization <= 1.0:
             raise ValueError("gpu_memory_utilization must be in (0, 1]")
         self.gpu_memory_utilization = float(gpu_memory_utilization)
+        if max_model_len < 0:
+            raise ValueError("max_model_len must be non-negative")
+        self.max_model_len = int(max_model_len)
+        self.enforce_eager = bool(enforce_eager)
         self.readiness_timeout = readiness_timeout
         self.bind_host = bind_host
         self.endpoint_host = endpoint_host or bind_host
@@ -549,6 +555,10 @@ class VllmBackend:
             "--gpu-memory-utilization",
             str(self.gpu_memory_utilization),
         ]
+        if self.max_model_len:
+            command.extend(("--max-model-len", str(self.max_model_len)))
+        if self.enforce_eager:
+            command.append("--enforce-eager")
         log_path = self.cache_dir / f"{hashlib.sha256(model_id.encode()).hexdigest()[:16]}.log"
         log = log_path.open("ab")
         try:

--- a/shared/allocator/qualification.py
+++ b/shared/allocator/qualification.py
@@ -1,0 +1,170 @@
+"""Runtime lifecycle qualification with durable, machine-readable evidence."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+from shared import jsonio
+
+
+@dataclass(frozen=True, slots=True)
+class QualificationStep:
+    name: str
+    passed: bool
+    duration_seconds: float
+    detail: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class QualificationReport:
+    runtime: str
+    model_id: str
+    passed: bool
+    started_at: float
+    completed_at: float
+    artifact_sha256: str
+    fetched_artifact: bool
+    cleaned_artifact: bool
+    steps: tuple[QualificationStep, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def qualify_runtime(
+    *,
+    runtime: str,
+    backend: Any,
+    model_id: str,
+    port: int,
+    inference: Callable[[Any], tuple[int, str]],
+    artifact_source: str = "",
+    artifact_sha256: str = "",
+    artifact_size_mb: int = 0,
+    cleanup_artifact: bool = False,
+) -> QualificationReport:
+    """Exercise fetch → warm → ownership/readiness → inference → drain/stop.
+
+    Every attempted teardown runs from ``finally``. Cleanup applies only to an artifact fetched by
+    this run, never to a pre-existing cache entry.
+    """
+
+    started_at = time.time()
+    steps: list[QualificationStep] = []
+    handle = None
+    fetched = False
+    cleaned = False
+    observed_digest = ""
+
+    def step(name: str, operation: Callable[[], Any], describe: Callable[[Any], str] = str) -> Any:
+        step_started = time.monotonic()
+        try:
+            result = operation()
+            detail = describe(result) if result is not None else "ok"
+            steps.append(QualificationStep(name, True, time.monotonic() - step_started, detail))
+            return result
+        except Exception as exc:
+            steps.append(
+                QualificationStep(
+                    name,
+                    False,
+                    time.monotonic() - step_started,
+                    f"{type(exc).__name__}: {exc}",
+                )
+            )
+            raise
+
+    try:
+        cached = step("inventory", backend.cached_models, lambda value: f"{len(value)} cached")
+        if model_id not in cached:
+            if not artifact_source or not artifact_sha256 or artifact_size_mb <= 0:
+                raise RuntimeError(
+                    "uncached qualification requires artifact source, digest, and size bound"
+                )
+            observed_digest = step(
+                "fetch",
+                lambda: backend.fetch_artifact(
+                    model_id, artifact_source, artifact_sha256, artifact_size_mb
+                ),
+            )
+            fetched = True
+        else:
+            observed_digest = step(
+                "artifact-identity", lambda: backend.artifact_sha256(model_id)
+            )
+            if artifact_sha256 and observed_digest != artifact_sha256.lower():
+                raise RuntimeError("cached artifact digest does not match the requested revision")
+        handle = step("warm", lambda: backend.start(model_id, port), lambda value: str(value.runtime))
+        step(
+            "ownership",
+            lambda: _require(backend.owns(handle, model_id), "runtime ownership was not proven"),
+        )
+        step(
+            "readiness",
+            lambda: _require(backend.ready(handle, model_id), "native readiness was not proven"),
+        )
+        def run_inference():
+            result = inference(handle)
+            _require(result[0] > 0, "real inference produced no output")
+            return result
+
+        step(
+            "real-inference",
+            run_inference,
+            lambda value: f"{value[0]} output units · {value[1]}",
+        )
+        def probe_activity():
+            active = backend.active_requests(handle, model_id)
+            if active is not None:
+                _require(isinstance(active, int) and active >= 0, "activity probe is malformed")
+            return active
+
+        step("activity-probe", probe_activity)
+    except Exception as exc:
+        if not steps or steps[-1].passed:
+            steps.append(QualificationStep("qualification", False, 0.0, str(exc)))
+    finally:
+        if handle is not None:
+            try:
+                step("drain-stop", lambda: backend.stop(handle, model_id))
+            except Exception:
+                pass
+        if fetched and cleanup_artifact and observed_digest:
+            try:
+                step("artifact-cleanup", lambda: backend.evict_artifact(model_id, observed_digest))
+                cleaned = True
+            except Exception:
+                pass
+        close = getattr(backend, "close", None)
+        if callable(close):
+            close()
+    passed = (
+        all(item.passed for item in steps)
+        and any(item.name == "real-inference" for item in steps)
+        and any(item.name == "drain-stop" for item in steps)
+    )
+    return QualificationReport(
+        runtime=runtime,
+        model_id=model_id,
+        passed=passed,
+        started_at=started_at,
+        completed_at=time.time(),
+        artifact_sha256=observed_digest,
+        fetched_artifact=fetched,
+        cleaned_artifact=cleaned,
+        steps=tuple(steps),
+    )
+
+
+def save_report(path: Path, report: QualificationReport) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    jsonio.atomic_write_json(path, report.to_dict(), mode=0o600)
+
+
+def _require(condition: bool, message: str) -> str:
+    if not condition:
+        raise RuntimeError(message)
+    return "ok"

--- a/shared/media/media_handler.py
+++ b/shared/media/media_handler.py
@@ -257,7 +257,7 @@ class MediaHandler:
             completed_node_steps = 0
             last_node = None
             last_max = 0
-            ws_url = self.comfyui_url.replace("http://", "ws://").replace("/api", "/ws")
+            ws_url = self._websocket_url(self.comfyui_url)
             try:
                 import websocket
                 ws = websocket.create_connection(ws_url, timeout=600)
@@ -353,6 +353,17 @@ class MediaHandler:
         yield "data: [DONE]"
         self._cleanup_files(collected)
 
+    @staticmethod
+    def _websocket_url(comfyui_url: str) -> str:
+        base = comfyui_url.rstrip("/")
+        if base.endswith("/api"):
+            base = base[:-4]
+        if base.startswith("https://"):
+            base = f"wss://{base[8:]}"
+        elif base.startswith("http://"):
+            base = f"ws://{base[7:]}"
+        return f"{base}/ws"
+
     def _get_output_dir(self) -> str:
         """Locate ComfyUI's output directory.
 
@@ -370,8 +381,8 @@ class MediaHandler:
         except Exception:
             pass
         candidates = [
-            str(paths.home() / "public" / "temp_comfy_output"),
             str(paths.home() / "services" / "ComfyUI" / "output"),
+            str(paths.home() / "public" / "temp_comfy_output"),
         ]
         for path in candidates:
             if os.path.isdir(path):

--- a/tests/test_allocator_orchestrator.py
+++ b/tests/test_allocator_orchestrator.py
@@ -12,6 +12,7 @@ from shared.allocator.orchestrator import (
     EngineOrchestratorBackend,
     OllamaBackend,
     _parse_hf_snapshot_source,
+    _vllm_process_env,
 )
 from shared.allocator.runtime import ManagedModelRuntime, RuntimeHandle
 
@@ -233,3 +234,21 @@ def test_vllm_snapshot_sources_require_full_commit_identity() -> None:
         _parse_hf_snapshot_source("hf://Qwen/Qwen3.8@main")
     with pytest.raises(RuntimeError, match="full immutable"):
         _parse_hf_snapshot_source("hf://Qwen/Qwen3.8@abc123")
+
+
+def test_vllm_environment_activates_wheel_packaged_cuda_compiler(
+    tmp_path, monkeypatch
+) -> None:
+    binary = tmp_path / "bin" / "vllm"
+    binary.parent.mkdir(parents=True)
+    binary.touch()
+    cuda_bin = tmp_path / "lib" / "python3.12" / "site-packages" / "nvidia" / "cu13" / "bin"
+    cuda_bin.mkdir(parents=True)
+    (cuda_bin / "nvcc").touch()
+    monkeypatch.delenv("CUDA_HOME", raising=False)
+    monkeypatch.setenv("PATH", "/usr/bin")
+
+    env = _vllm_process_env(binary)
+
+    assert env["CUDA_HOME"] == str(cuda_bin.parent)
+    assert env["PATH"].split(":", 1)[0] == str(cuda_bin)

--- a/tests/test_allocator_orchestrator.py
+++ b/tests/test_allocator_orchestrator.py
@@ -248,8 +248,9 @@ def test_vllm_environment_activates_wheel_packaged_cuda_compiler(
     monkeypatch.delenv("CUDA_HOME", raising=False)
     monkeypatch.setenv("PATH", "/usr/bin")
 
-    env = _vllm_process_env(binary)
+    env = _vllm_process_env(binary, use_flashinfer_sampler=False)
 
     assert env["CUDA_HOME"] == str(cuda_bin.parent)
     assert env["PATH"].split(":", 1)[0] == str(cuda_bin)
     assert str(binary.parent) in env["PATH"].split(":")
+    assert env["VLLM_USE_FLASHINFER_SAMPLER"] == "0"

--- a/tests/test_allocator_orchestrator.py
+++ b/tests/test_allocator_orchestrator.py
@@ -172,8 +172,29 @@ def test_ollama_start_failure_never_returns_a_routable_handle() -> None:
     backend.client.close()
     backend.client = httpx.Client(transport=httpx.MockTransport(handler))
 
-    with pytest.raises(httpx.HTTPStatusError):
+    with pytest.raises(RuntimeError, match="Ollama warm failed with HTTP 500"):
         backend.start("broken", 18_100)
+
+
+def test_ollama_fetch_never_replaces_a_preexisting_different_digest() -> None:
+    existing = "a" * 64
+    calls = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request.url.path)
+        if request.url.path == "/api/tags":
+            return httpx.Response(
+                200,
+                json={"models": [{"name": "tiny", "digest": existing, "size": 4}]},
+            )
+        raise AssertionError(request.url)
+
+    backend = OllamaBackend()
+    backend.client.close()
+    backend.client = httpx.Client(transport=httpx.MockTransport(handler))
+    with pytest.raises(RuntimeError, match="refusing to replace"):
+        backend.fetch_artifact("tiny", "ollama://tiny", "b" * 64, 10)
+    assert calls == ["/api/tags", "/api/tags"]
 
 
 def test_comfyui_advertises_only_configured_bundle_and_unloads_native_memory() -> None:

--- a/tests/test_allocator_orchestrator.py
+++ b/tests/test_allocator_orchestrator.py
@@ -252,3 +252,4 @@ def test_vllm_environment_activates_wheel_packaged_cuda_compiler(
 
     assert env["CUDA_HOME"] == str(cuda_bin.parent)
     assert env["PATH"].split(":", 1)[0] == str(cuda_bin)
+    assert str(binary.parent) in env["PATH"].split(":")

--- a/tests/test_allocator_qualification.py
+++ b/tests/test_allocator_qualification.py
@@ -155,4 +155,5 @@ def test_parser_exposes_physical_runtime_qualification():
     assert args.gpu_memory_utilization == 0.90
     assert args.max_model_len == 0
     assert args.enforce_eager is False
+    assert args.disable_flashinfer_sampler is False
     assert args.cleanup_artifact is True

--- a/tests/test_allocator_qualification.py
+++ b/tests/test_allocator_qualification.py
@@ -153,4 +153,6 @@ def test_parser_exposes_physical_runtime_qualification():
     assert args.handler.__name__ == "cmd_allocator_qualify"
     assert args.tensor_parallel_size == 1
     assert args.gpu_memory_utilization == 0.90
+    assert args.max_model_len == 0
+    assert args.enforce_eager is False
     assert args.cleanup_artifact is True

--- a/tests/test_allocator_qualification.py
+++ b/tests/test_allocator_qualification.py
@@ -152,4 +152,5 @@ def test_parser_exposes_physical_runtime_qualification():
     )
     assert args.handler.__name__ == "cmd_allocator_qualify"
     assert args.tensor_parallel_size == 1
+    assert args.gpu_memory_utilization == 0.90
     assert args.cleanup_artifact is True

--- a/tests/test_allocator_qualification.py
+++ b/tests/test_allocator_qualification.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import json
+import os
+
+from cli import parser
+from shared.allocator.qualification import qualify_runtime, save_report
+from shared.allocator.runtime import RuntimeHandle
+
+
+class FakeBackend:
+    def __init__(self, *, cached=True, fail_inference=False):
+        self.cached = cached
+        self.fail_inference = fail_inference
+        self.calls = []
+        self.running = False
+
+    def cached_models(self):
+        self.calls.append("inventory")
+        return ("tiny",) if self.cached else ()
+
+    def artifact_sha256(self, model):
+        assert model == "tiny"
+        return "a" * 64
+
+    def fetch_artifact(self, model, source, digest, size):
+        self.calls.append(("fetch", model, source, digest, size))
+        self.cached = True
+        return digest
+
+    def start(self, model, port):
+        self.calls.append(("warm", model, port))
+        self.running = True
+        return RuntimeHandle(123, port, model_path=model, runtime="fake")
+
+    def owns(self, handle, model):
+        return self.running and handle.model_path == model
+
+    def ready(self, handle, model):
+        return self.owns(handle, model)
+
+    def active_requests(self, handle, model):
+        assert self.owns(handle, model)
+        return 0
+
+    def stop(self, handle, model):
+        assert self.owns(handle, model)
+        self.calls.append("stop")
+        self.running = False
+
+    def evict_artifact(self, model, digest):
+        self.calls.append(("evict", model, digest))
+        self.cached = False
+
+
+def test_qualification_proves_full_real_lifecycle_and_keeps_preexisting_artifact():
+    backend = FakeBackend()
+    report = qualify_runtime(
+        runtime="fake",
+        backend=backend,
+        model_id="tiny",
+        port=18001,
+        artifact_sha256="a" * 64,
+        inference=lambda _handle: (4, "real response"),
+        cleanup_artifact=True,
+    )
+    assert report.passed
+    assert [item.name for item in report.steps] == [
+        "inventory",
+        "artifact-identity",
+        "warm",
+        "ownership",
+        "readiness",
+        "real-inference",
+        "activity-probe",
+        "drain-stop",
+    ]
+    assert not report.fetched_artifact
+    assert not report.cleaned_artifact
+    assert "stop" in backend.calls
+
+
+def test_failed_inference_still_stops_and_cleans_only_new_artifact():
+    backend = FakeBackend(cached=False)
+
+    def fail(_handle):
+        raise RuntimeError("native generation failed")
+
+    report = qualify_runtime(
+        runtime="fake",
+        backend=backend,
+        model_id="tiny",
+        port=18001,
+        artifact_source="test://tiny",
+        artifact_sha256="a" * 64,
+        artifact_size_mb=10,
+        inference=fail,
+        cleanup_artifact=True,
+    )
+    assert not report.passed
+    assert "stop" in backend.calls
+    assert ("evict", "tiny", "a" * 64) in backend.calls
+    assert report.fetched_artifact and report.cleaned_artifact
+    assert next(item for item in report.steps if item.name == "real-inference").passed is False
+
+
+def test_missing_uncached_identity_is_reported_without_warming():
+    backend = FakeBackend(cached=False)
+    report = qualify_runtime(
+        runtime="fake",
+        backend=backend,
+        model_id="tiny",
+        port=18001,
+        inference=lambda _handle: (1, "unused"),
+    )
+    assert not report.passed
+    assert report.steps[-1].name == "qualification"
+    assert "digest" in report.steps[-1].detail
+    assert "stop" not in backend.calls
+
+
+def test_report_is_owner_only_and_json_round_trips(tmp_path):
+    report = qualify_runtime(
+        runtime="fake",
+        backend=FakeBackend(),
+        model_id="tiny",
+        port=1,
+        inference=lambda _handle: (1, "ok"),
+    )
+    target = tmp_path / "report.json"
+    save_report(target, report)
+    assert json.loads(target.read_text())["passed"] is True
+    if os.name == "posix":
+        assert target.stat().st_mode & 0o077 == 0
+
+
+def test_parser_exposes_physical_runtime_qualification():
+    args = parser.build_parser().parse_args(
+        [
+            "allocator",
+            "qualify",
+            "vllm",
+            "Qwen/tiny",
+            "--artifact-source",
+            "hf://Qwen/tiny@" + "a" * 40,
+            "--artifact-sha256",
+            "b" * 64,
+            "--artifact-size-mb",
+            "1000",
+            "--cleanup-artifact",
+        ]
+    )
+    assert args.handler.__name__ == "cmd_allocator_qualify"
+    assert args.tensor_parallel_size == 1
+    assert args.cleanup_artifact is True

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -587,6 +587,26 @@ def test_image_gen_steps_default_comes_from_the_workflow():
         assert asked["prompt"][sampler_id]["inputs"]["steps"] == 12
 
 
+def test_media_handler_builds_comfyui_websocket_url():
+    from shared.media.media_handler import MediaHandler
+
+    assert MediaHandler._websocket_url("http://127.0.0.1:8188") == "ws://127.0.0.1:8188/ws"
+    assert MediaHandler._websocket_url("https://comfy.example/api/") == "wss://comfy.example/ws"
+
+
+def test_media_handler_prefers_the_installed_comfyui_output(monkeypatch, tmp_path):
+    from shared.media import media_handler
+
+    installed = tmp_path / "services" / "ComfyUI" / "output"
+    legacy = tmp_path / "public" / "temp_comfy_output"
+    installed.mkdir(parents=True)
+    legacy.mkdir(parents=True)
+    monkeypatch.setattr(media_handler.paths, "home", lambda: tmp_path)
+    monkeypatch.setattr(media_handler.httpx, "get", lambda *args, **kwargs: SimpleNamespace(status_code=500))
+
+    assert media_handler.MediaHandler("http://127.0.0.1:8188")._get_output_dir() == str(installed)
+
+
 def test_create_venv_seeds_pip_into_the_uv_venv(monkeypatch, tmp_path):
     """`uv venv` ships no pip; when uv resolves a system Python that lacks ensurepip (a 3.11 rc did
     exactly this) grid's pip bootstrap has nothing to fall back to. `_create_venv` must pass `--seed`


### PR DESCRIPTION
Stacked follow-up to #71. Adds an operator command and durable owner-only report for physical Ollama, ComfyUI, and vLLM lifecycle qualification: immutable inventory/fetch, warm, ownership, native readiness, real inference/workflow output, activity probe, drain/stop, and scoped cleanup. Tightens Ollama overwrite safety and native errors, and fixes vLLM child reaping. Machine A physically passed Ollama with a disposable SmolLM2 135M canary; the canary was removed. The same harness correctly caught the existing gpt-oss:20b tensor size-overflow failure without deleting it. 318 focused tests pass. Base will be retargeted to main after #71 merges.