### PR TITLE
feat: a grid can be keyed on an operating system (ADR 0039)

### DIFF
--- a/cli/auth.py
+++ b/cli/auth.py
@@ -22,7 +22,7 @@ from urllib.parse import urlencode
 from shared import run_records
 
 if TYPE_CHECKING:  # annotations only (PEP 563) — the runtime import stays lazy, in the handlers
-    from . import signout
+    from . import os_grid_notice, signout
 
 
 # Cap the server-supplied poll interval so a misbehaving/misconfigured control plane can't
@@ -38,7 +38,7 @@ _SESSION_EXPIRED_RE = re.compile(r"[A-Z]+ \S+ failed \((?:401|403)\):")
 def cmd_login(args: argparse.Namespace) -> int:
     from remote import control_plane, credentials
 
-    from . import signout
+    from . import os_grid_notice, signout
 
     as_json = getattr(args, "json", False)
     api_url = credentials.api_url()
@@ -65,7 +65,8 @@ def cmd_login(args: argparse.Namespace) -> int:
         raise SystemExit("Sign-in was approved but the control plane returned no session token. "
                          "Run `grid login` to try again.")
     user = approved.get("user") or {}
-    networks = _validated(control_plane.fetch_tokens(session_token, device_id, api_url))
+    fetched = control_plane.fetch_tokens(session_token, device_id, api_url)
+    networks = _validated(fetched.networks)
 
     credentials.save_credentials({
         "session_token": session_token,
@@ -75,7 +76,8 @@ def cmd_login(args: argparse.Namespace) -> int:
     })
     signout.warn_stranded(previous_networks, networks)
     # Deliberately no `state.set_active("remote", …)` here — login never auto-selects a grid.
-    return _report_login(user.get("email", ""), networks, as_json=as_json)
+    return _report_login(user.get("email", ""), networks,
+                         absence=os_grid_notice.absence(fetched.os_served), as_json=as_json)
 
 
 def _await_approval(started: dict[str, Any], api_url: str) -> dict[str, Any]:
@@ -141,10 +143,12 @@ def _print_signin_prompt(url: str, user_code: str, *, to_stderr: bool) -> None:
     print(f"  Code: {user_code}", file=stream)
 
 
-def _report_login(email: str, networks: list[dict[str, Any]], *, as_json: bool) -> int:
+def _report_login(email: str, networks: list[dict[str, Any]], *,
+                  absence: os_grid_notice.OsGridAbsence | None = None, as_json: bool) -> int:
     if as_json:
         grids = [{"name": n["name"], "type": n.get("network_type")} for n in networks]
-        print(json.dumps({"signed_in": True, "email": email, "grids": grids, "active": None}))
+        print(json.dumps({"signed_in": True, "email": email, "grids": grids, "active": None,
+                          "os_grid": absence.as_json() if absence else None}))
         return 0
     if networks:
         listed = ", ".join(n["name"] for n in networks)
@@ -152,6 +156,7 @@ def _report_login(email: str, networks: list[dict[str, Any]], *, as_json: bool) 
         print("Run `grid use <name>` to pick one.")
     else:
         print(f"Signed in as {email}. You don't belong to any grids yet.")
+    _print_os_grid_absence(absence)
     return 0
 
 
@@ -360,7 +365,7 @@ def cmd_sync(args: argparse.Namespace) -> int:
     """
     from remote import control_plane, credentials
 
-    from . import signout
+    from . import os_grid_notice, signout
 
     as_json = getattr(args, "json", False)
     # One credentials snapshot for both the auth gate and the merge below. Reading the session token
@@ -388,7 +393,7 @@ def cmd_sync(args: argparse.Namespace) -> int:
         raise
     # Validate outside the try: a malformed bundle is a data error, not a session error, so it must
     # surface as-is (never rewritten to "session expired").
-    networks = _validated(raw)
+    networks = _validated(raw.networks)
     # Authoritative overwrite of the stored grid list; session_token / api_url / user are preserved.
     # Immutable update — a fresh dict, never the loaded one mutated in place. state.json is untouched.
     credentials.save_credentials({**data, "networks": networks})
@@ -404,17 +409,33 @@ def cmd_sync(args: argparse.Namespace) -> int:
             "were cleared locally. Re-run `grid sync` if this may be transient.",
             file=sys.stderr,
         )
-    return _report_sync(networks, as_json=as_json)
+    return _report_sync(networks, absence=os_grid_notice.absence(raw.os_served), as_json=as_json)
 
 
-def _report_sync(networks: list[dict[str, Any]], *, as_json: bool) -> int:
+def _report_sync(networks: list[dict[str, Any]], *,
+                 absence: os_grid_notice.OsGridAbsence | None = None, as_json: bool) -> int:
     if as_json:
         grids = [{"name": n["name"], "type": n.get("network_type")} for n in networks]
-        print(json.dumps({"synced": True, "grids": grids}))
+        print(json.dumps({"synced": True, "grids": grids,
+                          "os_grid": absence.as_json() if absence else None}))
         return 0
     if networks:
         listed = ", ".join(n["name"] for n in networks)
         print(f"Synced {len(networks)} grid(s): {listed}.")
     else:
         print("Synced 0 grids.")
+    _print_os_grid_absence(absence)
     return 0
+
+
+def _print_os_grid_absence(absence: os_grid_notice.OsGridAbsence | None) -> None:
+    """Say why there is no OS grid in the list, on the human path only (ADR 0039 D-k).
+
+    Stdout beside the command's own report, not stderr: this is part of the answer to what was asked,
+    not a warning that something went wrong — and it never is. ``--json`` never reaches here; the same
+    fact rides the ``os_grid`` field instead, so stdout stays parseable and a script sees what a
+    person sees. ``None`` — an OS grid you have, or a control plane too old to have said — prints
+    nothing at all, which is this whole feature's ordinary case.
+    """
+    if absence is not None:
+        print(absence.line())

--- a/cli/grid_credential.py
+++ b/cli/grid_credential.py
@@ -105,10 +105,25 @@ class _RefreshFailed(Exception):
         if self.status == 401:
             return f"{lead}\nRun `grid login` to sign in again."
         if self.status == 403:
-            # The refresh credential is fine; the *membership* it names is not. `grid login` re-mints
-            # from the same membership, so recommending it would send the user in a circle.
-            return (f"{lead}\nThat is about your membership of this grid, not your sign-in — "
-                    f"`grid login` will not change it.")
+            # The refresh credential is fine; the *membership* it names is not. What re-establishes a
+            # membership is **not the same on every grid type**, so this may not promise an outcome:
+            # on the types that predate OS grids it is a row somebody else controls and re-signing in
+            # is a circle, while on an `os-community` grid (ADR 0039 D-e) there is no row at all —
+            # membership is re-derived from the `os=` claim that only the token fetch sends, so
+            # `grid sync` is the entire repair. Naming the cheap thing to try and what it means when
+            # it does not work is true of both.
+            #
+            # ⚠️ **Deliberately not branched on the grid's type.** The stored record does carry a
+            # `network_type`, but it is a snapshot from the last login/sync that nothing refreshes on
+            # a token exchange — and keying the advice on it would put a fourth copy of the
+            # `os-community` literal in this repository, which by decision holds none (see
+            # `tests/test_os_grid_type_lockstep.py`). That copy would degrade silently: renamed at
+            # the far end the branch simply stops firing and the inverted sentence is back, with
+            # nothing red. A refusal `code` on the wire is worse still — exactly three are parsed
+            # across these seams and keeping that count low is the contract.
+            return (f"{lead}\nThat is about your membership of this grid, not your sign-in. Run "
+                    f"`grid sync` to re-check it; if the grid still refuses afterwards the "
+                    f"membership itself is gone, and signing in again will not bring it back.")
         return (f"{lead}\nNothing is wrong with your sign-in; the control plane could not mint a "
                 f"token. Try again shortly.")
 

--- a/cli/os_grid_notice.py
+++ b/cli/os_grid_notice.py
@@ -22,9 +22,21 @@ person in front of it could take apart:
 
 Three rules the wording and the plumbing both answer to:
 
-- **Quiet in the ordinary case.** Somebody who has an OS grid, and anybody talking to a control plane
-  too old to send the key, sees nothing new. A line on every ordinary sign-in is a line people learn
-  to scroll past, and it would fire for every user of every deployment that has not enabled OS grids.
+- **Quiet in the two cases that are not this feature's answer.** Somebody who has an OS grid sees
+  nothing new, and so does anybody talking to a control plane too old to send the key — ``None`` is
+  not ``False``, and reporting a refusal that was never made is the one direction D-k exists to keep
+  quiet. A line on every ordinary sign-in is a line people learn to scroll past.
+  ⚠️ **A deployment that serves no OS grid is NOT one of those cases, and reading this bullet as
+  though it were is the mistake to avoid.** ``os_served`` is ``False`` there — *the feature switched
+  off with nothing provisioned* is the FIRST of the four deployment states ADR 0039 D-k says
+  ``false`` deliberately collapses — so every user of such a deployment does see this line on every
+  ``grid login`` and ``grid sync``. That is the decision and not an oversight: all four states are
+  one fact to the person in front of them, *this service is not giving me one*, and the alternative
+  that separated them (a reason string) was rejected for publishing a deployment's configuration to
+  every stranger who signs in, on the one grid type whose premise is that its members are strangers.
+  An earlier draft of this bullet implied the opposite and was read in review as a defect;
+  ``test_a_deployment_serving_no_os_grid_at_all_still_says_so`` pins the decided behaviour, and
+  changing it needs an amendment to D-k rather than an edit here.
 - **Never a failure.** An absent OS grid is an ordinary answer — an empty answer that says why is
   still an empty answer. Nothing here touches an exit code, and nothing here raises.
   ⚠️ **And nothing here speaks over a failure either.** `cli.auth.cmd_sync` raises before the fetch

--- a/cli/os_grid_notice.py
+++ b/cli/os_grid_notice.py
@@ -1,0 +1,128 @@
+"""Why there is no OS grid in your list — one line on ``grid login`` and ``grid sync`` (ADR 0039 D-k).
+
+An *OS grid* is a grid keyed on an operating system rather than on an email domain (see
+``shared.system.os_grid``). Three different things leave somebody looking at a grid list with no OS
+grid in it, and until this module they shared one symptom that neither a support conversation nor the
+person in front of it could take apart:
+
+1. **The CLI is too old to send an OS claim at all.** Nothing here can report that — a CLI that has
+   this module is not that CLI — but the control plane can see it, which is why ``os_served`` is on
+   the reply rather than being computed locally.
+2. **The control plane handed this call no OS grid** — that OS is not one it serves, or nothing has
+   been provisioned for it. Reported from ``os_served``. ⚠️ **Not "the feature is switched off
+   there"**, which is what this issue's own text said and what ADR 0039 D-k's amendment exists to
+   correct: that switch governs creation and not admission, so a deployment with it off still serves
+   an OS grid that already exists. D-k lists the four deployment states this one flag collapses, and
+   why the reason-string that would have separated them lost.
+3. **The machine's operating system resolves to no token at all** — a BSD, a frozen build that names
+   no system. ⚠️ **The CLI answers this one itself, with no round trip**: it knows its own system and
+   the closed set of tokens it can emit, so the answer is already in hand before the request is made.
+   That independence is load-bearing, not an optimisation — folding this into the ``os_served`` branch
+   would make the honest answer depend on the far end agreeing to talk.
+
+Three rules the wording and the plumbing both answer to:
+
+- **Quiet in the ordinary case.** Somebody who has an OS grid, and anybody talking to a control plane
+  too old to send the key, sees nothing new. A line on every ordinary sign-in is a line people learn
+  to scroll past, and it would fire for every user of every deployment that has not enabled OS grids.
+- **Never a failure.** An absent OS grid is an ordinary answer — an empty answer that says why is
+  still an empty answer. Nothing here touches an exit code, and nothing here raises.
+  ⚠️ **And nothing here speaks over a failure either.** `cli.auth.cmd_sync` raises before the fetch
+  returns when the session has expired, so a machine outside the token set is told its session
+  expired and nothing about OS grids. That is deliberate, not an oversight to be hoisted: a failed
+  command should report its failure, and burying the one actionable sentence under a side fact serves
+  nobody. The line arrives on the next command that succeeds. "Without a round trip" (above) is about
+  why the CLI *can* answer cause 3 without the far end, not a requirement that it answer despite it.
+- **The same fact reaches a script.** ``--json`` carries :meth:`OsGridAbsence.as_json` rather than
+  dropping what the human line says.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from shared.system import os_grid
+
+#: This machine runs an operating system this CLI has no OS token for, so no OS grid can exist for
+#: it — cause 3, answered without asking anybody.
+UNSUPPORTED_SYSTEM = "unsupported_system"
+
+#: This machine has a token, and the control plane says it was handed no OS grid for it — cause 2.
+NOT_SERVED = "not_served"
+
+#: What to call a machine that does not even name its own system (``platform.system()`` answers the
+#: empty string on some frozen builds). Rare, and a sentence with a hole in it reads as a bug.
+_UNNAMED_SYSTEM = "this system"
+
+
+def _listed(tokens: tuple[str, ...]) -> str:
+    """``("a", "b", "c")`` → ``"a, b and c"`` — the closed set, read out in a sentence."""
+    if len(tokens) < 2:
+        return "".join(tokens)
+    return f"{', '.join(tokens[:-1])} and {tokens[-1]}"
+
+
+@dataclass(frozen=True)
+class OsGridAbsence:
+    """Why this machine has no OS grid — the one fact, in the two shapes it is reported in.
+
+    ``os_token`` is ``None`` exactly when ``reason`` is :data:`UNSUPPORTED_SYSTEM`: having no token
+    IS that reason. Both are carried anyway rather than one being derived, so a script may key on
+    whichever it finds clearer and neither reading can drift from the other.
+    """
+
+    reason: str
+    system: str
+    os_token: str | None
+
+    def line(self) -> str:
+        """The one line a person sees. Names the machine's OS and says nothing else failed.
+
+        ⚠️ **The cause clause must never restate the four words before it.** The first draft read
+        *"No OS grid for FreeBSD: this CLI has no OS grid for that operating system"* — a colon that
+        promises a reason and delivers the subject again, in a feature whose whole purpose is to say
+        why. Naming the closed set is the only thing that makes the unsupported case actionable: it
+        is what lets somebody see they are outside it and stop looking.
+
+        ⚠️ **The set is DERIVED from `OS_TOKENS`, never written out**, so it cannot claim a grid this
+        CLI could not ask for and it grows itself when `omarchy` lands (ADR 0039 D-c, issue 04). It
+        is spelled in OS **tokens** rather than prettied labels on purpose — a label map here would
+        be a fourth copy of `macos`→`macOS` across these repositories, and grid-apis'
+        `os_networks._OS_LABELS` already carries the warning that the two must stay separate values
+        because a prettied-up derivation would silently move the gate. Speaking in tokens throughout
+        also keeps this sentence's subject one kind of value.
+        """
+        cause = (
+            f"grid has one only for {_listed(os_grid.OS_TOKENS)}"
+            if self.reason == UNSUPPORTED_SYSTEM
+            else "the control plane isn't serving one"
+        )
+        named = self.os_token or self.system or _UNNAMED_SYSTEM
+        return f"No OS grid for {named}: {cause}. Your other grids are unaffected."
+
+    def as_json(self) -> dict[str, Any]:
+        """The same fact for a script — what ``--json`` puts under ``os_grid``."""
+        return {"reason": self.reason, "system": self.system, "os_token": self.os_token}
+
+
+def absence(os_served: bool | None) -> OsGridAbsence | None:
+    """Why this machine has no OS grid, or ``None`` when there is nothing to say.
+
+    ``os_served`` is the control plane's answer from ``remote.control_plane.TokenFetch`` — ``True``
+    served, ``False`` not served, ``None`` a control plane too old to have said.
+
+    ⚠️ **The local answer is decided FIRST and does not look at ``os_served`` at all.** A machine
+    outside the closed token set has no OS grid whatever the far end reports, the two causes have
+    different remedies, and printing both lines would be worse than printing neither.
+    """
+    token = os_grid.os_token()
+    if token is None:
+        return OsGridAbsence(
+            reason=UNSUPPORTED_SYSTEM, system=os_grid.system_name(), os_token=None)
+    # `is False` and never `not os_served`: `None` is an older control plane that did not send the
+    # key, and reporting a refusal it never made is the one direction D-k exists to keep quiet.
+    if os_served is False:
+        return OsGridAbsence(
+            reason=NOT_SERVED, system=os_grid.system_name(), os_token=token)
+    return None

--- a/cli/remote_provider.py
+++ b/cli/remote_provider.py
@@ -376,7 +376,15 @@ def cmd_remote_join(args: argparse.Namespace) -> int:
         print("Nothing joined.")
         return 0
     engine_id = _REMOTE_IDENTITY
-    meta_name = getattr(args, "name", None) or socket.gethostname()
+    # Two facts, not one string. `--name mybox` and a box whose hostname IS `mybox` produce the same
+    # display name and mean opposite things about who wrote it — and on an `os-community` grid the
+    # public overview publishes the name only when a person chose it (ADR 0039 D-n, issue 16). The
+    # relay never guesses from the string: measured on the live fleet a heuristic is wrong in both
+    # directions (`Grid` and `8x50902-67-qwen38-27b` are chosen; `MacBooks-MacBook-Pro-7.local` is
+    # not). So the distinction is kept here, carried through the run record, and stated on the wire.
+    chosen_name = getattr(args, "name", None)
+    meta_name = chosen_name or socket.gethostname()
+    name_chosen = bool(chosen_name)
 
     # ⚠️ **Before the lock, and before anything is stopped.** A provider that was serving inference
     # a second ago must still be serving it after a task check that failed — so this may not run
@@ -415,9 +423,9 @@ def cmd_remote_join(args: argparse.Namespace) -> int:
         # Union, media, bundles and concurrency inherit TOGETHER, and the alias guard reads `base` too:
         # aliases are positionally keyed to a record's models and are NOT carried by the spec merge, so
         # inheriting an aliased union would drop its aliases. It is refused with the existing
-        # leave-then-rejoin instruction instead. (`meta_name` is not inherited by either path — it comes
-        # from `--name` or the hostname.) Same shape as `_leave_one_engine`'s
-        # `survivors or list(records.values())` (ADR 0010).
+        # leave-then-rejoin instruction instead. (`meta_name` and `meta_name_chosen` are not inherited
+        # by either path — they come from `--name` or the hostname, freshly, on every join.) Same shape
+        # as `_leave_one_engine`'s `survivors or list(records.values())` (ADR 0010).
         if deferred_target_error is not None and not live:
             # Nothing running to restart, so there is no union to inherit and `--respawn` has nothing
             # to act on: the operator gets the guidance auto-detect would have given them anyway.
@@ -438,9 +446,16 @@ def cmd_remote_join(args: argparse.Namespace) -> int:
         # An idempotent re-join (no new engine/model, and no display-name/media/bundle change) is a no-op,
         # so it doesn't needlessly restart a live identity. A change in ANY of those does respawn to apply
         # it — there is no other way to rename or add a bundle in Slice 1.
+        # ⚠️ **Whether the name was CHOSEN is part of the display name for this purpose**, and the case
+        # it is here for is the one the string comparison cannot see: `--name mybox` on a box already
+        # called `mybox`. Same string, opposite fact — and without this half the operator is told
+        # "already serving", the relay never hears the claim, and the name stays withheld on an
+        # `os-community` grid with nothing anywhere to say why (ADR 0039 D-n).
         if (
             live and not changed and media == base_media and bundles == base_bundles
-            and meta_name == _identity_field(live, "meta_name") and not rotated_live
+            and meta_name == _identity_field(live, "meta_name")
+            and _states_the_same_name_choice(live, name_chosen)
+            and not rotated_live
             and not respawn
         ):
             # Lazy, per this module's import rule: `cli.dispatch` imports it while `cli` is still
@@ -477,12 +492,15 @@ def cmd_remote_join(args: argparse.Namespace) -> int:
                     file=sys.stderr,
                 )
             return 0
+        dropped_claim = _dropped_name_claim_note(live, meta_name, name_chosen)
+        if dropped_claim:
+            print(dropped_claim, file=sys.stderr)
         _reject_unserveable_union(merged_specs, args, base)
         _warn_shadowed_models(merged_specs)  # the serve loop logs this too; show it on the operator's terminal
 
         record = _build_record(
             args, network_id, engine_id, signaling_url, merged_specs,
-            media=media, meta_name=meta_name, bundles=bundles,
+            media=media, meta_name=meta_name, name_chosen=name_chosen, bundles=bundles,
         )
         # Preserve the live identity's --max-concurrency across an additive join, like media/bundles/meta
         # above. It sizes the running N-worker poll pool (remote/serve._serve_loop), so a re-join that
@@ -1102,6 +1120,62 @@ def _identity_field(live: list[dict[str, object]], key: str) -> object:
     return record.get(key) if record is not None else None
 
 
+def _states_the_same_name_choice(live: list[dict[str, object]], name_chosen: bool) -> bool:
+    """Whether the live identity already claims what this join claims about who named the box.
+
+    ADR 0039 D-n. `--name mybox` on a machine whose hostname is already `mybox` produces the display
+    name the record holds and means the opposite thing about who wrote it, so the string comparison
+    beside this one cannot see the change. Without this the operator is told *"already serving"*, the
+    relay never hears the claim, and the name stays withheld on an `os-community` grid with nothing
+    anywhere to say why.
+
+    ⚠️ **A record that does not state the fact does not disagree with it.** A record written before
+    this key existed says nothing, and "no facts" must never read as "bad facts" — the same rule
+    `service_truth` follows one branch over, and the one
+    `test_remote_join_noop_over_a_record_from_an_older_build_behaves_exactly_as_before` exists to
+    keep: upgrading the CLI is never a new failure, so it must not turn every re-join that passed
+    `--name` into a reload nobody asked for. The key lands on the record the first time this identity
+    is genuinely respawned — which running the new serve child requires anyway, since only that child
+    puts `name_chosen` on the wire.
+
+    Compared by IDENTITY against `True` once the record does state it, for the reason the wire half
+    does: absent and anything-not-`True` both mean *not chosen*, and `"false"` is truthy.
+    """
+    stated = _identity_field(live, "meta_name_chosen")
+    return stated is None or name_chosen == (stated is True)
+
+
+def _dropped_name_claim_note(
+    live: list[dict[str, object]], meta_name: str, name_chosen: bool
+) -> str | None:
+    """The one name change a join makes with nothing on screen to show for it (ADR 0039 D-n).
+
+    `meta_name` is not inherited, so a `grid join` without `--name` has always reset the display name
+    to this box's hostname. On a machine whose hostname IS the name that was chosen, that reset
+    produces the identical string and drops the claim underneath it — the join reports what it always
+    reports, and a grid that publishes only chosen names quietly stops naming the machine.
+
+    Acting on it is correct and is the mirror of the claim: both change what the relay is told. This
+    only says so. Returns None whenever the operator can already see the difference — a name that
+    actually changed is in the join's own output — or when the record never stated a claim, since a
+    record from an older build is not evidence anybody dropped anything.
+
+    ⚠️ **The sentence names no network type.** This repository deliberately holds no `os-community`
+    constant of its own (`tests/test_os_grid_type_lockstep.py` says why), and which grids act on the
+    claim is the relay's business, not this CLI's to re-derive.
+    """
+    if name_chosen or _identity_field(live, "meta_name_chosen") is not True:
+        return None
+    if meta_name != _identity_field(live, "meta_name"):
+        return None
+    return (
+        f"Note: {meta_name!r} is now reported as this machine's hostname rather than a name you "
+        f"chose — the string is the same, the claim is not.\n"
+        f"Some grids publish a machine's name only when its operator chose one; re-run with "
+        f"`--name {meta_name}` to keep it published there."
+    )
+
+
 def _reject_unserveable_union(
     merged_specs: list[dict[str, object]], args: argparse.Namespace, live: list[dict[str, object]]
 ) -> None:
@@ -1413,6 +1487,7 @@ def _build_record(
     specs: list[dict[str, object]],
     media: bool = False,
     meta_name: str | None = None,
+    name_chosen: bool = False,
     bundles: list[str] | None = None,
 ) -> dict[str, object]:
     """The remote engine's run record — non-secret routing only; the token stays in credentials.toml.
@@ -1436,6 +1511,11 @@ def _build_record(
         "node_id": f"node-{uuid.uuid4().hex[:12]}",
         "grid_id": network_id,  # the remote network_id doubles as the run record's grid_id
         "meta_name": meta_name,  # grid-page display name (--name, or hostname); NOT the record key
+        # Whether a PERSON wrote that name, kept apart from it because `meta_name` above cannot say
+        # (ADR 0039 D-n). Read back by `remote.serve._meta` a process later and stated on the wire as
+        # `name_chosen`; a record written before this key existed has none, which reads as NOT chosen
+        # — the fail-closed direction, and the one an os-community grid needs.
+        "meta_name_chosen": name_chosen,
         "pid": 0,
         "signaling_url": signaling_url,
         "endpoint_url": single_endpoint,

--- a/docs/adr/0039-a-grid-can-be-keyed-on-an-os.md
+++ b/docs/adr/0039-a-grid-can-be-keyed-on-an-os.md
@@ -541,8 +541,91 @@ premise was tested against the paths its own scan cannot see — `apply_sync_sna
 `ProjectRow`, no raw or bulk insert exists, no migration seeds one — rather than trusted. ⚠️ It also
 found one **residue this decision did not consider**: the node's `name` on the same public payload
 is the provider's hostname, and consumer systems commonly derive a default machine name from the
-owner's. Weaker than an address and **not yet measured**; issue 15 carries the measurement to take
-and the candidate answers. D-m is not amended on the strength of an unmeasured claim.
+owner's. Weaker than an address, and at the time unmeasured — so D-m was left unamended rather than
+widened on a claim nobody had checked. **The measurement was taken 2026-09-03 and the residue is
+real; it is answered by D-n below, not by amending this decision.**
+
+## D-n — The machine's name is withheld too, unless its operator chose it
+
+D-m nulled the address and deliberately left the machine described. The enumeration it asked for
+(issue 15) found the machine's **name** sitting on the same unauthenticated payload — and consumer
+operating systems commonly derive a default machine name from the owner's, so on a grid of strangers
+that field may carry a person's given name with nobody having chosen to publish anything.
+
+**MEASURED 2026-09-03, macOS 26.6, on a machine that has never been renamed:**
+
+| | value |
+|---|---|
+| account `RealName` | `MacBook Pro` |
+| `scutil --get ComputerName` | `MacBook's MacBook Pro` |
+| `scutil --get LocalHostName` | `MacBooks-MacBook-Pro-7` |
+| `scutil --get HostName` | *not set* |
+| `platform.node()` | `MacBooks-MacBook-Pro-7.local` |
+
+Setup Assistant writes `<first word of the account's full name>'s <model>`. Three things say this was
+auto-derived and never typed: the possessive survives, `HostName` is unset, and the `-7` tail is
+Bonjour's collision counter. An account named "Kelvin Nguyen" on the same path yields
+`Kelvins-MacBook-Pro.local`. ⚠️ **n=1, and this account's own name is not a person's** — it
+establishes the derivation RULE with the account's full name on both sides of it, not a leaked human
+name observed in the wild.
+
+**And it is already on a live payload.** All 39 `__private-server` processes on the prod VM were
+asked for their own `GET /grid/overview`: 11 nodes answered, and one is named
+`MacBooks-MacBook-Pro-7.local` verbatim. ⚠️ **Not a prevalence estimate** — no `os-community` grid
+exists in prod yet, so none of those 11 is the population at issue, and 10 of them are hand-named.
+
+⚠️ **The Linux half is NOT measured, and this decision does not rest on it.** Every Linux node in the
+fleet is a datacenter box named by a provisioner, never by a desktop installer. The desktop that
+matters here is **Omarchy** (issue 04, still `needs-info`), not Ubuntu. Measuring it can only widen
+this decision's reach; it cannot overturn a residue already observed on a live row.
+
+**DECIDED 2026-09-03 (issue 15): on `os-community` the overview publishes a node's name only when the
+provider states its operator chose it. Otherwise it falls back to the anonymous label the route
+already computes.** Keyed by equality against the type literal — the same shape as D-i, D-l and D-m —
+and answered inside `member_identity_access` beside them, because that module exists precisely so a
+fourth surface finds one predicate rather than two conventions.
+
+- **Why not withhold every name on this type.** The relay cannot tell a name a person chose from a
+  hostname nobody chose: both arrive on the one `meta["name"]` key. And on a real fleet operators
+  **do** name their machines, frequently after their people — the prod sweep found `3d-artist-<given
+  name>`, `video-editor-<given name>`, `ml-engineer-<given name>`, all deliberate. Withholding
+  unconditionally takes the dashboard away from the operator who chose to publish, and protects
+  nobody who had not already decided. The thing the payload is missing is *who wrote this string*, so
+  that is what gets added rather than a blanket refusal.
+- **The provider says so explicitly — `name_chosen` on the register meta — and the relay never
+  guesses.** A heuristic ("does this look like a hostname") is wrong in both directions on the
+  measured fleet: `Grid`, `mac-studio-turtle` and `8x50902-67-qwen38-27b` are all chosen and all look
+  machine-generated, while `MacBooks-MacBook-Pro-7.local` looks like a model number.
+- **Absent means NOT chosen, so every degrade is fail-closed.** An old provider that never learns the
+  key has its name withheld on this type — the private answer, not the leaky one. An old relay
+  ignores the key and behaves as it does today. So the protection strengthens monotonically as the
+  relay lands, and there is **no hazardous ordering in either direction**.
+- ⚠️ **There are TWO provider halves, not one, and issue 15's scan named only the first.** grid-src
+  `provider_runtime/provider/lifecycle.py:365` is `opts.node_name or platform.node() or "node"`; the
+  **public CLI** `cli/remote_provider.py:379` is `getattr(args, "name", None) or socket.gethostname()`.
+  An `os-community` member runs the *second* — so this decision gains a half in **autonomous-grid**, a
+  repo the enumeration explicitly said it said nothing about, and a fix applied to one sibling leaves
+  the other publishing hostnames while every suite stays green.
+- **Why `node-<node_id[:6]>` is admissible here when D-m rejected "a stable non-identifying handle".**
+  D-m's objection was to a durable pseudonym standing in for a **person's address** — a second
+  spelling of who a provider is. This label stands in for the **machine**, `node_id` itself is not on
+  the payload, and the relay has emitted exactly this string for every nameless node since long
+  before this type existed. It introduces no identifier the payload did not already carry.
+- **No app half, measured rather than assumed.** `OverviewNode.name` is a non-null `final String`
+  parsed as `'${j['name'] ?? ''}'`, and the anonymous label is a case the UI has always rendered. So
+  the app needs no change and has no ordering in either direction.
+
+Two alternatives were rejected, each for a stated reason:
+
+- **Fall back to the anonymous label unconditionally on this type.** Three lines, no new wire key, and
+  it was the first candidate written. Rejected on the measurement above: it erases the deliberate
+  namer along with the accidental one, and the deliberate namer is the majority of every real fleet
+  observed.
+- **Accept it and say so in D-m.** Defensible while the claim was unmeasured — a hostname is the
+  machine's name and an operator can change it. Rejected now that it is measured: a given name
+  reaches the public payload with *nobody having chosen anything*, and "the operator can rename the
+  machine" asks a person to first know that a leak exists. That is the same reasoning D-m used to
+  refuse "somebody serving on a public pool publishes themselves by serving".
 
 ## Considered options
 

--- a/docs/adr/0039-a-grid-can-be-keyed-on-an-os.md
+++ b/docs/adr/0039-a-grid-can-be-keyed-on-an-os.md
@@ -78,10 +78,18 @@ symptom is a person's grid changing every time they use their other machine.
 
 Two consequences are deliberate, not oversights:
 
-- **The roster is empty by construction.** No member holds an allowlist row and none can be
-  synthesized, so `list_grid_members` reports nobody. On a grid of strangers that is correct — it must
-  not publish ten thousand people's email addresses. (Note that `handler._require_managed_member`
-  otherwise lets *any* active member read the roster and invite.)
+- **The roster carries nobody the OS gate admitted.** No member admitted by the OS gate holds an
+  allowlist row and none can be synthesized, so none of them appears in `list_grid_members`. On a grid
+  of strangers that is what matters — it must not publish ten thousand people's email addresses.
+  (Note that `handler._require_managed_member` otherwise lets *any* active member read the roster and
+  invite.)
+
+  ⚠️ **Not literally "reports nobody", and the earlier wording here said so.** The grid's own
+  **owner** — the platform account that created it — holds an ordinary allowlist row like any other
+  grid's owner, and the roster returns it: `test_the_roster_of_an_os_grid_reports_nobody_and_that_is
+  _deliberate` asserts `== ["platform@autonomous.ai"]`, one row, not zero. The claim worth making is
+  the one the test actually proves, and it is the load-bearing one; "empty" was a shorter sentence
+  that would eventually be read as an invariant and relied on. Corrected 2026-08-28 after review.
 - **The grid exists only in the CLI.** `grid ls` reads the locally-stored list that `GET /tokens`
   filled (`cli/remote_grid.cmd_remote_ls`, `remote/control_plane.fetch_tokens`); a browser session has
   no CLI OS to report, so `/me` and `/networks` show nothing. The app is out of scope for this feature
@@ -89,6 +97,41 @@ Two consequences are deliberate, not oversights:
 
 The membership fact is therefore about a **session on a machine**, not about a person: *you are a
 macOS user for as long as the machine you are typing on is a macOS machine.*
+
+⚠️ **A third consequence, found while building issue 02 and NOT yet decided: the refresh-credential
+path carries no OS claim, so it cannot renew an OS grid's token.** `POST /v1/grid/tokens/{id}` with a
+`refresh_token` re-resolves the caller through `store.member_for_access`, and on this type that call
+has nothing to match on — so it answers 403 *"Member is not active"*. `GET /tokens` still issues a
+bundle whose `refresh_token` is therefore inert on this one type.
+
+It bites where the CLI refreshes by itself rather than by a person's command: `remote/serve.py`'s
+serve loop and `cli/grid_credential.py` both exchange the refresh credential on a 401, and a 401 is
+what every `network_epoch` bump produces. The access token's own TTL is a year, so this is not a
+routine expiry — it is what happens the first time an OS grid's epoch moves under a machine that is
+serving on it. The recovery exists and is a person's command (`grid sync` re-fetches with `os=`).
+
+⚠️ **This paragraph originally ended "which is why this is a gap rather than a break". That was
+wrong, and the correction matters more than the original claim.** The refusal is **not read-only**:
+`handler.refresh_token` calls `store.rotate_refresh_credential(...)` — which commits an `UPDATE`
+replacing `refresh_token_hash` — *before* it consults `member_for_access`. On this type that check
+is guaranteed to fail, so the credential is rotated away, the replacement is generated, and the 403
+discards it. The CLI persists nothing on a failed refresh, so the machine is left holding a token
+the server no longer knows: every later attempt answers `401 "Invalid or expired refresh
+credential"`, not this 403, and **shipping the `os=`-on-refresh fix does not heal a machine it has
+already happened to** — only a person re-running `grid login`/`grid sync` does. "The recovery
+exists" was reasoning about a refusal that does not consume what it refuses; this one does.
+
+That makes the ordering a defect in its own right, independent of the wire shape chosen below: a
+refusal on this route must not spend the credential it is refusing, on **any** network type. This
+type merely reaches the path every single time, which is why it surfaced here.
+`.scratch/os-grid-type/issues/10-an-os-grids-credential-can-be-renewed.md` carries both halves.
+
+Deciding it means choosing between two shapes, and the choice belongs with whoever owns the serving
+slice: carry `os` on the refresh request too (the request stays the whole membership fact, at the
+cost of a second wire value in a second place), or let a refusal on this type mean *re-sync* to the
+CLI rather than *end of run*. What must NOT happen is the third option — persisting the OS the bundle
+was minted with — which is exactly the stored-`grid_users.os` shape rejected above, arriving through
+a side door.
 
 ## D-f — `name` is the label, `access_os` is the gate, the unique index is on `access_os`
 
@@ -124,9 +167,43 @@ condition has to be re-derived rather than copied.
 
 ## D-i — The task plane is refused at the door on this type
 
-Project creation and task creation are refused on an `os-community` grid. Because the type is new
-there is no existing project anywhere on it, so refusing the entry points refuses the whole plane
-without a gate on each of the thirty-odd modules that make it up.
+**Project creation** is refused on an `os-community` grid, and that single refusal is the whole
+plane's gate. A project is never minted as a side effect — `projects.ensure_project` is the only
+thing on the relay that writes a `ProjectRow` and `POST /relay/v1/projects` is its only caller (a
+projectless task create is *refused*, not helped, since ADR 0033 D-a). So with creation refused no
+project can ever exist on such a grid, and every task create, turn create, commit, read and stream
+downstream is addressing a project that is not there and answers exactly what it already answers for
+one — no gate on each of the thirty-odd modules that make the plane up, and no hand-maintained table
+of which routes need one.
+
+⚠️ **This paragraph previously read "Project creation and task creation are refused", which was
+wrong in a way worth recording: it describes the OUTCOME (the task plane is unusable) as though it
+were the MECHANISM (two gates).** Issue 05's acceptance criterion 3 requires a task create on such a
+grid to answer the ordinary project-not-found 404 — asserted, so that the "nothing downstream needs
+a gate" claim is checked rather than assumed — and a second refusal on `POST /tasks` would both
+contradict that and start the per-route list this decision exists to avoid. The reasoning sentence
+that follows the claim always argued for one gate; only the claim sentence was loose. Amended
+2026-08-28 when issue 05 was built, after the conflict was flagged rather than silently reconciled.
+
+⚠️ **The premise "because the type is new there is no existing project anywhere on it" is not
+strictly true, and the residue is known.** A grid *re-typed* onto `os-community` returns after the
+restart carrying whatever projects it already had — grid-apis refuses that re-type in both
+directions (issue 02), but grid-src's own `VALID_NETWORK_TYPE_INPUTS` still admits it, so a
+self-hosted operator can reach the state. What survives is: no NEW project can be created (403), a
+stranger gets the project-shaped 404 because `grid_access_enabled()` is False on this type and
+nothing is grid-visible, and only a pre-existing project still serves the members whose rows already
+exist.
+
+⚠️ **Those rows are NOT "access the owner granted by hand", and an earlier draft of this paragraph
+said they were.** On the likeliest source grid — a `private-domain` one, where `grid_access_enabled()`
+is True — a membership row is **self-minted on read**: `project_access` admits any authenticated
+caller to a grid-visible project (`:295`) and then writes the `ProjectMemberRow` (`:401`). So the
+surviving cohort is *everyone who ever opened a grid-visible project on that grid*, including the
+invited outsiders D-k admits, who are on other email domains entirely. That is a materially larger
+and less deliberate set than "the people the owner admitted", and it is the reason issue 09 is worth
+doing rather than filing as a curiosity. Corrected 2026-08-28 after review. Pinned by
+`TestTheOnePlaceTheSingleGateDoesNotReach` rather than left to be rediscovered. Closing it is a
+separate slice — see `.scratch/os-grid-type/issues/09-the-grid-src-re-type-door-onto-an-os-grid.md`.
 
 grid-src's `task_domains` — the mechanism built to stop a provider receiving a checkout of somebody
 else's repository — is an **email-domain allowlist**, and its own docstring explains why it cannot serve here:

--- a/docs/adr/0039-a-grid-can-be-keyed-on-an-os.md
+++ b/docs/adr/0039-a-grid-can-be-keyed-on-an-os.md
@@ -306,9 +306,110 @@ the machine's OS is outside D-c's set. The CLI reports the third itself (it know
 set of tokens it can emit, so no round trip is needed), and `GET /tokens` carries an `os_served` key
 for the other two.
 
+⚠️ **Two clauses of that paragraph are superseded by the amendment below and are kept only because
+this is what was decided at the time.** "The control plane has the feature off" names
+`GRID_OS_GRID_ENABLED`, which governs creation and not admission — read literally it produces a flag
+that contradicts this decision's own fourth rule. And the symptom is not only an empty `grid ls`: the
+common case is a grid list with several grids in it and no OS grid among them, which is why the CLI
+says the line whatever else the list contains.
+
 `os_served` is a new key on an existing endpoint and therefore degrades **silently** against an old
 control plane — the key is absent and the CLI prints nothing, which is exactly the previous behaviour,
 so the degrade is clean.
+
+⚠️ **AMENDED 2026-09-03 (issue 07): `os_served` reports what the ANSWER contains, never what the
+deployment is configured to do** — and the sentence above, read literally, gets it wrong. "The control
+plane has the feature off" names `GRID_OS_GRID_ENABLED`, but that switch governs **creation and not
+admission**, which is the whole point of the long ⚠️ on `os_networks.os_grids_enabled`: switching it
+off during an incident stops any new OS grid being claimed and deliberately does not cut the providers
+already serving a live one off from it. So a deployment with the switch off still hands a machine a
+credential for an OS grid that already exists — and a flag derived from the switch would read `false`
+for a caller holding that grid in the very same body, putting *"no OS grid for macOS"* on the screen
+over the top of one. That would break this decision's own first rule (somebody who has an OS grid sees
+nothing new) using this decision's own key.
+
+So the control plane computes it as *"is an `os-community` grid among the bundles this call is
+returning"* — keyed by equality against the type literal, never on "did anything come back", since a
+flag that went true the moment the caller had any grid at all would be true for nearly everybody and
+say nothing. ⚠️ **And against `os-community` alone, never the `AUTO_PROVISIONED_NETWORK_TYPES` family
+one identifier away** — that set also holds `private-domain`, which this same route provisions for the
+caller on this same call, so the sibling predicate reads `true` for nearly every signed-in account and
+switches the feature off in silence for exactly the corporate population. Found in review, and the
+negative control that catches it has to seed a `private-domain` grid specifically: a
+`permissioned-public` one is outside that family and cannot separate the two predicates.
+
+Consequences worth writing down:
+
+- **It is not derivable by the CLI**, which is why it has to be sent. This repository deliberately
+  holds no `os-community` constant of its own (see the note in `tests/test_os_grid_type_lockstep.py`)
+  — it *prints* the `network_type` it is handed and never compares it — so the flag is the only thing
+  on the wire that can tell "you were served an OS grid" from "you were not".
+- **The three causes do NOT all become separable, and this decision's opening sentence must not be
+  read as promising they do.** What ships separates cause 3, locally, from *everything else*;
+  `os_served` separates "you were served one" from "you were not". Causes 1 and 2 stay one line —
+  which is all the acceptance asked for, and from inside a CLI new enough to have this code cause 1
+  cannot happen anyway. It stays separable by whoever reads the raw response, which is where it was
+  always going to be answered.
+- **`false` therefore collapses at least four deployment states**, and saying so is worth more than a
+  flag that pretends otherwise: the feature switched off with nothing provisioned; this OS absent from
+  `GRID_OS_GRID_TOKENS`; a provision that failed and left the row `pending`; and no platform account
+  configured to own one. All four are one fact to the person in front of them — *this service is not
+  giving me one* — which is what the line says. Naming them apart would mean publishing a
+  deployment's configuration to every stranger who signs in.
+
+**The alternative that would have kept this decision's original promise, and why it lost.** A reason
+**string** — `served` / `os_not_served` / `not_configured` — instead of a bool would have separated the
+four states above and delivered the "three causes" sentence literally. It was rejected on three
+counts, none of which is that it is harder to build. It **publishes a deployment's configuration to
+every stranger who signs in**, on the one grid type whose whole premise is that its members are
+strangers. It adds a **parsed wire enum**, against the standing rule that exactly three refusal codes
+are read anywhere in these repositories and that keeping the count that low IS the contract — a fourth
+reader is a fourth thing a reworded far end can break, and everything else is displayed verbatim. And
+it buys **nothing the acceptance asked for**: the CLI prints one line for every not-served value, so
+the extra states reach a person as the same sentence and reach a script as a field nothing acts on. A
+support conversation that needs them apart reads the deployment's own configuration, which is where
+that fact lives.
+
+⚠️ **The `--json` payload gained a key, and that IS a compatibility event** — the one part of this an
+older client can see. `grid login --json` and `grid sync --json` now always carry `os_grid` (an object,
+or `null`). Always-present rather than emitted only when there is something to say, because a key that
+comes and goes is one every script has to guard; the cost is that "behaves exactly as it did before" is
+true of the prose and not of the payload shape. Nothing known consumes it — the desktop app drives both
+commands in human mode and reads only the device-login lines and the exit code — but it is recorded
+here rather than discovered later.
+
+⚠️ **`os_served` answers for the ANSWER, not for the claim, and those differ on two rows.**
+`list_visible_networks` admits a grid six ways and only the `access_os` arm consults the claim — so a
+caller admitted by `owner_google_sub` (which, by D-d, is the platform account on *every* OS grid) or
+by an active member row reads `True` whatever it claimed. Tightening the computation to
+`access_os == os_token` was considered and not done: "were you handed one" is the honest question for
+a boolean, the platform account is not a population this feature serves, and tightening adds a second
+place that has to agree about the claim. Pinned by
+`test_os_served_answers_for_the_ANSWER_and_not_for_the_claim`, because the two readings are one `and`
+apart, the CLI prints nothing on a `True`, and the wrong one is therefore invisible from outside.
+
+⚠️ **`grid ls` gained nothing, deliberately — and it is where a person actually looks.** This
+decision's opening names an empty `grid ls` as the symptom, and `cli/remote_grid.cmd_remote_ls` still
+prints its empty-list line with no way to say why. The local cause (cause 3) could be answered there
+for free — it needs no round trip and no stored state — but the control-plane cause could not, because
+nothing persists `os_served`, and a `grid ls` that explains one of the two causes and stays silent on
+the other is a worse answer than one that explains neither. The line lives on the two commands that
+actually talk to the control plane, and it is those two a person runs when a grid is missing. Revisit
+this together, if at all: persisting the flag beside the grid list is the change that would make
+`grid ls` able to answer both.
+
+⚠️ **The line is NOT printed when the command itself fails.** `grid sync` against an expired session
+raises before the fetch returns, so a machine outside the token set is told its session expired and
+nothing about OS grids. Deliberate: a failed command should report its failure, and burying the
+actionable sentence under a side fact serves nobody — the line arrives on the next command that
+succeeds. "Without a control-plane round trip being required to produce it" is about why the CLI *can*
+answer cause 3 independently of the far end, not a requirement that it speak over a failure.
+
+The tri-state is load-bearing on the CLI side: `True` served, `False` refused, **`None` the control
+plane did not say**. Collapsing `None` into `False` — the obvious tidy-up — is what would put "this
+control plane isn't serving one" in front of every user of every deployment that has not shipped this
+key yet, which is the one direction this decision exists to keep quiet. So the CLI compares by
+identity against the two booleans and reads anything else (a string, a number, a null) as `None`.
 
 ## D-l — The member-usage panel is refused on this type
 

--- a/docs/adr/0039-a-grid-can-be-keyed-on-an-os.md
+++ b/docs/adr/0039-a-grid-can-be-keyed-on-an-os.md
@@ -574,10 +574,25 @@ asked for their own `GET /grid/overview`: 11 nodes answered, and one is named
 `MacBooks-MacBook-Pro-7.local` verbatim. ⚠️ **Not a prevalence estimate** — no `os-community` grid
 exists in prod yet, so none of those 11 is the population at issue, and 10 of them are hand-named.
 
-⚠️ **The Linux half is NOT measured, and this decision does not rest on it.** Every Linux node in the
-fleet is a datacenter box named by a provisioner, never by a desktop installer. The desktop that
-matters here is **Omarchy** (issue 04, still `needs-info`), not Ubuntu. Measuring it can only widen
-this decision's reach; it cannot overturn a residue already observed on a live row.
+**The other three tokens of D-c's taxonomy, read the same day.** ⚠️ These are **source reads of the
+installers**, not measurements on installed machines, and are held to that lower standard — they
+bound this decision's reach, they are not what it rests on.
+
+- **`linux` (Ubuntu desktop) leaks too**, by the installer's own generator:
+  `ubuntu-desktop-provision`'s `identity_model.dart` returns `'$username-${_productName.value}'` as
+  the suggested hostname. A login name rather than a full name — weaker than macOS's possessive, and
+  the same class.
+- **`omarchy` does NOT leak**, which matters because it is the one desktop Linux this feature has a
+  grid for. `basecamp/omarchy` contains **zero** hostname references — `boot.sh` layers onto an
+  existing Arch install — so the name comes from `archinstall`, whose default is the constant
+  `hostname: str = 'archlinux'`.
+- **`windows` is unmeasured**, and was never in issue 15's scope.
+- **The fleet as deployed carries no person's name**: the dev VM is `grid-dev` from cloud-init, and
+  every Linux node in the prod sweep is provisioner-named.
+
+So the residue is a **desktop-consumer** phenomenon and, among the four tokens, confirmed on `macos`
+and indicated on `linux`. None of that changes the decision — a residue observed on a live row is not
+overturned by the count of platforms sharing it — but it does say who D-n protects.
 
 **DECIDED 2026-09-03 (issue 15): on `os-community` the overview publishes a node's name only when the
 provider states its operator chose it. Otherwise it falls back to the anonymous label the route

--- a/docs/adr/0039-a-grid-can-be-keyed-on-an-os.md
+++ b/docs/adr/0039-a-grid-can-be-keyed-on-an-os.md
@@ -98,11 +98,13 @@ Two consequences are deliberate, not oversights:
 The membership fact is therefore about a **session on a machine**, not about a person: *you are a
 macOS user for as long as the machine you are typing on is a macOS machine.*
 
-⚠️ **A third consequence, found while building issue 02 and NOT yet decided: the refresh-credential
-path carries no OS claim, so it cannot renew an OS grid's token.** `POST /v1/grid/tokens/{id}` with a
-`refresh_token` re-resolves the caller through `store.member_for_access`, and on this type that call
-has nothing to match on — so it answers 403 *"Member is not active"*. `GET /tokens` still issues a
-bundle whose `refresh_token` is therefore inert on this one type.
+⚠️ **A third consequence, found while building issue 02 and since resolved (see the decision at the
+end of this section): the refresh-credential path carried no OS claim, so it could not renew an OS
+grid's token.** `POST /v1/grid/tokens/{id}` with a `refresh_token` re-resolves the caller through
+`store.member_for_access`, and on this type that call had nothing to match on — so it answered 403
+*"Member is not active"*. `GET /tokens` still issued a bundle whose `refresh_token` was therefore
+inert on this one type. The account below is kept in the past tense on purpose: it is the reasoning
+the decision rests on, and a later reader deciding whether to simplify the wire needs it.
 
 It bites where the CLI refreshes by itself rather than by a person's command: `remote/serve.py`'s
 serve loop and `cli/grid_credential.py` both exchange the refresh credential on a 401, and a 401 is
@@ -126,12 +128,34 @@ refusal on this route must not spend the credential it is refusing, on **any** n
 type merely reaches the path every single time, which is why it surfaced here.
 `.scratch/os-grid-type/issues/10-an-os-grids-credential-can-be-renewed.md` carries both halves.
 
-Deciding it means choosing between two shapes, and the choice belongs with whoever owns the serving
-slice: carry `os` on the refresh request too (the request stays the whole membership fact, at the
-cost of a second wire value in a second place), or let a refusal on this type mean *re-sync* to the
-CLI rather than *end of run*. What must NOT happen is the third option — persisting the OS the bundle
-was minted with — which is exactly the stored-`grid_users.os` shape rejected above, arriving through
-a side door.
+**DECIDED 2026-08-29 (issue 10): the refresh request carries the `os` claim too.** Two shapes were on
+the table, and the second turned out not to solve the problem at all:
+
+- **Chosen — carry `os` on the refresh request.** The request stays the whole membership fact, so D-e
+  is untouched and the gate on renewal is the same equality test as the gate on sign-in. The cost is
+  a second wire value in a second place, which is paid for by pinning it: the fetch's query parameter
+  and the renewal's body key are two independent spellings and get two independent lockstep cases,
+  plus a third asserting this CLI's own two call sites agree with each other.
+- **Rejected — let a refusal on this type mean *re-sync* rather than *end of run*.** It reads cheaper
+  (no new wire value) and it is not: **it cannot deliver unattended renewal, which is the entire
+  point.** `grid sync` needs a session token, and `SESSION_TTL_SECONDS` is 24 hours — so a provider
+  running longer than a day still ends at a human with a browser, which is exactly the state being
+  fixed. It also has to tell this refusal from a genuine loss of membership, and the only local
+  signal is the stored `network_type`, which `cli/grid_credential.py` already records as *"a snapshot
+  from the last login/sync that nothing refreshes on a token exchange"* — stale precisely on a grid
+  that was re-typed. Doing it on a wire `code` instead is worse: exactly three are parsed across
+  these seams and keeping that count low is the contract.
+- **Still forbidden — persisting the OS the bundle was minted with.** The stored-`grid_users.os`
+  shape rejected above, arriving through a side door. Pinned by
+  `test_the_os_a_bundle_was_minted_with_is_never_persisted`, which renews twice on one OS and then
+  claims another: if anything anywhere had remembered the first answer, that call would succeed.
+
+⚠️ **The chosen shape has no rollout ordering in either direction, and that was MEASURED rather than
+assumed.** `TokenRefreshRequest` does not forbid extra fields (Pydantic's default is `ignore`), so a
+newer CLI against an older control plane has the key dropped in silence and behaves exactly as it did
+before; an older CLI against a newer control plane sends nothing and likewise. The check mattered:
+the sibling model in these repos, grid-src's `task_files.parse_files`, **refuses** unknown keys and
+answers 422 — the same change against that model would have been a break, not a degrade.
 
 ## D-f — `name` is the label, `access_os` is the gate, the unique index is on `access_os`
 

--- a/docs/adr/0039-a-grid-can-be-keyed-on-an-os.md
+++ b/docs/adr/0039-a-grid-can-be-keyed-on-an-os.md
@@ -90,6 +90,10 @@ Two consequences are deliberate, not oversights:
   _deliberate` asserts `== ["platform@autonomous.ai"]`, one row, not zero. The claim worth making is
   the one the test actually proves, and it is the load-bearing one; "empty" was a shorter sentence
   that would eventually be read as an invariant and relied on. Corrected 2026-08-28 after review.
+
+  ⚠️ **The roster is not the only surface that would publish those addresses.** The member-usage
+  panel reaches the same emails by a different mechanism — observed traffic, not the allowlist — so
+  this bullet's reasoning does not close it. It is closed separately, in D-l.
 - **The grid exists only in the CLI.** `grid ls` reads the locally-stored list that `GET /tokens`
   filled (`cli/remote_grid.cmd_remote_ls`, `remote/control_plane.fetch_tokens`); a browser session has
   no CLI OS to report, so `/me` and `/networks` show nothing. The app is out of scope for this feature
@@ -278,6 +282,60 @@ for the other two.
 control plane — the key is absent and the CLI prints nothing, which is exactly the previous behaviour,
 so the degrade is clean.
 
+## D-l — The member-usage panel is refused on this type
+
+`GET /relay/v1/grid/members/usage` (grid-src `relay.py`) returns one row per consumer: the person's
+email alongside their `requests` / `tokens_in` / `tokens_cached` / `tokens_out`. Its gate is
+`_extract_auth(request, "inference:models")` — the scope every consumer needs to use the grid at all —
+so on a grid that keeps no allowlist it reduces to *"do you hold a token for this grid"*. That is the
+right gate on the types it was written for, and its docstring says why: requiring a snapshot row
+unconditionally would lock every caller out of a grid that keeps no roster. On `os-community` the same
+sentence means **every stranger in the world running this operating system**, so the panel would hand
+each of them every other one's email address and spend.
+
+⚠️ **D-e does not already cover this: same concern, second mechanism.** D-e's roster answer holds *by
+construction* — nothing about a person's OS is persisted, so `list_grid_members` has no rows admitted
+by the OS gate to return. This route's emails do not come from the allowlist. They come from
+`node_answered_query.member_snapshot()`, traffic the relay actually observed, which no membership
+model can empty. Widening `_requires_allowlist` to this type (issue 01) is what makes the route
+reachable here, and a reader who stops at D-e will conclude the surface is closed when it is not.
+
+⚠️ **The app being out of scope is not the containment it looks like.** D-e says an OS grid exists
+only in the CLI, and `member_usage_provider.dart` is this route's only reader — but the exposure is the
+*route*, not the panel. Any token holder can call it directly, and on this type every member is a token
+holder. A UI that never renders it is not a gate.
+
+**DECIDED 2026-08-29 (issue 08): the route is refused on `os-community`, at the door.** The same shape
+as D-i and for the reason that worked there — one predicate keyed on the type, rather than a per-caller
+filter that has to stay correct forever. Nobody on a grid of strangers has a reason to audit another
+stranger's spend, so the refusal takes nothing away from anybody. Three costs, stated rather than
+hidden:
+
+- One more network-type predicate to keep in step with the others in this ADR.
+- It must be keyed by **equality** against the `os-community` literal, never on the truthiness of a
+  missing key — the standing rule of the lockstep register, which has five entries that exist because
+  of that one mistake.
+- The pin needs a **positive control**: a test proving the route still serves a `private-domain` grid
+  unchanged. Without it the refusal is equally satisfied by a route that has been switched off for
+  everybody.
+
+The alternatives, and what each would have cost:
+
+- **Return the caller's own row only.** Keeps the endpoint uniform and the app's parsing untouched, and
+  costs a response *shape* that varies by network type — the sort of thing a later reader reports as a
+  bug, on a path no test in the app exercises.
+- **Drop the email and report totals only.** Preserves *how busy is this grid* without naming anybody,
+  and costs an absent email every client must render, plus the docstring's promise that the panel
+  reading this "has the roster keyed by email already".
+- **Decide the exposure is acceptable and say so.** Legitimate on its face — the figures are token
+  counts, not content — but it trades ten thousand strangers' email addresses for a panel that, on this
+  type, answers a question nobody is asking.
+
+There is **no rollout ordering** and no half in this repo: the refusal changes no response on any other
+type, and the app is unchanged because D-e keeps an OS grid out of its reach entirely. If the app is
+ever brought into scope, this refusal is one more thing to revisit alongside D-e, not a thing that will
+already be right.
+
 ## Considered options
 
 - **An onboarding default (auto-join, private-domain shape, for everyone).** Rejected: it reintroduces
@@ -295,6 +353,8 @@ so the degrade is clean.
 - One more hand-duplicated wire literal across three repos (grid-apis `store.py`, grid-src
   `network_runtime.py` and `grid_auth.py`), with a rollout order that is the reverse of its neighbours.
 - A grid type on which billing is permanently off by decision rather than by omission (D-g).
+- One route refused purely because the grid admits strangers (D-l), and a standing question for every
+  future route that reads "this grid has no allowlist": is its gate still the one it was written for?
 - A grid type with no roster and no presence outside the CLI (D-e) — acceptable only while the app
   stays out of scope. Bringing the app in later means revisiting D-e first, not bolting a query on.
 - `grid ls` gains a `os-community` row that most users will never have created, and the type string is

--- a/docs/adr/0039-a-grid-can-be-keyed-on-an-os.md
+++ b/docs/adr/0039-a-grid-can-be-keyed-on-an-os.md
@@ -193,6 +193,34 @@ and the only remaining remedy would be taking the whole grid down. ⚠️ The pr
 bites a token whose roles are exactly `{"consumer"}`; on this type members are `both`, so the role
 condition has to be re-derived rather than copied.
 
+**As built (issue 06).** The role condition moved out of both predicates into a named per-type
+answer, so the two questions — *which types does the denylist reach* and *whom does it bite there* —
+are asked separately rather than one being inferred from the other. Each side carries a
+`DENYLIST_NETWORK_TYPES` collection naming the two types, and a function that answers the second
+question per type: grid-apis `store.denylist_governs` (which `_is_denied_consumer` now calls before
+its `is_denied` query), grid-src `grid_auth._is_open_consumer` (unrenamed, so this decision still
+names it). The rule that keeps the control plane's two ladders honest is that **every arm of
+`member_for_access` that synthesizes a member must ask**, because the cohort is per type and the
+question needs the member the arm just built — it cannot be hoisted below the ladder. On `permissioned-providers` the answer is unchanged — roles exactly `{"consumer"}`; on
+`os-community` it is every member. Both were verified by mutation: carrying the providers condition
+across kills 11 grid-apis tests and 14 grid-src tests.
+
+Two consequences of the widening are worth recording because neither is obvious from the decision
+above. The **owner** of an OS grid is deniable, since `create_network` writes every creator an
+allowlist row and on this type the denylist governs every role — deliberately not exempted, because
+`is_admin` reads ownership rather than that row, so the account that denied itself can always lift
+it. ⚠️ That cost `member_for_access` a fourth denial check, on its **owner-by-`google_sub`** arm,
+found in review: `create_network` keys the owner's row on their EMAIL while every ownership test
+compares `google_sub`, so a change of address falls both ladders through to their owner arm. The
+visibility drop already applied to the member `_map_visible_row` synthesizes there; the mint did not,
+and on `permissioned-providers` that asymmetry was invisible because `_owner_member`'s `["admin"]` is
+governed by the allowlist. On this type it meant the grid vanished from `GET /tokens` while
+`POST /tokens/{id}` renewed it forever. And the FE's `/managed-networks/{id}/denylist` routes keep their `permissioned-providers`
+guard: its stated reason ("the only type where a denylist has any effect") is what D-h makes false,
+but those routes moderate a grid a *person* created by shelling out to that person's own CLI, and an
+OS grid is owned by a configured platform account (D-d). The admin `/networks/{id}/denylist` trio
+carries no type guard and is the door onto an OS grid.
+
 ## D-i — The task plane is refused at the door on this type
 
 **Project creation** is refused on an `os-community` grid, and that single refusal is the whole

--- a/docs/adr/0039-a-grid-can-be-keyed-on-an-os.md
+++ b/docs/adr/0039-a-grid-can-be-keyed-on-an-os.md
@@ -1,0 +1,200 @@
+# A grid can be keyed on an OS, and that grid is a public one
+
+Status: accepted (2026-08-28)
+
+`private-domain` (grid-apis `store.NETWORK_TYPE_PRIVATE_DOMAIN`) auto-provisions one grid per email
+domain and admits every account of that domain with no allowlist row. It works because a shared email
+domain is a *proxy for a company* — people who already trust each other.
+
+We now want the same "you already belong somewhere" experience keyed on the **operating system** a
+person runs, so that somebody with no company domain still lands in a grid where compute is being
+shared. This ADR records that the shape may be copied but the **premise may not**: same OS implies no
+trust relationship whatsoever, and three separate mechanisms in the system today are built on the
+premise that it does.
+
+## D-a — The type is `os-community`, and it is a community pool for inference
+
+One new `network_type`, `os-community`, whose purpose is **sharing inference compute among strangers
+who run the same OS**. Not an onboarding default that happens to be public, and not a compute-
+compatibility filter — those were the two alternatives, and each would have produced a different
+design (see *Considered options*).
+
+The literal deliberately avoids `private` and `restricted`. `private-domain` is not private — it is
+open to a whole domain — and that misnomer already cost an ADR 0034 D-k correction (`project_access.py`
+records it: the claim that "grid *is* company" is true of the domain and false of the roster). Reusing
+either word on a grid that is genuinely open to strangers would repeat that mistake with higher stakes.
+
+## D-b — The OS gate is a filter, not a security boundary
+
+The CLI reports its own OS. The control plane cannot verify it. This is the same class of value as
+`device_id`, which is a `uuid4` the CLI generates and writes to `~/.grid/device.toml`
+(`remote/credentials.device_id`).
+
+Written down because the gate looks like an access control and is not one: it stops *mistakes*, not
+*intent*. Nothing downstream may be justified by "only macOS machines are on the macOS grid".
+
+## D-c — The taxonomy is closed, and `other` never becomes a grid
+
+Exactly four tokens: `macos`, `windows`, `linux`, `omarchy`. An unrecognised Linux resolves to
+`linux`; anything else resolves to **nothing**, and no grid is provisioned.
+
+The closed set is forced by D-d: auto-provisioning on an open value space means every unrecognised
+string becomes a permanent empty grid. `shared/system/host.platform_kind()` already carries an `other`
+bucket for exactly this reason, and `other` must never reach this path.
+
+⚠️ **Omarchy is Arch-based, and whether `/etc/os-release` distinguishes it from stock Arch is
+UNMEASURED.** `shared/engine/installer._detect_distro` reads `ID=`/`ID_LIKE=` and is the shape to
+follow, but if Omarchy reports `ID=arch` then a second signal is required. Measure on a real Omarchy
+box before implementing; do not infer it.
+
+`platform_kind()` was rejected as the vocabulary even though it already exists and is already on the
+wire (`remote/serve.py` heartbeat `load["platform"]`). It answers *"which binaries run here"* — a
+compute question — and reusing it would split the macOS community across two grids by CPU generation
+(`macos-arm64` / `macos-x86_64`). Two questions, two vocabularies, even where today's values overlap.
+
+## D-d — Auto-provisioned, owned by a configured system account
+
+The grid is claimed on first sighting like `private-domain`, but `owner_google_sub` comes from
+configuration, **never from the first account seen**.
+
+`private-domain` makes the first account of a domain the owner, and an owner is not a formality:
+`handler._require_managed_creator` makes them the only account that may start, stop, delete, rename or
+re-type the grid, and `store._owner_member` grants them `roles=["admin"]`. On a domain that is a
+colleague. On an OS grid it would be the first stranger in the world to run that OS, holding delete
+rights over everybody else's grid.
+
+## D-e — Membership is stateless, computed from the OS claimed on `GET /tokens`
+
+Nothing about a person's OS is persisted. The CLI sends `os=` alongside `device_id` on
+`GET /v1/grid/tokens`, and that request's value decides which OS grid it receives a token for.
+
+The alternative shapes were rejected on modelling grounds. A domain is **derivable from stored data**
+(`grid_users.email`), which is why `store._domain_member` can synthesize membership from
+`(network, email)` alone and `list_domain_member_emails` can build a roster in one query. An OS is
+derivable from nothing we store, and `grid_network_devices` cannot help because it is keyed on
+`network_id` — you would have to already be a member of the macOS grid to be found as a macOS user.
+Storing one OS per account (`grid_users.os`) would force a many-valued fact into one cell, and its
+symptom is a person's grid changing every time they use their other machine.
+
+Two consequences are deliberate, not oversights:
+
+- **The roster is empty by construction.** No member holds an allowlist row and none can be
+  synthesized, so `list_grid_members` reports nobody. On a grid of strangers that is correct — it must
+  not publish ten thousand people's email addresses. (Note that `handler._require_managed_member`
+  otherwise lets *any* active member read the roster and invite.)
+- **The grid exists only in the CLI.** `grid ls` reads the locally-stored list that `GET /tokens`
+  filled (`cli/remote_grid.cmd_remote_ls`, `remote/control_plane.fetch_tokens`); a browser session has
+  no CLI OS to report, so `/me` and `/networks` show nothing. The app is out of scope for this feature
+  and this is what pays for the small design.
+
+The membership fact is therefore about a **session on a machine**, not about a person: *you are a
+macOS user for as long as the machine you are typing on is a macOS machine.*
+
+## D-f — `name` is the label, `access_os` is the gate, the unique index is on `access_os`
+
+`name` carries the human label (`macOS`), a new `access_os` column carries the gate token (`macos`),
+and the partial unique index that makes the auto-provision claim atomic sits on **`access_os`**, not on
+`name` (compare `uq_grid_networks_private_domain_live`, which sits on `lower(name)`).
+
+`private-domain` makes `name` do two jobs, and `store.domain_gate_for` exists only to hide the fact
+that the two domain types keep their gate in different places. Not repeating that here means a user who
+names their own grid `macos` collides with nothing.
+
+## D-g — Inference on an `os-community` grid is free, and stays free
+
+`relay._billing_on` (grid-src) opens with `if config.grid_network_type != "permissioned-providers":
+return False`, and grid-apis `store.set_network_billing_mode` says the same ("effective only on
+permissioned-providers"). We are not widening it. Consumers pay nothing and providers earn nothing.
+
+Widening it would mean opening a seam that ADR 0034 D-i and issue 53 already sit on, plus wallets and
+balances for strangers. Free is the only behaviour that works without touching it, so free is what we
+ship and what this ADR commits to.
+
+## D-h — The denylist IS widened to this type
+
+`store._is_denied_consumer` and grid-src `grid_auth._is_open_consumer` both open by testing for
+`permissioned-providers`; the latter's docstring states "Denylist enforcement is scoped to this type
+only". Both are widened to admit `os-community`.
+
+This is the one enforcement mechanism we extend, and the reason is asymmetric with D-g: without it
+there is **no way at all** to stop an abusive account on a grid that admits strangers automatically,
+and the only remaining remedy would be taking the whole grid down. ⚠️ The predicate as written only
+bites a token whose roles are exactly `{"consumer"}`; on this type members are `both`, so the role
+condition has to be re-derived rather than copied.
+
+## D-i — The task plane is refused at the door on this type
+
+Project creation and task creation are refused on an `os-community` grid. Because the type is new
+there is no existing project anywhere on it, so refusing the entry points refuses the whole plane
+without a gate on each of the thirty-odd modules that make it up.
+
+grid-src's `task_domains` — the mechanism built to stop a provider receiving a checkout of somebody
+else's repository — is an **email-domain allowlist**, and its own docstring explains why it cannot serve here:
+"two people on `gmail.com` are not one company". Unset it filters nothing at all ("Unset ⇒ nothing is
+filtered"), so on a grid with no domain it is not a weak control, it is an inapplicable one.
+
+Task serving is already opt-in and off by default (`remote/task_opt_in.serving_enabled`, `GRID_TASKS`),
+so nobody is exposed today who did not switch it on. That is a brake, not a boundary, and the plane's
+value — projects, git, agents — is a *team collaboration* feature that means nothing among strangers.
+Refusing it takes nothing away from D-a and is the narrowing direction.
+
+⚠️ grid-src's `project_access.grid_access_enabled()`
+(`grid_cli/private_server/project_access.py` — **not** this repository, which has a same-named
+module of its own) gates grid-wide project visibility on `private-domain` and
+must **never** be widened to `os-community`. D-i makes it moot, but the test that pins it is what stops
+a later reader "completing the set".
+
+## D-j — grid-src rolls out BEFORE the control plane
+
+The opposite of the ordering that applies to the web-tool routes, and it must be written down or it
+will be inferred wrongly from the neighbouring case.
+
+Auto-provisioning is not an INSERT: grid-apis `managed_networks.build_create_argv` shells out
+`grid network create <name> --network-type os-community …`, and that `grid` binary **is grid-src**.
+grid-src validates with `choices=VALID_NETWORK_TYPES` (`grid_cli/cli.py`), so a control plane that
+knows the type before grid-src does gets argparse exit 2, a failed create, and a grid stuck at
+`pending` retrying forever. Loud and fail-closed, but wrong.
+
+⚠️ **That name is a shadowing alias, and following it to the wrong set leaves the failure in
+place.** `grid_cli/cli.py` opens `VALID_NETWORK_TYPES = network_runtime.VALID_NETWORK_TYPE_INPUTS`,
+so argparse's choices are the **INPUTS tuple** and not `network_runtime.VALID_NETWORK_TYPES` beside
+it. Both need the token, and so does `PUBLIC_NETWORK_TYPES`: `cmd_network_create` refuses
+`--advertise-url` on a non-public type and `build_create_argv` always passes that flag, so a type
+missing from the public set fails this same create one layer further in.
+
+The public CLI has **no** ordering in either direction: `os=` is a new query parameter on an existing
+endpoint, so an old control plane ignores it silently, and a new control plane facing an old CLI simply
+issues nobody a token.
+
+## D-k — Absence is reported, because three causes share one symptom
+
+An empty `grid ls` can mean the CLI is too old to send `os`, the control plane has the feature off, or
+the machine's OS is outside D-c's set. The CLI reports the third itself (it knows its own OS and the
+set of tokens it can emit, so no round trip is needed), and `GET /tokens` carries an `os_served` key
+for the other two.
+
+`os_served` is a new key on an existing endpoint and therefore degrades **silently** against an old
+control plane — the key is absent and the CLI prints nothing, which is exactly the previous behaviour,
+so the degrade is clean.
+
+## Considered options
+
+- **An onboarding default (auto-join, private-domain shape, for everyone).** Rejected: it reintroduces
+  precisely what `domain_networks.private_domain_blocklist` exists to prevent — its comment names the
+  case, "so `k@gmail.com` does not create a grid shared by every Gmail account" — at a larger scale,
+  while inheriting a trust premise that does not hold.
+- **A compute-compatibility pool.** Rejected as a *grid*: the platform of every node is already on the
+  wire in the heartbeat, so grouping by it is a routing question, not a new membership boundary.
+- **Reusing `permissionless` plus a discovery rule** (no new type at all). Rejected for one concrete
+  reason: `store.list_visible_networks` makes every `permissionless` grid visible to every account, so
+  each person's `grid ls` would grow by one line per OS forever.
+
+## Consequences
+
+- One more hand-duplicated wire literal across three repos (grid-apis `store.py`, grid-src
+  `network_runtime.py` and `grid_auth.py`), with a rollout order that is the reverse of its neighbours.
+- A grid type on which billing is permanently off by decision rather than by omission (D-g).
+- A grid type with no roster and no presence outside the CLI (D-e) — acceptable only while the app
+  stays out of scope. Bringing the app in later means revisiting D-e first, not bolting a query on.
+- `grid ls` gains a `os-community` row that most users will never have created, and the type string is
+  printed to them verbatim (`cli/remote_grid.cmd_remote_ls`).

--- a/docs/adr/0039-a-grid-can-be-keyed-on-an-os.md
+++ b/docs/adr/0039-a-grid-can-be-keyed-on-an-os.md
@@ -405,6 +405,16 @@ like the roster* — it is *what does this surface publish on a grid of stranger
 gate*. The predicate is shared for this reason: `member_identity_access` owns both answers, so the
 fourth surface finds one module rather than two conventions.
 
+**The enumeration this paragraph asked for has since been done** (issue 15, 2026-08-29), and its
+answer is *no fourth unclosed email mechanism on the relay*: six sites emit an address, two are
+closed here (D-l, D-m), three are unreachable behind D-i, one is a token's own subject. D-i's
+premise was tested against the paths its own scan cannot see — `apply_sync_snapshot` writes no
+`ProjectRow`, no raw or bulk insert exists, no migration seeds one — rather than trusted. ⚠️ It also
+found one **residue this decision did not consider**: the node's `name` on the same public payload
+is the provider's hostname, and consumer systems commonly derive a default machine name from the
+owner's. Weaker than an address and **not yet measured**; issue 15 carries the measurement to take
+and the candidate answers. D-m is not amended on the strength of an unmeasured claim.
+
 ## Considered options
 
 - **An onboarding default (auto-join, private-domain shape, for everyone).** Rejected: it reintroduces

--- a/docs/adr/0039-a-grid-can-be-keyed-on-an-os.md
+++ b/docs/adr/0039-a-grid-can-be-keyed-on-an-os.md
@@ -331,10 +331,79 @@ The alternatives, and what each would have cost:
   counts, not content — but it trades ten thousand strangers' email addresses for a panel that, on this
   type, answers a question nobody is asking.
 
+⚠️ **D-l is not the last word on this exposure either, and its own review proved it.** The public
+overview publishes `provider_email` with no gate at all; that is a THIRD mechanism, closed separately
+in D-m. A first draft of this route's refusal sent the refused caller *to that overview* for "the
+grid's own totals, naming nobody" — false, and a good illustration of how easily this area is
+reasoned about one surface at a time.
+
 There is **no rollout ordering** and no half in this repo: the refusal changes no response on any other
 type, and the app is unchanged because D-e keeps an OS grid out of its reach entirely. If the app is
 ever brought into scope, this refusal is one more thing to revisit alongside D-e, not a thing that will
 already be right.
+
+## D-m — The public overview names no provider on this type
+
+`GET /relay/v1/grid/overview` is **public and unauthenticated** — its own docstring says so, and it
+takes no `_extract_auth` at all. For every node whose role is `provider` or `both` and whose
+heartbeat is inside the TTL, `overview.build_grid_overview` emits `provider_email`, joined from
+`UserRow.email`, beside the machine's name, chip, VRAM and the models it serves.
+
+On a `private-domain` grid that is a company publishing its own people's machines, which is what the
+web UI was built for. On `os-community` every member is minted `both` and the type's whole premise is
+that strangers share compute — so anyone who knows the grid's signaling URL can read the address of
+everybody serving on it, with no credential at all.
+
+⚠️ **This is the THIRD mechanism onto one exposure, and each of the first two was closed by an
+argument that does not reach it.** D-e empties the roster *by construction* — no OS membership is
+persisted, so `list_grid_members` has no row to return. D-l refuses `/grid/members/usage`, whose
+emails come from observed traffic rather than the allowlist. This one reads `NodeRow` joined to
+`UserRow`: rows a provider writes by the act of serving, on a route with **no gate whatsoever**. So
+the door left open was the *weakest*-gated of the three, which is not a decision anybody made — it is
+the shape of finding the mechanisms one at a time.
+
+**DECIDED 2026-08-29 (issue 14): `provider_email` is sent as `null` on `os-community`, and the key
+stays.** Keyed by equality against the type literal, the same shape as D-l and D-i.
+
+- **The key stays and the value goes.** Omitting it would make the payload's *shape* vary by network
+  type, which is the cost D-l explicitly rejected when it turned down "return the caller's own row
+  only" — a shape that differs per type is the sort of thing a later reader reports as a bug.
+- **Overloading `null` is deliberate.** It already means "the control plane could not resolve the
+  owner", and a client cannot tell that from "withheld". Nothing should: both render as a machine
+  nobody is named for, and a distinguishable "withheld" would advertise that there is a name to ask
+  for.
+- **No app half, measured rather than assumed.** `OverviewNode.providerEmail` is already
+  `String?`, parsed as `j['provider_email'] as String?`, and its own doc comment says "Null on an
+  older relay, or when the control plane couldn't resolve the owner". `nodeHostHandle` returns `''`,
+  and `node_groups` collects every unattributed machine into **one headless block** — a designed-for
+  case, not a degenerate one. So there is no rollout ordering in either direction.
+
+Three alternatives were on the table, and each was rejected for a stated reason:
+
+- **A stable non-identifying handle** (the node name, or a digest of the address). Keeps "which
+  machine is this" while dropping the identity, and costs a second spelling of who a provider is. The
+  deciding objection is that a digest which is stable across polls — and it must be, or the machines
+  regroup on every refresh — is a durable pseudonymous identifier, which is a different privacy
+  claim from the one the word "anonymous" makes.
+- **Authenticate the overview on this type.** The narrowest change to the payload, and it is the gate
+  the sibling route already has. Rejected because on this type **every member is a token holder**: it
+  converts an unauthenticated leak into an authenticated one, which is precisely what D-l refused to
+  accept for `/grid/members/usage`. It would also take the public dashboard away from the one grid
+  type whose whole point is that strangers can find it.
+- **Accept the exposure and say so.** Defensible on its face — somebody serving on a public pool
+  arguably publishes themselves by serving. Rejected because they do not: a person runs `grid join`
+  on a machine, and nothing in that act says their email address becomes readable by anyone on the
+  internet who knows a URL. ⚠️ The app already knew and said so — `node_display.nodeHostHandle`
+  carries the comment "Not a privacy measure and shouldn't be mistaken for one: `/grid/overview` is
+  unauthenticated and carries the whole address." A relay-side decision was the missing half, not a
+  finding nobody had made.
+
+⚠️ **The rule this ADR keeps re-learning, written once here.** Three surfaces have now published a
+member's identity on this type, and in each case the previous decision looked like it covered the
+next. Before adding a route that reads `UserRow.email`, or widening one, the question is not *is this
+like the roster* — it is *what does this surface publish on a grid of strangers, and what is its
+gate*. The predicate is shared for this reason: `member_identity_access` owns both answers, so the
+fourth surface finds one module rather than two conventions.
 
 ## Considered options
 
@@ -353,8 +422,11 @@ already be right.
 - One more hand-duplicated wire literal across three repos (grid-apis `store.py`, grid-src
   `network_runtime.py` and `grid_auth.py`), with a rollout order that is the reverse of its neighbours.
 - A grid type on which billing is permanently off by decision rather than by omission (D-g).
-- One route refused purely because the grid admits strangers (D-l), and a standing question for every
-  future route that reads "this grid has no allowlist": is its gate still the one it was written for?
+- One route refused and one payload field withheld purely because the grid admits strangers (D-l,
+  D-m), and a standing question for every future surface that reads `UserRow.email`: what does it
+  publish on a grid of strangers, and what is its gate? Three surfaces have now had to be answered
+  one at a time; `member_identity_access` exists so the fourth finds one module rather than two
+  conventions.
 - A grid type with no roster and no presence outside the CLI (D-e) — acceptable only while the app
   stays out of scope. Bringing the app in later means revisiting D-e first, not bolting a query on.
 - `grid ls` gains a `os-community` row that most users will never have created, and the type string is

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -168,6 +168,20 @@ commands exit with guidance to switch — sign-in is a remote concept. See
 [ADR 0002](./adr/0002-remote-sign-in.md) and
 [ADR 0023](./adr/0023-signing-out-with-live-serve-children.md).
 
+Both commands say one line when there is no **OS grid** for this machine — the grid that exists for
+everyone running one operating system, provisioned for you rather than created by you. It names
+either the system this CLI has no OS grid for, listing the ones it does have (a BSD, say), or the
+fact that the control plane is serving none for yours — so the two do not have to be told apart by
+guesswork. It is never an error and it never changes an exit code. Somebody who has an OS grid sees
+nothing extra, and so does anyone whose control plane is too old to answer the question. See
+[ADR 0039](./adr/0039-a-grid-can-be-keyed-on-an-os.md).
+
+⚠️ `--json` carries the same fact under a **new `os_grid` key, present on every `grid login --json`
+and `grid sync --json`** — an object with `reason`, `system` and `os_token`, or `null` when there is
+nothing to say. It is `null` rather than absent on purpose: a key that comes and goes is one every
+script has to guard. It is the one part of this that is not invisible to a client written before it,
+so a consumer comparing the whole payload shape sees one more key.
+
 ## Grid Lifecycle
 
 ```

--- a/remote/control_plane.py
+++ b/remote/control_plane.py
@@ -16,6 +16,8 @@ from urllib.parse import quote
 
 import httpx
 
+from shared.system import os_grid
+
 from . import credentials
 
 
@@ -65,8 +67,25 @@ def poll_device_login(device_code: str, api_url: str | None = None) -> dict[str,
 
 
 def fetch_tokens(session_token: str, device_id: str, api_url: str | None = None) -> list[dict[str, Any]]:
+    """Every grid this account may reach from THIS machine, each with a fresh credential.
+
+    Carries the machine's **OS token** as ``os=`` beside ``device_id`` when it has one (ADR 0039 D-e),
+    which is what decides whether an OS grid is among them. Both call sites — `grid login` and
+    `grid sync` — go through here, so the machine speaks for itself once rather than in two places
+    that could answer differently.
+
+    The parameter is **omitted entirely** on a machine outside the closed token set, never sent empty:
+    the far end gates by equality against a grid's own token, and an empty string would be a second
+    spelling of "no claim" for it to recognise. It is also new on an existing endpoint, so an older
+    control plane simply ignores it and this call behaves exactly as it did before (ADR 0039 D-j — the
+    public CLI has no rollout ordering in either direction).
+    """
+    params = {"device_id": device_id}
+    machine_os = os_grid.os_token()
+    if machine_os:
+        params["os"] = machine_os
     with _client(api_url, session_token) as client:
-        resp = _send(client, "GET", "/v1/grid/tokens", params={"device_id": device_id})
+        resp = _send(client, "GET", "/v1/grid/tokens", params=params)
         # `or []` coerces both a missing key and an explicit null to an empty list.
         return list(resp.json().get("networks") or [])
 

--- a/remote/control_plane.py
+++ b/remote/control_plane.py
@@ -120,9 +120,37 @@ def fetch_tokens(session_token: str, device_id: str, api_url: str | None = None)
         params["os"] = machine_os
     with _client(api_url, session_token) as client:
         resp = _send(client, "GET", "/v1/grid/tokens", params=params)
-    payload = resp.json()
+    try:
+        payload = resp.json()
+    except (ValueError, RecursionError):
+        # Not JSON at all, or nested past the parser's recursion limit. ⚠️ `RecursionError` is NOT a
+        # `ValueError` — `json.loads` raises it on a deeply nested body and no `except ValueError`
+        # sees it — and an empty 200 body raises here too, which is why this route does not use
+        # `_json_or_empty`: its `{}` would be read as zero grids, which is the very thing below.
+        payload = None
     if not isinstance(payload, dict):
-        payload = {}  # a body that is not an object carries neither networks nor a flag
+        # ⚠️ **REFUSED, never read as "zero grids".** This used to fall back to `{}`, and the cost of
+        # that is one caller away: `cli.auth.cmd_sync` overwrites `[[networks]]` authoritatively, so
+        # an empty answer discards every grid's access AND refresh token — and refresh rotation makes
+        # them unrecoverable. A body that is not an object is a control-plane fault or something
+        # sitting in front of it, and neither is a reason to destroy a credential store.
+        #
+        # `_validated` does not catch it and cannot: it is the trust boundary for bad ROWS and
+        # iterates the list, so a non-object body yields nothing to validate and sails straight
+        # through. This is the same check one level up, on the shape that holds the rows.
+        #
+        # A `ControlPlaneError` (a `SystemExit` subclass) rather than a raised `AttributeError`: the
+        # CLI's clean-error idiom, a sentence and a non-zero exit. ⚠️ The wording must not match
+        # `cli.auth._SESSION_EXPIRED_RE` — anchored on `_raise`'s "<METHOD> <URL> failed (401):" — or
+        # somebody would be told to run `grid login` for a fault no credential can fix.
+        raise ControlPlaneError(
+            f"The control plane answered GET /v1/grid/tokens with a "
+            f"{type(payload).__name__} rather than an object, so this CLI cannot tell which grids "
+            f"you have. Nothing was changed locally; re-run `grid sync` if this may be transient."
+            # `NoneType` covers both a literal JSON `null` and a body that would not parse — the
+            # remedy is the same sentence, and naming the parse error would put a server's raw output
+            # in front of somebody who can do nothing with it.
+        )
     served = payload.get(OS_SERVED_KEY)
     return TokenFetch(
         # `or []` coerces both a missing key and an explicit null to an empty list.

--- a/remote/control_plane.py
+++ b/remote/control_plane.py
@@ -11,6 +11,7 @@ is reached in local mode (dispatch gates the remote commands to remote mode).
 from __future__ import annotations
 
 import os
+from dataclasses import dataclass
 from typing import Any
 from urllib.parse import quote
 
@@ -19,7 +20,6 @@ import httpx
 from shared.system import os_grid
 
 from . import credentials
-
 
 # Control-plane HTTP timeout (seconds). The default suits every fast call; managed-network *create* is
 # synchronous and can exceed it while the backend boots the master, so it is overridable via
@@ -66,7 +66,38 @@ def poll_device_login(device_code: str, api_url: str | None = None) -> dict[str,
         return _send(client, "POST", "/v1/grid/auth/device/poll", json={"device_code": device_code}).json()
 
 
-def fetch_tokens(session_token: str, device_id: str, api_url: str | None = None) -> list[dict[str, Any]]:
+#: The key on the token-fetch reply that says whether this machine was handed an OS grid (ADR 0039
+#: D-k). Named once, because the pin comparing it to grid-apis' own spelling reads it from here —
+#: `tests/test_os_grid_type_lockstep.py`.
+OS_SERVED_KEY = "os_served"
+
+
+@dataclass(frozen=True)
+class TokenFetch:
+    """What ``GET /v1/grid/tokens`` answered: the grids, and why an OS grid may not be among them.
+
+    ``os_served`` is a *tri-state* and every one of the three means something different (ADR 0039
+    D-k):
+
+    - ``True`` — this call was handed a credential for an OS grid. Nothing to report.
+    - ``False`` — this call was handed none. ⚠️ **Not "none for the OS this machine claimed"** — the
+      far end answers for what is IN the body, and the visibility query admits a row six ways of
+      which only one consults the claim (ownership does not), so the platform account that owns every
+      OS grid reads ``True`` whatever it claims. The difference reaches no ordinary user and reaches
+      no printed line, but the sentence has to stay honest about what the flag measures.
+    - ``None`` — the control plane did not say. A new key on an existing endpoint degrades silently,
+      so this is what an older control plane produces, and it must print exactly nothing.
+
+    ⚠️ **`False` and `None` are not interchangeable.** Collapsing them would put "this control plane
+    isn't serving one" in front of everybody who has not upgraded their control plane yet — the one
+    direction ADR 0039 D-k exists to keep quiet.
+    """
+
+    networks: list[dict[str, Any]]
+    os_served: bool | None
+
+
+def fetch_tokens(session_token: str, device_id: str, api_url: str | None = None) -> TokenFetch:
     """Every grid this account may reach from THIS machine, each with a fresh credential.
 
     Carries the machine's **OS token** as ``os=`` beside ``device_id`` when it has one (ADR 0039 D-e),
@@ -79,6 +110,9 @@ def fetch_tokens(session_token: str, device_id: str, api_url: str | None = None)
     spelling of "no claim" for it to recognise. It is also new on an existing endpoint, so an older
     control plane simply ignores it and this call behaves exactly as it did before (ADR 0039 D-j — the
     public CLI has no rollout ordering in either direction).
+
+    Answers the ``os_served`` key alongside them (ADR 0039 D-k) — see :class:`TokenFetch`, which is
+    what turns an empty grid list into one that can say WHY it is empty.
     """
     params = {"device_id": device_id}
     machine_os = os_grid.os_token()
@@ -86,8 +120,20 @@ def fetch_tokens(session_token: str, device_id: str, api_url: str | None = None)
         params["os"] = machine_os
     with _client(api_url, session_token) as client:
         resp = _send(client, "GET", "/v1/grid/tokens", params=params)
+    payload = resp.json()
+    if not isinstance(payload, dict):
+        payload = {}  # a body that is not an object carries neither networks nor a flag
+    served = payload.get(OS_SERVED_KEY)
+    return TokenFetch(
         # `or []` coerces both a missing key and an explicit null to an empty list.
-        return list(resp.json().get("networks") or [])
+        networks=list(payload.get("networks") or []),
+        # Compared by IDENTITY against the two booleans, never for truthiness. `"false"` is the value
+        # that makes this matter: it is truthy in Python, so a truthiness test would read a control
+        # plane refusing to serve an OS grid as serving one. Anything that is not a real `bool` — a
+        # string, a number, a null — is read as "did not say" and prints nothing, which is the same
+        # clean degrade an older control plane already gets.
+        os_served=served if served is True or served is False else None,
+    )
 
 
 def refresh_network_token(

--- a/remote/control_plane.py
+++ b/remote/control_plane.py
@@ -98,11 +98,30 @@ def refresh_network_token(
     Unauthenticated by design — the ``refresh_token`` in the body *is* the credential, so no
     session/access Bearer is attached (matches the reference client). A failed refresh surfaces as
     a clean ``SystemExit`` via ``_send``; the caller treats that as end-of-run.
+
+    **The OS claim rides this call too** (ADR 0039 D-e, issue 10), and it has to. On an
+    ``os-community`` grid the request IS the whole membership fact — nothing about the OS is stored —
+    so an exchange that carried no claim matched nothing, and the bundle ``fetch_tokens`` hands out
+    contained a ``refresh_token`` that was inert on exactly that one network type. A machine serving
+    an OS grid then went dark the first time the grid's ``network_epoch`` moved, since that is what
+    makes the relay answer 401 and sends the serve loop here.
+
+    Same discipline as the fetch: read from the one place that decides, and **omit the key entirely**
+    when this machine claims no OS rather than sending an empty string, so the far end never has a
+    second spelling of "no claim" to recognise. Also the same absence of rollout ordering, and for a
+    reason worth keeping written down: the far end's body model does not forbid unknown fields, so a
+    newer CLI against an older control plane has this key dropped in silence and behaves exactly as it
+    did before. That was **measured, not assumed** — a sibling model elsewhere in these repos refuses
+    unknown keys and answers 422, which would have made this a break rather than a degrade.
     """
+    body: dict[str, Any] = {"refresh_token": refresh_token}
+    machine_os = os_grid.os_token()
+    if machine_os:
+        body["os"] = machine_os
     with _client(api_url) as client:
         return _send(
             client, "POST", f"/v1/grid/tokens/{network_id}",
-            json={"refresh_token": refresh_token},
+            json=body,
         ).json()
 
 

--- a/remote/serve.py
+++ b/remote/serve.py
@@ -1089,7 +1089,8 @@ def _meta(record: dict[str, Any], engine_id: str) -> dict[str, Any]:
 
     The display name comes from the record's ``meta_name`` (the ``--name`` a remote operator gave, or
     the box's hostname when omitted), falling back to ``engine_id`` for a record written before the
-    singleton change. A multi-engine identity shows the kinds it gathered (e.g. ``ollama+vllm``) when no
+    singleton change. ``name_chosen`` says which of those two it was — see the comment on it below.
+    A multi-engine identity shows the kinds it gathered (e.g. ``ollama+vllm``) when no
     explicit ``--engine-label`` was given, so the page reflects what is actually serving.
     """
     label = record.get("engine_label")
@@ -1109,7 +1110,22 @@ def _meta(record: dict[str, Any], engine_id: str) -> dict[str, Any]:
             label = "comfyui"
         else:
             label = "llama.cpp"
-    meta = {"name": record.get("meta_name") or engine_id, "engine": label}
+    # `name_chosen` is the second half of the name and travels with it: whether a PERSON wrote that
+    # string or it is just this box's hostname (ADR 0039 D-n, issue 16). The relay publishes an
+    # unchosen name on every grid type but `os-community`, where a hostname is a stranger's machine
+    # naming its owner to anyone with the URL. It is never inferred from the string — measured on the
+    # live fleet, a heuristic gets `MacBooks-MacBook-Pro-7.local` (not chosen) and `Grid` (chosen)
+    # backwards — so the provider states it and the relay believes it.
+    #
+    # ⚠️ **`is True`, not truthiness.** A record written before this key existed has none, and absent
+    # must read as NOT chosen: this is a new key on an existing payload, so it degrades in silence and
+    # the fail-closed direction is the only thing standing in for a 404 nobody gets. Same precedent as
+    # the `engine_id` fallback above.
+    meta = {
+        "name": record.get("meta_name") or engine_id,
+        "name_chosen": record.get("meta_name_chosen") is True,
+        "engine": label,
+    }
     # What the machine IS — chip on Apple Silicon, card elsewhere. Without it the grid page can only
     # say the hostname and the OS ("Grid-Relay · macOS"), which is the same sentence for a laptop
     # and for a 192 GB Mac Studio. Empty fields are dropped rather than sent blank: the relay merges

--- a/shared/system/host.py
+++ b/shared/system/host.py
@@ -31,7 +31,13 @@ class HostInfo:
 def platform_kind() -> str:
     """Coarse OS/arch class advertised in the heartbeat so the grid knows what a node runs:
     ``linux`` · ``macos-arm64`` (Apple Silicon) · ``macos-x86_64`` (Intel Mac) · ``windows`` · ``other``.
-    Same classification drives the VRAM path in ``gpu.load_snapshot`` (Apple Silicon vs Intel Mac)."""
+    Same classification drives the VRAM path in ``gpu.load_snapshot`` (Apple Silicon vs Intel Mac).
+
+    ⚠️ **Not the OS-grid vocabulary — see `shared.system.os_grid.os_token`.** This answers *"which
+    binaries run here"*, a compute question, and splits macOS by CPU generation; the OS token answers
+    *"which community does this machine belong to"*. Two questions, two vocabularies, deliberately
+    kept apart (ADR 0039 D-c) even where today's values overlap — folding them together would put
+    Apple Silicon and Intel Mac users in two different grids."""
     system = platform.system()
     if system == "Linux":
         return "linux"

--- a/shared/system/os_grid.py
+++ b/shared/system/os_grid.py
@@ -1,0 +1,62 @@
+"""Which OS grid this machine claims to belong to — the **OS token** (ADR 0039 D-b, D-c).
+
+An *OS grid* is a grid keyed on an operating system rather than on an email domain: sign in on a Mac
+and you are already a member of the macOS grid. The **OS token** is the value a machine and a grid are
+matched on, and this module is the ONLY place in this CLI that decides what this machine's is. It
+travels as the ``os=`` query parameter on the control-plane token fetch (``remote.control_plane
+.fetch_tokens``) — the only channel there is, because the device-login start and poll calls carry
+nothing about the machine and the browser that approves a sign-in may be a different device entirely.
+
+⚠️ **This is not `host.platform_kind()`, and the two must not be merged.** That one answers *"which
+binaries run here"* and splits macOS by CPU generation (``macos-arm64`` / ``macos-x86_64``); reusing it
+would put Apple Silicon and Intel Mac users in two different communities. Two questions, two
+vocabularies, even where today's values overlap (ADR 0039 D-c).
+
+⚠️ **The taxonomy is CLOSED, and that is what makes auto-provisioning safe.** An unrecognised system
+resolves to ``None`` and no grid is provisioned for it; on an open value space every unrecognised
+string would become a permanent empty grid. `platform_kind()` carries an ``other`` bucket for this
+reason — ``other`` must never reach this path, which is why nothing here has a fallback token.
+
+⚠️ **A machine's OS is a CLAIM, never a fact.** The control plane cannot verify it, exactly as it
+cannot verify ``device_id`` (a ``uuid4`` this CLI writes to ``~/.grid/device.toml``). The gate it feeds
+stops *mistakes*, not *intent*, and nothing downstream may be justified by "only macOS machines are on
+the macOS grid" (ADR 0039 D-b).
+
+``omarchy`` is the fourth token in ADR 0039 D-c and is deliberately **absent here**: it is Arch-based
+and whether ``/etc/os-release`` distinguishes it from stock Arch is UNMEASURED. Adding it on an
+unverified signal would silently sort every Arch user into the Omarchy grid — the exact mis-sorting the
+closed set exists to prevent. `.scratch/os-grid-type/issues/04-omarchy-gets-its-own-grid.md` owns it,
+and owns taking the measurement first; that is also where the ``/etc/os-release`` read arrives (see
+``shared.engine.installer._detect_distro`` for the shape it will follow).
+"""
+
+from __future__ import annotations
+
+import platform
+
+OS_MACOS = "macos"
+OS_WINDOWS = "windows"
+OS_LINUX = "linux"
+
+#: Every token this CLI can emit. Closed by decision (ADR 0039 D-c) — see the module docstring.
+OS_TOKENS: tuple[str, ...] = (OS_MACOS, OS_WINDOWS, OS_LINUX)
+
+# `platform.system()` → OS token. Only the systems that HAVE a grid appear; everything else — a BSD, a
+# Java runtime, the empty string a frozen build can report — is absent and resolves to None.
+_BY_SYSTEM = {
+    "Darwin": OS_MACOS,
+    "Windows": OS_WINDOWS,
+    "Linux": OS_LINUX,
+}
+
+
+def os_token() -> str | None:
+    """This machine's OS token, or ``None`` when it has no OS grid.
+
+    ``None`` is an ordinary answer, not a failure: a machine outside the closed set simply has no OS
+    grid, keeps every other grid it belongs to, and sends no ``os`` parameter at all.
+
+    Every Linux resolves to ``linux``, including a distribution nobody has heard of — an unusual
+    choice of distribution must not exclude somebody from the general Linux grid.
+    """
+    return _BY_SYSTEM.get(platform.system())

--- a/shared/system/os_grid.py
+++ b/shared/system/os_grid.py
@@ -7,6 +7,12 @@ travels as the ``os=`` query parameter on the control-plane token fetch (``remot
 .fetch_tokens``) — the only channel there is, because the device-login start and poll calls carry
 nothing about the machine and the browser that approves a sign-in may be a different device entirely.
 
+It also **names** this machine's system for a person (:func:`system_name`), which is a different job
+from deciding its token and is here for one reason: both answers come from a single reading of
+``platform.system()``, so the sentence somebody is shown and the value the gate compares can never be
+talking about different machines. Do not "tidy" that function out on the grounds that it decides no
+token — it is what stops a second read appearing somewhere else.
+
 ⚠️ **This is not `host.platform_kind()`, and the two must not be merged.** That one answers *"which
 binaries run here"* and splits macOS by CPU generation (``macos-arm64`` / ``macos-x86_64``); reusing it
 would put Apple Silicon and Intel Mac users in two different communities. Two questions, two
@@ -50,6 +56,23 @@ _BY_SYSTEM = {
 }
 
 
+def system_name() -> str:
+    """What this machine calls its own operating system — ``platform.system()``, trimmed.
+
+    ⚠️ **The single read.** :func:`os_token` resolves its answer FROM this one, so the name shown to a
+    person and the token sent on the wire cannot come from two different readings of the same call —
+    which is what the module docstring promises and what a second bare ``platform.system()`` four
+    lines away quietly broke.
+
+    The name a PERSON is shown when there is no OS grid for their machine (ADR 0039 D-k), which is why
+    it is the raw value and not a prettied-up one: on a system outside the closed set there is no token
+    to name and no label to look one up by, so the only honest thing to print is what the machine
+    itself answers. It can be the empty string on a frozen build — the same systems that resolve to no
+    token — so a caller must have something to say when it is.
+    """
+    return platform.system().strip()
+
+
 def os_token() -> str | None:
     """This machine's OS token, or ``None`` when it has no OS grid.
 
@@ -58,5 +81,9 @@ def os_token() -> str | None:
 
     Every Linux resolves to ``linux``, including a distribution nobody has heard of — an unusual
     choice of distribution must not exclude somebody from the general Linux grid.
+
+    Resolved from :func:`system_name` rather than from its own ``platform.system()`` call, so the two
+    answers this module gives are one reading. The trim that comes with it is free: a padded system
+    name matched nothing before and matches its grid now.
     """
-    return _BY_SYSTEM.get(platform.system())
+    return _BY_SYSTEM.get(system_name())

--- a/tests/grid_src_repo.py
+++ b/tests/grid_src_repo.py
@@ -1,0 +1,65 @@
+"""Where grid-src is, for the cross-repo lockstep suites that read its source.
+
+Every seam between these repositories is wire-level with no import path across it, so the shared
+constants are hand-duplicated and kept in step by tests that PARSE the other repository. Those
+tests need to find it, and finding it is the part that quietly decides whether they run at all:
+`tests/test_task_lease.py` names one worktree by absolute path, which is why its cross-repo checks
+skip in every other worktree on the machine.
+
+One copy, here, because two hand-written path derivations drift exactly like two hand-written
+constants — and a resolver that drifts does not fail, it skips.
+"""
+from __future__ import annotations
+
+import os
+import pathlib
+
+
+def grid_src_root() -> pathlib.Path | None:
+    """grid-src's checkout, or ``None`` when this machine does not have one beside this worktree.
+
+    Derived from THIS file's location rather than written out, so the checks run in whichever
+    worktree they are checked out into instead of skipping everywhere but one. The convention is
+    `<repo>-feats/<slug>` beside `<repo>`, so a worktree of `autonomous-grid` at
+    `…/autonomous-grid-feats/<slug>` looks for `…/grid-src-feats/<slug>` first and falls back to
+    the main `…/grid-src` checkout.
+
+    `GRID_SRC_REPO` — the cross-repo E2E's own override — wins over both, so a machine that lays
+    the repositories out differently can still run these. It is **validated**, and a bad one raises
+    rather than skips; see the comment on that branch for why the difference matters here.
+    """
+    override = os.environ.get("GRID_SRC_REPO")
+    if override:
+        # ⚠️ **Validated, and a bad one RAISES rather than skips.** `tests/e2e_cross_repo/
+        # _harness.py` defaults this same variable to one hardcoded worktree, so on this machine the
+        # ordinary way to acquire it is to export it for a different suite entirely — and an
+        # override that points somewhere else is a person's configuration mistake, not evidence that
+        # grid-src is absent. Skipping there would turn every pin in both lockstep suites off with
+        # a message saying the repository is not here while it sits right beside this one.
+        root = pathlib.Path(override)
+        if not (root / "grid_cli" / "private_server").is_dir():
+            raise AssertionError(
+                f"GRID_SRC_REPO={override!r} does not hold grid_cli/private_server, so it is not a "
+                f"grid-src checkout. Unset it to fall back to the worktree beside this one — the "
+                f"cross-repo E2E harness defaults it to a DIFFERENT worktree, and left exported it "
+                f"silently decides what every lockstep check reads")
+        return root
+
+    here = pathlib.Path(__file__).resolve().parent.parent  # the autonomous-grid checkout
+    projects = here.parent
+    candidates = []
+    if projects.name == "autonomous-grid-feats":
+        candidates.append(projects.parent / "grid-src-feats" / here.name)
+        candidates.append(projects.parent / "grid-src")
+    else:
+        candidates.append(projects / "grid-src")
+    for candidate in candidates:
+        if (candidate / "grid_cli" / "private_server").is_dir():
+            return candidate
+    return None
+
+
+def grid_src_private_server() -> pathlib.Path | None:
+    """grid-src's `private_server` package — the relay's own source tree."""
+    root = grid_src_root()
+    return None if root is None else root / "grid_cli" / "private_server"

--- a/tests/grid_src_repo.py
+++ b/tests/grid_src_repo.py
@@ -1,4 +1,4 @@
-"""Where grid-src is, for the cross-repo lockstep suites that read its source.
+"""Where the sibling repositories are, for the cross-repo lockstep suites that read their source.
 
 Every seam between these repositories is wire-level with no import path across it, so the shared
 constants are hand-duplicated and kept in step by tests that PARSE the other repository. Those
@@ -7,12 +7,68 @@ tests need to find it, and finding it is the part that quietly decides whether t
 skip in every other worktree on the machine.
 
 One copy, here, because two hand-written path derivations drift exactly like two hand-written
-constants — and a resolver that drifts does not fail, it skips.
+constants — and a resolver that drifts does not fail, it skips. That is also why **grid-apis** is
+resolved here rather than in the one suite that reads it (`test_os_grid_type_lockstep.py`): the
+module keeps its `grid_src_repo` name for the sake of the two suites already importing it, but the
+rule it exists for is about path derivations, not about which repository they point at.
 """
 from __future__ import annotations
 
 import os
 import pathlib
+
+
+def _sibling_root(
+    marker: pathlib.Path, repo: str, env_var: str, *, hint: str = ""
+) -> pathlib.Path | None:
+    """A sibling checkout of ``repo``, or ``None`` when this machine has none beside this worktree.
+
+    Derived from THIS file's location rather than written out, so the checks run in whichever
+    worktree they are checked out into instead of skipping everywhere but one. The convention is
+    `<repo>-feats/<slug>` beside `<repo>`, so a worktree of `autonomous-grid` at
+    `…/autonomous-grid-feats/<slug>` looks for `…/<repo>-feats/<slug>` first and falls back to the
+    main `…/<repo>` checkout.
+
+    ``marker`` is a directory that must exist under a candidate for it to count as that repository —
+    the difference between "found it" and "found a directory with the right name".
+
+    ``env_var`` wins over both, and is **validated**: a bad one raises rather than skips, because an
+    override pointing somewhere else is a person's configuration mistake, not evidence the
+    repository is absent. Skipping there would turn every pin off with a message blaming the wrong
+    thing.
+    """
+    override = os.environ.get(env_var)
+    if override:
+        root = pathlib.Path(override)
+        if not (root / marker).is_dir():
+            raise AssertionError(
+                f"{env_var}={override!r} does not hold {marker}, so it is not a {repo} checkout. "
+                f"Unset it to fall back to the worktree beside this one"
+                + (f" — {hint}" if hint else ""))
+        return root
+
+    here = pathlib.Path(__file__).resolve().parent.parent  # the autonomous-grid checkout
+    projects = here.parent
+    candidates = []
+    if projects.name == "autonomous-grid-feats":
+        candidates.append(projects.parent / f"{repo}-feats" / here.name)
+        candidates.append(projects.parent / repo)
+    else:
+        candidates.append(projects / repo)
+    for candidate in candidates:
+        if (candidate / marker).is_dir():
+            return candidate
+    return None
+
+
+def grid_apis_root() -> pathlib.Path | None:
+    """grid-apis' checkout — the CONTROL PLANE — or ``None`` when it is not beside this worktree.
+
+    A third repository joined the lockstep with ADR 0039's `os-community` literal: grid-apis
+    `grid_networks/store.py` holds a copy of it, alongside grid-src's two. `GRID_APIS_REPO`
+    overrides the derivation.
+    """
+    return _sibling_root(pathlib.Path("grid_networks"), "grid-apis", "GRID_APIS_REPO")
 
 
 def grid_src_root() -> pathlib.Path | None:
@@ -24,39 +80,24 @@ def grid_src_root() -> pathlib.Path | None:
     `…/autonomous-grid-feats/<slug>` looks for `…/grid-src-feats/<slug>` first and falls back to
     the main `…/grid-src` checkout.
 
-    `GRID_SRC_REPO` — the cross-repo E2E's own override — wins over both, so a machine that lays
+    ⚠️ `GRID_SRC_REPO` — the cross-repo E2E's own override — wins over both, so a machine that lays
     the repositories out differently can still run these. It is **validated**, and a bad one raises
-    rather than skips; see the comment on that branch for why the difference matters here.
+    rather than skips: `tests/e2e_cross_repo/_harness.py` defaults this same variable to one
+    hardcoded worktree, so on this machine the ordinary way to acquire it is to export it for a
+    different suite entirely — and an override that points somewhere else is a person's
+    configuration mistake, not evidence that grid-src is absent. Skipping there would turn every pin
+    in both lockstep suites off with a message saying the repository is not here while it sits right
+    beside this one.
     """
-    override = os.environ.get("GRID_SRC_REPO")
-    if override:
-        # ⚠️ **Validated, and a bad one RAISES rather than skips.** `tests/e2e_cross_repo/
-        # _harness.py` defaults this same variable to one hardcoded worktree, so on this machine the
-        # ordinary way to acquire it is to export it for a different suite entirely — and an
-        # override that points somewhere else is a person's configuration mistake, not evidence that
-        # grid-src is absent. Skipping there would turn every pin in both lockstep suites off with
-        # a message saying the repository is not here while it sits right beside this one.
-        root = pathlib.Path(override)
-        if not (root / "grid_cli" / "private_server").is_dir():
-            raise AssertionError(
-                f"GRID_SRC_REPO={override!r} does not hold grid_cli/private_server, so it is not a "
-                f"grid-src checkout. Unset it to fall back to the worktree beside this one — the "
-                f"cross-repo E2E harness defaults it to a DIFFERENT worktree, and left exported it "
-                f"silently decides what every lockstep check reads")
-        return root
-
-    here = pathlib.Path(__file__).resolve().parent.parent  # the autonomous-grid checkout
-    projects = here.parent
-    candidates = []
-    if projects.name == "autonomous-grid-feats":
-        candidates.append(projects.parent / "grid-src-feats" / here.name)
-        candidates.append(projects.parent / "grid-src")
-    else:
-        candidates.append(projects / "grid-src")
-    for candidate in candidates:
-        if (candidate / "grid_cli" / "private_server").is_dir():
-            return candidate
-    return None
+    return _sibling_root(
+        pathlib.Path("grid_cli") / "private_server",
+        "grid-src",
+        "GRID_SRC_REPO",
+        hint=(
+            "the cross-repo E2E harness defaults it to a DIFFERENT worktree, and left exported it "
+            "silently decides what every lockstep check reads"
+        ),
+    )
 
 
 def grid_src_private_server() -> pathlib.Path | None:

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -18840,6 +18840,173 @@ def test_meta_uses_meta_name_for_grid_page_name(monkeypatch, tmp_path):
     assert serve._meta({"endpoint_url": "http://h/v1"}, "remote")["name"] == "remote"
 
 
+def test_meta_says_whether_a_person_chose_the_node_name(monkeypatch, tmp_path):
+    """`name_chosen` — the fact the relay needs to publish a name on an `os-community` grid.
+
+    ADR 0039 D-n. The relay never guesses from the string: measured on the live fleet, `Grid`,
+    `mac-studio-turtle` and `8x50902-67-qwen38-27b` are all chosen and all look machine-generated,
+    while `MacBooks-MacBook-Pro-7.local` looks like a model number. So the provider states it, and
+    this is the half of that statement the public CLI sends.
+
+    ⚠️ **A record written before this change has no such key, and must read as NOT chosen.** That is
+    the fail-closed direction and it is load-bearing: this is a new key on an existing payload, so
+    nothing 404s to say it went missing. Same precedent as `meta_name` falling back to `engine_id`
+    for a pre-singleton record.
+    """
+    from remote import serve
+
+    chosen = {"meta_name": "mybox", "meta_name_chosen": True, "endpoint_url": "http://h/v1"}
+    assert serve._meta(chosen, "remote")["name_chosen"] is True
+
+    hostname = {"meta_name": "MacBooks-MacBook-Pro-7.local", "meta_name_chosen": False,
+                "endpoint_url": "http://h/v1"}
+    assert serve._meta(hostname, "remote")["name_chosen"] is False
+
+    # A record written by a build from before this key existed — absent, so not chosen.
+    old = {"meta_name": "mybox", "endpoint_url": "http://h/v1"}
+    assert serve._meta(old, "remote")["name_chosen"] is False, (
+        "a record written before D-n read as CHOSEN, so the hostname of every provider that has "
+        "not re-joined is published on an os-community grid — silently")
+
+    # The name itself is untouched either way: D-n withholds on the relay, never here.
+    assert serve._meta(hostname, "remote")["name"] == "MacBooks-MacBook-Pro-7.local"
+
+
+def test_remote_join_records_whether_the_operator_chose_the_name(monkeypatch, tmp_path):
+    """`--name` given survives into the run record, which is where `_meta` reads it a process later.
+
+    `cmd_remote_join`'s `args.name or socket.gethostname()` collapses two different facts into one
+    string, so the record needs its own key or the distinction is gone by the time the serve child
+    builds the meta a process later.
+    """
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_remote_spawn(monkeypatch)
+
+    assert cli.main(["join", "--at", "http://h:11434/v1", "-m", "llama3", "--name", "mybox"]) == 0
+
+    record = cli.provider._read_records("n1")["remote"]
+    assert record["meta_name"] == "mybox"
+    assert record["meta_name_chosen"] is True
+
+
+def test_remote_join_without_a_name_records_the_hostname_as_not_chosen(monkeypatch, tmp_path):
+    """The other half, and the one D-n exists for: a hostname nobody typed."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_remote_spawn(monkeypatch)
+    monkeypatch.setattr(
+        cli.remote_provider.socket, "gethostname", lambda: "MacBooks-MacBook-Pro-7.local")
+
+    assert cli.main(["join", "--at", "http://h:11434/v1", "-m", "llama3"]) == 0
+
+    record = cli.provider._read_records("n1")["remote"]
+    assert record["meta_name"] == "MacBooks-MacBook-Pro-7.local"
+    assert record["meta_name_chosen"] is False
+
+
+def test_dropping_name_on_a_box_the_hostname_already_matches_says_the_claim_was_dropped(
+    monkeypatch, tmp_path, capsys
+):
+    """The mirror of the claim, and the only direction that changes nothing on screen.
+
+    `meta_name` is not inherited — a `grid join` without `--name` has always reset the display name to
+    the hostname. On a box whose hostname IS the name that was chosen, that reset produces the same
+    string and drops the claim underneath it, so an operator sees a join that changed nothing while
+    the grid page quietly stops naming their machine on a type that publishes only chosen names.
+
+    Acting on it is right and is the mirror of `test_choosing_the_name_the_hostname_already_had_is_not
+    _a_no_op`: both change what the relay is told. What is added here is *saying so*.
+
+    ⚠️ The sentence never names a network type. This repository deliberately holds no `os-community`
+    constant — `tests/test_os_grid_type_lockstep.py` says why — so the note describes the claim, and
+    which grids act on it is the relay's business.
+    """
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_remote_spawn(monkeypatch)
+    monkeypatch.setattr(cli.remote_provider.run_records, "terminate_pid", lambda pid: True)
+    monkeypatch.setattr(cli.remote_provider.socket, "gethostname", lambda: "mybox")
+
+    assert cli.main(["join", "--at", "http://h:11434/v1", "-m", "llama3", "--name", "mybox"]) == 0
+    monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
+    capsys.readouterr()
+    assert cli.main(["join", "--at", "http://h:11434/v1", "-m", "llama3"]) == 0
+
+    record = cli.provider._read_records("n1")["remote"]
+    assert record["meta_name"] == "mybox" and record["meta_name_chosen"] is False
+    err = capsys.readouterr().err
+    assert "mybox" in err and "--name mybox" in err, (
+        f"the claim was dropped with nothing on screen to say so: {err!r}")
+
+
+def test_a_join_that_keeps_the_claim_says_nothing_about_it(monkeypatch, tmp_path, capsys):
+    """The negative control. A note that fired on an ordinary re-join would be noise on every box."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_remote_spawn(monkeypatch)
+    monkeypatch.setattr(cli.remote_provider.run_records, "terminate_pid", lambda pid: True)
+    monkeypatch.setattr(cli.remote_provider.socket, "gethostname", lambda: "mybox")
+
+    assert cli.main(["join", "--at", "http://h:11434/v1", "-m", "llama3", "--name", "mybox"]) == 0
+    monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
+    capsys.readouterr()
+    assert cli.main(["join", "--at", "http://h:8000/v1", "-m", "qwen", "--name", "mybox"]) == 0
+
+    assert "--name" not in capsys.readouterr().err
+
+
+def test_a_record_that_never_stated_who_named_the_box_does_not_disagree_with_this_join(
+    monkeypatch, tmp_path, capsys
+):
+    """Upgrading is never a new failure — the rule the sidecar gate already keeps, one key over.
+
+    A record written before D-n carries no `meta_name_chosen`, and "no facts" must not read as "bad
+    facts". Read as *not chosen* here, every re-join that passes `--name` on every upgraded provider
+    on every grid type would stop being a no-op and hot-reload a healthy child for a rename nobody
+    asked for. The key lands the first time the identity is genuinely respawned, which running the
+    new serve child needs anyway — only that child puts `name_chosen` on the wire at all.
+
+    Pairs with `test_choosing_the_name_the_hostname_already_had_is_not_a_no_op` below: there the
+    record DOES state the fact and states the other one, so the same-string re-join must act.
+    """
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _seed_live_identity_record(pid=4242, engines=[
+        {"endpoint_url": "http://h:11434/v1", "models": ["llama3"], "engine_label": "ollama"},
+    ], started_at="2020-01-01T00:00:00+00:00",  # a pre-D-n record: no `meta_name_chosen` at all
+        registered_at="2020-01-01T00:00:01+00:00")
+    _seed_heartbeat_sidecar()
+    monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
+    spawned = _mock_remote_spawn(monkeypatch)
+
+    assert cli.main(["join", "--at", "http://h:11434/v1", "-m", "llama3", "--name", "mybox"]) == 0
+
+    assert "Already serving on team; nothing to append." in capsys.readouterr().out
+    assert spawned["signals"] == [], "a healthy child was reloaded for a fact its record never stated"
+
+
+def test_choosing_the_name_the_hostname_already_had_is_not_a_no_op(monkeypatch, tmp_path):
+    """`--name mybox` on a box already called `mybox` CHANGES what the grid may publish.
+
+    The no-op gate compares display names, and these two joins produce the same string — so without
+    `meta_name_chosen` in the gate an operator who deliberately claims their machine's name is told
+    "already serving" and the relay never hears the claim. The name on the page would stay withheld
+    on an os-community grid, with nothing anywhere to say why.
+    """
+    import signal as _sig
+
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    spawned = _mock_remote_spawn(monkeypatch)
+    monkeypatch.setattr(cli.remote_provider.run_records, "terminate_pid", lambda pid: True)
+    monkeypatch.setattr(cli.remote_provider.socket, "gethostname", lambda: "mybox")
+
+    assert cli.main(["join", "--at", "http://h:11434/v1", "-m", "llama3"]) == 0
+    monkeypatch.setattr(cli.remote_provider.run_records, "pid_alive", lambda pid: True)
+    assert cli.main(["join", "--at", "http://h:11434/v1", "-m", "llama3", "--name", "mybox"]) == 0
+
+    record = cli.provider._read_records("n1")["remote"]
+    assert record["meta_name_chosen"] is True, (
+        "the claim was swallowed by the no-op gate: same string, different fact")
+    assert spawned["signals"] == [(4242, _sig.SIGHUP)], (
+        "the running child was never told, so it keeps advertising the old fact")
+
+
 def test_meta_labels_all_external_union_as_external(monkeypatch, tmp_path):
     """A union of external --at engines (each engine_label=None) shows engine='external' on the grid page,
     not the built-in 'llama.cpp' default; only a built-in --serve spec (no endpoint_url) is 'llama.cpp'

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -11644,7 +11644,7 @@ def test_control_plane_fetch_tokens_attaches_bearer_and_query(monkeypatch, tmp_p
 
     _mock_control_plane(monkeypatch, handler)
     nets = control_plane.fetch_tokens("sess-tok", "dev-1")
-    assert nets == [{"network_id": "n1", "name": "team"}]
+    assert nets.networks == [{"network_id": "n1", "name": "team"}]
     assert seen["auth"] == "Bearer sess-tok"
     assert seen["device_id"] == "dev-1"
 
@@ -11654,7 +11654,7 @@ def test_control_plane_fetch_tokens_defaults_missing_networks_to_empty(monkeypat
 
     monkeypatch.setenv("GRID_HOME", str(tmp_path))
     _mock_control_plane(monkeypatch, lambda r: httpx.Response(200, json={"networks": None}))
-    assert control_plane.fetch_tokens("sess", "dev-1") == []
+    assert control_plane.fetch_tokens("sess", "dev-1").networks == []
 
 
 # --- the OS token on the token fetch (ADR 0039 D-b, D-c, D-e) --------------------------------------
@@ -11678,7 +11678,7 @@ def _fetch_tokens_query(monkeypatch, system):
         return httpx.Response(200, json={"networks": []})
 
     _mock_control_plane(monkeypatch, handler)
-    assert control_plane.fetch_tokens("sess-tok", "dev-1") == []
+    assert control_plane.fetch_tokens("sess-tok", "dev-1").networks == []
     return seen["params"]
 
 
@@ -11709,6 +11709,67 @@ def test_fetch_tokens_sends_no_os_parameter_when_the_system_resolves_to_nothing(
     params = _fetch_tokens_query(monkeypatch, system)
     assert "os" not in params
     assert params["device_id"] == "dev-1"
+
+
+# --- `os_served`, the answer to "why is there no OS grid in my list" (ADR 0039 D-k) ---------------
+# Read off the RESPONSE rather than inferred from the grid list, and deliberately so: this repository
+# holds no `os-community` constant of its own (see `tests/test_os_grid_type_lockstep.py`), so the
+# network types in the bundle are strings it prints and never compares. The key is the only thing
+# here that can tell "you were served an OS grid" from "you were not".
+
+
+def _fetch_tokens_answer(monkeypatch, tmp_path, payload):
+    """What `fetch_tokens` makes of a control plane that answered ``payload``."""
+    from remote import control_plane
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    _mock_control_plane(monkeypatch, lambda r: httpx.Response(200, json=payload))
+    return control_plane.fetch_tokens("sess-tok", "dev-1")
+
+
+def test_fetch_tokens_carries_the_os_served_flag_beside_the_networks(monkeypatch, tmp_path):
+    answer = _fetch_tokens_answer(
+        monkeypatch, tmp_path,
+        {"networks": [{"network_id": "n1", "name": "macOS"}], "os_served": True})
+    assert answer.os_served is True
+    assert answer.networks == [{"network_id": "n1", "name": "macOS"}]  # the networks are untouched
+
+
+def test_fetch_tokens_reports_an_explicit_false_as_false(monkeypatch, tmp_path):
+    """The whole point of the key: an empty list that says WHY it is empty."""
+    answer = _fetch_tokens_answer(monkeypatch, tmp_path, {"networks": [], "os_served": False})
+    assert answer.os_served is False
+    assert answer.networks == []
+
+
+def test_fetch_tokens_reports_a_missing_os_served_as_unknown(monkeypatch, tmp_path):
+    """An older control plane does not send the key, and that must not read as ``False``.
+
+    ADR 0039 D-k: a new key on an existing endpoint degrades silently. ``None`` is what makes the CLI
+    print nothing and behave exactly as it did before — a ``False`` here would put "this control plane
+    isn't serving one" in front of everybody who has not upgraded their control plane yet.
+    """
+    answer = _fetch_tokens_answer(monkeypatch, tmp_path, {"networks": []})
+    assert answer.os_served is None
+
+
+@pytest.mark.parametrize("value", ["false", "true", 0, 1, "", None, [], {}])
+def test_fetch_tokens_reads_a_non_boolean_os_served_as_unknown(monkeypatch, tmp_path, value):
+    """Anything that is not a real ``bool`` degrades to "the control plane did not say".
+
+    Compared by identity against ``True``/``False``, never for truthiness — the standing rule for
+    every wire enum in these repositories. ``"false"`` is the one that matters most: truthy in Python,
+    so a truthiness test would read a control plane REFUSING to serve an OS grid as serving one.
+    """
+    answer = _fetch_tokens_answer(monkeypatch, tmp_path, {"networks": [], "os_served": value})
+    assert answer.os_served is None
+
+
+def test_fetch_tokens_survives_a_body_that_is_not_an_object(monkeypatch, tmp_path):
+    """A list, or anything else that is not a JSON object, is no networks and no flag — never a crash
+    inside `grid login`. The bundle is the trust boundary; `_validated` is what refuses bad rows."""
+    answer = _fetch_tokens_answer(monkeypatch, tmp_path, [{"network_id": "n1"}])
+    assert (answer.networks, answer.os_served) == ([], None)
 
 
 def test_control_plane_raises_on_error_status(monkeypatch, tmp_path):
@@ -19209,8 +19270,13 @@ def test_live_identities_reports_an_unreadable_table_as_unscanned(monkeypatch, t
 # grid login / grid logout (cli/auth.py + dispatch gate)
 # ---------------------------------------------------------------------------
 
-def _device_flow(monkeypatch, *, poll_statuses, networks, started=None):
-    """Wire control_plane + webbrowser + sleep for a cmd_login run; return a calls record."""
+def _device_flow(monkeypatch, *, poll_statuses, networks, started=None, os_served=None):
+    """Wire control_plane + webbrowser + sleep for a cmd_login run; return a calls record.
+
+    ``os_served`` is the control plane's answer to "were you handed an OS grid" (ADR 0039 D-k) and
+    defaults to ``None`` — a control plane too old to send the key, which is what every test that
+    predates it was really exercising and the one value that makes `grid login` say nothing new.
+    """
     from cli import auth
     from remote import control_plane
 
@@ -19224,7 +19290,7 @@ def _device_flow(monkeypatch, *, poll_statuses, networks, started=None):
 
     def fetch(session_token, device_id, api_url=None):
         calls["fetch_device_id"], calls["fetch_session"] = device_id, session_token
-        return networks
+        return control_plane.TokenFetch(networks=networks, os_served=os_served)
 
     monkeypatch.setattr(control_plane, "fetch_tokens", fetch)
 
@@ -19426,7 +19492,14 @@ def test_relogin_reuses_device_id_and_overwrites_tokens(monkeypatch, tmp_path):
 
 
 def test_login_json_emits_names_only_and_no_tokens(monkeypatch, tmp_path, capsys):
+    import platform
+
     monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    # ⚠️ Pinned, because the `os_grid` field below is otherwise MACHINE-DEPENDENT (ADR 0039 D-k):
+    # on a system outside the closed OS-token set this payload would carry an absence and the
+    # exact-equality assertion would fail on who ran it. `None` — nothing to report — is what a Mac,
+    # a Linux box or a Windows box all produce against a control plane that sent no `os_served`.
+    monkeypatch.setattr(platform, "system", lambda: "Darwin")
     _device_flow(
         monkeypatch,
         poll_statuses=[_APPROVED],
@@ -19439,6 +19512,7 @@ def test_login_json_emits_names_only_and_no_tokens(monkeypatch, tmp_path, capsys
     assert json.loads(captured.out) == {
         "signed_in": True, "email": "a@b.com",
         "grids": [{"name": "team", "type": "permissioned-public"}], "active": None,
+        "os_grid": None,
     }
     for secret in ("SESS-secret", "AT-secret", "RT-secret"):
         assert secret not in captured.out
@@ -20168,8 +20242,13 @@ def _sync_seed(networks: list[dict[str, Any]] | None = None, *, session_token: s
 
 
 def _sync_patch_fetch(monkeypatch: pytest.MonkeyPatch, networks: list[dict[str, Any]],
-                      calls: list[dict[str, Any]] | None = None) -> None:
+                      calls: list[dict[str, Any]] | None = None,
+                      os_served: bool | None = None) -> None:
     """Patch control_plane.fetch_tokens to return `networks` (no live control plane).
+
+    ``os_served`` is the control plane's answer to "were you handed an OS grid" (ADR 0039 D-k);
+    ``None`` — the default — is a control plane too old to send the key, so `grid sync` prints
+    nothing new and every test written before it keeps asserting the same output.
 
     Note for anyone adding a sync test: `grid sync` overwrites `[[networks]]` authoritatively, so it
     asks `signout.warn_stranded` which grids still have a live serve child — which reads the real host
@@ -20182,7 +20261,7 @@ def _sync_patch_fetch(monkeypatch: pytest.MonkeyPatch, networks: list[dict[str, 
     def fake_fetch_tokens(session_token, device_id, api_url=None):
         if calls is not None:
             calls.append({"session_token": session_token, "device_id": device_id, "api_url": api_url})
-        return [dict(n) for n in networks]
+        return control_plane.TokenFetch(networks=[dict(n) for n in networks], os_served=os_served)
 
     monkeypatch.setattr(control_plane, "fetch_tokens", fake_fetch_tokens)
 
@@ -20210,7 +20289,8 @@ def test_sync_gated_in_local_mode(monkeypatch, tmp_path):
 
     monkeypatch.setenv("GRID_HOME", str(tmp_path))  # default mode is local
     called = []
-    monkeypatch.setattr(control_plane, "fetch_tokens", lambda *a, **k: called.append(1) or [])
+    monkeypatch.setattr(control_plane, "fetch_tokens",
+                        lambda *a, **k: called.append(1) or control_plane.TokenFetch([], None))
     with pytest.raises(SystemExit) as exc:
         cli.main(["sync"])
     assert "remote" in str(exc.value).lower()
@@ -20223,7 +20303,8 @@ def test_sync_requires_login(monkeypatch, tmp_path):
 
     monkeypatch.setenv("GRID_HOME", str(tmp_path))  # not signed in
     called = []
-    monkeypatch.setattr(control_plane, "fetch_tokens", lambda *a, **k: called.append(1) or [])
+    monkeypatch.setattr(control_plane, "fetch_tokens",
+                        lambda *a, **k: called.append(1) or control_plane.TokenFetch([], None))
     with pytest.raises(SystemExit) as exc:
         _run_sync()
     assert "signed in" in str(exc.value).lower()  # require_session message
@@ -20439,9 +20520,16 @@ def test_sync_treats_a_renamed_grid_as_the_same_grid(monkeypatch, tmp_path, caps
 def test_sync_json_keeps_stdout_clean_while_warning_about_a_stranded_child(monkeypatch, tmp_path, capsys):
     """The warning is a human line on stderr; `--json` stdout stays parseable, as it already does for
     the 0-grids wipe warning beside it."""
+    import platform
+
     from shared import run_records
 
     monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    # ⚠️ Pinned, because the `os_grid` field below is otherwise MACHINE-DEPENDENT (ADR 0039 D-k):
+    # on a system outside the closed OS-token set this payload would carry an absence and the
+    # exact-equality assertion would fail on who ran it. `None` — nothing to report — is what a Mac,
+    # a Linux box or a Windows box all produce against a control plane that sent no `os_served`.
+    monkeypatch.setattr(platform, "system", lambda: "Darwin")
     _sync_seed([_sync_bundle("net-b")])
     run_records.write_record("net-b", "remote", {
         "engine_id": "remote", "grid_id": "net-b", "pid": 4242,
@@ -20452,7 +20540,7 @@ def test_sync_json_keeps_stdout_clean_while_warning_about_a_stranded_child(monke
 
     assert _run_sync(["sync", "--json"]) == 0
     captured = capsys.readouterr()
-    assert json.loads(captured.out) == {"synced": True, "grids": []}
+    assert json.loads(captured.out) == {"synced": True, "grids": [], "os_grid": None}
     assert "grid leave net-b" in captured.err
 
 
@@ -20467,7 +20555,7 @@ def test_sync_concurrent_logout_does_not_strand_partial_file(monkeypatch, tmp_pa
 
     def logout_then_return(session_token, device_id, api_url=None):
         credentials.clear_credentials()  # concurrent `grid logout` deletes the file mid-call
-        return [dict(_sync_bundle("net-a"))]
+        return control_plane.TokenFetch(networks=[dict(_sync_bundle("net-a"))], os_served=None)
 
     monkeypatch.setattr(control_plane, "fetch_tokens", logout_then_return)
     assert _run_sync() == 0
@@ -20531,7 +20619,14 @@ def test_sync_other_error_propagates_unchanged(monkeypatch, tmp_path):
 
 
 def test_sync_json_emits_names_only_and_no_tokens(monkeypatch, tmp_path, capsys):
+    import platform
+
     monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    # ⚠️ Pinned, because the `os_grid` field below is otherwise MACHINE-DEPENDENT (ADR 0039 D-k):
+    # on a system outside the closed OS-token set this payload would carry an absence and the
+    # exact-equality assertion would fail on who ran it. `None` — nothing to report — is what a Mac,
+    # a Linux box or a Windows box all produce against a control plane that sent no `os_served`.
+    monkeypatch.setattr(platform, "system", lambda: "Darwin")
     _sync_seed([_sync_bundle("net-a", name="team", access_token="AT-secret",
                              refresh_token="RT-secret")], session_token="SESS-secret")
     _sync_patch_fetch(monkeypatch, [_sync_bundle("net-a", name="team", access_token="AT-secret",
@@ -20541,13 +20636,21 @@ def test_sync_json_emits_names_only_and_no_tokens(monkeypatch, tmp_path, capsys)
     captured = capsys.readouterr()
     assert json.loads(captured.out) == {
         "synced": True, "grids": [{"name": "team", "type": "permissioned-public"}],
+        "os_grid": None,
     }
     for secret in ("SESS-secret", "AT-secret", "RT-secret"):
         assert secret not in captured.out
 
 
 def test_sync_json_survives_empty_list_warning(monkeypatch, tmp_path, capsys):
+    import platform
+
     monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    # ⚠️ Pinned, because the `os_grid` field below is otherwise MACHINE-DEPENDENT (ADR 0039 D-k):
+    # on a system outside the closed OS-token set this payload would carry an absence and the
+    # exact-equality assertion would fail on who ran it. `None` — nothing to report — is what a Mac,
+    # a Linux box or a Windows box all produce against a control plane that sent no `os_served`.
+    monkeypatch.setattr(platform, "system", lambda: "Darwin")
     _sync_seed([_sync_bundle("net-a")])
     _disable_orphan_sweep(monkeypatch)
     _sync_patch_fetch(monkeypatch, [])
@@ -20555,9 +20658,284 @@ def test_sync_json_survives_empty_list_warning(monkeypatch, tmp_path, capsys):
     assert _run_sync(["sync", "--json"]) == 0
     captured = capsys.readouterr()
     # stdout stays clean, parseable JSON; the human warning is confined to stderr
-    assert json.loads(captured.out) == {"synced": True, "grids": []}
+    assert json.loads(captured.out) == {"synced": True, "grids": [], "os_grid": None}
     assert "Warning" not in captured.out
     assert "cleared locally" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# A missing OS grid says why (ADR 0039 D-k) — `cli/os_grid_notice.py`
+# ---------------------------------------------------------------------------
+# Three different things leave somebody with no OS grid in their list, and today they share one
+# symptom. The CLI answers one of them on its own — it knows its own operating system and the closed
+# set of tokens it can emit — and the control plane's `os_served` answers the other two.
+#
+# The bar the whole section is written against: nothing here may turn an absent OS grid into a failed
+# command, and somebody who HAS an OS grid must see no new output at all. A line on every ordinary
+# sign-in is a line people learn to scroll past.
+
+
+def _absence(monkeypatch, system, os_served):
+    """The notice a machine running ``system`` produces for that ``os_served`` answer."""
+    import platform
+
+    from cli import os_grid_notice
+
+    monkeypatch.setattr(platform, "system", lambda: system)
+    return os_grid_notice.absence(os_served)
+
+
+@pytest.mark.parametrize("os_served", [True, False, None])
+def test_a_system_with_no_os_token_is_answered_without_the_control_plane(monkeypatch, os_served):
+    """The CLI's own answer, and it does not consult the round trip AT ALL — including the `True`.
+
+    ADR 0039 D-k gives this cause to the CLI precisely because no round trip is needed for it: the
+    machine knows its own system and the closed set of tokens it can emit. Parametrised over every
+    answer the control plane can give so the independence is pinned rather than assumed — a later
+    refactor that folded this into the `os_served` branch would still pass on `False` alone.
+    """
+    from cli import os_grid_notice
+
+    absent = _absence(monkeypatch, "FreeBSD", os_served)
+    assert absent is not None
+    assert absent.reason == os_grid_notice.UNSUPPORTED_SYSTEM
+    assert absent.system == "FreeBSD"
+    assert absent.os_token is None  # there is no token — that IS the reason
+    assert "FreeBSD" in absent.line()
+
+
+def test_a_control_plane_that_serves_no_grid_for_this_os_is_a_different_answer(monkeypatch):
+    from cli import os_grid_notice
+
+    absent = _absence(monkeypatch, "Darwin", False)
+    assert absent is not None
+    assert absent.reason == os_grid_notice.NOT_SERVED
+    assert (absent.system, absent.os_token) == ("Darwin", "macos")
+
+
+def _cause_clause(absent):
+    """Everything after ``absent``'s sentence names the machine — that is, the CAUSE, on its own.
+
+    ⚠️ **The two cases can never share a machine** — one has an OS token and the other by definition
+    has none — so their raw sentences ALWAYS differ by that name, and comparing whole lines is
+    satisfied by the name even when both branches give the same cause. Measured, not guessed:
+    collapsing `line()`'s two cause clauses into one left this file green, including the test named
+    for the distinction.
+
+    ⚠️ **The subject is removed by its known PREFIX, never by `str.replace`.** The first version of
+    this helper blanked every occurrence of the name — which on the unsupported branch also blanks it
+    inside the list of tokens that branch names, so two identical clauses came out different and the
+    mirror of that mutation survived anyway. Over-blanking is the same failure as no blanking: the
+    comparison stops looking at the cause.
+    """
+    named = absent.os_token or absent.system
+    assert named, "the fixtures below name their system; a blank one would blank nothing"
+    prefix = f"No OS grid for {named}: "
+    line = absent.line()
+    assert line.startswith(prefix), (prefix, line)  # the shape this helper is cutting on
+    clause = line[len(prefix):]
+    assert clause.strip(), line  # never vacuous — an empty clause would compare equal to anything
+    return clause
+
+
+def test_the_two_reasons_do_not_read_as_the_same_sentence(monkeypatch):
+    """ADR 0039 D-k's whole purpose — a support conversation must be able to tell them apart."""
+    unsupported = _absence(monkeypatch, "FreeBSD", False)
+    not_served = _absence(monkeypatch, "Darwin", False)
+
+    # Both directions of the same mistake. Collapsing EITHER branch onto the other's clause must
+    # fail here: fixing one direction and leaving the mirror alive is what a whole-line comparison
+    # did, and what an over-blanking helper did after it.
+    assert _cause_clause(unsupported) != _cause_clause(not_served)
+    # And the name really is in the line a person reads — blanked above, never absent.
+    assert "FreeBSD" in unsupported.line() and "FreeBSD" not in not_served.line()
+
+
+@pytest.mark.parametrize("os_served", [True, None])
+def test_nothing_is_said_when_the_machine_has_a_token_and_no_refusal(monkeypatch, os_served):
+    """`True` is somebody who HAS an OS grid; `None` is a control plane too old to have said.
+
+    Both must be silent, and for different reasons: the first has nothing to report, and the second
+    is the clean silent degrade — the key is absent, so the CLI behaves exactly as it did before.
+    """
+    assert _absence(monkeypatch, "Darwin", os_served) is None
+
+
+@pytest.mark.parametrize("system", ["Linux", "Windows", "Darwin"])
+def test_every_system_the_cli_has_a_token_for_stays_quiet_when_served(monkeypatch, system):
+    assert _absence(monkeypatch, system, True) is None
+
+
+def test_a_system_that_does_not_even_name_itself_still_produces_a_sentence(monkeypatch):
+    """`platform.system()` answers the empty string on some frozen builds — already in the closed
+    set's list of things that resolve to no token. The line must still say something."""
+    absent = _absence(monkeypatch, "", False)
+    assert absent is not None and absent.line().strip()
+    assert "for :" not in absent.line()  # never a sentence with the subject missing
+
+
+def test_the_unsupported_line_names_every_token_this_cli_could_have_claimed(monkeypatch):
+    """The cause clause has to carry a FACT, not restate its own subject (ADR 0039 D-k).
+
+    ⚠️ **Derived from `OS_TOKENS`, so it cannot drift from what this CLI can actually ask for.**
+    Written out by hand it would keep naming three systems after `omarchy` lands (issue 04) — a line
+    telling somebody on the Omarchy grid that no grid exists for them. Asserted against the constant
+    rather than against the three of today, or this test would be the thing that has to be remembered.
+    """
+    from shared.system import os_grid
+
+    line = _absence(monkeypatch, "FreeBSD", False).line()
+    for token in os_grid.OS_TOKENS:
+        assert token in line, (token, line)
+    assert "FreeBSD" in line
+
+
+def test_the_absence_carries_the_same_fact_to_a_script_as_to_a_person(monkeypatch):
+    """ADR 0039 D-k / issue 07: `--json` must not lose what the human line says.
+
+    `os_token` is `None` exactly when the reason is `unsupported_system` — the two are one fact seen
+    twice, and a script may key on either.
+    """
+    from cli import os_grid_notice
+
+    assert _absence(monkeypatch, "FreeBSD", False).as_json() == {
+        "reason": os_grid_notice.UNSUPPORTED_SYSTEM, "system": "FreeBSD", "os_token": None}
+    assert _absence(monkeypatch, "Darwin", False).as_json() == {
+        "reason": os_grid_notice.NOT_SERVED, "system": "Darwin", "os_token": "macos"}
+
+
+# --- and the same fact, where a person actually meets it: `grid login` and `grid sync` -------------
+
+
+def _login_output(monkeypatch, tmp_path, capsys, *, system, os_served, args=("login", "--no-browser")):
+    import platform
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    monkeypatch.setattr(platform, "system", lambda: system)
+    _device_flow(monkeypatch, poll_statuses=[_APPROVED], networks=[], os_served=os_served)
+    code = cli.cmd_login(cli.build_parser().parse_args(list(args)))
+    return code, capsys.readouterr()
+
+
+def _sync_output(monkeypatch, tmp_path, capsys, *, system, os_served, args=("sync",)):
+    import platform
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    _sync_seed([], session_token="sess-1")
+    _disable_orphan_sweep(monkeypatch)
+    monkeypatch.setattr(platform, "system", lambda: system)
+    _sync_patch_fetch(monkeypatch, [], os_served=os_served)
+    code = _run_sync(args)
+    return code, capsys.readouterr()
+
+
+# Each command paired with the LAST thing it prints of its own accord, which is what the absence line
+# is appended after. Pairing them is what lets every case below assert on that command's own report
+# instead of on a phrase from the new sentence: keying on `"OS grid" not in out` would go vacuous the
+# moment `line()` is reworded to drop those two words, with nothing to notice. It also retires an `or`
+# across the two helpers that could not say which half had fired.
+_COMMAND_OUTPUTS = [
+    pytest.param(_login_output, "Signed in as a@b.com. You don't belong to any grids yet.\n",
+                 id="login"),
+    pytest.param(_sync_output, "Synced 0 grids.\n", id="sync"),
+]
+
+
+@pytest.mark.parametrize("output,reported", _COMMAND_OUTPUTS)
+def test_a_machine_outside_the_token_set_is_told_so_on_sign_in_and_on_sync(
+    monkeypatch, tmp_path, capsys, output, reported
+):
+    code, captured = output(monkeypatch, tmp_path, capsys, system="FreeBSD", os_served=None)
+    assert code == 0  # an absent OS grid is not a failure
+    assert "FreeBSD" in captured.out
+    assert reported in captured.out  # said as well as, never instead of
+
+
+@pytest.mark.parametrize("output,reported", _COMMAND_OUTPUTS)
+def test_a_control_plane_serving_no_os_grid_says_so_on_sign_in_and_on_sync(
+    monkeypatch, tmp_path, capsys, output, reported
+):
+    code, captured = output(monkeypatch, tmp_path, capsys, system="Darwin", os_served=False)
+    assert code == 0
+    assert "macos" in captured.out
+    assert "FreeBSD" not in captured.out
+    assert reported in captured.out
+
+
+@pytest.mark.parametrize("output,reported", _COMMAND_OUTPUTS)
+@pytest.mark.parametrize("os_served", [True, None])
+def test_nothing_extra_is_printed_when_there_is_nothing_to_report(
+    monkeypatch, tmp_path, capsys, output, os_served, reported
+):
+    """`None` is the pin on ADR 0039 D-k's silent degrade: against a control plane that does not send
+    the key, this prints nothing extra and behaves exactly as it did before.
+
+    ⚠️ Asserted as *the command's own report is the last thing on stdout*, never as "the new
+    sentence's words are absent". A phrase test passes for free the day somebody rewords `line()`,
+    and this is the criterion that keeps the feature quiet for everybody who has an OS grid — the one
+    least likely to be noticed if it silently stopped being checked.
+    """
+    code, captured = output(monkeypatch, tmp_path, capsys, system="Darwin", os_served=os_served)
+    assert code == 0
+    assert captured.out.endswith(reported), captured.out
+
+
+@pytest.mark.parametrize("output,reported", _COMMAND_OUTPUTS)
+def test_the_line_never_displaces_what_the_command_already_said(
+    monkeypatch, tmp_path, capsys, output, reported
+):
+    """It is an extra line, not a replacement — `grid sync` still reports its count, `grid login`
+    still reports the account, and something follows it.
+
+    ⚠️ **The `code == 0` here is a regression guard, not evidence.** Nothing in `absence()` or
+    `_print_os_grid_absence` raises or returns, so no mutation of today's code can fail it; it is
+    here so that an implementation which later grows a raise cannot land quietly. Do not read the
+    green as the suite defending the criterion — it defends it against the future, not the present.
+    """
+    code, captured = output(monkeypatch, tmp_path, capsys, system="FreeBSD", os_served=False)
+    assert code == 0
+    assert reported in captured.out            # the command's own report survived...
+    assert not captured.out.endswith(reported)  # ...and the line was appended after it
+
+
+def test_login_json_carries_the_absence_as_a_field(monkeypatch, tmp_path, capsys):
+    from cli import os_grid_notice
+
+    _, captured = _login_output(monkeypatch, tmp_path, capsys, system="FreeBSD", os_served=False,
+                                args=("login", "--no-browser", "--json"))
+    payload = json.loads(captured.out)
+    assert payload["os_grid"] == {
+        "reason": os_grid_notice.UNSUPPORTED_SYSTEM, "system": "FreeBSD", "os_token": None}
+    assert payload["signed_in"] is True  # the rest of the answer is unchanged
+
+
+def test_sync_json_carries_the_absence_as_a_field(monkeypatch, tmp_path, capsys):
+    from cli import os_grid_notice
+
+    _, captured = _sync_output(monkeypatch, tmp_path, capsys, system="Darwin", os_served=False,
+                               args=("sync", "--json"))
+    payload = json.loads(captured.out)
+    assert payload["os_grid"] == {
+        "reason": os_grid_notice.NOT_SERVED, "system": "Darwin", "os_token": "macos"}
+    assert payload["synced"] is True
+
+
+@pytest.mark.parametrize("os_served", [True, None])
+def test_the_json_field_is_null_rather_than_absent_when_there_is_nothing_to_say(
+    monkeypatch, tmp_path, capsys, os_served
+):
+    """A key that comes and goes is a key every script has to guard; `null` is one shape to read."""
+    _, login = _login_output(monkeypatch, tmp_path, capsys, system="Darwin", os_served=os_served,
+                             args=("login", "--no-browser", "--json"))
+    assert json.loads(login.out)["os_grid"] is None
+
+
+def test_the_json_line_is_not_also_printed_as_prose(monkeypatch, tmp_path, capsys):
+    """`--json` keeps stdout parseable — the fact rides the field, never a sentence beside it."""
+    _, captured = _sync_output(monkeypatch, tmp_path, capsys, system="FreeBSD", os_served=False,
+                               args=("sync", "--json"))
+    assert json.loads(captured.out)["os_grid"]["system"] == "FreeBSD"
+    assert "FreeBSD" not in captured.err
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -11765,11 +11765,105 @@ def test_fetch_tokens_reads_a_non_boolean_os_served_as_unknown(monkeypatch, tmp_
     assert answer.os_served is None
 
 
-def test_fetch_tokens_survives_a_body_that_is_not_an_object(monkeypatch, tmp_path):
-    """A list, or anything else that is not a JSON object, is no networks and no flag — never a crash
-    inside `grid login`. The bundle is the trust boundary; `_validated` is what refuses bad rows."""
-    answer = _fetch_tokens_answer(monkeypatch, tmp_path, [{"network_id": "n1"}])
-    assert (answer.networks, answer.os_served) == ([], None)
+@pytest.mark.parametrize("body", [[{"network_id": "n1"}], [], "ok", 7])
+def test_fetch_tokens_refuses_a_body_that_is_not_an_object(monkeypatch, tmp_path, body):
+    """A 200 whose body is not a JSON object is a DATA error, and must never read as "zero grids".
+
+    ⚠️ **This overturns the rule the previous test encoded** ("no networks and no flag — never a
+    crash"), and the reason is what that rule cost. `_validated` is the trust boundary for bad ROWS,
+    but it iterates a list: a body that is not an object yields no rows to validate, sails through,
+    and `cmd_sync` then writes `networks: []` authoritatively — discarding every grid's access AND
+    refresh token, which refresh rotation makes unrecoverable. A stderr line saying it "may be
+    transient" is not a recovery.
+
+    "Never a crash" is still honoured and was never the same question: `ControlPlaneError` is a
+    `SystemExit` subclass, so this is the CLI's ordinary clean-error idiom — a sentence and a non-zero
+    exit, no traceback — not the `AttributeError` the code raised before the fallback was added.
+    """
+    from remote import control_plane
+
+    with pytest.raises(SystemExit) as exc:
+        _fetch_tokens_answer(monkeypatch, tmp_path, body)
+
+    assert isinstance(exc.value, control_plane.ControlPlaneError)
+    assert "/v1/grid/tokens" in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    ("label", "content"),
+    [("json null", b"null"), ("not json at all", b"<html>502</html>"), ("empty body", b"")])
+def test_fetch_tokens_refuses_a_body_it_cannot_read_as_an_object(
+    monkeypatch, tmp_path, label, content
+):
+    """The shapes that never reach `isinstance` — same fault, same refusal, still no traceback.
+
+    An empty 200 is why this route does not use the module's own `_json_or_empty`: its `{}` is exactly
+    the "zero grids" reading that costs the credential store. `RecursionError` is caught beside
+    `ValueError` because `json.loads` raises it on a deeply nested body and no `except ValueError`
+    would see it.
+    """
+    from remote import control_plane
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    _mock_control_plane(monkeypatch, lambda r: httpx.Response(200, content=content))
+
+    with pytest.raises(control_plane.ControlPlaneError) as exc:
+        control_plane.fetch_tokens("sess-tok", "dev-1")
+
+    assert "/v1/grid/tokens" in str(exc.value), label
+
+
+def test_the_malformed_body_refusal_is_not_mistaken_for_an_expired_session(monkeypatch, tmp_path):
+    """`cmd_sync` rewrites one class of failure and must not rewrite this one.
+
+    Its `_SESSION_EXPIRED_RE` is anchored on `control_plane._raise`'s "<METHOD> <URL> failed (401):"
+    rendering. A refusal that matched it would tell somebody to run `grid login` for a control plane
+    that answered 200 with a broken body — sending them to re-authenticate against a fault no
+    credential can fix.
+    """
+    with pytest.raises(SystemExit) as exc:
+        _fetch_tokens_answer(monkeypatch, tmp_path, [])
+
+    assert cli.auth._SESSION_EXPIRED_RE.match(str(exc.value)) is None
+
+
+def test_sync_keeps_every_stored_credential_when_the_answer_is_malformed(monkeypatch, tmp_path):
+    """The failure the refusal above exists to prevent, asserted where it would actually happen.
+
+    `cmd_sync`'s overwrite is authoritative and last-writer-wins, so there is no second copy of a
+    refresh token anywhere once it has run.
+    """
+    from remote import credentials
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    _disable_orphan_sweep(monkeypatch)
+    _sync_seed([_sync_bundle("net-a", refresh_token="RT-a"), _sync_bundle("net-b")])
+    _mock_control_plane(monkeypatch, lambda r: httpx.Response(200, json=[]))
+
+    with pytest.raises(SystemExit):
+        _run_sync()
+
+    data = credentials.load_credentials()
+    assert [n["network_id"] for n in data["networks"]] == ["net-a", "net-b"]
+    assert data["networks"][0]["refresh_token"] == "RT-a"
+
+
+def test_sync_still_accepts_an_ordinary_empty_answer(monkeypatch, tmp_path):
+    """The negative control, and the case the refusal must NOT swallow.
+
+    A control plane that genuinely serves this account no grids answers `{"networks": []}` — an
+    object. That is an ordinary answer, it still clears the stored list, and it still warns. Without
+    this, the refusal above is satisfied by a CLI that had stopped honouring a real removal.
+    """
+    from remote import credentials
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    _disable_orphan_sweep(monkeypatch)
+    _sync_seed([_sync_bundle("net-a")])
+    _mock_control_plane(monkeypatch, lambda r: httpx.Response(200, json={"networks": []}))
+
+    assert _run_sync() == 0
+    assert credentials.load_credentials()["networks"] == []
 
 
 def test_control_plane_raises_on_error_status(monkeypatch, tmp_path):
@@ -20878,6 +20972,37 @@ def test_a_control_plane_that_serves_no_grid_for_this_os_is_a_different_answer(m
     assert absent is not None
     assert absent.reason == os_grid_notice.NOT_SERVED
     assert (absent.system, absent.os_token) == ("Darwin", "macos")
+
+
+@pytest.mark.parametrize("system", ["Darwin", "Linux", "Windows"])
+def test_a_deployment_serving_no_os_grid_at_all_still_says_so(monkeypatch, system):
+    """The state a reviewer will read as a bug, pinned as the decision it is (ADR 0039 D-k).
+
+    A control plane with `GRID_OS_GRID_ENABLED` off and nothing provisioned answers `os_served:
+    false` for **every** caller — `grid_networks/handler.get_tokens` computes it as "is an
+    os-community grid among the bundles this call is returning", and `_ensure_os_network` creates
+    none while the switch is off. So on that deployment every user on every supported system sees
+    this line on every sign-in and every sync.
+
+    ⚠️ **That is decided, not accidental.** D-k names *the feature switched off with nothing
+    provisioned* as the first of four states `false` collapses, and says all four reach a person as
+    the same sentence — *this service is not giving me one*. The alternative that would have kept
+    them apart, a reason string, was rejected on three counts, none of which was difficulty.
+
+    So this test exists to make a "fix" fail. Suppressing the line for a not-serving deployment would
+    ALSO suppress it for the three other states, including a provision that failed and left the row
+    `pending` — which is the state somebody actually needs to be told about. If the noise is judged
+    too high, the change is an amendment to D-k.
+    """
+    from cli import os_grid_notice
+
+    absent = _absence(monkeypatch, system, False)
+
+    assert absent is not None, (
+        f"a {system} machine on a deployment serving no OS grid was told nothing — D-k decided it "
+        f"is told; amend the ADR rather than the code")
+    assert absent.reason == os_grid_notice.NOT_SERVED
+    assert "isn't serving one" in absent.line()
 
 
 def _cause_clause(absent):

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -11722,9 +11722,19 @@ def test_control_plane_raises_on_error_status(monkeypatch, tmp_path):
 
 
 def test_control_plane_refresh_network_token_posts_refresh_unauthenticated(monkeypatch, tmp_path):
+    import platform
+
     from remote import control_plane
 
     monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    # ⚠️ Pinned, because this body is otherwise MACHINE-DEPENDENT and the exact-equality assertion
+    # below would pass or fail on who ran it. Since ADR 0039 D-e the call also carries the machine's
+    # OS claim, so it is two keys on a Mac or a Linux box and one on anything outside the closed set
+    # — this test failed on the developer's Mac and would have passed untouched on a BSD. Pinning
+    # keeps the assertion EXACT (which is what catches an unconditional extra field being added)
+    # rather than loosening it to a subset check. The claim's own presence and omission are covered
+    # by `test_the_refresh_exchange_carries_the_os_token_too` and its sibling.
+    monkeypatch.setattr(platform, "system", lambda: "Darwin")
     seen = {}
 
     def handler(request):
@@ -11737,7 +11747,7 @@ def test_control_plane_refresh_network_token_posts_refresh_unauthenticated(monke
     bundle = control_plane.refresh_network_token(network_id="n1", refresh_token="RT1")
     assert bundle == {"access_token": "AT2", "refresh_token": "RT2"}
     assert (seen["method"], seen["path"]) == ("POST", "/v1/grid/tokens/n1")
-    assert seen["body"] == {"refresh_token": "RT1"}
+    assert seen["body"] == {"refresh_token": "RT1", "os": "macos"}
     assert seen["auth"] is None  # the refresh token IS the credential — no Bearer header
 
 
@@ -39030,3 +39040,98 @@ def test_a_root_the_operator_NAMED_is_not_judged_by_the_defaults_rules(
     assert _the_child_would_claim_tasks(spawned), (
         f"a root the operator named was judged by the default's rules: {capsys.readouterr().err!r}")
     assert not (tmp_path / "never-made").exists(), "the default root was made despite a named one"
+
+
+def _refresh_body(monkeypatch, system):
+    """The JSON body `refresh_network_token` builds on a machine whose ``platform.system()`` is that."""
+    import json as _json
+    import platform
+
+    from remote import control_plane
+
+    monkeypatch.setattr(platform, "system", lambda: system)
+    seen = {}
+
+    def handler(request):
+        seen["body"] = _json.loads(request.content)
+        return httpx.Response(200, json={"access_token": "a", "refresh_token": "r"})
+
+    _mock_control_plane(monkeypatch, handler)
+    control_plane.refresh_network_token(network_id="grid-1", refresh_token="rt-1")
+    return seen["body"]
+
+
+@pytest.mark.parametrize(
+    "system,expected",
+    [("Darwin", "macos"), ("Linux", "linux"), ("Windows", "windows")])
+def test_the_refresh_exchange_carries_the_os_token_too(monkeypatch, tmp_path, system, expected):
+    """ADR 0039 D-e, issue 10 — the claim rides the RENEWAL, not only the first fetch.
+
+    On an `os-community` grid nothing about the OS is stored, so a refresh that carried no claim
+    matched nothing and was refused: the bundle the fetch handed out contained a `refresh_token` that
+    was inert on exactly one network type. A machine serving such a grid then went dark the first time
+    the grid's `network_epoch` moved, and the recovery was a person — `grid sync` needs a session
+    token, and those live 24 hours.
+
+    Asserted at the wire, and on the BODY rather than the query string: this route is a POST and the
+    refresh credential already travels in the body, so the claim goes with it.
+    """
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    body = _refresh_body(monkeypatch, system)
+    assert body["os"] == expected
+    assert body["refresh_token"] == "rt-1"  # the claim rides ALONGSIDE the credential, never instead
+
+
+@pytest.mark.parametrize("system", ["FreeBSD", "Java", ""])
+def test_the_refresh_exchange_omits_the_os_key_when_there_is_no_token(monkeypatch, tmp_path, system):
+    """Omitted entirely, never an empty string — the same discipline as the fetch, for the same reason.
+
+    The far end gates by equality against a grid's own token, so an empty string would be a second
+    spelling of "no claim" for it to recognise. And a machine outside the closed set must still renew
+    every OTHER grid it belongs to: this call is not about OS grids, it merely also serves them.
+    """
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    body = _refresh_body(monkeypatch, system)
+    assert "os" not in body
+    assert body["refresh_token"] == "rt-1"
+
+
+def test_the_serve_loops_own_refresh_carries_the_os_claim(monkeypatch, tmp_path):
+    """The scenario issue 10 exists for, asserted at the loop rather than at the HTTP helper.
+
+    An access token lives a year, so a serving machine does not refresh on expiry — it refreshes when
+    the grid's `network_epoch` moves, which makes the relay answer 401 and sends `_ServeState.refresh`
+    here. On an `os-community` grid that exchange used to be refused, and because a refused exchange
+    also CONSUMED the credential, the machine went dark permanently with no person watching.
+
+    Asserted through `_ServeState.refresh` and not `control_plane.refresh_network_token` because the
+    loop is the caller that matters and it passes no claim of its own: it inherits one because the
+    helper reads `os_grid.os_token()` itself. A future refactor that threaded the claim through the
+    loop's arguments instead would leave the helper's own test green and this one red, which is the
+    right way round.
+    """
+    import json as _json
+    import platform
+
+    from remote import credentials, serve
+
+    monkeypatch.setattr(platform, "system", lambda: "Darwin")
+    state = _serve_state(monkeypatch, tmp_path)
+    credentials.save_credentials({"networks": [
+        {"network_id": "n1", "access_token": "AT", "refresh_token": "RT"}]})
+    seen = {}
+
+    def handler(request):
+        seen["body"] = _json.loads(request.content)
+        return httpx.Response(200, json={"access_token": "AT-2", "refresh_token": "RT-2"})
+
+    _mock_control_plane(monkeypatch, handler)
+
+    assert serve._ServeState.refresh(state, "AT") is True
+    assert seen["body"]["os"] == "macos"
+    assert seen["body"]["refresh_token"] == "RT"
+    # And the loop kept what it was given, so the NEXT 401 does not replay a spent credential.
+    assert state.token() == "AT-2"
+    stored = next(n for n in credentials.load_credentials()["networks"] if n["network_id"] == "n1")
+    assert stored["access_token"] == "AT-2"
+    assert stored["refresh_token"] == "RT-2"

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -31642,6 +31642,45 @@ def test_launch_refusals_distinguish_a_dead_credential_from_a_broken_control_pla
         assert seen["spawns"] == [], "nothing is started on a refusal"
 
 
+def test_launch_never_tells_a_403_that_re_syncing_cannot_restore_the_membership(monkeypatch,
+                                                                                tmp_path):
+    """The one piece of advice in this file that is INVERTED on `os-community` grids (ADR 0039 D-e).
+
+    A 403 on the refresh exchange says the membership the refresh credential names is not currently
+    good. On every grid type that predates OS grids that membership is a stored row somebody else
+    controls, so `grid login` re-mints from the same row and re-signing in really is a circle — which
+    is what this message used to state flatly. On an OS grid there is no row at all: membership is
+    re-derived on every request from the `os=` claim that ONLY the token fetch sends, so
+    `grid sync` / `grid login` is the *whole* repair, and a machine told "signing in will not change
+    it" is a machine told to give up on the one thing that works.
+
+    So the message may not promise either outcome. It names the cheap thing to try and says what it
+    means when that does not work, which is true on both kinds of grid — and stays out of the
+    business of guessing which one this is, because a local `network_type` is a snapshot from the
+    last sync and a fourth copy of a cross-repo literal this repository deliberately does not hold.
+    """
+    from remote import control_plane
+
+    _seed_launch_with_token(monkeypatch, tmp_path, _jwt({"exp": _in(-86400)}))
+    _mock_token_refresh(monkeypatch, error=control_plane.ControlPlaneError(
+        "POST https://api.example/v1/grid/tokens/n1 failed (403): "
+        '{"detail": "Not allowed on this Grid network"}', status=403))
+    _capture_launch(monkeypatch)
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["launch", "claude"])
+    message = str(exc.value)
+    assert "grid sync" in message, (
+        "the refusal must name the command that re-makes the OS claim, which is the only repair "
+        f"there is on an OS grid: {message}")
+    assert "will not change it" not in message, (
+        "the flat denial is false on an `os-community` grid, where re-syncing is the whole repair: "
+        f"{message}")
+    # The 401/403 split still has to survive the rewording: a 403 is not "your sign-in expired", and
+    # a message that read that way would send the user to a browser for a membership problem.
+    assert "not your sign-in" in message, message
+
+
 def test_launch_warns_and_launches_when_a_still_valid_token_cannot_be_renewed(monkeypatch, tmp_path,
                                                                               capsys):
     """The clause that bounds failing open: never cost the user a launch **that would have worked**.

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -11657,6 +11657,60 @@ def test_control_plane_fetch_tokens_defaults_missing_networks_to_empty(monkeypat
     assert control_plane.fetch_tokens("sess", "dev-1") == []
 
 
+# --- the OS token on the token fetch (ADR 0039 D-b, D-c, D-e) --------------------------------------
+# `os=` is the ONLY channel a machine has to say what it runs: the device-login start and poll calls
+# carry nothing about the machine, and the browser that approves a sign-in may be a different device
+# entirely. Asserted AT THE WIRE rather than on `os_grid.os_token`'s internals — what matters is what a
+# machine of a given system ends up sending, and the parameter is what the control plane gates on.
+
+
+def _fetch_tokens_query(monkeypatch, system):
+    """The query string `fetch_tokens` builds on a machine whose ``platform.system()`` is ``system``."""
+    import platform
+
+    from remote import control_plane
+
+    monkeypatch.setattr(platform, "system", lambda: system)
+    seen = {}
+
+    def handler(request):
+        seen["params"] = dict(request.url.params)
+        return httpx.Response(200, json={"networks": []})
+
+    _mock_control_plane(monkeypatch, handler)
+    assert control_plane.fetch_tokens("sess-tok", "dev-1") == []
+    return seen["params"]
+
+
+@pytest.mark.parametrize(
+    "system,expected",
+    [("Darwin", "macos"), ("Linux", "linux"), ("Windows", "windows")])
+def test_fetch_tokens_sends_the_os_token_of_the_machine_it_runs_on(
+    monkeypatch, tmp_path, system, expected
+):
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    params = _fetch_tokens_query(monkeypatch, system)
+    assert params["os"] == expected
+    assert params["device_id"] == "dev-1"  # the OS rides ALONGSIDE the device id, never instead of it
+
+
+@pytest.mark.parametrize("system", ["FreeBSD", "Java", ""])
+def test_fetch_tokens_sends_no_os_parameter_when_the_system_resolves_to_nothing(
+    monkeypatch, tmp_path, system
+):
+    """ADR 0039 D-c: anything outside the closed set resolves to NOTHING, and the call still works.
+
+    Absent, never an empty string or a placeholder: the control plane's gate is an equality test
+    against a grid's own token, and `os=` sent empty would be one more value that has to be
+    recognised as "no claim" at the far end. The request itself must not fail — a machine with no OS
+    grid still has every other grid it belongs to.
+    """
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    params = _fetch_tokens_query(monkeypatch, system)
+    assert "os" not in params
+    assert params["device_id"] == "dev-1"
+
+
 def test_control_plane_raises_on_error_status(monkeypatch, tmp_path):
     from remote import control_plane
 
@@ -20769,6 +20823,28 @@ def test_remote_ls_json_emits_grid_and_type(monkeypatch, tmp_path, capsys):
     assert cli.main(["ls", "--json"]) == 0
     assert json.loads(capsys.readouterr().out) == [
         {"grid": "team", "type": "permissioned-public", "id": "n1"}]
+
+
+def test_remote_ls_prints_an_os_grid_like_any_other_type(monkeypatch, tmp_path, capsys):
+    """An OS grid is a row like any other, and its type is printed VERBATIM (ADR 0039 Consequences).
+
+    `grid ls` reads the locally-stored list `GET /tokens` filled, and this repository holds no
+    `os-community` constant to compare against — the type is whatever the control plane said. So the
+    thing worth pinning is that a type this CLI has never heard of still renders in full: a renderer
+    that mapped known types to labels would print a blank column for the one grid most users will
+    never have created, and `grid ls` is the ONLY surface an OS grid has (ADR 0039 D-e — a browser
+    session has no machine to report, so `/me` and the app show nothing).
+    """
+    _seed_remote(monkeypatch, tmp_path, networks=[
+        {"network_id": "n1", "name": "team", "network_type": "permissioned-public"},
+        {"network_id": "n2", "name": "macOS", "network_type": "os-community"}])
+    assert cli.main(["ls"]) == 0
+    out = capsys.readouterr().out
+    assert "macOS" in out and "os-community" in out
+    assert "team" in out and "permissioned-public" in out  # the ordinary row is untouched
+    assert cli.main(["ls", "--json"]) == 0
+    assert json.loads(capsys.readouterr().out)[1] == {
+        "grid": "macOS", "type": "os-community", "id": "n2"}
 
 
 def test_remote_list_alias_lists_like_ls(monkeypatch, tmp_path, capsys):

--- a/tests/test_os_grid_type_lockstep.py
+++ b/tests/test_os_grid_type_lockstep.py
@@ -759,3 +759,173 @@ def test_the_flag_this_cli_names_is_the_one_it_actually_reads(monkeypatch, tmp_p
     assert read == {control_plane.OS_SERVED_KEY}, (
         f"`control_plane.OS_SERVED_KEY` is {control_plane.OS_SERVED_KEY!r} but `fetch_tokens` does "
         f"not read that key out of the answer — the constant and the parser have drifted apart")
+
+
+# --- who wrote the machine's name (ADR 0039 D-n, issue 16) ----------------------------------------
+
+# A boolean on the register meta saying whether the machine's `name` was chosen by a PERSON or is
+# just the box's hostname. On `os-community` the relay's public overview publishes the name only when
+# it was chosen; every other type publishes both, unchanged.
+#
+# ⚠️ **THREE copies, and two of them are providers in different repositories.** grid-src's fleet
+# runtime (`provider_runtime/provider/lifecycle.node_name_meta`) and this repository's public CLI
+# (`remote/serve._meta` — the binary an `os-community` member actually installs) each SEND it;
+# grid-src's relay (`private_server/overview.py`, through `member_identity_access
+# .published_node_name`) READS it. A rename on any one of the three leaves the other two green.
+#
+# ⚠️ **It degrades SILENTLY in both directions**, which is what makes this a pin rather than an
+# argument. The register meta is a MERGE, not a schema: an unknown key is stored and ignored, and a
+# missing key is not an error to anybody. Rename the provider's half and every suite in both
+# repositories stays green, every heartbeat succeeds, and the only symptom is that machines whose
+# operators DID name them stop being named on one grid type. Rename the relay's and the same thing
+# happens from the other end.
+#
+# ⚠️ **The rollout order is NONE, in either direction, and it is not hazardous either way** — the
+# fail-closed direction is what buys that. An old provider against a new relay sends nothing, absent
+# reads as *not chosen*, and the name is withheld: the private answer. An old relay against a new
+# provider stores the key and ignores it, which is today's behaviour exactly.
+
+#: The key that has been on this meta since the grid page existed — the positive control on both
+#: sides, and the proof each reader below is looking at the right dict.
+_META_CONTROL_KEY = "name"
+
+#: grid-src's relay half: the module that decides what the public overview calls a machine, and the
+#: function it hands the provider's claim to.
+_OVERVIEW = "grid_cli/private_server/overview.py"
+_OVERVIEW_GATE = "published_node_name"
+#: Its keyword — the argument carrying the provider's claim, as opposed to the name itself.
+_OVERVIEW_CLAIM_KEYWORD = "chosen"
+
+#: grid-src's own provider half: the fleet runtime's, which is NOT the one an os-community member
+#: runs but is the one most likely to be forgotten when the public CLI's is edited.
+_PROVIDER_LIFECYCLE = "grid_cli/provider_runtime/provider/lifecycle.py"
+_PROVIDER_META_FUNCTION = "node_name_meta"
+
+
+def _meta_key_the_relay_reads_as_chosen():
+    """The meta key grid-src's overview hands to its D-n gate, read off the call itself.
+
+    Read from the CALL rather than from a constant in `member_identity_access`, because what has to
+    keep agreeing with this CLI is the string looked up in the provider's payload — and a constant is
+    one refactor away from not being that string. Every shape this cannot read raises: a helper that
+    returned a plausible subset would guard nothing, and what it failed to guard would fail silently
+    too.
+    """
+    tree = _module(_OVERVIEW)
+    calls = [node for node in ast.walk(tree)
+             if isinstance(node, ast.Call)
+             and (getattr(node.func, "id", None) == _OVERVIEW_GATE
+                  or getattr(node.func, "attr", None) == _OVERVIEW_GATE)]
+    assert len(calls) == 1, (
+        f"expected exactly one call to {_OVERVIEW_GATE} in grid-src's {_OVERVIEW}, found "
+        f"{len(calls)} — the overview was restructured, so teach this pin the new shape rather than "
+        f"letting it read the wrong one")
+
+    claim = next((kw for kw in calls[0].keywords if kw.arg == _OVERVIEW_CLAIM_KEYWORD), None)
+    assert claim is not None, (
+        f"grid-src's {_OVERVIEW_GATE} call no longer passes {_OVERVIEW_CLAIM_KEYWORD}= — the claim "
+        f"is spelled somewhere else now, so teach this pin where")
+
+    keys = {node.value for node in ast.walk(claim.value)
+            if isinstance(node, ast.Constant) and isinstance(node.value, str)}
+    assert len(keys) == 1, (
+        f"grid-src reads its {_OVERVIEW_CLAIM_KEYWORD}= from "
+        f"{sorted(keys) or 'no string key at all'} in {_OVERVIEW}, so this check cannot tell which "
+        f"meta key carries the claim — teach it the new shape rather than deleting the pin")
+    return keys.pop()
+
+
+def _meta_keys_the_grid_src_provider_sends():
+    """Every constant key grid-src's fleet provider puts on the register meta's name pair."""
+    tree = _module(_PROVIDER_LIFECYCLE)
+    function = next(
+        (n for n in tree.body
+         if isinstance(n, ast.FunctionDef) and n.name == _PROVIDER_META_FUNCTION), None)
+    assert function is not None, (
+        f"grid-src's {_PROVIDER_LIFECYCLE} no longer defines {_PROVIDER_META_FUNCTION} — the fleet "
+        f"provider builds its name meta somewhere else now, so teach this pin where it went rather "
+        f"than letting it skip")
+
+    returns = [node for node in ast.walk(function) if isinstance(node, ast.Return)]
+    assert len(returns) == 1 and isinstance(returns[0].value, ast.Dict), (
+        f"grid-src's {_PROVIDER_META_FUNCTION} no longer returns a single dict literal, so this pin "
+        f"cannot read what it sends — teach it the new shape")
+
+    keys = set()
+    for key in returns[0].value.keys:
+        assert isinstance(key, ast.Constant) and isinstance(key.value, str), (
+            f"grid-src's {_PROVIDER_META_FUNCTION} builds a key this pin cannot read "
+            f"({ast.dump(key) if key is not None else '**spread'}); teach it the new shape")
+        keys.add(key.value)
+    return keys
+
+
+def _meta_key_this_cli_sends():
+    """The key this CLI's register meta uses to state that a person chose the name.
+
+    Measured by BUILDING two metas that differ in exactly that fact and asking which key moved,
+    rather than by reading this repository's source: what the relay has to recognise is the string
+    that arrives on the wire, and a pin that parsed `remote/serve.py` would go on agreeing with
+    grid-src about a spelling nobody sends.
+    """
+    from remote import serve
+
+    base = {"meta_name": "mybox", "endpoint_url": "http://h/v1"}
+    chosen = serve._meta({**base, "meta_name_chosen": True}, "remote")
+    unchosen = serve._meta({**base, "meta_name_chosen": False}, "remote")
+
+    # Positive control FIRST: prove `_meta` built a real payload at all. Without it a helper that
+    # returned two empty dicts would report "no key carries the claim" and read as drift that has not
+    # happened — the failure mode every pin in this file guards against explicitly.
+    assert chosen.get(_META_CONTROL_KEY) == "mybox" == unchosen.get(_META_CONTROL_KEY), (
+        f"positive control: `serve._meta` did not even put {_META_CONTROL_KEY!r} on the meta, so its "
+        f"verdict about the claim means nothing — fix the harness before believing it")
+
+    moved = {key for key in set(chosen) | set(unchosen) if chosen.get(key) != unchosen.get(key)}
+    assert len(moved) == 1, (
+        f"`serve._meta` answered differently on {sorted(moved) or 'no key at all'} for a chosen name "
+        f"and an unchosen one, so this check cannot tell which key carries the claim — teach it the "
+        f"new shape rather than deleting the pin")
+    return moved.pop()
+
+
+def test_the_key_saying_who_named_the_machine_is_spelled_the_same_on_both_sides_of_the_call():
+    """What this CLI sends and what grid-src's relay reads, compared against each other.
+
+    Neither repository can catch this alone, which is the whole reason it is written here. This
+    repository's `test_meta_says_whether_a_person_chose_the_node_name` asserts what the CLI sends,
+    grid-src's `test_os_grid_member_identity.py` asserts what the relay reads, and a developer
+    renaming the key updates the test on their own side along with the code. Both suites stay green,
+    the key stops being recognised, and every machine on an `os-community` grid whose operator DID
+    name it goes back to `node-<id>` — silently, because an unknown key on a merged meta payload is
+    stored and ignored rather than refused (ADR 0039 D-n).
+    """
+    read = _meta_key_the_relay_reads_as_chosen()
+    sent = _meta_key_this_cli_sends()
+
+    assert sent == read, (
+        f"this CLI states the claim as {sent!r} and grid-src's {_OVERVIEW} reads {read!r} — the key "
+        f"is dropped in silence, so a name its operator chose stops being published on an "
+        f"os-community grid and NOTHING goes red; edit BOTH sides")
+
+
+def test_the_other_provider_half_in_grid_src_sends_the_same_key():
+    """The half issue 15's audit named and issue 16 nearly repeated: grid-src's own fleet runtime.
+
+    ⚠️ **There are TWO provider halves and they are in different repositories.** An `os-community`
+    member runs the PUBLIC CLI pinned above; the grid-src runtime is what runs on the fleet. A fix
+    applied to one leaves the other publishing hostnames with every suite in both repositories still
+    green — the exact shape that has bitten this codebase before — so the relay's single reader is
+    pinned against BOTH senders rather than against whichever one was edited last.
+    """
+    read = _meta_key_the_relay_reads_as_chosen()
+    sends = _meta_keys_the_grid_src_provider_sends()
+
+    assert _META_CONTROL_KEY in sends, (
+        f"positive control: grid-src's {_PROVIDER_META_FUNCTION} does not appear to send "
+        f"{_META_CONTROL_KEY!r} either, so this check is reading the wrong function — fix the "
+        f"harness before believing its verdict")
+    assert read in sends, (
+        f"grid-src's relay reads {read!r} but its own provider runtime sends {sorted(sends)} — the "
+        f"fleet's machines are all published as `node-<id>` on an os-community grid, or all "
+        f"published by hostname, and nothing anywhere goes red; edit BOTH sides")

--- a/tests/test_os_grid_type_lockstep.py
+++ b/tests/test_os_grid_type_lockstep.py
@@ -297,3 +297,178 @@ def test_the_control_plane_admits_the_type_as_a_valid_one():
     assert OS_COMMUNITY in members, (
         f"{OS_COMMUNITY} is missing from grid-apis' VALID_NETWORK_TYPES, so `normalize_network_type` "
         f"raises on every OS grid row the store reads")
+
+
+# --- the `os=` query parameter's NAME, this slice's SECOND cross-repo value -----------------------
+# The type literal above is not the only value the OS gate hand-duplicates across a repository
+# boundary. The claim itself rides as a query parameter on `GET /v1/grid/tokens`, and its name is
+# written independently in two places with no import between them: `params["os"]` in this
+# repository's `remote/control_plane.fetch_tokens`, and `alias="os"` on grid-apis'
+# `grid_networks/handler.get_tokens`.
+#
+# ⚠️ **It degrades SILENTLY, which is why it needs a pin rather than an argument.** An unknown query
+# parameter is not an error to any HTTP framework — it is dropped. So a rename on one side alone
+# leaves both repositories green (each repo's own test asserts what that repo does, and both are
+# still right), every request succeeds, every other grid is issued exactly as before, and the only
+# symptom is that no machine is ever admitted to an OS grid. Nothing is red and nothing is loud.
+#
+# ⚠️ **The rollout order is NONE, in either direction — derived, not copied from the rows above.**
+# The type literal a few tests up rolls grid-src first because grid-apis SHELLS OUT to it; this value
+# has no such asymmetry. It is a new key on an EXISTING endpoint, and both halves already treat
+# "no claim" as an ordinary answer: an old control plane ignores what a new CLI sends, and a new
+# control plane facing an old CLI reads the absent parameter as a machine claiming nothing. Either
+# way the caller keeps every grid it already had and simply gets no OS grid (ADR 0039 D-j).
+
+_APIS_HANDLER = "grid_networks/handler.py"
+
+# The route the claim rides on, named by its DECORATOR and not by the Python function's name: what
+# has to keep agreeing is the endpoint, and a handler renamed while `GET /tokens` stays put is not
+# drift. `_APIS_ROUTER` is the module-level `APIRouter` every route in that file is hung off.
+_APIS_ROUTER = "router"
+_TOKENS_METHOD = "get"
+_TOKENS_PATH = "/tokens"
+
+# The parameter that has ridden on this call since long before OS grids — the positive control. It is
+# also the one that proves the two readers below are looking at the same request: the CLI sends it
+# beside the OS claim and the control plane declares it beside the OS parameter.
+_CONTROL_PARAMETER = "device_id"
+
+
+def _apis_route(method, path):
+    """The function grid-apis hangs off ``@router.<method>("<path>")``, or an assertion.
+
+    Found by decorator rather than by name so that renaming the handler — an ordinary refactor that
+    breaks no seam — does not read as drift, while moving or deleting the ROUTE does.
+    """
+    tree = _apis_module(_APIS_HANDLER)
+    matches = [
+        node for node in tree.body
+        # ⚠️ BOTH function kinds. `async def` is an `ast.AsyncFunctionDef`, a separate node type that
+        # is NOT a subclass of `ast.FunctionDef` — and grid-apis' handler module already spells 15 of
+        # its routes that way. Matching only the sync kind meant that converting this one handler to
+        # `async def` — an ordinary refactor that moves no route and breaks no seam — emptied the
+        # match list and fired the assertion below, reporting drift that had not happened. A pin that
+        # cries wolf on a legitimate refactor is a pin somebody deletes.
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        for decorator in node.decorator_list
+        if isinstance(decorator, ast.Call)
+        and isinstance(decorator.func, ast.Attribute) and decorator.func.attr == method
+        and getattr(decorator.func.value, "id", None) == _APIS_ROUTER
+        and decorator.args and isinstance(decorator.args[0], ast.Constant)
+        and decorator.args[0].value == path
+    ]
+    assert len(matches) == 1, (
+        f"expected exactly one @{_APIS_ROUTER}.{method}({path!r}) handler in grid-apis' "
+        f"{_APIS_HANDLER}, found {len(matches)} — the route moved or was split, so teach this check "
+        f"where it went rather than letting the pin read the wrong function")
+    return matches[0]
+
+
+def _query_parameter_names(function):
+    """Every query parameter a FastAPI handler accepts, as ``{python name: wire name}``.
+
+    FastAPI takes the wire name from ``Query(alias=…)`` when there is one and from the Python
+    parameter's own name when there is not: `device_id` is the second kind, `os` the first — a
+    parameter actually *called* ``os`` would shadow the stdlib module for the whole function, which
+    is why the alias exists at all and why the two names differ here.
+
+    ``Header``-defaulted parameters are deliberately excluded: they are the same ``Call`` shape with
+    the same ``alias=`` keyword, and folding them in would let ``Authorization`` satisfy a check
+    about the query string.
+
+    Every shape this cannot read raises rather than being skipped over. A lockstep helper that
+    returns a plausible subset is worse than no helper at all, because what it guards fails silently
+    too — the same rule `_resolve` and `_collection` follow above.
+    """
+    spec = function.args
+    # `defaults` covers the TAIL of the positional parameters; `kw_defaults` is one-for-one with the
+    # keyword-only ones and holds None where there is no default. Handling both means a handler that
+    # is later given a `*` separator keeps being read instead of quietly emptying this dict.
+    pairs = list(zip(spec.args[len(spec.args) - len(spec.defaults):], spec.defaults))
+    pairs += [(arg, default)
+              for arg, default in zip(spec.kwonlyargs, spec.kw_defaults) if default is not None]
+
+    names = {}
+    for arg, default in pairs:
+        if not isinstance(default, ast.Call):
+            continue  # a plain Python default — not a FastAPI parameter declaration at all
+        kind = getattr(default.func, "id", None) or getattr(default.func, "attr", None)
+        if kind != "Query":
+            continue
+        alias = next((kw.value for kw in default.keywords if kw.arg == "alias"), None)
+        if alias is None:
+            names[arg.arg] = arg.arg
+            continue
+        assert isinstance(alias, ast.Constant) and isinstance(alias.value, str), (
+            f"grid-apis' {arg.arg} declares an alias this check cannot read "
+            f"({type(alias).__name__}); teach it the new shape rather than deleting the check")
+        names[arg.arg] = alias.value
+    return names
+
+
+def _os_parameter_the_cli_sends(monkeypatch, tmp_path):
+    """The query-parameter name this CLI actually puts on the wire, read off a real request.
+
+    Read from the request rather than from the source, because what the control plane has to
+    recognise is the string that reaches it — `params["os"]` is one refactor away from being built
+    somewhere else, and a pin that parsed this repository's source would then be pinning a spelling
+    nobody sends.
+    """
+    import platform
+
+    import httpx
+
+    from remote import control_plane
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    # A fixed system, so the claim is present whatever this developer's own machine runs: a machine
+    # outside the closed token set sends no `os=` at all (ADR 0039 D-c), and a suite that skipped on
+    # a BSD laptop would be a pin that quietly stopped pinning.
+    monkeypatch.setattr(platform, "system", lambda: "Darwin")
+    seen = {}
+
+    def handler(request):
+        seen["params"] = dict(request.url.params)
+        return httpx.Response(200, json={"networks": []})
+
+    real_client = httpx.Client
+    monkeypatch.setattr(
+        control_plane.httpx,
+        "Client",
+        lambda *a, **k: real_client(*a, **{**k, "transport": httpx.MockTransport(handler)}),
+    )
+    control_plane.fetch_tokens("sess-tok", "dev-1")
+
+    params = seen.get("params") or {}
+    assert _CONTROL_PARAMETER in params, (
+        f"positive control: `fetch_tokens` sent {sorted(params)} and not even {_CONTROL_PARAMETER}, "
+        f"so its answer about the OS claim means nothing — fix the harness")
+    claim = set(params) - {_CONTROL_PARAMETER}
+    assert len(claim) == 1, (
+        f"`fetch_tokens` put {sorted(params)} on the wire, so this check cannot tell which parameter "
+        f"carries the OS claim — teach it the new shape rather than deleting the pin")
+    return claim.pop()
+
+
+def test_the_os_claims_parameter_is_spelled_the_same_on_both_sides_of_the_call(monkeypatch,
+                                                                               tmp_path):
+    """The name the CLI sends and the name the control plane declares, compared against each other.
+
+    Neither repository can catch this alone, and that is the whole point of writing it here: this
+    repository's `test_fetch_tokens_sends_the_os_token_of_the_machine_it_runs_on` asserts what the
+    CLI sends, grid-apis' own suite asserts what it accepts, and a developer renaming the parameter
+    would update the test on their side along with the code. Both suites stay green, the parameter
+    stops being recognised, and no machine is admitted to an OS grid — silently, because an unknown
+    query parameter is dropped rather than refused.
+    """
+    accepted = _query_parameter_names(_apis_route(_TOKENS_METHOD, _TOKENS_PATH))
+    assert _CONTROL_PARAMETER in accepted.values(), (
+        f"positive control: grid-apis' {_TOKENS_METHOD.upper()} {_TOKENS_PATH} does not appear to "
+        f"take {_CONTROL_PARAMETER} either, so this check is reading the wrong thing — fix the "
+        f"harness before believing its verdict")
+
+    sent = _os_parameter_the_cli_sends(monkeypatch, tmp_path)
+    assert sent in accepted.values(), (
+        f"this CLI sends the OS claim as {sent!r}, but grid-apis' {_TOKENS_METHOD.upper()} "
+        f"{_TOKENS_PATH} accepts {sorted(accepted.values())} — the parameter is dropped, so nobody "
+        f"is ever issued an OS grid and nothing anywhere goes red (ADR 0039 D-e); edit BOTH sides")

--- a/tests/test_os_grid_type_lockstep.py
+++ b/tests/test_os_grid_type_lockstep.py
@@ -630,3 +630,132 @@ def test_the_fetch_and_the_renewal_agree_with_each_other(monkeypatch, tmp_path):
     assert fetch == refresh, (
         f"this CLI announces the OS claim as {fetch!r} when signing in and {refresh!r} when renewing; "
         f"a machine would be admitted to an OS grid and then silently unable to renew on it")
+
+
+# --- the ANSWER's key, this slice's FOURTH cross-repo value ----------------------------------------
+# Everything above pins what the CLI SAYS. `os_served` is the one value on this seam that travels the
+# other way: `GET /v1/grid/tokens` reports whether this call was handed an OS grid, so the three
+# causes of "my grid list has no OS grid in it" stop sharing one symptom (ADR 0039 D-k). It is
+# written independently on both sides with no import between them — a key in the dict grid-apis'
+# `get_tokens` returns, and `OS_SERVED_KEY` in this repository's `remote/control_plane.py`.
+#
+# ⚠️ **It degrades SILENTLY in BOTH directions, which is what makes it the quietest value here.** An
+# unknown key in a JSON body is not an error to anybody: renamed on the control plane, this CLI reads
+# it as absent and says nothing, which is by design indistinguishable from an older control plane —
+# the exact behaviour D-k specifies for that case. So a rename leaves both repositories green, every
+# request succeeding, and the feature that exists to explain an absent OS grid silently explaining
+# nothing. There is no symptom to notice, which is why this needs a pin rather than an argument.
+#
+# ⚠️ **The rollout order is NONE, in either direction**, and for the same reason the `os=` parameter
+# has none: a new key on an existing endpoint. An old control plane sends nothing and the CLI prints
+# nothing (the previous behaviour exactly); an old CLI ignores what a new control plane sends.
+
+#: The key that has been in this answer since long before OS grids — the positive control on the
+#: grid-apis side, and the proof the reader below is looking at the right dict.
+_TOKENS_CONTROL_KEY = "networks"
+
+
+def _apis_answer_keys(function):
+    """Every constant string key grid-apis puts in a dict it RETURNS from this handler.
+
+    Read off the `return` statements rather than a response model, because this route declares none —
+    it returns a plain dict, so the literal is the contract. Anything this cannot read raises instead
+    of narrowing the set in silence: a lockstep helper that returns a plausible subset guards nothing,
+    and what it fails to guard fails silently too.
+    """
+    keys = set()
+    returns = [node for node in ast.walk(function) if isinstance(node, ast.Return)]
+    assert returns, (
+        f"grid-apis' {function.name} has no `return` at all — this pin cannot read what the route "
+        f"answers, so teach it the new shape rather than letting it compare an empty set")
+    for node in returns:
+        assert isinstance(node.value, ast.Dict), (
+            f"grid-apis' {function.name} returns a {type(node.value).__name__} rather than a dict "
+            f"literal; teach this pin the new shape instead of letting it read nothing")
+        for key in node.value.keys:
+            assert isinstance(key, ast.Constant) and isinstance(key.value, str), (
+                f"grid-apis' {function.name} builds a response key this pin cannot read "
+                f"({ast.dump(key) if key is not None else '**spread'}); teach it the new shape")
+            keys.add(key.value)
+    return keys
+
+
+def _os_served_keys_the_cli_reads(monkeypatch, tmp_path, candidates):
+    """Which of ``candidates`` this CLI actually reads as "you were handed an OS grid".
+
+    Measured by ANSWERING with each key in turn and asking what `fetch_tokens` made of it, rather
+    than by reading this repository's source: what has to keep agreeing is the string that arrives,
+    and a constant is one refactor away from not being the string the parser looks up.
+
+    ``False`` is the probe value on purpose. It is the answer that must produce a *line* — "the
+    control plane isn't serving one" — and it is truthy nowhere, so a key that flips the CLI's answer
+    to `False` is unambiguously the one being read.
+    """
+    import httpx
+
+    from remote import control_plane
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    real_client = httpx.Client
+
+    def answering(payload):
+        monkeypatch.setattr(
+            control_plane.httpx,
+            "Client",
+            lambda *a, **k: real_client(*a, **{
+                **k, "transport": httpx.MockTransport(lambda r: httpx.Response(200, json=payload))}),
+        )
+        return control_plane.fetch_tokens("sess-tok", "dev-1")
+
+    # Positive control FIRST: prove the transport patch reaches the real parser at all. Without it a
+    # helper that answered nobody would report "no key is read" and read as drift that has not
+    # happened — the failure mode every other pin in this file guards against explicitly.
+    control = answering({_TOKENS_CONTROL_KEY: [{"network_id": "n1", "name": "team"}]})
+    assert control.networks == [{"network_id": "n1", "name": "team"}], (
+        f"positive control: `fetch_tokens` made {control!r} of an ordinary answer, so its verdict "
+        f"about {_TOKENS_CONTROL_KEY} means nothing — fix the harness before believing it")
+    assert control.os_served is None, (
+        "positive control: `fetch_tokens` reported an os_served with no such key in the answer, so "
+        "the probe below cannot tell which key set it — fix the harness")
+
+    return {key for key in candidates
+            if answering({_TOKENS_CONTROL_KEY: [], key: False}).os_served is False}
+
+
+def test_the_key_that_says_why_there_is_no_os_grid_is_spelled_the_same_on_both_sides(monkeypatch,
+                                                                                     tmp_path):
+    """What grid-apis answers and what this CLI reads, compared against each other.
+
+    Neither repository can catch this alone. grid-apis' own suite asserts the key it emits, this
+    repository's `test_fetch_tokens_carries_the_os_served_flag_beside_the_networks` asserts the key it
+    reads, and a developer renaming it updates the test on their side along with the code. Both
+    suites stay green and the absent OS grid stops saying why — with no error anywhere, because an
+    unrecognised key in a JSON body is simply dropped.
+    """
+    answered = _apis_answer_keys(_apis_route(_TOKENS_METHOD, _TOKENS_PATH))
+    assert _TOKENS_CONTROL_KEY in answered, (
+        f"positive control: grid-apis' {_TOKENS_METHOD.upper()} {_TOKENS_PATH} does not appear to "
+        f"answer {_TOKENS_CONTROL_KEY} either, so this check is reading the wrong function — fix the "
+        f"harness before believing its verdict")
+
+    read = _os_served_keys_the_cli_reads(monkeypatch, tmp_path, answered)
+    assert len(read) == 1, (
+        f"grid-apis answers {sorted(answered)} on {_TOKENS_METHOD.upper()} {_TOKENS_PATH}, and this "
+        f"CLI reads {sorted(read) or 'none of them'} as the OS-grid flag — the key is dropped in "
+        f"silence, so an absent OS grid stops saying why and NOTHING goes red (ADR 0039 D-k); edit "
+        f"BOTH sides, or teach this pin the new spelling")
+
+
+def test_the_flag_this_cli_names_is_the_one_it_actually_reads(monkeypatch, tmp_path):
+    """`OS_SERVED_KEY` is what the pin above compares; nothing yet says the parser uses it.
+
+    A constant that has drifted from the code beside it is worse than no constant: the cross-repo
+    check would go on comparing grid-apis to a name this CLI no longer looks up, and would keep
+    reporting agreement while the seam was broken.
+    """
+    from remote import control_plane
+
+    read = _os_served_keys_the_cli_reads(monkeypatch, tmp_path, {control_plane.OS_SERVED_KEY})
+    assert read == {control_plane.OS_SERVED_KEY}, (
+        f"`control_plane.OS_SERVED_KEY` is {control_plane.OS_SERVED_KEY!r} but `fetch_tokens` does "
+        f"not read that key out of the answer — the constant and the parser have drifted apart")

--- a/tests/test_os_grid_type_lockstep.py
+++ b/tests/test_os_grid_type_lockstep.py
@@ -3,8 +3,9 @@
 grid-src holds **two** copies of this literal — `grid_cli/network_runtime.py`, which decides whether
 `grid network create --network-type os-community` is even a legal argv, and
 `grid_cli/private_server/grid_auth.py`, which decides whether a token the control plane signed for
-that grid is admitted at the master. grid-apis will hold a third. There is no import path between
-any of them, so they are kept in step by editing every side — and by this test.
+that grid is admitted at the master. **grid-apis `grid_networks/store.py` is the third**, and it is
+the one that decides whether a grid of this type can exist in the database at all. There is no import
+path between any of them, so they are kept in step by editing every side — and by this test.
 
 ⚠️ **The deploy order is the REVERSE of the web-tool routes' and must not be inferred from them.**
 grid-src rolls out FIRST, before the control plane, because auto-provisioning an OS grid is not an
@@ -15,14 +16,15 @@ argparse exit 2, a failed create, and a grid stuck at `pending` retrying forever
 fail-closed, but wrong. (The *public* CLI in this repository has no ordering in either direction:
 `os=` is a new query parameter on an existing endpoint.)
 
-⚠️ Per this repository's rule for every cross-repo assertion, this **skips unless the grid-src
-worktree sits beside this one** — i.e. it skips in CI, and a green CI proves nothing about it. Run
-it locally, on a machine that has both.
+⚠️ Per this repository's rule for every cross-repo assertion, each case here **skips unless the
+worktree it reads sits beside this one** — grid-src for most, grid-apis for the last two — i.e. they
+skip in CI, and a green CI proves nothing about any of them. Run it locally, on a machine that has
+all three.
 
 Its own module rather than more of `tests/test_task_lease.py`: nothing here is about the task plane,
 and that file names one worktree by absolute path, which is why its checks skip in every *other*
-worktree. This one resolves grid-src from its own location (`tests/grid_src_repo.py`), the same way
-`tests/test_starter_engine_lockstep.py` does.
+worktree. This one resolves both siblings from its own location (`tests/grid_src_repo.py`), the same
+way `tests/test_starter_engine_lockstep.py` does.
 """
 from __future__ import annotations
 
@@ -30,17 +32,20 @@ import ast
 
 import pytest
 
-from tests.grid_src_repo import grid_src_root
+from tests.grid_src_repo import grid_apis_root, grid_src_root
 
-# This repository's side of the pin.
+# The literal, as ADR 0039 D-a fixes it.
 #
-# ⚠️ **A literal in the test, and deliberately so for now — this repository has no `os-community`
-# constant to read.** `cli/remote_grid.cmd_remote_ls` prints whatever `network_type` the control
-# plane hands it, so nothing here compares the string to anything; ADR 0039's own Consequences list
-# the copies as grid-apis, grid-src `network_runtime` and grid-src `grid_auth`, with no half in this
-# repo. That makes this an ADR-to-grid-src pin rather than a two-repo one, which is weaker than the
-# sibling starter-engine suite (that one reads `api_catalog.WHITELISTS`, a real authority).
-# **When the `os=` / `os_served` slice gives this repo a constant of its own, re-point this at it.**
+# ⚠️ **A literal in the test, and this repository still holds no `os-community` constant of its own
+# — deliberately.** `cli/remote_grid.cmd_remote_ls` prints whatever `network_type` the control plane
+# hands it, and the `os=` slice gave this repo an OS *token* vocabulary
+# (`shared/system/os_grid.OS_TOKENS` — `macos`/`windows`/`linux`) which is a **different value**:
+# that one names a machine, this one names a grid type. Do not "finally" re-point this constant at
+# `os_grid`; they would then agree by accident and this pin would be checking nothing.
+#
+# What HAS changed is that the pin now has two independent authorities on the other side rather than
+# one — grid-src and grid-apis — so a rename on either is caught by the other's copy, not merely by
+# a string written here.
 OS_COMMUNITY = "os-community"
 
 # The name both grid-src modules give their copy, and a literal that predates this slice — the
@@ -50,28 +55,37 @@ _CONSTANT = "NETWORK_TYPE_OS_COMMUNITY"
 _CONTROL_CONSTANT = "NETWORK_TYPE_PRIVATE_DOMAIN"
 _CONTROL_VALUE = "private-domain"
 
-_SKIP = "grid-src worktree is not beside this one; the lockstep cannot be checked here"
+_SKIP = "the {repo} worktree is not beside this one; the lockstep cannot be checked here"
 
 
-def _module(relative_path):
-    """Parse one grid-src module, or skip. Never returns something plausible on a miss.
+def _parse(root, repo, relative_path):
+    """Parse one module of a sibling repository, or skip. Never plausible-looking on a miss.
 
-    ⚠️ **Only "no grid-src at all" skips. A missing named module RAISES.** By the time this runs,
-    `grid_src_root()` has already proved `grid_cli/private_server/` exists under that root, so a
-    module absent from it has been renamed or moved — which is drift, exactly what this suite is
-    for, and reporting it as "the repository is not beside this one" would turn five of the six
-    assertions off with a message blaming the wrong thing. `_collection` and `_open_network_types`
-    raise for the same class of change one level down; this is the same rule at file granularity.
+    ⚠️ **Only "no such repository at all" skips. A missing named module RAISES.** By the time this
+    runs the resolver has already proved a marker directory exists under that root, so a module
+    absent from it has been renamed or moved — which is drift, exactly what this suite is for, and
+    reporting it as "the repository is not beside this one" would turn the assertions off with a
+    message blaming the wrong thing. `_collection` and `_open_network_types` raise for the same class
+    of change one level down; this is the same rule at file granularity.
     """
-    root = grid_src_root()
     if root is None:
-        pytest.skip(_SKIP)
+        pytest.skip(_SKIP.format(repo=repo))
     source = root / relative_path
     if not source.exists():
         raise AssertionError(
-            f"grid-src is at {root} but has no {relative_path} — the module was renamed or moved, "
+            f"{repo} is at {root} but has no {relative_path} — the module was renamed or moved, "
             f"so teach this check where it went rather than letting it skip")
     return ast.parse(source.read_text())
+
+
+def _module(relative_path):
+    """Parse one grid-src module."""
+    return _parse(grid_src_root(), "grid-src", relative_path)
+
+
+def _apis_module(relative_path):
+    """Parse one grid-apis module — the control plane, the literal's third copy."""
+    return _parse(grid_apis_root(), "grid-apis", relative_path)
 
 
 def _targets(node):
@@ -241,3 +255,45 @@ def test_the_master_admits_an_os_grid_with_no_allowlist_snapshot_entry():
         f"grid-src's _requires_allowlist does not admit {OS_COMMUNITY} without an allowlist entry, "
         f"so every member of every OS grid is refused at the master with no row anyone can add "
         f"(ADR 0039 D-a, D-e)")
+
+
+# --- the control plane's copy, the third one ------------------------------------------------------
+# grid-apis is the CLIENT for this literal, not the server, and that is what makes its rollout order
+# the reverse of the web-tool routes': `managed_networks.build_create_argv` shells out
+# `grid network create … --network-type os-community` and that binary is grid-src. So a mismatch here
+# is not a 404 to be degraded around — it is a failed create and a grid stuck at `pending`.
+
+_APIS_STORE = "grid_networks/store.py"
+
+
+def test_the_control_plane_spells_the_type_the_way_grid_src_does():
+    """A rename on one side alone is silent in the OTHER direction too.
+
+    grid-apis renamed and grid-src not: the create argv carries a literal grid-src's argparse has
+    never heard of, so the auto-provision exits 2 and the grid never comes up. grid-src renamed and
+    grid-apis not: every create succeeds and the master then refuses every member, because
+    `_requires_allowlist` no longer recognises what the token says.
+    """
+    constants = _string_constants(_apis_module(_APIS_STORE))
+    assert constants.get(_CONTROL_CONSTANT) == _CONTROL_VALUE, (
+        f"positive control: this check can no longer read even {_CONTROL_CONSTANT} out of "
+        f"grid-apis' {_APIS_STORE}, so its answer about {_CONSTANT} means nothing — fix the harness")
+    assert constants.get(_CONSTANT) == OS_COMMUNITY, (
+        f"grid-apis' {_APIS_STORE} spells the OS grid type {constants.get(_CONSTANT)!r}; grid-src and "
+        f"this repository say {OS_COMMUNITY!r} (ADR 0039 D-a) — edit EVERY side")
+
+
+def test_the_control_plane_admits_the_type_as_a_valid_one():
+    """Missing from `VALID_NETWORK_TYPES`, `normalize_network_type` RAISES rather than refuses.
+
+    Every gate, serializer and predicate in that store runs the value through it, so the type would
+    not merely be rejected — the grid would be unreadable, and each read would surface as a 500
+    rather than as anything naming the type.
+    """
+    members = _collection(_apis_module(_APIS_STORE), "VALID_NETWORK_TYPES", _APIS_STORE)
+    assert _CONTROL_VALUE in members, (
+        f"positive control: {_CONTROL_VALUE} is missing from grid-apis' VALID_NETWORK_TYPES too, so "
+        f"this check is reading the wrong thing — fix the harness before believing its verdict")
+    assert OS_COMMUNITY in members, (
+        f"{OS_COMMUNITY} is missing from grid-apis' VALID_NETWORK_TYPES, so `normalize_network_type` "
+        f"raises on every OS grid row the store reads")

--- a/tests/test_os_grid_type_lockstep.py
+++ b/tests/test_os_grid_type_lockstep.py
@@ -472,3 +472,119 @@ def test_the_os_claims_parameter_is_spelled_the_same_on_both_sides_of_the_call(m
         f"this CLI sends the OS claim as {sent!r}, but grid-apis' {_TOKENS_METHOD.upper()} "
         f"{_TOKENS_PATH} accepts {sorted(accepted.values())} — the parameter is dropped, so nobody "
         f"is ever issued an OS grid and nothing anywhere goes red (ADR 0039 D-e); edit BOTH sides")
+
+
+# --- the same claim on the RENEWAL, which is a body key and not a query parameter ------------------
+
+#: grid-apis' Pydantic model for the refresh exchange's body. A different route, a different shape,
+#: and therefore a THIRD hand-duplicated spelling of the same claim (ADR 0039 D-e, issue 10).
+_REFRESH_MODEL = "TokenRefreshRequest"
+#: Its pre-existing field, the positive control — the credential the exchange has always carried.
+_REFRESH_CONTROL_FIELD = "refresh_token"
+
+
+def _apis_model_fields(model_name):
+    """The field names grid-apis declares on a Pydantic model, or an assertion naming what it found."""
+    tree = _apis_module(_APIS_HANDLER)
+    classes = [
+        node for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == model_name
+    ]
+    assert len(classes) == 1, (
+        f"expected exactly one `class {model_name}` in grid-apis' {_APIS_HANDLER}, found "
+        f"{len(classes)} — the model moved or was renamed, so teach this check where it went rather "
+        f"than letting the pin read nothing")
+    return {
+        node.target.id
+        for node in classes[0].body
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name)
+    }
+
+
+def _os_key_the_cli_sends_on_a_refresh(monkeypatch, tmp_path):
+    """The body key this CLI actually puts on a refresh, read off a real request.
+
+    Read from the request and not the source, for the same reason the query-parameter pin above is:
+    what the far end must recognise is the string that reaches it.
+    """
+    import json
+    import platform
+
+    import httpx
+
+    from remote import control_plane
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    # Fixed, so the claim is present whatever this developer's machine runs — see the note above.
+    monkeypatch.setattr(platform, "system", lambda: "Darwin")
+    seen = {}
+
+    def handler(request):
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"access_token": "a", "refresh_token": "r"})
+
+    real_client = httpx.Client
+    monkeypatch.setattr(
+        control_plane.httpx,
+        "Client",
+        lambda *a, **k: real_client(*a, **{**k, "transport": httpx.MockTransport(handler)}),
+    )
+    control_plane.refresh_network_token(network_id="grid-1", refresh_token="rt-1")
+
+    body = seen.get("body") or {}
+    assert _REFRESH_CONTROL_FIELD in body, (
+        f"positive control: `refresh_network_token` sent {sorted(body)} and not even "
+        f"{_REFRESH_CONTROL_FIELD}, so its answer about the OS claim means nothing — fix the harness")
+    claim = set(body) - {_REFRESH_CONTROL_FIELD}
+    assert len(claim) == 1, (
+        f"`refresh_network_token` put {sorted(body)} on the wire, so this check cannot tell which key "
+        f"carries the OS claim — teach it the new shape rather than deleting the pin")
+    return claim.pop()
+
+
+def test_the_os_claim_on_a_renewal_is_spelled_the_same_on_both_sides(monkeypatch, tmp_path):
+    """The renewal's copy of the claim, pinned separately from the fetch's — they are two spellings.
+
+    ⚠️ **Pinning the query parameter does not pin this.** The fetch carries the claim in the URL and
+    the refresh carries it in a JSON body, so they are written in different places on both sides and
+    can drift apart independently. Renaming only the body key leaves the fetch pin green.
+
+    And this one degrades even more quietly than the fetch's, because it is a key on an EXISTING body
+    whose model does not forbid unknown fields: dropped in silence, the exchange still answers, and
+    the only symptom is that a machine on an OS grid can never renew — which looks exactly like the
+    bug this slice was written to remove, reappearing with nothing red anywhere.
+    """
+    declared = _apis_model_fields(_REFRESH_MODEL)
+    assert _REFRESH_CONTROL_FIELD in declared, (
+        f"positive control: grid-apis' {_REFRESH_MODEL} does not declare {_REFRESH_CONTROL_FIELD} "
+        f"either, so this check is reading the wrong class — fix the harness before believing it")
+
+    sent = _os_key_the_cli_sends_on_a_refresh(monkeypatch, tmp_path)
+    assert sent in declared, (
+        f"this CLI sends the OS claim on a refresh as {sent!r}, but grid-apis' {_REFRESH_MODEL} "
+        f"declares {sorted(declared)} — the key is IGNORED rather than refused (the model does not "
+        f"forbid extras), so a machine on an OS grid silently never renews (ADR 0039 D-e); either "
+        f"rename both sides together or teach this pin the new spelling")
+
+
+def test_the_fetch_and_the_renewal_agree_with_each_other(monkeypatch, tmp_path):
+    """Both ends of one claim, so the two spellings cannot drift apart inside this repository either.
+
+    The pins above each compare this CLI against grid-apis. Nothing yet says the CLI's own two call
+    sites agree — and a machine that announced `os` on sign-in and `os_token` on renewal would be
+    admitted and then quietly unable to renew, which is the same outage arriving one step later.
+
+    ⚠️ **A context per call, and it is not tidiness.** Both helpers patch `control_plane.httpx.Client`
+    and capture the real one first; run under a single `monkeypatch` the second captures the FIRST
+    one's replacement, so its handler never fires and it reads an empty body. That is not a
+    hypothetical — it is what this test did when written, and the helper's positive control is what
+    said so instead of letting the comparison report a verdict it had not measured.
+    """
+    with pytest.MonkeyPatch.context() as on_sign_in:
+        fetch = _os_parameter_the_cli_sends(on_sign_in, tmp_path)
+    with pytest.MonkeyPatch.context() as on_renewal:
+        refresh = _os_key_the_cli_sends_on_a_refresh(on_renewal, tmp_path)
+
+    assert fetch == refresh, (
+        f"this CLI announces the OS claim as {fetch!r} when signing in and {refresh!r} when renewing; "
+        f"a machine would be admitted to an OS grid and then silently unable to renew on it")

--- a/tests/test_os_grid_type_lockstep.py
+++ b/tests/test_os_grid_type_lockstep.py
@@ -1,0 +1,243 @@
+"""`os-community`, pinned across the repository boundary (ADR 0039 D-a, D-j).
+
+grid-src holds **two** copies of this literal — `grid_cli/network_runtime.py`, which decides whether
+`grid network create --network-type os-community` is even a legal argv, and
+`grid_cli/private_server/grid_auth.py`, which decides whether a token the control plane signed for
+that grid is admitted at the master. grid-apis will hold a third. There is no import path between
+any of them, so they are kept in step by editing every side — and by this test.
+
+⚠️ **The deploy order is the REVERSE of the web-tool routes' and must not be inferred from them.**
+grid-src rolls out FIRST, before the control plane, because auto-provisioning an OS grid is not an
+INSERT: grid-apis `managed_networks.build_create_argv` shells out
+`grid network create <name> --network-type os-community --advertise-url … --port … --network-id …`
+and that `grid` binary IS grid-src. A control plane that knows the literal before grid-src does gets
+argparse exit 2, a failed create, and a grid stuck at `pending` retrying forever — loud and
+fail-closed, but wrong. (The *public* CLI in this repository has no ordering in either direction:
+`os=` is a new query parameter on an existing endpoint.)
+
+⚠️ Per this repository's rule for every cross-repo assertion, this **skips unless the grid-src
+worktree sits beside this one** — i.e. it skips in CI, and a green CI proves nothing about it. Run
+it locally, on a machine that has both.
+
+Its own module rather than more of `tests/test_task_lease.py`: nothing here is about the task plane,
+and that file names one worktree by absolute path, which is why its checks skip in every *other*
+worktree. This one resolves grid-src from its own location (`tests/grid_src_repo.py`), the same way
+`tests/test_starter_engine_lockstep.py` does.
+"""
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from tests.grid_src_repo import grid_src_root
+
+# This repository's side of the pin.
+#
+# ⚠️ **A literal in the test, and deliberately so for now — this repository has no `os-community`
+# constant to read.** `cli/remote_grid.cmd_remote_ls` prints whatever `network_type` the control
+# plane hands it, so nothing here compares the string to anything; ADR 0039's own Consequences list
+# the copies as grid-apis, grid-src `network_runtime` and grid-src `grid_auth`, with no half in this
+# repo. That makes this an ADR-to-grid-src pin rather than a two-repo one, which is weaker than the
+# sibling starter-engine suite (that one reads `api_catalog.WHITELISTS`, a real authority).
+# **When the `os=` / `os_served` slice gives this repo a constant of its own, re-point this at it.**
+OS_COMMUNITY = "os-community"
+
+# The name both grid-src modules give their copy, and a literal that predates this slice — the
+# positive control, so a helper that has quietly stopped finding anything fails as a HARNESS fault
+# rather than reading as "the seam is fine".
+_CONSTANT = "NETWORK_TYPE_OS_COMMUNITY"
+_CONTROL_CONSTANT = "NETWORK_TYPE_PRIVATE_DOMAIN"
+_CONTROL_VALUE = "private-domain"
+
+_SKIP = "grid-src worktree is not beside this one; the lockstep cannot be checked here"
+
+
+def _module(relative_path):
+    """Parse one grid-src module, or skip. Never returns something plausible on a miss.
+
+    ⚠️ **Only "no grid-src at all" skips. A missing named module RAISES.** By the time this runs,
+    `grid_src_root()` has already proved `grid_cli/private_server/` exists under that root, so a
+    module absent from it has been renamed or moved — which is drift, exactly what this suite is
+    for, and reporting it as "the repository is not beside this one" would turn five of the six
+    assertions off with a message blaming the wrong thing. `_collection` and `_open_network_types`
+    raise for the same class of change one level down; this is the same rule at file granularity.
+    """
+    root = grid_src_root()
+    if root is None:
+        pytest.skip(_SKIP)
+    source = root / relative_path
+    if not source.exists():
+        raise AssertionError(
+            f"grid-src is at {root} but has no {relative_path} — the module was renamed or moved, "
+            f"so teach this check where it went rather than letting it skip")
+    return ast.parse(source.read_text())
+
+
+def _targets(node):
+    """The names a module-level assignment binds — plain or annotated, one shape for both.
+
+    `NETWORK_TYPE_OS_COMMUNITY: str = "os-community"` is as ordinary as the bare form, and reading
+    only the bare one would report the constant ABSENT rather than say it could not read it — a
+    loud failure pointing at the wrong cause. `tests/test_starter_engine_lockstep.py` already
+    handles `AnnAssign` for its own constant; this keeps the two suites reading the same Python.
+    """
+    if isinstance(node, ast.Assign):
+        return node.targets
+    if isinstance(node, ast.AnnAssign) and node.value is not None:
+        return [node.target]
+    return []
+
+
+def _string_constants(tree):
+    """Every module-level ``NAME = "literal"`` in the module, as a dict."""
+    found = {}
+    for node in tree.body:
+        value = getattr(node, "value", None)
+        if not isinstance(value, ast.Constant) or not isinstance(value.value, str):
+            continue
+        for target in _targets(node):
+            if isinstance(target, ast.Name):
+                found[target.id] = value.value
+    return found
+
+
+def _resolve(elements, constants, where):
+    """The string VALUES of a collection's elements, following ``NETWORK_TYPE_*`` names.
+
+    Every shape this does not understand is an assertion rather than a shrug: a check that silently
+    returns a plausible subset is worse than no check, because what it guards fails silently too.
+    """
+    values = set()
+    for element in elements:
+        if isinstance(element, ast.Constant) and isinstance(element.value, str):
+            values.add(element.value)
+        elif isinstance(element, ast.Name):
+            assert element.id in constants, (
+                f"grid-src's {where} names {element.id}, which is not a module-level string "
+                f"constant in that file — teach this check the new shape rather than deleting it")
+            values.add(constants[element.id])
+        else:
+            # TRY004 wants a TypeError here; this is a HARNESS fault, not a caller's bad argument —
+            # and `assert False` would vanish under `python -O`, which is the one way this check
+            # could go quiet.
+            raise AssertionError(  # noqa: TRY004
+                f"grid-src's {where} holds something this check cannot read "
+                f"({type(element).__name__}); teach it the new shape rather than deleting the check")
+    return values
+
+
+def _collection(tree, name, relative_path):
+    """A module-level collection assignment's members, resolved to their string values."""
+    constants = _string_constants(tree)
+    for node in tree.body:
+        if not any(getattr(t, "id", None) == name for t in _targets(node)):
+            continue
+        value = node.value
+        # `frozenset({...})` / `set([...])` — the collection is the call's single argument.
+        if isinstance(value, ast.Call) and len(value.args) == 1:
+            value = value.args[0]
+        assert isinstance(value, (ast.Set, ast.Tuple, ast.List)), (
+            f"grid-src's {name} is no longer a literal collection, so this lockstep check cannot "
+            f"read it — teach this helper the new shape rather than deleting the check")
+        return _resolve(value.elts, constants, f"{name} in {relative_path}")
+
+    raise AssertionError(
+        f"{name} is no longer defined in grid-src's {relative_path} — it was renamed or moved, so "
+        f"teach this check where it went rather than deleting it")
+
+
+def _open_network_types():
+    """The types `grid_auth._requires_allowlist` admits with NO allowlist snapshot entry.
+
+    Read out of the function's single ``if nt in (...)`` membership test. The other comparison in
+    that function is `set(roles) != {"consumer"}`, which is not an `in`, so exactly one match is
+    expected and anything else is a restructuring this check must be taught rather than trusted.
+    """
+    relative_path = "grid_cli/private_server/grid_auth.py"
+    tree = _module(relative_path)
+    constants = _string_constants(tree)
+    function = next(
+        (n for n in tree.body
+         if isinstance(n, ast.FunctionDef) and n.name == "_requires_allowlist"), None)
+    assert function is not None, (
+        f"grid-src's {relative_path} no longer defines _requires_allowlist — the master's "
+        f"allowlist decision moved, so teach this check where it went")
+
+    memberships = [
+        node for node in ast.walk(function)
+        if isinstance(node, ast.Compare)
+        and len(node.ops) == 1 and isinstance(node.ops[0], ast.In)
+        and isinstance(node.comparators[0], (ast.Set, ast.Tuple, ast.List))
+    ]
+    assert len(memberships) == 1, (
+        f"expected exactly one `nt in (...)` test in grid-src's _requires_allowlist, found "
+        f"{len(memberships)} — the function was restructured, so teach this check the new shape")
+    return _resolve(
+        memberships[0].comparators[0].elts, constants, f"_requires_allowlist in {relative_path}")
+
+
+# --- the literal ---------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    ["grid_cli/network_runtime.py", "grid_cli/private_server/grid_auth.py"])
+def test_both_grid_src_copies_spell_the_type_the_way_this_repo_prints_it(relative_path):
+    """One literal, two files, and this repository's `grid ls` prints whatever they say.
+
+    A rename on one side alone is not an error anywhere in grid-src: `network_runtime` renamed and
+    `grid_auth` not means every create succeeds and every member is then refused at the master;
+    the other way round means the control plane's auto-provision dies at argparse.
+    """
+    constants = _string_constants(_module(relative_path))
+    assert constants.get(_CONTROL_CONSTANT) == _CONTROL_VALUE, (
+        f"positive control: this check can no longer read even {_CONTROL_CONSTANT} out of "
+        f"{relative_path}, so its answer about {_CONSTANT} means nothing — fix the harness")
+    assert constants.get(_CONSTANT) == OS_COMMUNITY, (
+        f"grid-src's {relative_path} spells the OS grid type {constants.get(_CONSTANT)!r}, this "
+        f"repository prints {OS_COMMUNITY!r} (ADR 0039 D-a); edit BOTH sides")
+
+
+# --- the four sets that have to name it -----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "collection,why",
+    [
+        ("VALID_NETWORK_TYPES",
+         ("`normalize_network_type` refuses the type outright, so the control plane's "
+          "auto-provision exits non-zero and the grid stays at `pending`, retrying forever "
+          "(ADR 0039 D-j)")),
+        ("VALID_NETWORK_TYPE_INPUTS",
+         ("`grid network create --network-type os-community` is argparse exit 2 — the same D-j "
+          "failure, one layer earlier, and `network set-type` loses the value with it")),
+        ("PUBLIC_NETWORK_TYPES",
+         ("`cmd_network_create` refuses `--advertise-url` on a non-public type and grid-apis "
+          "`build_create_argv` always passes it, so the auto-provision dies just as hard")),
+    ])
+def test_the_network_runtime_sets_that_decide_whether_a_grid_can_be_created(collection, why):
+    relative_path = "grid_cli/network_runtime.py"
+    members = _collection(_module(relative_path), collection, relative_path)
+    assert _CONTROL_VALUE in members, (
+        f"positive control: {_CONTROL_VALUE} is missing from grid-src's {collection} too, so this "
+        f"check is reading the wrong thing — fix the harness before believing its verdict")
+    assert OS_COMMUNITY in members, f"{OS_COMMUNITY} is missing from grid-src's {collection}: {why}"
+
+
+def test_the_master_admits_an_os_grid_with_no_allowlist_snapshot_entry():
+    """The one whose absence is NOT caught by any create succeeding.
+
+    An `os-community` in every set above but missing here is a grid that provisions, starts, appears
+    in `grid ls` — and 403s every member at the master. ⚠️ It cannot be fixed by adding an allowlist
+    row either: ADR 0039 D-e persists nothing about a person's OS, so the roster is empty by
+    construction and there is no row for anyone to add.
+    """
+    open_types = _open_network_types()
+    assert _CONTROL_VALUE in open_types, (
+        f"positive control: {_CONTROL_VALUE} is missing from grid-src's _requires_allowlist too, "
+        f"so this check is reading the wrong branch — fix the harness")
+    assert OS_COMMUNITY in open_types, (
+        f"grid-src's _requires_allowlist does not admit {OS_COMMUNITY} without an allowlist entry, "
+        f"so every member of every OS grid is refused at the master with no row anyone can add "
+        f"(ADR 0039 D-a, D-e)")

--- a/tests/test_os_grid_type_lockstep.py
+++ b/tests/test_os_grid_type_lockstep.py
@@ -299,6 +299,48 @@ def test_the_control_plane_admits_the_type_as_a_valid_one():
         f"raises on every OS grid row the store reads")
 
 
+# --- the denylist's reach, a rule with a half in each repository (ADR 0039 D-h) --------------------
+# The one enforcement mechanism this type widens, and the only lever that can stop ONE abusive
+# account on a grid that admits strangers automatically. Its two halves answer different questions —
+# the control plane decides what a caller SEES and is issued, the master decides what a credential
+# already in flight is SERVED — so a widening applied to one side alone leaves an account that has
+# vanished from its own grid list and is still being served at the relay, or the reverse.
+
+#: The predicate that decides WHO a denylist row refuses is not the same on every type, and this
+#: check cannot read that half: it is a role condition inside a function body, spelled differently
+#: in the two repositories on purpose (grid-apis has no allowlist predicate to be the inverse of).
+#: Each repository pins its own role condition against a `both` member — the role an OS grid's gate
+#: actually mints — and a mutation run proved both matrices fail when the providers type's
+#: `== {"consumer"}` is carried across. What travels between repositories, and what this reads, is
+#: the SET of types the denylist reaches at all.
+_DENYLIST_TYPES = "DENYLIST_NETWORK_TYPES"
+_DENYLIST_CONTROL_VALUE = "permissioned-providers"
+
+
+@pytest.mark.parametrize(
+    "side,relative_path,parse",
+    [
+        ("grid-src's master", "grid_cli/private_server/grid_auth.py", _module),
+        ("grid-apis' control plane", "grid_networks/store.py", _apis_module),
+    ])
+def test_the_denylist_reaches_an_os_grid_on_both_sides_of_the_call(side, relative_path, parse):
+    """Neither repository's own suite can see this: each is right about its own half.
+
+    ⚠️ The failure is **silent in both directions**. Widened here and not there, an operator bans an
+    account, watches the grid disappear from its `grid ls`, and the credential in that machine's
+    `~/.grid` keeps being served until it expires — a year. Widened there and not here, the ban bites
+    at the relay while `GET /tokens` keeps handing the same account a fresh credential every sign-in,
+    which reads as a broken grid rather than as a ban.
+    """
+    members = _collection(parse(relative_path), _DENYLIST_TYPES, relative_path)
+    assert _DENYLIST_CONTROL_VALUE in members, (
+        f"positive control: {_DENYLIST_CONTROL_VALUE} is missing from {side} {_DENYLIST_TYPES} too, "
+        f"so this check is reading the wrong thing — fix the harness before believing its verdict")
+    assert OS_COMMUNITY in members, (
+        f"{side} {_DENYLIST_TYPES} does not name {OS_COMMUNITY}, so the denylist reaches an OS grid "
+        f"on one side of the call and not the other (ADR 0039 D-h) — edit BOTH sides")
+
+
 # --- the `os=` query parameter's NAME, this slice's SECOND cross-repo value -----------------------
 # The type literal above is not the only value the OS gate hand-duplicates across a repository
 # boundary. The claim itself rides as a query parameter on `GET /v1/grid/tokens`, and its name is

--- a/tests/test_starter_engine_lockstep.py
+++ b/tests/test_starter_engine_lockstep.py
@@ -25,44 +25,13 @@ and its grid-src resolver is different: that file names one worktree by absolute
 its checks skip in every *other* worktree. This one derives the sibling from its own location.
 """
 
-import os
-import pathlib
-
 import pytest
+
+from tests.grid_src_repo import grid_src_private_server as _grid_src_private_server
 
 # The grid-src module holding the relay's copy, and the name of the copy inside it.
 _RELAY_MODULE = "starter_engine.py"
 _RELAY_CONSTANT = "GRID_RUN_ENGINE_KINDS"
-
-
-def _grid_src_private_server():
-    """grid-src's `private_server` package, or ``None`` when this machine does not have it.
-
-    Derived from THIS file's location rather than written out, so the check runs in whichever
-    worktree it is checked out into instead of skipping everywhere but one. The convention is
-    `<repo>-feats/<slug>` beside `<repo>`, so a worktree of `autonomous-grid` at
-    `…/autonomous-grid-feats/<slug>` looks for `…/grid-src-feats/<slug>` first and falls back to the
-    main `…/grid-src` checkout.
-
-    `GRID_SRC_REPO` — the cross-repo E2E's own override — wins over both, so a machine that lays the
-    repositories out differently can still run this.
-    """
-    override = os.environ.get("GRID_SRC_REPO")
-    if override:
-        return pathlib.Path(override) / "grid_cli" / "private_server"
-
-    here = pathlib.Path(__file__).resolve().parent.parent  # the autonomous-grid checkout
-    projects = here.parent
-    candidates = []
-    if projects.name == "autonomous-grid-feats":
-        candidates.append(projects.parent / "grid-src-feats" / here.name)
-        candidates.append(projects.parent / "grid-src")
-    else:
-        candidates.append(projects / "grid-src")
-    for candidate in candidates:
-        if (candidate / "grid_cli" / "private_server").is_dir():
-            return candidate / "grid_cli" / "private_server"
-    return None
 
 
 def _relay_grid_run_kinds():


### PR DESCRIPTION
Ships the public CLI's half of **ADR 0039 — a grid can be keyed on an OS**: a machine claims
its operating system when it signs in, and is admitted to the community grid for that OS.

## What is in THIS repo

- `shared/system/os_grid.py` — the closed token set (`macos`/`windows`/`linux`/`omarchy`) and
  `os_token()`. No env override, deliberately: the claim is derived from the machine, not typed.
- `remote/control_plane.py` — sends `os=` on `GET /v1/grid/tokens`, and a **second spelling** of
  the same claim on the renewal body. The two are written in different places on both sides and
  drift independently, so both are pinned.
- `cli/os_grid_notice.py` — three causes leave somebody with no OS grid; this says which, and stays
  quiet in the two cases that are not this feature's answer. `os_served` is read as a **tri-state**:
  `None` (an older control plane did not say) is not `False` (it said no).
- `remote/serve.py` — `name_chosen` on the register meta. An `os-community` member runs THIS CLI's
  provider half, not grid-src's, so this is the half that decides whether a stranger's hostname is
  published on a public page.
- `fix:` a malformed token answer no longer empties the credential store — latent on **every** grid
  type since the route was written, found because `os-community` reaches it on every refresh.
- ADR 0039 itself (this repo is the cross-repo decision authority).

## Cross-repo — read before deploying

Three repos, no code dependency, every seam is wire-level. **Deploy order is part of the product:**

- **grid-src BEFORE grid-apis.** The control plane shells out `grid network create --network-type
  os-community` and that binary IS grid-src. Wrong order ⇒ argparse exit 2, a grid stuck `pending`
  retrying forever.
- **relay before the control plane** for the denylist widening. Wrong order ⇒ a ban is *exactly
  ineffective against the account it was written for*, for up to a year.
- **This CLI has no ordering in either direction.** `os=` is a new query parameter on an existing
  endpoint: an old control plane drops it, a new one reads an old CLI's silence as claiming nothing.

## Verification

- `tests/test_os_grid_type_lockstep.py` (new, 931 lines) compares the two repos' spellings
  **against each other**, not against a constant either side can move with its own tests.
- Full suite green after the sync-down merge of `main` (v0.3.28).
- **Verified live on the dev VM**, both halves deployed in ADR order, each proven from the running
  process rather than from git: admission by a non-owner; the same account on two machines getting
  two different OS grids and neither seeing the other's; task plane refused at its single gate;
  member-usage panel 403 against a 200 control; provider e-mail and machine name withheld against a
  control grid publishing both from the same relay build; denylist biting both halves and releasing
  again; a real completion served free.

## Known open, deliberately

- `windows` hostname derivation is unmeasured (issue 15's last box). It does **not** gate this:
  D-n withholds regardless of what any platform's default turns out to be.
- Omarchy's own grid is a separate slice, blocked on a measurement nobody has taken.
- grid-src's re-type door onto an `os-community` grid is a separate slice (issue 09), named in D-i.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZ33AtDj2SctoLg37yYsy8
