### PR TITLE
[Train 2/3 — after #77] Benchmark held-out Goal pass rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,6 +657,9 @@ grid train packs
 # Turn successful, independently evaluated agent work into training data
 grid train dataset --grid <grid-name> --out ./goal-data
 
+# Measure the model where it matters: independently completed held-out Goals
+grid train benchmark --suite suite.json --model <model> --run-dir ./benchmark
+
 # Turn support tickets into a reply-drafting model
 grid train init --pack support-replies
 

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -1777,6 +1777,7 @@ def _add_launch(sub) -> None:
 def _add_train(sub) -> None:
     from .train import (
         cmd_train_autopilot,
+        cmd_train_benchmark,
         cmd_train_collect,
         cmd_train_convert,
         cmd_train_dataset,
@@ -1896,6 +1897,33 @@ def _add_train(sub) -> None:
     dataset.add_argument("--force", action="store_true",
                          help="Replace an existing output directory.")
     dataset.set_defaults(handler=cmd_train_dataset)
+
+    benchmark = train_sub.add_parser(
+        "benchmark", help="Run a held-out Goal suite and report independent pass rate"
+    )
+    benchmark.add_argument("--suite", required=True, help="Version-1 Goal suite JSON file.")
+    benchmark.add_argument("--model", required=True, help="Candidate model served by the Grid.")
+    benchmark.add_argument("--grid", default=None,
+                           help="Remote grid to use (default: active remote grid).")
+    benchmark.add_argument("--run-dir", required=True,
+                           help="Durable local ledger; reuse it to resume safely.")
+    benchmark.add_argument("--repeat", type=int, default=1,
+                           help="Submit each case N times for a soak run (default: 1).")
+    benchmark.add_argument("--min-pass-rate", type=float, default=1.0,
+                           help="Required independent Goal pass rate (default: 1.0).")
+    benchmark.add_argument("--timeout", type=float, default=86_400,
+                           help="Maximum seconds to wait this invocation (default: 86400).")
+    benchmark.add_argument("--poll", type=float, default=5,
+                           help="Status polling interval in seconds (default: 5).")
+    benchmark.add_argument("--no-wait", action="store_true",
+                           help="Submit missing cases, save the ledger and return.")
+    benchmark.add_argument("--min-execution-nodes", type=_positive_node_count, default=1,
+                           metavar="N", help="Require N distinct execution nodes per Goal.")
+    benchmark.add_argument("--require-worker-revision", type=_worker_revision, default=None,
+                           metavar="REV", help="Require a clean worker revision prefix.")
+    benchmark.add_argument("--require-agent-sequence", type=_agent_sequence, default=None,
+                           metavar="AGENT,...", help="Require an ordered harness handoff.")
+    benchmark.set_defaults(handler=cmd_train_benchmark)
 
     auto = train_sub.add_parser(
         "autopilot", help="Improve a model from captured work, unattended (see `schedule`)"

--- a/cli/train.py
+++ b/cli/train.py
@@ -335,6 +335,58 @@ def cmd_train_dataset(args: argparse.Namespace) -> int:
     return 0 if result.accepted else 1
 
 
+def cmd_train_benchmark(args: argparse.Namespace) -> int:
+    """Run an independently evaluated held-out Goal suite on one Grid model."""
+    from remote import relay
+    from train.goal_benchmark import load_suite, run_benchmark
+
+    from .goal import _verify_evidence
+    from .remote_task import _resolve, _resolve_project
+
+    base, token, label = _resolve(args)
+    try:
+        suite = load_suite(args.suite)
+        result = run_benchmark(
+            suite, args.run_dir, grid=label, model=args.model, repeats=args.repeat,
+            threshold=args.min_pass_rate, timeout_seconds=args.timeout,
+            poll_seconds=args.poll, wait=not args.no_wait,
+            resolve_project=lambda project: _resolve_project(base, token, project),
+            submit=lambda case, project_id, key: relay.create_goal(
+                base, token, project_id=project_id, objective=case["objective"],
+                done_when=case["done_when"], model=args.model,
+                token_budget=case.get("token_budget", suite.get("token_budget", 1_000_000)),
+                tools=case.get("tools", suite.get("tools", [])),
+                name=f"benchmark-{case['id']}",
+                agents=case.get("agents", suite.get("agents", ["codex"])),
+                required_capabilities=case.get(
+                    "required_capabilities", suite.get("required_capabilities", [])),
+                evals=case["evals"],
+                allow_subgoals=bool(case.get("allow_subgoals",
+                                             suite.get("allow_subgoals", False))),
+                idempotency_key=key),
+            get_status=lambda goal_id: relay.get_goal(base, token, goal_id),
+            get_evidence=lambda goal_id: relay.get_goal_evidence(base, token, goal_id),
+            verify=lambda evidence: _verify_evidence(
+                evidence, min_execution_nodes=args.min_execution_nodes,
+                require_inference=True,
+                require_worker_revision=args.require_worker_revision,
+                require_agent_sequence=args.require_agent_sequence),
+        )
+    except ValueError as exc:
+        raise SystemExit(f"grid train: {exc}") from None
+    state = "complete" if result.complete else "running"
+    print(f"Goal benchmark: {result.passed}/{result.total} passed "
+          f"({result.pass_rate:.1%}) · {state}")
+    print(f"Run: {result.run_dir / 'benchmark.json'}")
+    if not result.complete:
+        print("Rerun the same command and --run-dir to resume without creating duplicate Goals.")
+    elif result.met_threshold:
+        print(f"PASS — met the {result.threshold:.1%} held-out Goal pass-rate bar.")
+    else:
+        print(f"HOLD — below the {result.threshold:.1%} held-out Goal pass-rate bar.")
+    return 0 if result.met_threshold or (args.no_wait and not result.complete) else 1
+
+
 def cmd_train_autopilot(args: argparse.Namespace) -> int:
     """One unattended cycle over captured work: build tonight's data, train, prove, ship or bin."""
     from train.autopilot import history, run_cycle

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -706,6 +706,8 @@ grid train init [--pack <name>] [--dest <dir>] [--config <path>] [--force]
 grid train packs [--json]                         # bundled task packs for business data
 grid train dataset [--grid <name>] [--goal-id <id>]... [--out <dir>]
                    [--holdout <fraction>] [--seed <seed>] [--format jsonl|parquet|both] [--force]
+grid train benchmark --suite <file> --model <model> --run-dir <dir> [--grid <name>]
+                     [--repeat <n>] [--min-pass-rate <0..1>] [--no-wait]
 
 grid train sft [--backend auto|mlx|torch] [--iters <n>] [--run-dir <dir>] [--config <path>]
 grid train run [--config <path>]                  # the feedback loop (GRPO via TRL)
@@ -764,6 +766,20 @@ every data file, so a training run can name exactly what it consumed.
 grid train dataset --grid forge --out ./forge-goals --format both
 # train on forge-goals/train/sft.jsonl; measure on forge-goals/held_out/
 ```
+
+`grid train benchmark` measures the trained model at the product boundary: can its agent finish
+held-out Goals? A version-1 suite names disposable Grid projects and carries immutable independent
+evals. All cases are submitted before polling, so the existing distributed queue spreads them
+across the fleet. The only headline metric is independently verified Goal pass rate.
+
+The run directory is a durable ledger. Every idempotency key is saved before its create request,
+so closing the terminal or losing a response cannot duplicate a Goal; rerun the same command to
+resume. `--repeat 100 --timeout 172800` turns the suite into a 48-hour soak. The optional evidence
+gates can require several execution nodes, a clean worker revision, or a Codex/Claude handoff.
+Use disposable projects because benchmark agents really act; a held-out test must never mutate a
+production repository or call a production write tool.
+
+See [`fixtures/goal-benchmark-suite.json`](fixtures/goal-benchmark-suite.json) for the file shape.
 
 - **`grid train sft`** is imitation: it learns from the answers your team already wrote and needs
   nothing but the machine in front of you. `--backend auto` picks MLX on Apple Silicon and torch

--- a/docs/fixtures/goal-benchmark-suite.json
+++ b/docs/fixtures/goal-benchmark-suite.json
@@ -1,0 +1,41 @@
+{
+  "version": 1,
+  "project": "training-benchmark-sandbox",
+  "agents": ["codex"],
+  "token_budget": 1000000,
+  "cases": [
+    {
+      "id": "health-endpoint",
+      "objective": "Add a small health endpoint and document it.",
+      "done_when": "health.json exists, is valid, and reports ok=true.",
+      "evals": [
+        {
+          "type": "json",
+          "version": 1,
+          "name": "health contract",
+          "path": "health.json",
+          "max_bytes": 4096,
+          "checks": [
+            {"pointer": "/ok", "op": "equals", "value": true}
+          ]
+        }
+      ]
+    },
+    {
+      "id": "operator-notes",
+      "objective": "Write a concise operator runbook for the sample service.",
+      "done_when": "RUNBOOK.md exists and includes startup and rollback instructions.",
+      "evals": [
+        {
+          "type": "file",
+          "version": 1,
+          "name": "runbook contract",
+          "path": "RUNBOOK.md",
+          "min_bytes": 80,
+          "max_bytes": 20000,
+          "contains": ["Startup", "Rollback"]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_train_goal_benchmark.py
+++ b/tests/test_train_goal_benchmark.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from train.goal_benchmark import load_suite, run_benchmark
+
+
+def _suite():
+    return {"version": 1, "project": "sandbox", "cases": [{
+        "id": "build-game", "objective": "Build a game", "done_when": "all checks pass",
+        "evals": [{"kind": "artifact", "path": "game.html"}],
+    }]}
+
+
+def test_suite_requires_measurable_independent_cases(tmp_path):
+    path = tmp_path / "suite.json"
+    path.write_text(json.dumps(_suite()))
+    assert load_suite(path)["cases"][0]["id"] == "build-game"
+    broken = _suite()
+    broken["cases"][0]["evals"] = []
+    path.write_text(json.dumps(broken))
+    with pytest.raises(ValueError, match="independent Grid eval"):
+        load_suite(path)
+
+
+def test_benchmark_submits_all_cases_then_reports_simple_pass_rate(tmp_path):
+    suite = _suite()
+    suite["cases"].append({"id": "bad", "objective": "Do bad", "done_when": "check",
+                           "evals": [{"kind": "artifact", "path": "x"}]})
+    submitted = []
+    statuses = {"goal-build-game": "complete", "goal-bad": "failed"}
+
+    result = run_benchmark(
+        suite, tmp_path / "run", grid="forge", model="local", threshold=0.5,
+        poll_seconds=0, submit=lambda case, _project, _key: (
+            submitted.append(case["id"]) or {"id": f"goal-{case['id']}", "status": "active"}),
+        get_status=lambda goal_id: {"status": statuses[goal_id]},
+        get_evidence=lambda goal_id: {"goal": {"id": goal_id, "access_token": "hidden"}},
+        resolve_project=lambda project: f"project-{project}", verify=lambda _evidence: [])
+    assert submitted == ["build-game", "bad"]
+    assert (result.passed, result.total, result.pass_rate, result.met_threshold) == (1, 2, 0.5, True)
+    state = json.loads((tmp_path / "run" / "benchmark.json").read_text())
+    assert state["result"]["pass_rate"] == 0.5
+    evidence = (tmp_path / "run" / "evidence" / "build-game-1.json").read_text()
+    assert "hidden" not in evidence and "[secret]" in evidence
+
+
+def test_benchmark_resume_reuses_goal_ids_and_idempotency_keys(tmp_path):
+    submitted = []
+    common = dict(
+        suite=_suite(), run_dir=tmp_path / "run", grid="forge", model="local",
+        submit=lambda case, _project, key: (
+            submitted.append((case["id"], key)) or {"id": "goal-1", "status": "active"}),
+        get_status=lambda _goal_id: {"status": "active"}, get_evidence=lambda _goal_id: {},
+        resolve_project=lambda project: project, verify=lambda _evidence: [])
+    first = run_benchmark(**common, wait=False)
+    second = run_benchmark(**common, wait=False)
+    assert not first.complete and not second.complete
+    assert len(submitted) == 1
+
+
+def test_benchmark_persists_idempotency_key_before_uncertain_create(tmp_path):
+    def uncertain(*_args):
+        raise SystemExit("response lost")
+
+    common = dict(
+        suite=_suite(), run_dir=tmp_path / "run", grid="forge", model="local", wait=False,
+        submit=uncertain, get_status=lambda _goal_id: {}, get_evidence=lambda _goal_id: {},
+        resolve_project=lambda project: project, verify=lambda _evidence: [])
+    with pytest.raises(SystemExit, match="response lost"):
+        run_benchmark(**common)
+    first_key = json.loads((tmp_path / "run" / "benchmark.json").read_text())["cases"][0][
+        "idempotency_key"]
+    observed = []
+    common["submit"] = lambda _case, _project, key: (
+        observed.append(key) or {"id": "goal-1", "status": "active"})
+    run_benchmark(**common)
+    assert observed == [first_key]
+
+
+def test_benchmark_requires_same_inputs_when_resuming(tmp_path):
+    common = dict(
+        suite=_suite(), run_dir=tmp_path / "run", grid="forge", model="local", wait=False,
+        submit=lambda *_args: {"id": "goal-1", "status": "active"},
+        get_status=lambda _goal_id: {}, get_evidence=lambda _goal_id: {},
+        resolve_project=lambda project: project, verify=lambda _evidence: [])
+    run_benchmark(**common)
+    with pytest.raises(ValueError, match="different benchmark"):
+        run_benchmark(**{**common, "model": "other"})
+
+
+def test_benchmark_timeout_is_resumable_not_a_terminal_failure(tmp_path, monkeypatch):
+    ticks = iter((0.0, 2.0))
+    monkeypatch.setattr("train.goal_benchmark.time.monotonic", lambda: next(ticks))
+    result = run_benchmark(
+        _suite(), tmp_path / "run", grid="forge", model="local", timeout_seconds=1,
+        poll_seconds=0, submit=lambda *_args: {"id": "goal-1", "status": "active"},
+        get_status=lambda _goal_id: {"status": "active"}, get_evidence=lambda _goal_id: {},
+        resolve_project=lambda project: project, verify=lambda _evidence: [])
+    assert not result.complete and result.pass_rate == 0
+    state = json.loads((tmp_path / "run" / "benchmark.json").read_text())
+    assert "rerun" in state["cases"][0]["failures"][0]
+
+
+def test_parser_exposes_goal_benchmark_surface():
+    from cli.parser import build_parser
+
+    args = build_parser().parse_args([
+        "train", "benchmark", "--suite", "suite.json", "--model", "qwen",
+        "--run-dir", "run", "--grid", "forge", "--repeat", "20",
+        "--min-execution-nodes", "3", "--require-agent-sequence", "codex,claude"])
+    assert args.repeat == 20 and args.min_execution_nodes == 3
+    assert args.require_agent_sequence == ("codex", "claude")

--- a/train/README.md
+++ b/train/README.md
@@ -341,6 +341,7 @@ train/
 ├── ui.py                  read-only dashboard of runs and their curves
 ├── capture.py             learn from served work: store, redact, prune, weigh, build a dataset
 ├── goal_dataset.py        verified Goal evidence → redacted, deduped train/held-out datasets
+├── goal_benchmark.py      held-out Goal suite → independently verified pass rate / soak ledger
 ├── autopilot.py           the unattended loop over captured work
 ├── schedule.py            put that loop in the user's own scheduler (launchd / systemd --user)
 ├── connectors.py          pull examples from Zendesk / HubSpot (env-var tokens, never stored)

--- a/train/goal_benchmark.py
+++ b/train/goal_benchmark.py
@@ -1,0 +1,241 @@
+"""Held-out Grid Goal evaluation and soak runs.
+
+A benchmark is an authored suite of measurable Goals against disposable projects/sandboxes.  The
+candidate agent never sees the answer key beyond each Goal's immutable eval contract; the relay
+runs those evals and this client independently verifies its evidence.  The metric is intentionally
+one number: completed-and-verified Goals / submitted Goals.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+from .goal_dataset import sanitize
+
+SCHEMA_VERSION = 1
+TERMINAL = frozenset({"complete", "failed", "cancelled", "budget_limited", "usage_limited"})
+_CASE_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,63}")
+
+
+@dataclass(frozen=True)
+class BenchmarkResult:
+    run_dir: Path
+    passed: int
+    total: int
+    pass_rate: float
+    threshold: float
+    complete: bool
+
+    @property
+    def met_threshold(self) -> bool:
+        return self.complete and self.pass_rate >= self.threshold
+
+
+def _canonical(value: object) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"),
+                      ensure_ascii=False).encode("utf-8")
+
+
+def load_suite(path: Path | str) -> dict:
+    source = Path(path).expanduser()
+    try:
+        suite = json.loads(source.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise ValueError(f"could not read Goal suite {source}: {exc}") from exc
+    if not isinstance(suite, dict) or suite.get("version") != 1:
+        raise ValueError("Goal suite must be a JSON object with version 1")
+    cases = suite.get("cases")
+    if not isinstance(cases, list) or not 1 <= len(cases) <= 1000:
+        raise ValueError("Goal suite cases must contain 1-1000 cases")
+    seen = set()
+    for index, case in enumerate(cases):
+        prefix = f"cases[{index}]"
+        if not isinstance(case, dict):
+            raise ValueError(f"{prefix} must be an object")
+        case_id = case.get("id")
+        if not isinstance(case_id, str) or not _CASE_ID.fullmatch(case_id):
+            raise ValueError(f"{prefix}.id must be a 1-64 character stable identifier")
+        if case_id in seen:
+            raise ValueError(f"duplicate Goal suite case id {case_id!r}")
+        seen.add(case_id)
+        for field in ("objective", "done_when"):
+            if not isinstance(case.get(field), str) or not case[field].strip():
+                raise ValueError(f"{prefix}.{field} must be non-empty text")
+        evals = case.get("evals")
+        if not isinstance(evals, list) or not evals or any(not isinstance(x, dict) for x in evals):
+            raise ValueError(f"{prefix}.evals must contain independent Grid eval definitions")
+        if not case.get("project") and not suite.get("project"):
+            raise ValueError(f"{prefix} needs project, or the suite needs a default project")
+        agents = case.get("agents", suite.get("agents", ["codex"]))
+        if (not isinstance(agents, list) or not agents
+                or any(agent not in ("codex", "claude") for agent in agents)):
+            raise ValueError(f"{prefix}.agents must contain codex and/or claude")
+        tools = case.get("tools", suite.get("tools", []))
+        if not isinstance(tools, list) or any(not isinstance(tool, dict) for tool in tools):
+            raise ValueError(f"{prefix}.tools must be a list of Goal tool definitions")
+    return suite
+
+
+def suite_hash(suite: dict) -> str:
+    return hashlib.sha256(_canonical(suite)).hexdigest()
+
+
+def _write(path: Path, value: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.parent.chmod(0o700)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    temporary.chmod(0o600)
+    os.replace(temporary, path)
+
+
+def _new_state(suite: dict, *, grid: str, model: str, repeats: int,
+               threshold: float) -> dict:
+    digest = suite_hash(suite)
+    benchmark_id = str(uuid.uuid4())
+    cases = []
+    for repetition in range(1, repeats + 1):
+        for case in suite["cases"]:
+            run_id = f"{case['id']}#{repetition}"
+            cases.append({
+                "run_id": run_id, "case_id": case["id"], "repetition": repetition,
+                "idempotency_key": str(uuid.uuid5(uuid.NAMESPACE_URL,
+                                                   f"grid-goal-benchmark:{benchmark_id}:{run_id}")),
+                "goal_id": None, "status": "not_submitted", "passed": None,
+                "failures": [],
+            })
+    return {"schema_version": SCHEMA_VERSION, "benchmark_id": benchmark_id,
+            "suite_hash": digest, "grid": grid,
+            "model": model, "repeats": repeats, "threshold": threshold,
+            "started_at": time.strftime("%Y-%m-%dT%H:%M:%S%z"), "cases": cases}
+
+
+def _load_or_create(run_dir: Path, suite: dict, *, grid: str, model: str,
+                    repeats: int, threshold: float) -> dict:
+    path = run_dir / "benchmark.json"
+    if not path.is_file():
+        return _new_state(suite, grid=grid, model=model, repeats=repeats, threshold=threshold)
+    try:
+        state = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise ValueError(f"could not resume {path}: {exc}") from exc
+    expected = {"suite_hash": suite_hash(suite), "grid": grid, "model": model,
+                "repeats": repeats, "threshold": threshold}
+    mismatched = [key for key, value in expected.items() if state.get(key) != value]
+    if mismatched:
+        raise ValueError("run directory belongs to a different benchmark: " + ", ".join(mismatched))
+    return state
+
+
+def _summarize(state: dict, run_dir: Path) -> BenchmarkResult:
+    cases = state["cases"]
+    passed = sum(case.get("passed") is True for case in cases)
+    complete = all(case.get("status") in TERMINAL for case in cases)
+    total = len(cases)
+    rate = passed / total if total else 0.0
+    state["result"] = {"passed": passed, "total": total, "pass_rate": rate,
+                       "complete": complete, "met_threshold": complete and rate >= state["threshold"]}
+    if complete and "finished_at" not in state:
+        state["finished_at"] = time.strftime("%Y-%m-%dT%H:%M:%S%z")
+    _write(run_dir / "benchmark.json", state)
+    return BenchmarkResult(run_dir, passed, total, rate, state["threshold"], complete)
+
+
+def run_benchmark(
+    suite: dict, run_dir: Path | str, *, grid: str, model: str, repeats: int = 1,
+    threshold: float = 1.0, timeout_seconds: float = 86_400, poll_seconds: float = 5,
+    wait: bool = True, submit: Callable[[dict, str, str], dict],
+    get_status: Callable[[str], dict], get_evidence: Callable[[str], dict],
+    resolve_project: Callable[[str], str],
+    verify: Callable[[dict], list[str]],
+) -> BenchmarkResult:
+    """Submit/resume a suite, then verify terminal evidence and calculate Goal pass rate."""
+    if not 1 <= repeats <= 10_000:
+        raise ValueError("repeats must be 1-10000")
+    if not 0 <= threshold <= 1:
+        raise ValueError("minimum pass rate must be between 0 and 1")
+    if timeout_seconds <= 0 or poll_seconds < 0:
+        raise ValueError("timeout must be positive and poll interval cannot be negative")
+    run_dir = Path(run_dir).expanduser()
+    run_dir.mkdir(parents=True, exist_ok=True)
+    run_dir.chmod(0o700)
+    state = _load_or_create(run_dir, suite, grid=grid, model=model,
+                            repeats=repeats, threshold=threshold)
+    # Persist the run identity and every idempotency key *before* the first network request. If the
+    # create response is lost after the relay commits, rerunning this directory recovers the same
+    # Goals instead of generating a fresh key and duplicating autonomous work.
+    _write(run_dir / "benchmark.json", state)
+    by_id = {case["id"]: case for case in suite["cases"]}
+    projects: dict[str, str] = {}
+
+    # Submit every independent case before polling. The relay's normal queue then fans the suite
+    # across all compatible workers; the benchmark client is not a second scheduler.
+    for item in state["cases"]:
+        if item.get("goal_id"):
+            continue
+        case = by_id[item["case_id"]]
+        project = str(case.get("project") or suite["project"])
+        try:
+            if project not in projects:
+                projects[project] = resolve_project(project)
+            created = submit(case, projects[project], item["idempotency_key"])
+            goal_id = created.get("id") if isinstance(created, dict) else None
+            if not isinstance(goal_id, str) or not goal_id:
+                raise RuntimeError("relay returned no Goal id")
+            item.update(goal_id=goal_id, status=str(created.get("status") or "active"))
+        except Exception as exc:
+            item.update(status="failed", passed=False,
+                        failures=[f"submission failed: {type(exc).__name__}: {exc}"])
+        _write(run_dir / "benchmark.json", state)
+    if not wait:
+        return _summarize(state, run_dir)
+
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        pending = [item for item in state["cases"] if item.get("status") not in TERMINAL]
+        if not pending:
+            break
+        if time.monotonic() >= deadline:
+            for item in pending:
+                item["failures"] = ["benchmark wait timed out; rerun with the same --run-dir to resume"]
+            _write(run_dir / "benchmark.json", state)
+            return _summarize(state, run_dir)
+        changed = False
+        for item in pending:
+            try:
+                current = get_status(item["goal_id"])
+                status = current.get("status") if isinstance(current, dict) else None
+                if isinstance(status, str) and status:
+                    changed |= item.get("status") != status
+                    item["status"] = status
+            except Exception as exc:
+                item["last_poll_error"] = sanitize(f"{type(exc).__name__}: {exc}")
+        if changed:
+            _write(run_dir / "benchmark.json", state)
+        if any(item.get("status") not in TERMINAL for item in state["cases"]):
+            time.sleep(poll_seconds)
+
+    for item in state["cases"]:
+        if item.get("passed") is not None:
+            continue
+        if item.get("status") != "complete":
+            item.update(passed=False, failures=[f"Goal ended {item.get('status')}"])
+            continue
+        try:
+            evidence = get_evidence(item["goal_id"])
+            failures = verify(evidence)
+            item.update(passed=not failures, failures=sanitize(failures))
+            _write(run_dir / "evidence" / f"{item['case_id']}-{item['repetition']}.json",
+                   sanitize(evidence))
+        except Exception as exc:
+            item.update(passed=False,
+                        failures=[sanitize(f"evidence failed: {type(exc).__name__}: {exc}")])
+        _write(run_dir / "benchmark.json", state)
+    return _summarize(state, run_dir)


### PR DESCRIPTION
## What\n- add `grid train benchmark` as the independent product-level eval\n- submit authored Goal suites up front so the existing distributed queue fans out\n- use a durable local ledger and stable idempotency keys for safe restart/resume\n- report one clear metric: independently verified Goal pass rate\n- support repeats, thresholds, timeouts, and node/revision/agent-handoff evidence gates\n\n## Safety\n- verifies relay evidence rather than trusting the agent's own verdict\n- sanitizes saved evidence\n- documents that suites must use disposable projects because Goals really act\n\n## Validation\n- 79 focused tests passed with ruff\n\n## Stack\nDepends on #77. Merge after the verified dataset PR and before distributed SFT jobs.