### PR TITLE
[Train 3/3 — after #78] Schedule local SFT across the Grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,6 +660,10 @@ grid train dataset --grid <grid-name> --out ./goal-data
 # Measure the model where it matters: independently completed held-out Goals
 grid train benchmark --suite suite.json --model <model> --run-dir ./benchmark
 
+# Queue local SFT on any compatible machine in a hosted/self-hosted grid
+grid train submit-sft --grid <grid-name> --project <id> \
+  --config grid-train.toml --data ./goal-data --backend mlx
+
 # Turn support tickets into a reply-drafting model
 grid train init --pack support-replies
 
@@ -674,6 +678,9 @@ grid train ui
 ```
 
 - The grid samples rollouts across its nodes; one machine holds the trainer.
+- SFT jobs use the same durable task/Git plane as Goals. A matching MLX or torch node claims one;
+  if the machine disappears, its lease expires and another compatible node restarts the job from
+  the immutable input commit.
 - The LoRA adapter it produces goes back to the serving nodes under a stable name, where `auto`
   keeps routing to it.
 - Rollouts run on your own hardware: training needs the token ids and logprobs a node sampled,

--- a/README.md
+++ b/README.md
@@ -664,6 +664,10 @@ grid train benchmark --suite suite.json --model <model> --run-dir ./benchmark
 grid train submit-sft --grid <grid-name> --project <id> \
   --config grid-train.toml --data ./goal-data --backend mlx
 
+# After the job completes: fetch and verify every adapter byte before use
+grid task fetch <task-id> --grid <grid-name> --into ./trained-result
+grid train verify-result ./trained-result/grid-train-result
+
 # Turn support tickets into a reply-drafting model
 grid train init --pack support-replies
 
@@ -681,6 +685,9 @@ grid train ui
 - SFT jobs use the same durable task/Git plane as Goals. A matching MLX or torch node claims one;
   if the machine disappears, its lease expires and another compatible node restarts the job from
   the immutable input commit.
+- Training jobs have their own bounded clocks (24 hours running and seven days queued by default),
+  and successful results carry a portable SHA-256 manifest. Exit code zero without a real adapter
+  is a failed job, not a false success.
 - The LoRA adapter it produces goes back to the serving nodes under a stable name, where `auto`
   keeps routing to it.
 - Rollouts run on your own hardware: training needs the token ids and logprobs a node sampled,

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -1792,6 +1792,7 @@ def _add_train(sub) -> None:
         cmd_train_run,
         cmd_train_schedule,
         cmd_train_submit_sft,
+        cmd_train_verify_result,
         cmd_train_serve,
         cmd_train_sft,
         cmd_train_ui,
@@ -1969,8 +1970,21 @@ def _add_train(sub) -> None:
                             help="Required worker type; explicit so scheduling is deterministic")
     submit_sft.add_argument("--iters", type=int, default=None,
                             help="Training iterations (MLX only)")
+    submit_sft.add_argument(
+        "--timeout-hours", type=int, default=24,
+        help="Maximum runtime after a trainer claims the job (default: 24; max: 168)")
+    submit_sft.add_argument(
+        "--queue-timeout-hours", type=int, default=168,
+        help="Maximum time to wait for a compatible trainer (default: 168; max: 720)")
     submit_sft.add_argument("--json", action="store_true")
     submit_sft.set_defaults(handler=cmd_train_submit_sft)
+
+    verify_result = train_sub.add_parser(
+        "verify-result", help="Verify a fetched distributed SFT adapter and its checksums"
+    )
+    verify_result.add_argument("path", help="Fetched grid-train-result directory")
+    verify_result.add_argument("--json", action="store_true")
+    verify_result.set_defaults(handler=cmd_train_verify_result)
 
     nightly = train_sub.add_parser(
         "nightly", help="One unattended cycle: train, prove it, ship it only if it won"

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -1791,6 +1791,7 @@ def _add_train(sub) -> None:
         cmd_train_pull,
         cmd_train_run,
         cmd_train_schedule,
+        cmd_train_submit_sft,
         cmd_train_serve,
         cmd_train_sft,
         cmd_train_ui,
@@ -1952,6 +1953,24 @@ def _add_train(sub) -> None:
     sft.add_argument("--run-dir", default=None,
                      help="Where to write adapter/log/run.json (default: a timestamped folder).")
     sft.set_defaults(handler=cmd_train_sft)
+
+    submit_sft = train_sub.add_parser(
+        "submit-sft", help="Queue SFT on any compatible machine in a remote Grid"
+    )
+    submit_sft.add_argument("--grid", default=None, help="Remote grid name or id")
+    project_arg.add_project(
+        submit_sft, required=False,
+        help="Project id carrying input/results (default: your own project named 'default').")
+    submit_sft.add_argument("--config", default=None,
+                            help="Run config (default: ./grid-train.toml)")
+    submit_sft.add_argument("--data", required=True,
+                            help="sft.jsonl or a `grid train dataset` output directory")
+    submit_sft.add_argument("--backend", choices=("mlx", "torch"), required=True,
+                            help="Required worker type; explicit so scheduling is deterministic")
+    submit_sft.add_argument("--iters", type=int, default=None,
+                            help="Training iterations (MLX only)")
+    submit_sft.add_argument("--json", action="store_true")
+    submit_sft.set_defaults(handler=cmd_train_submit_sft)
 
     nightly = train_sub.add_parser(
         "nightly", help="One unattended cycle: train, prove it, ship it only if it won"

--- a/cli/train.py
+++ b/cli/train.py
@@ -15,6 +15,7 @@ Verbs:
 from __future__ import annotations
 
 import argparse
+import base64
 import dataclasses
 import json
 from pathlib import Path
@@ -546,6 +547,100 @@ def cmd_train_sft(args: argparse.Namespace) -> int:
     adapter = run_sft(cfg, backend=args.backend, iters=args.iters, run_dir=args.run_dir)
     print(f"Adapter saved: {adapter}")
     print("Next: `grid train run` sharpens it with feedback, or `grid train eval` scores it now.")
+    return 0
+
+
+def cmd_train_submit_sft(args: argparse.Namespace) -> int:
+    """Put one local SFT run on the selected Grid's durable task queue."""
+    import tomli_w
+
+    from remote import relay
+    from train.config import load_config
+    from train.sft import load_examples
+
+    from . import project_arg, remote_task
+
+    args = project_arg.resolve(args)
+
+    config_path = args.config or DEFAULT_CONFIG
+    cfg = load_config(config_path)
+    source = Path(args.data).expanduser()
+    if source.is_dir():
+        candidates = (source / "train" / "sft.jsonl", source / "sft.jsonl")
+        source = next((path for path in candidates if path.is_file()), candidates[0])
+    if not source.is_file():
+        raise SystemExit(f"grid train: no SFT dataset found at {source}")
+    # Validate every row and the existing minimum before sending bytes over the network.
+    load_examples(source)
+    data = source.read_bytes()
+
+    def portable(value):
+        if isinstance(value, tuple):
+            return [portable(item) for item in value]
+        if isinstance(value, dict):
+            return {key: portable(item) for key, item in value.items()}
+        return value
+
+    trainer = dataclasses.asdict(cfg.trainer)
+    # The explicit task run-dir is authoritative and inside the result worktree.
+    trainer["output_dir"] = ""
+    portable_config = {
+        "model": {"name": cfg.model_name},
+        "rollout": portable(dataclasses.asdict(cfg.rollout)),
+        "data": {
+            "prompts_jsonl": "grid-train-input/prompts.jsonl",
+            "verifiers_env": "",
+            "verifiers_env_args": {},
+            "learn_from_teachers": cfg.data.learn_from_teachers,
+        },
+        # ``load_config`` requires a rewards path for the shared SFT/RL schema. SFT never imports
+        # it; keep the portable file inert rather than uploading arbitrary local Python.
+        "rewards": {"python_file": "grid-train-input/rewards.py"},
+        "trainer": trainer,
+        "deploy": portable(dataclasses.asdict(cfg.deploy)),
+    }
+    config_bytes = tomli_w.dumps(portable_config).encode("utf-8")
+    reward_stub = b"# SFT does not execute reward functions.\n"
+    files = [
+        {"path": "grid-train-input/grid-train.toml",
+         "content_b64": base64.b64encode(config_bytes).decode("ascii")},
+        {"path": "grid-train-input/sft.jsonl",
+         "content_b64": base64.b64encode(data).decode("ascii")},
+        {"path": "grid-train-input/rewards.py",
+         "content_b64": base64.b64encode(reward_stub).decode("ascii")},
+    ]
+    total = len(config_bytes) + len(data) + len(reward_stub)
+    if max(len(data), len(config_bytes), len(reward_stub)) > remote_task.MAX_FILE_BYTES:
+        raise SystemExit(
+            f"grid train: each submitted file must be at most {remote_task.MAX_FILE_BYTES} bytes")
+    if total > remote_task.MAX_TOTAL_BYTES:
+        raise SystemExit(
+            f"grid train: submitted files total {total} bytes; limit is "
+            f"{remote_task.MAX_TOTAL_BYTES}")
+
+    base, token, label = remote_task._resolve(args)
+    project_id = remote_task._resolve_project(base, token, args.project)
+    spec = {
+        "version": 1, "backend": args.backend,
+        "config": "grid-train-input/grid-train.toml", "run_dir": "grid-train-result",
+    }
+    if args.iters is not None:
+        if args.backend != "mlx":
+            raise SystemExit("grid train: --iters only applies to --backend mlx")
+        if args.iters < 1 or args.iters > 10_000_000:
+            raise SystemExit("grid train: --iters must be 1-10000000")
+        spec["iters"] = args.iters
+    job = relay.create_train_job(
+        base, token, project_id=project_id, spec=spec, files=files)
+    if not isinstance(job, dict) or job.get("project_id") != project_id:
+        raise SystemExit("grid train: the relay did not confirm the requested project")
+    if args.json:
+        print(json.dumps(job, indent=2))
+        return 0
+    task_id = job.get("id")
+    print(f"SFT job queued on {label}: {task_id}")
+    print(f"  grid task follow {task_id} --grid {label}")
+    print(f"  grid task fetch {task_id} --grid {label} --out grid-train-result")
     return 0
 
 

--- a/cli/train.py
+++ b/cli/train.py
@@ -620,9 +620,20 @@ def cmd_train_submit_sft(args: argparse.Namespace) -> int:
 
     base, token, label = remote_task._resolve(args)
     project_id = remote_task._resolve_project(base, token, args.project)
+    timeout_hours = getattr(args, "timeout_hours", 24)
+    queue_timeout_hours = getattr(args, "queue_timeout_hours", 168)
+    if not 1 <= timeout_hours <= 168:
+        raise SystemExit("grid train: --timeout-hours must be 1-168")
+    if not 1 <= queue_timeout_hours <= 720:
+        raise SystemExit("grid train: --queue-timeout-hours must be 1-720")
+    if queue_timeout_hours <= timeout_hours:
+        raise SystemExit(
+            "grid train: --queue-timeout-hours must be greater than --timeout-hours")
     spec = {
         "version": 1, "backend": args.backend,
         "config": "grid-train-input/grid-train.toml", "run_dir": "grid-train-result",
+        "run_timeout_seconds": timeout_hours * 3600,
+        "queue_timeout_seconds": queue_timeout_hours * 3600,
     }
     if args.iters is not None:
         if args.backend != "mlx":
@@ -640,7 +651,26 @@ def cmd_train_submit_sft(args: argparse.Namespace) -> int:
     task_id = job.get("id")
     print(f"SFT job queued on {label}: {task_id}")
     print(f"  grid task follow {task_id} --grid {label}")
-    print(f"  grid task fetch {task_id} --grid {label} --out grid-train-result")
+    print(f"  grid task fetch {task_id} --grid {label} --into grid-train-result")
+    print("  grid train verify-result grid-train-result/grid-train-result")
+    return 0
+
+
+def cmd_train_verify_result(args: argparse.Namespace) -> int:
+    """Verify the checksums and structure of a fetched distributed SFT result."""
+    from remote.train_worker import verify_result
+
+    try:
+        result = verify_result(Path(args.path))
+    except ValueError as exc:
+        raise SystemExit(f"grid train: {exc}") from None
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(f"Verified {args.path}")
+        print(f"  {result['backend']} adapter · {len(result['files'])} file(s) · "
+              f"{result['total_bytes']} bytes")
+        print(f"  base model: {result.get('model') or 'not recorded'}")
     return 0
 
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -711,7 +711,9 @@ grid train benchmark --suite <file> --model <model> --run-dir <dir> [--grid <nam
 
 grid train sft [--backend auto|mlx|torch] [--iters <n>] [--run-dir <dir>] [--config <path>]
 grid train submit-sft --data <sft.jsonl|dataset-dir> --backend mlx|torch
-                      [--grid <name>] [--project <id>] [--config <path>] [--iters <n>] [--json]
+                      [--grid <name>] [--project <id>] [--config <path>] [--iters <n>]
+                      [--timeout-hours <1..168>] [--queue-timeout-hours <1..720>] [--json]
+grid train verify-result <fetched-result-dir> [--json]
 grid train run [--config <path>]                  # the feedback loop (GRPO via TRL)
 grid train eval --run <dir> --candidate <name> [--adapter <dir>] [--base <name>] [--config <path>]
 grid train deploy --adapter <dir> [--gate] [--run <dir>] [--node <url>]... [--name <n>] [--config <path>]
@@ -797,19 +799,25 @@ GRID_TASK_AGENT_KINDS=codex,train-mlx grid join forge --tasks-only --respawn
 grid train submit-sft --grid forge --project <project-id> \
   --config grid-train.toml --data ./forge-goals --backend mlx
 grid task follow <task-id> --grid forge
-grid task fetch <task-id> --grid forge --out ./trained-result
+grid task fetch <task-id> --grid forge --into ./trained-result
+grid train verify-result ./trained-result/grid-train-result
 ```
 
 Use `train-torch`/`--backend torch` on CUDA or other torch training machines. Install `grid[train]`
 on a training worker; it advertises no training capacity unless every dependency for its backend
 is present. The backend is explicit, so the relay never guesses from a machine name.
 
-For runs longer than the one-hour task default, raise both sides deliberately: set
-`TASK_DEADLINE_SECONDS` on the self-hosted relay (and keep `TASK_QUEUE_DEADLINE_SECONDS` larger),
-then set the matching `GRID_TASK_TIMEOUT_SECONDS` on training workers. For example, a 24-hour run
-uses `86400`, with a relay queue deadline greater than `86400`. If the base model is not already
-cached, pass its registry credential explicitly with `GRID_TASK_ENV_PASSTHROUGH=HF_TOKEN`; normal
-worker environments do not leak ambient credentials into tasks.
+Training jobs do not inherit the ordinary one-hour agent-task clock. The defaults are 24 hours to
+run after a trainer claims the job and seven days to wait for compatible capacity. Override them
+per job with `--timeout-hours` and `--queue-timeout-hours`; the relay and worker validate the same
+bounded values, and the queue clock must be larger. If the base model is not already cached, pass
+its registry credential explicitly with `GRID_TASK_ENV_PASSTHROUGH=HF_TOKEN`; normal worker
+environments do not leak ambient credentials into tasks.
+
+A trainer exit is not success by itself. The worker requires a non-empty adapter plus a valid
+`run.json`, rewrites worker-local paths to portable relative paths, and writes `manifest.json` with
+the size and SHA-256 of every adapter file. `grid train verify-result` rechecks that manifest after
+fetch and refuses missing, added, symlinked or changed files.
 
 This is node scheduling and failover, not cross-machine DDP: one node owns the trainer for one job.
 If that node disappears, the task lease is reclaimed and another compatible node starts from the

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -710,6 +710,8 @@ grid train benchmark --suite <file> --model <model> --run-dir <dir> [--grid <nam
                      [--repeat <n>] [--min-pass-rate <0..1>] [--no-wait]
 
 grid train sft [--backend auto|mlx|torch] [--iters <n>] [--run-dir <dir>] [--config <path>]
+grid train submit-sft --data <sft.jsonl|dataset-dir> --backend mlx|torch
+                      [--grid <name>] [--project <id>] [--config <path>] [--iters <n>] [--json]
 grid train run [--config <path>]                  # the feedback loop (GRPO via TRL)
 grid train eval --run <dir> --candidate <name> [--adapter <dir>] [--base <name>] [--config <path>]
 grid train deploy --adapter <dir> [--gate] [--run <dir>] [--node <url>]... [--name <n>] [--config <path>]
@@ -780,6 +782,41 @@ Use disposable projects because benchmark agents really act; a held-out test mus
 production repository or call a production write tool.
 
 See [`fixtures/goal-benchmark-suite.json`](fixtures/goal-benchmark-suite.json) for the file shape.
+
+### Run SFT on the Grid
+
+`grid train submit-sft` schedules one complete SFT run on a compatible company machine. It reuses
+the existing durable task queue instead of creating a training scheduler: the config and dataset
+are committed to the selected project's Git history, a worker advertising exactly `train-mlx` or
+`train-torch` claims it, and the adapter/result directory is pushed back as the task result.
+
+```bash
+# Relay first, then enable compatible workers. Training is opt-in and is never in the default list.
+GRID_TASK_AGENT_KINDS=codex,train-mlx grid join forge --tasks-only --respawn
+
+grid train submit-sft --grid forge --project <project-id> \
+  --config grid-train.toml --data ./forge-goals --backend mlx
+grid task follow <task-id> --grid forge
+grid task fetch <task-id> --grid forge --out ./trained-result
+```
+
+Use `train-torch`/`--backend torch` on CUDA or other torch training machines. Install `grid[train]`
+on a training worker; it advertises no training capacity unless every dependency for its backend
+is present. The backend is explicit, so the relay never guesses from a machine name.
+
+For runs longer than the one-hour task default, raise both sides deliberately: set
+`TASK_DEADLINE_SECONDS` on the self-hosted relay (and keep `TASK_QUEUE_DEADLINE_SECONDS` larger),
+then set the matching `GRID_TASK_TIMEOUT_SECONDS` on training workers. For example, a 24-hour run
+uses `86400`, with a relay queue deadline greater than `86400`. If the base model is not already
+cached, pass its registry credential explicitly with `GRID_TASK_ENV_PASSTHROUGH=HF_TOKEN`; normal
+worker environments do not leak ambient credentials into tasks.
+
+This is node scheduling and failover, not cross-machine DDP: one node owns the trainer for one job.
+If that node disappears, the task lease is reclaimed and another compatible node starts from the
+same immutable input. Version 1 restarts that training attempt rather than resuming an optimizer
+checkpoint. Data and adapters cross only the selected Grid's self-hosted relay/project Git plane;
+project membership remains the authorization boundary. Deploy the Train-aware relay before
+enabling Train-aware workers.
 
 - **`grid train sft`** is imitation: it learns from the answers your team already wrote and needs
   nothing but the machine in front of you. `--backend auto` picks MLX on Apple Silicon and torch

--- a/remote/relay.py
+++ b/remote/relay.py
@@ -1080,6 +1080,24 @@ def create_task(
     return task
 
 
+def create_train_job(
+    signaling_url: str,
+    access_token: str,
+    *,
+    project_id: str,
+    spec: dict[str, Any],
+    files: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Submit a typed SFT task to a Goal/Train-aware relay."""
+    return _task_oneshot(
+        signaling_url, access_token, "POST", "/relay/v1/train/jobs",
+        json={"project_id": project_id, "spec": spec, "files": files},
+        missing_route_hint=(
+            "This grid's relay does not support Grid Train jobs yet. Upgrade the relay before "
+            "enabling train-mlx or train-torch workers."),
+    )
+
+
 # Every Goal endpoint arrived as one relay feature. A CLI ahead of its relay therefore gets
 # FastAPI's bare framework 404 from any of them. "Not Found" is especially misleading for status,
 # evidence and control: it sounds as if the Goal id is wrong, when the server has never heard of a

--- a/remote/task_agent.py
+++ b/remote/task_agent.py
@@ -845,7 +845,8 @@ def claude_available() -> bool:
 def _configured_task_harnesses() -> tuple[str, ...]:
     configured = (os.getenv("GRID_TASK_AGENT_KINDS") or "claude,codex").replace(",", " ").split()
     return tuple(dict.fromkeys(
-        kind for kind in configured if kind in ("claude", "codex")))
+        kind for kind in configured
+        if kind in ("claude", "codex", "train-mlx", "train-torch")))
 
 
 def preflight_before_serving() -> None:
@@ -853,8 +854,8 @@ def preflight_before_serving() -> None:
 
     A task-only node is agent capacity, not specifically Claude capacity.  Codex-only company
     machines are valid Grid workers, so a missing Claude binary must not reject one that can run
-    Codex's native Goal harness.  Conversely, merely having one of the two names configured is not
-    enough: the provider may advertise only a harness whose real binary and safety checks pass.
+    Codex's native Goal harness or a local trainer. Conversely, merely configuring a name is not
+    enough: the provider advertises only a worker whose real binary/dependency checks pass.
 
     Claude uses the same `preflight`/`resolve_binary`/sandbox-package checks as its claim path.
     Codex uses `task_codex.resolve_binary`, including the measured native-Goal protocol probe.  The
@@ -867,7 +868,8 @@ def preflight_before_serving() -> None:
     configured = _configured_task_harnesses()
     if not configured:
         raise RuntimeError(
-            "GRID_TASK_AGENT_KINDS enables no supported task harness; choose codex, claude, or both")
+            "GRID_TASK_AGENT_KINDS enables no supported task harness; choose claude, codex, "
+            "train-mlx and/or train-torch")
 
     failures: list[str] = []
     causes: list[BaseException] = []
@@ -893,6 +895,21 @@ def preflight_before_serving() -> None:
         except (Exception, SystemExit) as exc:
             failures.append(f"codex: {str(exc) or exc.__class__.__name__}")
             causes.append(exc)
+
+    if not usable:
+        # Imported here so normal task startup never imports optional training libraries.
+        from . import train_worker
+
+        for kind in ("train-mlx", "train-torch"):
+            if kind not in configured:
+                continue
+            try:
+                train_worker.preflight(kind)
+                usable = True
+                break
+            except (Exception, SystemExit) as exc:
+                failures.append(f"{kind}: {str(exc) or exc.__class__.__name__}")
+                causes.append(exc)
 
     if usable:
         # This is shared infrastructure, not a harness opinion. Ask once after at least one harness

--- a/remote/tasks.py
+++ b/remote/tasks.py
@@ -1035,6 +1035,7 @@ def run_task(job: dict[str, Any],
 
     if agent_kind.startswith("train-"):
         try:
+            timeout = train_worker.timeout(job, workspace)
             argv = train_worker.command(job, workspace)
             _returncode, raw = _run_child(
                 argv, timeout=timeout, publish=sink, cwd=str(workspace),
@@ -1049,7 +1050,13 @@ def run_task(job: dict[str, Any],
             return failed(f"training exited {exc.returncode}: {exc.stderr[-500:].strip()}")
         except (Exception, SystemExit) as exc:
             return failed(f"could not run training: {exc}")
+        try:
+            manifest = train_worker.finalize_result(job, workspace)
+        except (Exception, SystemExit) as exc:
+            return failed(f"training produced no usable adapter: {exc}")
         output = raw.strip() or f"{agent_kind.removeprefix('train-')} SFT complete"
+        output += (f"\nVerified adapter: {manifest['total_bytes']} bytes across "
+                   f"{len(manifest['files'])} file(s); manifest.json written")
         return TaskOutcome("completed", output[-_TASK_OUTPUT_MAX_CHARS:], None)
 
     if agent_kind == "codex":

--- a/remote/tasks.py
+++ b/remote/tasks.py
@@ -34,7 +34,7 @@ from dataclasses import dataclass, replace
 from typing import Any, Callable
 
 from . import (relay, task_agent, task_capacity, task_codex, task_codex_proxy, task_evict,
-               task_repo, task_stream)
+               task_repo, task_stream, train_worker)
 from shared.runtime_identity import grid_runtime_identity
 
 # Queue sentinels. Plain `object()`s rather than None or "" — a task's output legitimately contains
@@ -330,21 +330,24 @@ def decline_claim_once(serve_state: Any, task_id: str, *, attempt: int,
 def _configured_agent_kinds() -> tuple[str, ...]:
     """Supported harnesses the operator enabled, independent of temporary binary availability."""
     configured = (os.getenv("GRID_TASK_AGENT_KINDS") or "claude,codex").replace(",", " ").split()
-    allowed = {kind for kind in configured if kind in ("claude", "codex")}
-    invalid = [kind for kind in configured if kind not in ("claude", "codex")]
+    supported = ("claude", "codex", "train-mlx", "train-torch")
+    allowed = {kind for kind in configured if kind in supported}
+    invalid = [kind for kind in configured if kind not in supported]
     for kind in invalid:
         _warn(f"ignoring unsupported harness {kind!r} in GRID_TASK_AGENT_KINDS")
     # Empty or wholly invalid is fail closed: this provider claims no tasks instead of running a
     # harness its operator meant to disable.
-    return tuple(kind for kind in ("claude", "codex") if kind in allowed)
+    return tuple(kind for kind in supported if kind in allowed)
 
 
 def _agent_kinds() -> tuple[str, ...]:
-    """Harnesses this process can really execute; never advertise either one optimistically."""
+    """Workers this process can really execute; never advertise one optimistically."""
     configured = _configured_agent_kinds()
     kinds = ["claude"] if "claude" in configured and task_agent.claude_available() else []
     if "codex" in configured and task_codex.available():
         kinds.append("codex")
+    kinds.extend(kind for kind in ("train-mlx", "train-torch")
+                 if kind in configured and train_worker.available(kind))
     return tuple(kinds)
 
 
@@ -406,6 +409,9 @@ def _agent_profiles() -> tuple[dict[str, Any], ...]:
                                    | _declared_capabilities("GRID_CODEX_GOAL_CAPABILITIES")),
             "version": task_codex.distributed_goal_version(),
         })
+    for kind in ("train-mlx", "train-torch"):
+        if kind in kinds:
+            profiles.append({"kind": kind, "capabilities": ["sft"]})
     return tuple(profiles)
 
 
@@ -433,10 +439,9 @@ def has_non_claude_claim_capacity() -> bool:
     """Whether this process can keep claiming while Claude's subscription is paused.
 
     Kept beside the actual profile builder so heartbeat telemetry cannot invent a second admission
-    rule. Today Codex is the independent harness; future harnesses can extend this predicate when
-    they have their own capacity signal.
+    rule. Codex and local trainers have capacity independent of Claude's subscription.
     """
-    return any(profile.get("kind") == "codex" for profile in _agent_profiles())
+    return any(profile.get("kind") != "claude" for profile in _agent_profiles())
 
 
 def _claim_supported_now(job: dict[str, Any]) -> bool:
@@ -853,7 +858,7 @@ def run_task(job: dict[str, Any],
         return failed(f"task has no usable prompt (got {type(prompt).__name__})")
 
     agent_kind = str(job.get("agent_kind") or "claude")
-    if agent_kind not in ("claude", "codex"):
+    if agent_kind not in ("claude", "codex", "train-mlx", "train-torch"):
         return failed(f"the relay requested unsupported agent kind {agent_kind!r}")
     goal = job.get("goal")
     is_claude_goal = agent_kind == "claude" and isinstance(goal, dict)
@@ -918,8 +923,12 @@ def run_task(job: dict[str, Any],
         task_evict.touch(workspace)
         # Resolved HERE rather than with the argv below, which is now built after the checkout: a
         # provider with no Claude Code installed must fail before it fetches anything, not after.
-        binary = (task_codex.resolve_binary() if agent_kind == "codex"
-                  else task_agent.resolve_binary())
+        if agent_kind.startswith("train-"):
+            train_worker.preflight(agent_kind)
+            binary = ""
+        else:
+            binary = (task_codex.resolve_binary() if agent_kind == "codex"
+                      else task_agent.resolve_binary())
         if is_claude_goal:
             # Recheck after the claim as well as in the advertised profile. A binary can be
             # downgraded, replaced or runtime-quarantined while another worker's long poll is open;
@@ -1023,6 +1032,25 @@ def run_task(job: dict[str, Any],
             raise
         except (Exception, SystemExit) as exc:
             return failed(f"could not prepare the task's workspace: {exc}")
+
+    if agent_kind.startswith("train-"):
+        try:
+            argv = train_worker.command(job, workspace)
+            _returncode, raw = _run_child(
+                argv, timeout=timeout, publish=sink, cwd=str(workspace),
+                env=task_agent.child_env(
+                    author=task_repo.identity_or_default(
+                        job.get("author_name"), job.get("author_email")),
+                    workspace=workspace),
+                on_spawn=on_spawn)
+        except subprocess.TimeoutExpired:
+            return failed(f"training timed out after {timeout:.0f}s")
+        except _ChildFailed as exc:
+            return failed(f"training exited {exc.returncode}: {exc.stderr[-500:].strip()}")
+        except (Exception, SystemExit) as exc:
+            return failed(f"could not run training: {exc}")
+        output = raw.strip() or f"{agent_kind.removeprefix('train-')} SFT complete"
+        return TaskOutcome("completed", output[-_TASK_OUTPUT_MAX_CHARS:], None)
 
     if agent_kind == "codex":
         if inference is None:
@@ -1338,7 +1366,7 @@ def task_loop(state: Any, capacity: Any = None) -> None:
     `capacity` is this provider's reading of its own Claude subscription (issue 09), consulted before
     every claim. It defaults to the PROCESS-wide gate, which is what makes several Claude workers
     throttle on one reading of the one subscription they all spend. A mixed worker continues to
-    advertise Codex-only capacity because Codex uses Grid inference rather than that Claude window.
+    advertise non-Claude capacity because Codex and local trainers do not spend that Claude window.
     Withdrawing a harness is simply not advertising it at claim time: the queue waits for a provider
     that can run it.
     """
@@ -1349,7 +1377,7 @@ def task_loop(state: Any, capacity: Any = None) -> None:
         # configured harness whose binary is temporarily unavailable takes the recoverable suspend
         # path below instead, so installing/replacing it does not require an inference restart.
         _warn("task serving retired because GRID_TASK_AGENT_KINDS enables no supported harness; "
-              "choose codex, claude, or both (inference is unaffected)")
+              "choose claude, codex, train-mlx and/or train-torch (inference is unaffected)")
         state.tasks_stop.set()
         return
     # Two counters, not one: a provider alternating between a missing plane and a refusal would
@@ -1362,17 +1390,18 @@ def task_loop(state: Any, capacity: Any = None) -> None:
         excluded_agent_kinds: tuple[str, ...] = ()
         if pause > 0:
             # This signal belongs to Claude's subscription, not to the provider process and not to
-            # Codex. A mixed worker keeps offering its independent Codex harness instead of turning
-            # a vendor-specific refusal into fleet-wide Goal withdrawal.
-            codex_configured = "codex" in _configured_agent_kinds()
-            codex_available = codex_configured and any(
-                profile.get("kind") == "codex" for profile in _agent_profiles())
-            if not codex_available:
+            # Codex or local trainers. A mixed worker keeps offering independent capacity instead
+            # of turning a vendor-specific refusal into fleet-wide withdrawal.
+            configured_independent = {
+                kind for kind in _configured_agent_kinds() if kind != "claude"}
+            independent_available = any(
+                profile.get("kind") != "claude" for profile in _agent_profiles())
+            if not independent_available:
                 # Waiting on `tasks_stop` rather than sleeping, so teardown does not have to sit out
-                # the window. A Claude-only policy can wait for the vendor's exact reset. When Codex
-                # is configured but temporarily absent/quarantined, recheck locally at the ordinary
-                # claim backoff so installing or replacing it does not wait out a five-hour window.
-                wait = min(pause, _CLAIM_BACKOFF_SECONDS) if codex_configured else pause
+                # the window. A Claude-only policy can wait for the vendor's exact reset. When an
+                # independent worker is configured but temporarily absent, recheck locally at the
+                # ordinary claim backoff so installing it does not wait out a five-hour window.
+                wait = min(pause, _CLAIM_BACKOFF_SECONDS) if configured_independent else pause
                 state.tasks_stop.wait(wait)
                 continue
             excluded_agent_kinds = ("claude",)

--- a/remote/train_worker.py
+++ b/remote/train_worker.py
@@ -1,0 +1,92 @@
+"""Capability probe and argv construction for durable local SFT task workers.
+
+Training is a typed task, not an agent prompt. The relay authors a small JSON spec; the provider
+validates it again and invokes Grid's installed trainer without a shell. Input data and result
+adapters travel through the task worktree, while model caches stay local to the node.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import platform
+import sys
+from pathlib import Path
+from typing import Any
+
+BACKENDS = {"train-mlx": "mlx", "train-torch": "torch"}
+_TORCH_MODULES = ("torch", "transformers", "trl", "peft", "datasets")
+_MAX_ITERS = 10_000_000
+
+
+def available(agent_kind: str) -> bool:
+    """Whether this interpreter can execute the advertised training backend."""
+    backend = BACKENDS.get(agent_kind)
+    if backend == "mlx":
+        return (platform.system() == "Darwin" and platform.machine() == "arm64"
+                and importlib.util.find_spec("mlx_lm") is not None)
+    if backend == "torch":
+        return all(importlib.util.find_spec(name) is not None for name in _TORCH_MODULES)
+    return False
+
+
+def preflight(agent_kind: str) -> None:
+    """Fail with one actionable sentence before this worker advertises capacity."""
+    if agent_kind not in BACKENDS:
+        raise RuntimeError(f"unsupported training worker {agent_kind!r}")
+    if available(agent_kind):
+        return
+    if agent_kind == "train-mlx":
+        raise RuntimeError("train-mlx needs Apple Silicon and mlx-lm (install `grid[train]`)")
+    raise RuntimeError(
+        "train-torch needs torch, transformers, trl, peft and datasets "
+        "(install `grid[train]`)")
+
+
+def command(job: dict[str, Any], workspace: Path) -> list[str]:
+    """Return a shell-free command after validating the relay-authored spec and its paths."""
+    kind = str(job.get("agent_kind") or "")
+    backend = BACKENDS.get(kind)
+    if job.get("kind") != "train.sft" or backend is None:
+        raise ValueError("training workers only accept train.sft jobs for their exact backend")
+    try:
+        spec = json.loads(str(job.get("prompt") or ""))
+    except (TypeError, ValueError) as exc:
+        raise ValueError("training job has a malformed JSON spec") from exc
+    if not isinstance(spec, dict) or set(spec) - {
+            "version", "backend", "config", "run_dir", "iters"}:
+        raise ValueError("training job spec has unknown fields or is not an object")
+    if spec.get("version") != 1 or spec.get("backend") != backend:
+        raise ValueError("training job spec version or backend does not match its worker")
+
+    config = _inside(workspace, spec.get("config", "grid-train-input/grid-train.toml"))
+    run_dir = _inside(workspace, spec.get("run_dir", "grid-train-result"))
+    if not config.is_file():
+        raise ValueError(f"training config is missing: {config.relative_to(workspace)}")
+    iters = spec.get("iters")
+    if (iters is not None and (not isinstance(iters, int) or isinstance(iters, bool)
+                              or not 1 <= iters <= _MAX_ITERS)):
+        raise ValueError(f"training iters must be 1-{_MAX_ITERS}")
+    if iters is not None and backend != "mlx":
+        raise ValueError("training iters only applies to the mlx backend")
+
+    # -I keeps the checked-out project from shadowing Grid's installed ``cli`` package.
+    argv = [
+        sys.executable, "-I", "-m", "cli", "train", "sft",
+        "--config", str(config), "--backend", backend, "--run-dir", str(run_dir),
+    ]
+    if iters is not None:
+        argv += ["--iters", str(iters)]
+    return argv
+
+
+def _inside(workspace: Path, value: object) -> Path:
+    if not isinstance(value, str) or not value or value.startswith(("/", ".")):
+        raise ValueError("training paths must be safe relative paths")
+    parts = Path(value).parts
+    if ".." in parts:
+        raise ValueError("training paths must stay inside the task workspace")
+    root = workspace.resolve()
+    answer = (root / value).resolve()
+    if answer != root and root not in answer.parents:
+        raise ValueError("training paths must stay inside the task workspace")
+    return answer

--- a/remote/train_worker.py
+++ b/remote/train_worker.py
@@ -7,15 +7,21 @@ adapters travel through the task worktree, while model caches stay local to the 
 from __future__ import annotations
 
 import importlib.util
+import hashlib
 import json
 import platform
 import sys
+import tomllib
 from pathlib import Path
 from typing import Any
 
 BACKENDS = {"train-mlx": "mlx", "train-torch": "torch"}
 _TORCH_MODULES = ("torch", "transformers", "trl", "peft", "datasets")
 _MAX_ITERS = 10_000_000
+MIN_RUN_TIMEOUT_SECONDS = 3_600
+MAX_RUN_TIMEOUT_SECONDS = 7 * 24 * 3_600
+MIN_QUEUE_TIMEOUT_SECONDS = 3_600
+MAX_QUEUE_TIMEOUT_SECONDS = 30 * 24 * 3_600
 
 
 def available(agent_kind: str) -> bool:
@@ -42,8 +48,8 @@ def preflight(agent_kind: str) -> None:
         "(install `grid[train]`)")
 
 
-def command(job: dict[str, Any], workspace: Path) -> list[str]:
-    """Return a shell-free command after validating the relay-authored spec and its paths."""
+def spec(job: dict[str, Any], workspace: Path) -> dict[str, Any]:
+    """Validate one relay-authored training spec and resolve its confined paths."""
     kind = str(job.get("agent_kind") or "")
     backend = BACKENDS.get(kind)
     if job.get("kind") != "train.sft" or backend is None:
@@ -53,7 +59,8 @@ def command(job: dict[str, Any], workspace: Path) -> list[str]:
     except (TypeError, ValueError) as exc:
         raise ValueError("training job has a malformed JSON spec") from exc
     if not isinstance(spec, dict) or set(spec) - {
-            "version", "backend", "config", "run_dir", "iters"}:
+            "version", "backend", "config", "run_dir", "iters",
+            "run_timeout_seconds", "queue_timeout_seconds"}:
         raise ValueError("training job spec has unknown fields or is not an object")
     if spec.get("version") != 1 or spec.get("backend") != backend:
         raise ValueError("training job spec version or backend does not match its worker")
@@ -69,6 +76,31 @@ def command(job: dict[str, Any], workspace: Path) -> list[str]:
     if iters is not None and backend != "mlx":
         raise ValueError("training iters only applies to the mlx backend")
 
+    run_timeout = _bounded_seconds(
+        spec.get("run_timeout_seconds", 24 * 3_600),
+        "run timeout", MIN_RUN_TIMEOUT_SECONDS, MAX_RUN_TIMEOUT_SECONDS)
+    queue_timeout = _bounded_seconds(
+        spec.get("queue_timeout_seconds", 7 * 24 * 3_600),
+        "queue timeout", MIN_QUEUE_TIMEOUT_SECONDS, MAX_QUEUE_TIMEOUT_SECONDS)
+    if queue_timeout <= run_timeout:
+        raise ValueError("training queue timeout must be greater than its run timeout")
+    claimed_timeout = job.get("run_timeout_seconds")
+    if claimed_timeout is not None and claimed_timeout != run_timeout:
+        raise ValueError("training run timeout does not match the relay claim")
+    return {
+        **spec, "backend": backend, "config_path": config, "run_dir_path": run_dir,
+        "run_timeout_seconds": run_timeout, "queue_timeout_seconds": queue_timeout,
+    }
+
+
+def command(job: dict[str, Any], workspace: Path) -> list[str]:
+    """Return a shell-free command after validating the relay-authored spec and its paths."""
+    parsed = spec(job, workspace)
+    backend = parsed["backend"]
+    config = parsed["config_path"]
+    run_dir = parsed["run_dir_path"]
+    iters = parsed.get("iters")
+
     # -I keeps the checked-out project from shadowing Grid's installed ``cli`` package.
     argv = [
         sys.executable, "-I", "-m", "cli", "train", "sft",
@@ -77,6 +109,164 @@ def command(job: dict[str, Any], workspace: Path) -> list[str]:
     if iters is not None:
         argv += ["--iters", str(iters)]
     return argv
+
+
+def timeout(job: dict[str, Any], workspace: Path) -> float:
+    """The relay-authorized wall-clock budget for this exact training job."""
+    return float(spec(job, workspace)["run_timeout_seconds"])
+
+
+def finalize_result(job: dict[str, Any], workspace: Path) -> dict[str, Any]:
+    """Refuse false success and write a portable, checksummed adapter manifest."""
+    parsed = spec(job, workspace)
+    run_dir = parsed["run_dir_path"]
+    adapter = run_dir / "adapter"
+    run_file = run_dir / "run.json"
+    if run_dir.is_symlink() or not run_dir.is_dir():
+        raise ValueError("training completed without its result directory")
+    if adapter.is_symlink() or not adapter.is_dir():
+        raise ValueError("training completed without an adapter directory")
+    try:
+        run = json.loads(run_file.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, ValueError) as exc:
+        raise ValueError("training completed without a valid run.json") from exc
+    if not isinstance(run, dict) or run.get("stage") != "sft":
+        raise ValueError("training run.json does not describe an SFT run")
+    if run.get("backend") != parsed["backend"]:
+        raise ValueError("training result backend does not match the claimed worker")
+    try:
+        configured = tomllib.loads(parsed["config_path"].read_text(encoding="utf-8"))
+        expected_model = configured["model"]["name"]
+    except (KeyError, OSError, UnicodeDecodeError, tomllib.TOMLDecodeError, TypeError) as exc:
+        raise ValueError("training input has no valid base model") from exc
+    if not isinstance(expected_model, str) or not expected_model or run.get("model") != expected_model:
+        raise ValueError("training result model does not match its immutable config")
+
+    files = []
+    for path in sorted(adapter.rglob("*")):
+        if path.is_symlink():
+            raise ValueError("training adapter contains a symbolic link")
+        if not path.is_file():
+            continue
+        digest = hashlib.sha256()
+        size = 0
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                size += len(chunk)
+                digest.update(chunk)
+        files.append({
+            "path": path.relative_to(run_dir).as_posix(),
+            "bytes": size,
+            "sha256": digest.hexdigest(),
+        })
+    if not files:
+        raise ValueError("training completed with an empty adapter directory")
+
+    # A worker's absolute task path is meaningless after `grid task fetch`. Keep the existing
+    # run record useful by making the adapter location relative to that record.
+    run["adapter"] = "adapter"
+    run_file.write_text(json.dumps(run, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    manifest = {
+        "version": 1,
+        "kind": "train.sft",
+        "backend": parsed["backend"],
+        "model": expected_model,
+        "adapter": "adapter",
+        "run": "run.json",
+        "files": files,
+        "total_bytes": sum(item["bytes"] for item in files),
+    }
+    (run_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return manifest
+
+
+def verify_result(path: Path) -> dict[str, Any]:
+    """Verify a fetched distributed-training result against its portable manifest."""
+    supplied = path.expanduser()
+    if supplied.is_symlink() or not supplied.is_dir():
+        raise ValueError(f"training result is missing or unsafe: {supplied}")
+    root = supplied.resolve()
+    manifest_path = root / "manifest.json"
+    if manifest_path.is_symlink():
+        raise ValueError("training result manifest is unsafe")
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, ValueError) as exc:
+        raise ValueError(f"no valid training manifest at {manifest_path}") from exc
+    if (not isinstance(manifest, dict) or manifest.get("version") != 1
+            or manifest.get("kind") != "train.sft"):
+        raise ValueError("unsupported training result manifest")
+    backend = manifest.get("backend")
+    model = manifest.get("model")
+    if (backend not in BACKENDS.values() or not isinstance(model, str) or not model
+            or manifest.get("adapter") != "adapter" or manifest.get("run") != "run.json"):
+        raise ValueError("training result manifest has invalid run metadata")
+    run_path = root / "run.json"
+    if run_path.is_symlink():
+        raise ValueError("training run record is unsafe")
+    try:
+        run = json.loads(run_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, ValueError) as exc:
+        raise ValueError("training result has no valid run.json") from exc
+    if (not isinstance(run, dict) or run.get("stage") != "sft"
+            or run.get("backend") != backend or run.get("model") != model
+            or run.get("adapter") != "adapter"):
+        raise ValueError("training run record does not match its manifest")
+    adapter_root = root / "adapter"
+    if adapter_root.is_symlink() or not adapter_root.is_dir():
+        raise ValueError("training adapter directory is missing or unsafe")
+    expected = manifest.get("files")
+    if not isinstance(expected, list) or not expected:
+        raise ValueError("training result manifest lists no adapter files")
+    seen: set[str] = set()
+    total = 0
+    for item in expected:
+        if not isinstance(item, dict) or set(item) != {"path", "bytes", "sha256"}:
+            raise ValueError("training result manifest has a malformed file record")
+        relative = item["path"]
+        expected_bytes = item["bytes"]
+        expected_digest = item["sha256"]
+        if (not isinstance(relative, str) or not relative.startswith("adapter/")
+                or relative in seen):
+            raise ValueError("training result manifest has an unsafe or duplicate adapter path")
+        if (not isinstance(expected_bytes, int) or isinstance(expected_bytes, bool)
+                or expected_bytes < 0 or not isinstance(expected_digest, str)
+                or len(expected_digest) != 64
+                or any(character not in "0123456789abcdef" for character in expected_digest)):
+            raise ValueError("training result manifest has a malformed file record")
+        seen.add(relative)
+        artifact = _inside(root, relative)
+        if artifact.is_symlink() or not artifact.is_file():
+            raise ValueError(f"training adapter file is missing or unsafe: {relative}")
+        digest = hashlib.sha256()
+        size = 0
+        with artifact.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                size += len(chunk)
+                digest.update(chunk)
+        if size != expected_bytes or digest.hexdigest() != expected_digest:
+            raise ValueError(f"training adapter file failed verification: {relative}")
+        total += size
+    actual = {
+        path.relative_to(root).as_posix()
+        for path in adapter_root.rglob("*")
+        if path.is_file() or path.is_symlink()
+    }
+    if actual != seen:
+        raise ValueError("training adapter contains files not covered by its manifest")
+    manifest_total = manifest.get("total_bytes")
+    if (not isinstance(manifest_total, int) or isinstance(manifest_total, bool)
+            or manifest_total != total):
+        raise ValueError("training result manifest total does not match its files")
+    return manifest
+
+
+def _bounded_seconds(value: object, name: str, minimum: int, maximum: int) -> int:
+    if (not isinstance(value, int) or isinstance(value, bool)
+            or not minimum <= value <= maximum):
+        raise ValueError(f"training {name} must be {minimum}-{maximum} seconds")
+    return value
 
 
 def _inside(workspace: Path, value: object) -> Path:

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -37175,6 +37175,8 @@ _BOTH_SPELLINGS: list[tuple[list[str], list[str]]] = [
       "--model", "grid-model"],
      ["goal", "run", "--project", "P1", "--objective", "build", "--done-when",
       "checks pass", "--model", "grid-model"]),
+    (["train", "submit-sft", "P1", "--data", "sft.jsonl", "--backend", "mlx"],
+     ["train", "submit-sft", "--project", "P1", "--data", "sft.jsonl", "--backend", "mlx"]),
 ]
 
 

--- a/tests/test_train_jobs.py
+++ b/tests/test_train_jobs.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import threading
+import tomllib
+from types import SimpleNamespace
+
+import pytest
+
+from cli.train import cmd_train_submit_sft
+from remote import task_agent, tasks, train_worker
+from train.config import SAMPLE
+
+
+def test_train_worker_command_is_shell_free_and_confined(tmp_path):
+    config = tmp_path / "grid-train-input" / "grid-train.toml"
+    config.parent.mkdir()
+    config.write_text("[model]\nname='tiny'\n", encoding="utf-8")
+    job = {
+        "kind": "train.sft", "agent_kind": "train-mlx",
+        "prompt": json.dumps({"version": 1, "backend": "mlx", "iters": 12}),
+    }
+    argv = train_worker.command(job, tmp_path)
+    assert argv[:5] == [train_worker.sys.executable, "-I", "-m", "cli", "train"]
+    assert argv[-2:] == ["--iters", "12"]
+    assert not any(token in argv for token in ("sh", "bash", "-c"))
+
+    job["prompt"] = json.dumps({
+        "version": 1, "backend": "mlx", "run_dir": "../../outside"})
+    with pytest.raises(ValueError, match="inside|relative"):
+        train_worker.command(job, tmp_path)
+
+
+def test_training_profiles_are_opt_in_and_dependency_gated(monkeypatch):
+    monkeypatch.setenv("GRID_TASK_AGENT_KINDS", "train-mlx,train-torch")
+    monkeypatch.setattr(train_worker, "available", lambda kind: kind == "train-torch")
+    assert tasks._agent_profiles() == (
+        {"kind": "train-torch", "capabilities": ["sft"]},)
+    assert tasks.has_non_claude_claim_capacity()
+
+
+def test_claude_rate_limit_does_not_pause_training_worker(monkeypatch):
+    monkeypatch.setenv("GRID_TASK_AGENT_KINDS", "claude,train-torch")
+    monkeypatch.setattr(tasks, "_agent_profiles", lambda: (
+        {"kind": "claude", "capabilities": []},
+        {"kind": "train-torch", "capabilities": ["sft"]},
+    ))
+    state = SimpleNamespace(
+        stop=threading.Event(), tasks_stop=threading.Event(),
+        signaling_url="https://relay", token=lambda: "token",
+        refresh=lambda stale_token=None: False)
+    claims = []
+
+    def claim(_state, *, excluded_agent_kinds=()):
+        claims.append(excluded_agent_kinds)
+        state.tasks_stop.set()
+        return None
+
+    monkeypatch.setattr(tasks, "claim_once", claim)
+    capacity = SimpleNamespace(pause_seconds=lambda: 3600.0)
+    tasks.task_loop(state, capacity=capacity)
+    assert claims == [("claude",)]
+
+
+def test_run_task_executes_typed_trainer_without_agent(monkeypatch, tmp_path):
+    config = tmp_path / "grid-train-input" / "grid-train.toml"
+    config.parent.mkdir()
+    config.write_text("[model]\nname='tiny'\n", encoding="utf-8")
+    monkeypatch.setattr(task_agent, "workspace_for", lambda *_: tmp_path)
+    monkeypatch.setattr(task_agent, "ensure_workspace", lambda path: path)
+    monkeypatch.setattr(task_agent, "ensure_cache", lambda _path: None)
+    monkeypatch.setattr(tasks.task_evict, "touch", lambda _path: None)
+    monkeypatch.setattr(tasks.task_evict, "sweep", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(train_worker, "preflight", lambda _kind: None)
+    monkeypatch.setattr(task_agent, "child_env", lambda **_kwargs: {})
+    spawned = []
+
+    def run(argv, **kwargs):
+        spawned.append((argv, kwargs))
+        return 0, "Adapter saved: grid-train-result/adapter\n"
+
+    monkeypatch.setattr(tasks, "_run_child", run)
+    outcome = tasks.run_task({
+        "task_id": "T1", "project_id": "P1", "member_key": "member",
+        "conversation_id": "C1", "kind": "train.sft", "agent_kind": "train-torch",
+        "prompt": json.dumps({"version": 1, "backend": "torch"}),
+    })
+    assert outcome.state == "completed"
+    assert "Adapter saved" in outcome.output
+    assert spawned[0][0][1:5] == ["-I", "-m", "cli", "train"]
+    assert spawned[0][1]["cwd"] == str(tmp_path)
+
+
+def test_submit_sft_uploads_portable_config_and_data(monkeypatch, tmp_path, capsys):
+    config = tmp_path / "grid-train.toml"
+    config.write_text(SAMPLE.replace(
+        "# prompts_jsonl = \"tasks.jsonl\"", 'prompts_jsonl = "tasks.jsonl"').replace(
+            '# python_file = "rewards.py"', 'python_file = "rewards.py"'),
+        encoding="utf-8")
+    data = tmp_path / "dataset" / "train" / "sft.jsonl"
+    data.parent.mkdir(parents=True)
+    rows = [
+        {"messages": [{"role": "user", "content": f"question {i}"},
+                      {"role": "assistant", "content": f"answer {i}"}]}
+        for i in range(20)
+    ]
+    data.write_text("".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8")
+
+    from cli import remote_task
+    from remote import relay
+
+    monkeypatch.setattr(remote_task, "_resolve", lambda _args: ("https://relay", "token", "forge"))
+    monkeypatch.setattr(remote_task, "_resolve_project", lambda *_args: "project-1")
+    sent = {}
+
+    def create(*args, **kwargs):
+        sent.update(kwargs)
+        return {"id": "job-1", "project_id": "project-1", "state": "queued"}
+
+    monkeypatch.setattr(relay, "create_train_job", create)
+    args = argparse.Namespace(
+        config=str(config), data=str(tmp_path / "dataset"), backend="torch", iters=None,
+        grid="forge", project="project-1", json=False)
+    assert cmd_train_submit_sft(args) == 0
+    assert sent["spec"]["backend"] == "torch"
+    by_path = {
+        item["path"]: base64.b64decode(item["content_b64"])
+        for item in sent["files"]
+    }
+    uploaded = tomllib.loads(by_path["grid-train-input/grid-train.toml"].decode())
+    assert uploaded["data"]["prompts_jsonl"] == "grid-train-input/prompts.jsonl"
+    assert len(by_path["grid-train-input/sft.jsonl"].splitlines()) == 20
+    output = capsys.readouterr().out
+    assert "job-1" in output and "grid task fetch" in output

--- a/tests/test_train_jobs.py
+++ b/tests/test_train_jobs.py
@@ -9,7 +9,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from cli.train import cmd_train_submit_sft
+from cli.train import cmd_train_submit_sft, cmd_train_verify_result
 from remote import task_agent, tasks, train_worker
 from train.config import SAMPLE
 
@@ -26,6 +26,7 @@ def test_train_worker_command_is_shell_free_and_confined(tmp_path):
     assert argv[:5] == [train_worker.sys.executable, "-I", "-m", "cli", "train"]
     assert argv[-2:] == ["--iters", "12"]
     assert not any(token in argv for token in ("sh", "bash", "-c"))
+    assert train_worker.timeout(job, tmp_path) == 24 * 3600
 
     job["prompt"] = json.dumps({
         "version": 1, "backend": "mlx", "run_dir": "../../outside"})
@@ -79,6 +80,13 @@ def test_run_task_executes_typed_trainer_without_agent(monkeypatch, tmp_path):
 
     def run(argv, **kwargs):
         spawned.append((argv, kwargs))
+        adapter = tmp_path / "grid-train-result" / "adapter"
+        adapter.mkdir(parents=True)
+        (adapter / "adapter.safetensors").write_bytes(b"trained")
+        (adapter.parent / "run.json").write_text(json.dumps({
+            "stage": "sft", "backend": "torch", "model": "tiny",
+            "adapter": str(adapter),
+        }), encoding="utf-8")
         return 0, "Adapter saved: grid-train-result/adapter\n"
 
     monkeypatch.setattr(tasks, "_run_child", run)
@@ -91,6 +99,66 @@ def test_run_task_executes_typed_trainer_without_agent(monkeypatch, tmp_path):
     assert "Adapter saved" in outcome.output
     assert spawned[0][0][1:5] == ["-I", "-m", "cli", "train"]
     assert spawned[0][1]["cwd"] == str(tmp_path)
+    manifest = json.loads(
+        (tmp_path / "grid-train-result" / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["total_bytes"] == len(b"trained")
+    run = json.loads(
+        (tmp_path / "grid-train-result" / "run.json").read_text(encoding="utf-8"))
+    assert run["adapter"] == "adapter"
+
+    assert cmd_train_verify_result(argparse.Namespace(
+        path=str(tmp_path / "grid-train-result"), json=False)) == 0
+
+
+def test_verify_result_refuses_a_tampered_adapter(tmp_path):
+    config = tmp_path / "grid-train-input" / "grid-train.toml"
+    config.parent.mkdir()
+    config.write_text("[model]\nname='tiny'\n", encoding="utf-8")
+    result = tmp_path / "grid-train-result"
+    adapter = result / "adapter"
+    adapter.mkdir(parents=True)
+    artifact = adapter / "adapter.safetensors"
+    artifact.write_bytes(b"original")
+    (result / "run.json").write_text(json.dumps({
+        "stage": "sft", "backend": "torch", "model": "tiny", "adapter": str(adapter),
+    }), encoding="utf-8")
+    job = {
+        "kind": "train.sft", "agent_kind": "train-torch",
+        "prompt": json.dumps({"version": 1, "backend": "torch"}),
+    }
+    train_worker.finalize_result(job, tmp_path)
+    artifact.write_bytes(b"tampered")
+    with pytest.raises(SystemExit, match="failed verification"):
+        cmd_train_verify_result(argparse.Namespace(path=str(result), json=False))
+
+    artifact.write_bytes(b"original")
+    run = json.loads((result / "run.json").read_text(encoding="utf-8"))
+    run["model"] = "different-model"
+    (result / "run.json").write_text(json.dumps(run), encoding="utf-8")
+    with pytest.raises(ValueError, match="does not match"):
+        train_worker.verify_result(result)
+
+
+def test_run_task_refuses_a_zero_exit_without_an_adapter(monkeypatch, tmp_path):
+    config = tmp_path / "grid-train-input" / "grid-train.toml"
+    config.parent.mkdir()
+    config.write_text("[model]\nname='tiny'\n", encoding="utf-8")
+    monkeypatch.setattr(task_agent, "workspace_for", lambda *_: tmp_path)
+    monkeypatch.setattr(task_agent, "ensure_workspace", lambda path: path)
+    monkeypatch.setattr(task_agent, "ensure_cache", lambda _path: None)
+    monkeypatch.setattr(tasks.task_evict, "touch", lambda _path: None)
+    monkeypatch.setattr(tasks.task_evict, "sweep", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(train_worker, "preflight", lambda _kind: None)
+    monkeypatch.setattr(task_agent, "child_env", lambda **_kwargs: {})
+    monkeypatch.setattr(tasks, "_run_child", lambda *_args, **_kwargs: (0, "done"))
+
+    outcome = tasks.run_task({
+        "task_id": "T1", "project_id": "P1", "member_key": "member",
+        "conversation_id": "C1", "kind": "train.sft", "agent_kind": "train-torch",
+        "prompt": json.dumps({"version": 1, "backend": "torch"}),
+    })
+    assert outcome.state == "failed"
+    assert "no usable adapter" in outcome.error
 
 
 def test_submit_sft_uploads_portable_config_and_data(monkeypatch, tmp_path, capsys):
@@ -122,9 +190,12 @@ def test_submit_sft_uploads_portable_config_and_data(monkeypatch, tmp_path, caps
     monkeypatch.setattr(relay, "create_train_job", create)
     args = argparse.Namespace(
         config=str(config), data=str(tmp_path / "dataset"), backend="torch", iters=None,
+        timeout_hours=36, queue_timeout_hours=240,
         grid="forge", project="project-1", json=False)
     assert cmd_train_submit_sft(args) == 0
     assert sent["spec"]["backend"] == "torch"
+    assert sent["spec"]["run_timeout_seconds"] == 36 * 3600
+    assert sent["spec"]["queue_timeout_seconds"] == 240 * 3600
     by_path = {
         item["path"]: base64.b64decode(item["content_b64"])
         for item in sent["files"]
@@ -134,3 +205,4 @@ def test_submit_sft_uploads_portable_config_and_data(monkeypatch, tmp_path, caps
     assert len(by_path["grid-train-input/sft.jsonl"].splitlines()) == 20
     output = capsys.readouterr().out
     assert "job-1" in output and "grid task fetch" in output
+    assert "--into grid-train-result" in output

--- a/train/README.md
+++ b/train/README.md
@@ -373,7 +373,10 @@ existing task/Git plane: an explicit `train-mlx` or `train-torch` capability sel
 node, leases recover a job when a node disappears, and the adapter returns in the result commit.
 It is not distributed-data-parallel training; one job has one trainer, which is the architecture
 above. The first release restarts from the immutable input after node loss rather than resuming an
-optimizer checkpoint.
+optimizer checkpoint. Training gets a separate 24-hour run clock and seven-day queue clock by
+default, both bounded and recorded in the relay-authored job. A result is accepted only when the
+adapter exists and its portable manifest covers every file; after fetching, run
+`grid train verify-result <result-dir>` before loading it.
 
 ## Not built yet
 

--- a/train/README.md
+++ b/train/README.md
@@ -368,6 +368,13 @@ relates to all this is [`docs/topologies.md`](../docs/topologies.md).
 Heavy dependencies (torch, TRL, peft) live behind `pip install 'grid[train]'` and are imported
 lazily, so the rest of the CLI — and every test in this repo — runs without them.
 
+SFT can also be scheduled on the fleet with `grid train submit-sft`. This is deliberately the
+existing task/Git plane: an explicit `train-mlx` or `train-torch` capability selects one compatible
+node, leases recover a job when a node disappears, and the adapter returns in the result commit.
+It is not distributed-data-parallel training; one job has one trainer, which is the architecture
+above. The first release restarts from the immutable input after node loss rather than resuming an
+optimizer checkpoint.
+
 ## Not built yet
 
 Said plainly, because this branch is open and someone will look.


### PR DESCRIPTION
## What

- add `grid train submit-sft` for a portable config + verified SFT dataset
- reuse the durable task/Git plane; no second scheduler
- advertise explicit `train-mlx` and `train-torch` worker capabilities
- claim only on dependency-compatible nodes and return adapter artifacts in the result commit
- recover a lost machine through the existing lease/reclaim path
- give Train bounded per-job queue/run clocks instead of the ordinary one-hour agent-task limit
- reject zero-exit false success unless a real non-empty adapter and matching SFT run record exist
- add a portable SHA-256 result manifest and `grid train verify-result`

## Honest scope

- one trainer owns one job; this is node scheduling/failover, not cross-machine DDP
- v1 restarts from immutable input after node loss rather than resuming optimizer state
- training capacity is opt-in and absent from the default worker list
- relay-first rollout; private relay companion PR required

## Safety

- shell-free, allowlisted job spec
- isolated Python launch prevents a checkout from shadowing Grid's trainer package
- config/data/result paths are confined to the task worktree
- credentials require explicit passthrough
- fetched results reject missing, added, symlinked, changed, or metadata-mismatched adapter files

## Real acceptance

- isolated self-hosted relay with production-like 120-second leases
- real `mlx-community/SmolLM2-135M-Instruct` one-iteration SFT
- task `fbd1d906-5f9b-46d2-9e02-45ec9c59f843` completed on attempt 1
- result commit `4ac1e59098076e820010b467139814939d20187b` fetched into a clean client
- 1,315,662-byte adapter independently verified from per-file SHA-256 hashes
- controlled lease-loss tests prove attempt 2 keeps the identical immutable input commit on a different compatible provider

## Validation

- full public suite: 3,425 passed, 57 skipped, 7 deselected
- focused Train suite: 7 passed
- Ruff: clean
- wheel built and inspected for the Train CLI and worker modules
- private relay companion: final-base local + GitHub gates 326 passed each; shared tasks 129 passed; eligibility clocks 38 passed

## Stack

Depends on #78, which depends on #77. Merge autonomous-ai/autonomous-grid-cli#22 before enabling training workers.
