### PR TITLE
[Train 1/3 — after Relay #70] Build verified datasets from Goals

### DIFF
--- a/README.md
+++ b/README.md
@@ -654,6 +654,9 @@ than a generalist — worse than the frontier at everything, better at your thin
 # Ready-made setups for real business data
 grid train packs
 
+# Turn successful, independently evaluated agent work into training data
+grid train dataset --grid <grid-name> --out ./goal-data
+
 # Turn support tickets into a reply-drafting model
 grid train init --pack support-replies
 

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -1779,6 +1779,7 @@ def _add_train(sub) -> None:
         cmd_train_autopilot,
         cmd_train_collect,
         cmd_train_convert,
+        cmd_train_dataset,
         cmd_train_deploy,
         cmd_train_doctor,
         cmd_train_eval,
@@ -1877,6 +1878,24 @@ def _add_train(sub) -> None:
     collect.add_argument("--days", type=int, default=30, help="Window to summarise.")
     collect.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
     collect.set_defaults(handler=cmd_train_collect)
+
+    dataset = train_sub.add_parser(
+        "dataset", help="Build verified training data from completed Grid Goals"
+    )
+    dataset.add_argument("--grid", default=None,
+                         help="Remote grid to read (default: the active remote grid).")
+    dataset.add_argument("--goal-id", action="append", default=[],
+                         help="Only include this Goal (repeatable; default: all history).")
+    dataset.add_argument("--out", default=None,
+                         help="Output directory (default: grid-goals-<timestamp>).")
+    dataset.add_argument("--holdout", type=float, default=0.1,
+                         help="Fraction of whole Goals held out (default: 0.1).")
+    dataset.add_argument("--seed", default="1729",
+                         help="Stable split seed (default: 1729).")
+    dataset.add_argument("--format", choices=("jsonl", "parquet", "both"), default="jsonl")
+    dataset.add_argument("--force", action="store_true",
+                         help="Replace an existing output directory.")
+    dataset.set_defaults(handler=cmd_train_dataset)
 
     auto = train_sub.add_parser(
         "autopilot", help="Improve a model from captured work, unattended (see `schedule`)"

--- a/cli/train.py
+++ b/cli/train.py
@@ -299,6 +299,42 @@ def cmd_train_collect(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_train_dataset(args: argparse.Namespace) -> int:
+    """Build a versioned local dataset from independently evaluated Grid Goals."""
+    import time
+
+    from remote import relay
+    from train.goal_dataset import build_dataset
+
+    from .remote_task import _resolve
+
+    base, token, label = _resolve(args)
+    destination = Path(args.out or f"grid-goals-{time.strftime('%Y%m%d-%H%M%S')}")
+    goals = relay.list_goals(base, token, all=True)
+    if args.goal_id:
+        wanted = set(args.goal_id)
+        goals = [goal for goal in goals if goal.get("id") in wanted]
+        missing = sorted(wanted - {goal.get("id") for goal in goals})
+        if missing:
+            raise SystemExit("grid train: Goal not found: " + ", ".join(missing))
+    try:
+        result = build_dataset(
+            goals, lambda goal_id: relay.get_goal_evidence(base, token, goal_id), destination,
+            grid=label, holdout_fraction=args.holdout, seed=args.seed,
+            output_format=args.format, force=args.force)
+    except (FileExistsError, RuntimeError, ValueError) as exc:
+        raise SystemExit(f"grid train: {exc}") from None
+    print(f"Dataset: {result.destination}")
+    print(f"  accepted   {result.accepted} verified Goal trajectories")
+    print(f"  split      {result.train} train · {result.held_out} held out")
+    print(f"  excluded   {result.rejected} ({result.duplicates} duplicates)")
+    if result.accepted:
+        print("Next: point [data] at train/sft.jsonl and run `grid train sft`.")
+    else:
+        print("Nothing is trainable yet. See rejected.jsonl for the exact reason per Goal.")
+    return 0 if result.accepted else 1
+
+
 def cmd_train_autopilot(args: argparse.Namespace) -> int:
     """One unattended cycle over captured work: build tonight's data, train, prove, ship or bin."""
     from train.autopilot import history, run_cycle

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -704,6 +704,8 @@ grid train doctor [--config <path>] [--json]      # what this computer can do ri
 grid train where                                  # which grids training can use (LAN and hosted)
 grid train init [--pack <name>] [--dest <dir>] [--config <path>] [--force]
 grid train packs [--json]                         # bundled task packs for business data
+grid train dataset [--grid <name>] [--goal-id <id>]... [--out <dir>]
+                   [--holdout <fraction>] [--seed <seed>] [--format jsonl|parquet|both] [--force]
 
 grid train sft [--backend auto|mlx|torch] [--iters <n>] [--run-dir <dir>] [--config <path>]
 grid train run [--config <path>]                  # the feedback loop (GRPO via TRL)
@@ -744,6 +746,24 @@ Ready for stage one. `grid train sft` works on this computer right now.
 
 (The first line reads `torch on this machine` off Apple Silicon.) It exits 0 when either rung is
 ready, so a machine that can do stage one is not reported as a failure.
+
+### Learn from completed Goals
+
+`grid train dataset --grid <name>` turns Goal history into a local, versioned dataset. It accepts
+only completed trajectories with independently accepted Grid evals, and it runs the same offline
+evidence verifier used by `grid goal evidence --verify` before writing a byte. Incomplete,
+self-graded, pruned, tampered and duplicate trajectories go to `rejected.jsonl` with a reason.
+
+The command recursively redacts credentials and common personal identifiers, keeps complete Goals
+together, and makes a deterministic train/held-out split. It writes `trajectories.jsonl` for the
+full tool/eval history and `sft.jsonl` for today's trainers. `--format both` also writes Parquet
+(with `grid[train]` installed). `manifest.json` pins the schema, split seed, counts and SHA-256 of
+every data file, so a training run can name exactly what it consumed.
+
+```bash
+grid train dataset --grid forge --out ./forge-goals --format both
+# train on forge-goals/train/sft.jsonl; measure on forge-goals/held_out/
+```
 
 - **`grid train sft`** is imitation: it learns from the answers your team already wrote and needs
   nothing but the machine in front of you. `--backend auto` picks MLX on Apple Silicon and torch

--- a/tests/test_train_goal_dataset.py
+++ b/tests/test_train_goal_dataset.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from train import goal_dataset
+
+
+def _evidence(goal_id: str, *, text: str = "done") -> dict:
+    return {
+        "schema_version": 1,
+        "goal": {"id": goal_id, "status": "complete", "objective": "build it",
+                 "done_when": "tests pass", "model": "local-model",
+                 "evals": [{"definition_id": "eval-1", "kind": "command"}]},
+        "turns": [{"id": f"turn-{goal_id}", "prompt": "continue",
+                   "output": text, "state": "completed"}],
+        "attempt_events": [{"turn_id": f"turn-{goal_id}", "event": {
+            "type": "goal.act.request", "tool": "crm.update",
+            "arguments": {"authorization": "Bearer should-not-leak",
+                          "email": "person@example.com"}}}],
+        "inference": [{"turn_id": f"turn-{goal_id}", "model": "local-model"}],
+        "eval_runs": [{"id": f"run-{goal_id}", "turn_id": f"turn-{goal_id}",
+                       "definition_id": "eval-1", "state": "passed", "passed": True,
+                       "accepted": True, "score": 0.9,
+                       "evidence": {"access_token": "top-secret"}}],
+        "relationships": {"parent_goal_id": None, "children": []},
+    }
+
+
+def test_dataset_verifies_redacts_deduplicates_and_splits_whole_goals(tmp_path):
+    evidence = {"g1": _evidence("g1", text="contact me at person@example.com"),
+                "g2": _evidence("g2", text="a distinct answer"),
+                "g3": _evidence("g3", text="a distinct answer")}
+    # Turn/worker ids do not enter the fingerprint. This is deliberate: rerunning identical work
+    # on another machine is still one teaching example.
+    result = goal_dataset.build_dataset(
+        [{"id": key, "status": "complete"} for key in evidence], evidence.__getitem__,
+        tmp_path / "dataset", grid="forge", holdout_fraction=0.5,
+        verify=lambda _record: [])
+    assert (result.accepted, result.duplicates, result.train, result.held_out) == (2, 1, 1, 1)
+    rows = []
+    for split in ("train", "held_out"):
+        rows += [json.loads(line) for line in
+                 (tmp_path / "dataset" / split / "trajectories.jsonl").read_text().splitlines()]
+    dumped = json.dumps(rows)
+    assert "person@example.com" not in dumped
+    assert "should-not-leak" not in dumped and "top-secret" not in dumped
+    assert "[email]" in dumped and "[secret]" in dumped
+    assert {row["split"] for row in rows} == {"train", "held_out"}
+    manifest = json.loads((tmp_path / "dataset" / "manifest.json").read_text())
+    assert manifest["schema_version"] == 1
+    assert manifest["counts"] == {"accepted": 2, "duplicates": 1, "held_out": 1,
+                                  "rejected": 1, "train": 1}
+    assert manifest["files"]["train/sft.jsonl"]
+
+
+def test_dataset_refuses_self_graded_incomplete_and_failed_evidence(tmp_path):
+    no_eval = _evidence("no-eval")
+    no_eval["goal"]["evals"] = []
+    bad_eval = _evidence("bad-eval")
+    bad_eval["eval_runs"][0]["passed"] = False
+    result = goal_dataset.build_dataset(
+        [{"id": "active", "status": "active"},
+         {"id": "no-eval", "status": "complete"},
+         {"id": "bad-eval", "status": "complete"}],
+        {"no-eval": no_eval, "bad-eval": bad_eval}.__getitem__, tmp_path / "dataset",
+        grid="forge", verify=lambda record: (["tampered evidence"]
+                                              if record is bad_eval else []))
+    assert result.accepted == 0 and result.rejected == 3
+    rejected = [json.loads(line) for line in
+                (tmp_path / "dataset" / "rejected.jsonl").read_text().splitlines()]
+    assert any("no independent Grid eval" in " ".join(row["reasons"]) for row in rejected)
+    assert any("tampered evidence" in " ".join(row["reasons"]) for row in rejected)
+
+
+def test_dataset_refuses_to_overwrite_without_force(tmp_path):
+    destination = tmp_path / "dataset"
+    destination.mkdir()
+    (destination / "mine.txt").write_text("keep")
+    with pytest.raises(FileExistsError):
+        goal_dataset.build_dataset([], lambda _goal_id: {}, destination, grid="forge")
+    assert (destination / "mine.txt").read_text() == "keep"
+
+
+def test_dataset_cli_reads_selected_remote_grid(monkeypatch, tmp_path, capsys):
+    from cli.train import cmd_train_dataset
+    from remote import relay
+
+    monkeypatch.setattr("cli.remote_task._resolve", lambda _args: ("http://relay", "token", "forge"))
+    monkeypatch.setattr(relay, "list_goals", lambda *_args, **_kwargs:
+                        [{"id": "g1", "status": "complete"}])
+    monkeypatch.setattr(relay, "get_goal_evidence", lambda *_args: _evidence("g1"))
+    monkeypatch.setattr("cli.goal._verify_evidence", lambda *_args, **_kwargs: [])
+    args = SimpleNamespace(out=str(tmp_path / "dataset"), goal_id=[], holdout=0.1,
+                           seed="1729", format="jsonl", force=False, grid="forge")
+    assert cmd_train_dataset(args) == 0
+    assert "1 verified Goal trajectories" in capsys.readouterr().out
+
+
+def test_parser_exposes_goal_dataset_surface():
+    from cli.parser import build_parser
+
+    args = build_parser().parse_args(
+        ["train", "dataset", "--grid", "forge", "--format", "both", "--holdout", "0.2"])
+    assert args.grid == "forge" and args.format == "both" and args.holdout == 0.2

--- a/train/README.md
+++ b/train/README.md
@@ -340,6 +340,7 @@ train/
 ├── deploy.py              hot-load an adapter onto serving nodes
 ├── ui.py                  read-only dashboard of runs and their curves
 ├── capture.py             learn from served work: store, redact, prune, weigh, build a dataset
+├── goal_dataset.py        verified Goal evidence → redacted, deduped train/held-out datasets
 ├── autopilot.py           the unattended loop over captured work
 ├── schedule.py            put that loop in the user's own scheduler (launchd / systemd --user)
 ├── connectors.py          pull examples from Zendesk / HubSpot (env-var tokens, never stored)

--- a/train/goal_dataset.py
+++ b/train/goal_dataset.py
@@ -1,0 +1,295 @@
+"""Build trustworthy training data from completed Grid Goals.
+
+The relay already owns the hard part: an immutable record tying each turn, tool call, model
+request, Git handoff and evaluation to a leased worker.  This module is the deliberately boring
+consumer of that record.  It verifies before transforming, redacts before writing, and keeps the
+held-out split at the *Goal* boundary so turns from one trajectory can never leak into both sets.
+"""
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import json
+import math
+import os
+import re
+import shutil
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Iterable
+
+from .capture import clip, redact
+
+SCHEMA_VERSION = 1
+
+_SENSITIVE_KEY = re.compile(
+    r"(?:^|_)(?:access_?token|api_?key|authorization|cookie|credential|password|private_?key|"
+    r"refresh_?token|secret|session)(?:$|_)", re.IGNORECASE)
+_BEARER = re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._~+/=-]{8,}")
+_JWT = re.compile(r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b")
+_URL_CREDENTIAL = re.compile(r"(?i)(https?://)[^\s/@:]+:[^\s/@]+@")
+
+
+@dataclasses.dataclass(frozen=True)
+class DatasetResult:
+    destination: Path
+    accepted: int
+    rejected: int
+    duplicates: int
+    train: int
+    held_out: int
+
+
+def _canonical(value: object) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"),
+                      ensure_ascii=False).encode("utf-8")
+
+
+def _hash(value: object) -> str:
+    return hashlib.sha256(_canonical(value)).hexdigest()
+
+
+def sanitize(value: object, *, key: str = "") -> object:
+    """Recursively redact a JSON value without changing its container shape.
+
+    Text-pattern redaction alone cannot protect a field literally named ``access_token``.  Key
+    names therefore win, then bounded text is passed through the capture plane's established PII
+    scrubber plus credentials that commonly appear in HTTP/tool evidence.
+    """
+    if _SENSITIVE_KEY.search(key):
+        return "[secret]"
+    if isinstance(value, dict):
+        return {str(k): sanitize(v, key=str(k)) for k, v in value.items()}
+    if isinstance(value, list):
+        return [sanitize(item, key=key) for item in value]
+    if isinstance(value, str):
+        text = redact(clip(value, limit=64_000))
+        text = _BEARER.sub("Bearer [secret]", text)
+        text = _JWT.sub("[secret]", text)
+        return _URL_CREDENTIAL.sub(r"\1[secret]@", text)
+    return value
+
+
+def _accepted_evals(evidence: dict) -> tuple[list[dict], list[str]]:
+    goal = evidence.get("goal") if isinstance(evidence.get("goal"), dict) else {}
+    specs = goal.get("evals") if isinstance(goal.get("evals"), list) else []
+    turns = evidence.get("turns") if isinstance(evidence.get("turns"), list) else []
+    if not specs:
+        return [], ["no independent Grid eval"]
+    if not turns or not isinstance(turns[-1], dict):
+        return [], ["no final Goal turn"]
+    final_id = turns[-1].get("id")
+    runs = evidence.get("eval_runs") if isinstance(evidence.get("eval_runs"), list) else []
+    accepted = [run for run in runs if isinstance(run, dict)
+                and run.get("turn_id") == final_id and run.get("accepted") is True]
+    failures = []
+    for spec in specs:
+        definition = spec.get("definition_id") if isinstance(spec, dict) else None
+        matches = [run for run in accepted if run.get("definition_id") == definition
+                   and run.get("state") == "passed" and run.get("passed") is True]
+        if len(matches) != 1:
+            failures.append(f"eval {definition or '?'} has {len(matches)} accepted passing runs")
+    return accepted, failures
+
+
+def trajectory_record(evidence: dict, *, grid: str) -> tuple[dict | None, list[str]]:
+    """Convert one verified evidence document into the versioned training record shape."""
+    goal = evidence.get("goal") if isinstance(evidence.get("goal"), dict) else {}
+    turns = evidence.get("turns") if isinstance(evidence.get("turns"), list) else []
+    accepted_evals, failures = _accepted_evals(evidence)
+    if failures:
+        return None, failures
+    messages: list[dict] = [{
+        "role": "system",
+        "content": (f"Goal: {goal.get('objective') or ''}\n"
+                    f"Done when: {goal.get('done_when') or ''}"),
+    }]
+    for turn in turns:
+        if not isinstance(turn, dict):
+            return None, ["malformed turn"]
+        prompt, output = turn.get("prompt"), turn.get("output")
+        if not isinstance(prompt, str) or not prompt.strip():
+            return None, [f"turn {turn.get('id') or '?'} has no prompt"]
+        if not isinstance(output, str) or not output.strip():
+            return None, [f"turn {turn.get('id') or '?'} has no output"]
+        messages.extend(({"role": "user", "content": prompt},
+                         {"role": "assistant", "content": output}))
+
+    scores = [float(run["score"]) for run in accepted_evals
+              if isinstance(run.get("score"), (int, float))
+              and not isinstance(run.get("score"), bool)
+              and math.isfinite(float(run["score"]))]
+    record = sanitize({
+        "schema_version": SCHEMA_VERSION,
+        "goal_id": goal.get("id"),
+        "grid": grid,
+        "objective": goal.get("objective"),
+        "done_when": goal.get("done_when"),
+        "model": goal.get("model"),
+        "status": goal.get("status"),
+        "score": (sum(scores) / len(scores)) if scores else 1.0,
+        "messages": messages,
+        "turns": turns,
+        "tool_events": [item for item in evidence.get("attempt_events", [])
+                        if isinstance(item, dict)
+                        and isinstance(item.get("event"), dict)
+                        and str(item["event"].get("type") or "").startswith("goal.")],
+        "inference": evidence.get("inference", []),
+        "evals": goal.get("evals", []),
+        "eval_runs": accepted_evals,
+        "relationships": evidence.get("relationships", {}),
+    })
+    assert isinstance(record, dict)
+    # Relay ids say *where* an action ran, not what was learned. Exclude them so repeating the same
+    # trajectory on a different machine is deduplicated instead of overweighting one answer.
+    tool_semantics = [{key: item["event"].get(key)
+                       for key in ("type", "tool", "arguments", "result", "success")
+                       if key in item["event"]}
+                      for item in record["tool_events"]]
+    record["fingerprint"] = _hash({"messages": record["messages"],
+                                    "tool_events": tool_semantics})
+    return record, []
+
+
+def _held_out(fingerprint: str, seed: str, fraction: float) -> bool:
+    bucket = int(hashlib.sha256(f"{seed}:{fingerprint}".encode()).hexdigest()[:16], 16)
+    return bucket / float(0xFFFFFFFFFFFFFFFF) < fraction
+
+
+def split_records(records: list[dict], *, fraction: float, seed: str) -> tuple[list[dict], list[dict]]:
+    """Return (train, held-out), deterministically and only at whole-trajectory boundaries."""
+    ordered = sorted(records, key=lambda row: (row["fingerprint"], str(row.get("goal_id") or "")))
+    held = [row for row in ordered if _held_out(row["fingerprint"], seed, fraction)]
+    held_fingerprints = {row["fingerprint"] for row in held}
+    train = [row for row in ordered if row["fingerprint"] not in held_fingerprints]
+    # Small smoke-test corpora still need one honest held-out Goal and one training Goal.
+    if len(ordered) >= 2 and fraction > 0 and not held:
+        held, train = ordered[:1], ordered[1:]
+    elif len(ordered) >= 2 and not train:
+        train, held = ordered[:1], ordered[1:]
+    return train, held
+
+
+def _jsonl(path: Path, rows: Iterable[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n"
+                            for row in rows), encoding="utf-8")
+
+
+def _sft(row: dict) -> dict:
+    return {"messages": row["messages"], "metadata": {
+        "schema_version": row["schema_version"], "goal_id": row.get("goal_id"),
+        "fingerprint": row["fingerprint"], "score": row["score"],
+    }}
+
+
+def _write_parquet(path: Path, rows: list[dict]) -> None:
+    try:
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+    except ImportError as exc:
+        raise RuntimeError(
+            "Parquet export needs pyarrow; install the training dependencies with "
+            "`pip install 'grid[train]'`") from exc
+    flattened = [{
+        "schema_version": row["schema_version"], "split": row["split"],
+        "goal_id": row.get("goal_id"), "grid": row.get("grid"),
+        "model": row.get("model"), "score": row.get("score"),
+        "fingerprint": row["fingerprint"],
+        "messages_json": json.dumps(row["messages"], ensure_ascii=False),
+        "trajectory_json": json.dumps(row, ensure_ascii=False, sort_keys=True),
+    } for row in rows]
+    pq.write_table(pa.Table.from_pylist(flattened), path)
+
+
+def build_dataset(goals: Iterable[dict], fetch_evidence: Callable[[str], dict], destination: Path,
+                  *, grid: str, holdout_fraction: float = 0.1, seed: str = "1729",
+                  output_format: str = "jsonl", force: bool = False,
+                  verify: Callable[[dict], list[str]] | None = None) -> DatasetResult:
+    """Verify, filter, redact, dedupe, split and atomically publish one dataset directory."""
+    from cli.goal import _verify_evidence
+
+    if not 0 <= holdout_fraction < 1:
+        raise ValueError("held-out fraction must be at least 0 and less than 1")
+    if output_format not in ("jsonl", "parquet", "both"):
+        raise ValueError("format must be jsonl, parquet or both")
+    destination = Path(destination).expanduser()
+    if destination.exists() and (not destination.is_dir() or any(destination.iterdir())) and not force:
+        raise FileExistsError(f"{destination} exists (pass --force to replace it)")
+    verify = verify or (lambda record: _verify_evidence(record, require_inference=True))
+    records, rejected, seen = [], [], set()
+    duplicates = 0
+    for summary in goals:
+        goal_id = summary.get("id") if isinstance(summary, dict) else None
+        if not isinstance(goal_id, str) or not goal_id:
+            rejected.append({"goal_id": None, "reasons": ["malformed Goal summary"]})
+            continue
+        if summary.get("status") != "complete":
+            rejected.append({"goal_id": goal_id,
+                             "reasons": [f"status is {summary.get('status')!r}"]})
+            continue
+        try:
+            evidence = fetch_evidence(goal_id)
+        except Exception as exc:  # one unavailable Goal must not discard all earlier evidence
+            rejected.append({"goal_id": goal_id,
+                             "reasons": [f"evidence fetch failed: {type(exc).__name__}: {exc}"]})
+            continue
+        failures = verify(evidence)
+        record, transform_failures = trajectory_record(evidence, grid=grid)
+        failures.extend(transform_failures)
+        if failures or record is None:
+            rejected.append({"goal_id": goal_id, "reasons": sanitize(failures)})
+            continue
+        if record["fingerprint"] in seen:
+            duplicates += 1
+            rejected.append({"goal_id": goal_id, "reasons": ["duplicate trajectory"]})
+            continue
+        seen.add(record["fingerprint"])
+        records.append(record)
+
+    train, held = split_records(records, fraction=holdout_fraction, seed=seed)
+    for row in train:
+        row["split"] = "train"
+    for row in held:
+        row["split"] = "held_out"
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(tempfile.mkdtemp(prefix=f".{destination.name}-", dir=destination.parent))
+    staging.chmod(0o700)
+    try:
+        if output_format in ("jsonl", "both"):
+            for name, rows in (("train", train), ("held_out", held)):
+                _jsonl(staging / name / "trajectories.jsonl", rows)
+                _jsonl(staging / name / "sft.jsonl", (_sft(row) for row in rows))
+        if output_format in ("parquet", "both"):
+            _write_parquet(staging / "trajectories.parquet", train + held)
+        _jsonl(staging / "rejected.jsonl", rejected)
+        for directory in (item for item in staging.rglob("*") if item.is_dir()):
+            directory.chmod(0o700)
+        files = sorted(path for path in staging.rglob("*") if path.is_file())
+        manifest = {
+            "schema_version": SCHEMA_VERSION,
+            "kind": "grid-goal-trajectories",
+            "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            "grid": grid, "format": output_format, "seed": seed,
+            "holdout_fraction": holdout_fraction,
+            "counts": {"accepted": len(records), "rejected": len(rejected),
+                       "duplicates": duplicates, "train": len(train), "held_out": len(held)},
+            "files": {str(path.relative_to(staging)): hashlib.sha256(path.read_bytes()).hexdigest()
+                      for path in files},
+        }
+        (staging / "manifest.json").write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+                                                encoding="utf-8")
+        for path in (item for item in staging.rglob("*") if item.is_file()):
+            path.chmod(0o600)
+        if destination.is_dir():
+            shutil.rmtree(destination)
+        elif destination.exists():
+            destination.unlink()
+        os.replace(staging, destination)
+    except Exception:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+    return DatasetResult(destination, len(records), len(rejected), duplicates,
+                         len(train), len(held))


### PR DESCRIPTION
## What\n- add `grid train dataset` for completed Grid Goal evidence\n- require independent accepted evals and Grid-attributed inference\n- redact secrets/PII, deduplicate trajectories, and split by whole Goal\n- emit deterministic JSONL/optional Parquet plus a checksummed manifest and rejected rows\n\n## Safety\n- fail closed on missing, tampered, pruned, self-graded, or incomplete evidence\n- private atomic output with explicit `--force` replacement\n- no changes to the submitted Goal or Relay branches\n\n## Validation\n- 119 focused tests passed with ruff\n- read-only Forge smoke classified all 10 historical Goals honestly (0 accepted: legacy evidence lacked Grid-attributed inference or was non-terminal/failed)\n\n## Stack\nBase this PR on the stable Relay PR. Merge before the held-out benchmark and distributed SFT PRs.