### PR TITLE
feat: an Omarchy machine gets its own grid, called Omagrid

### DIFF
--- a/docs/adr/0039-a-grid-can-be-keyed-on-an-os.md
+++ b/docs/adr/0039-a-grid-can-be-keyed-on-an-os.md
@@ -42,10 +42,40 @@ The closed set is forced by D-d: auto-provisioning on an open value space means 
 string becomes a permanent empty grid. `shared/system/host.platform_kind()` already carries an `other`
 bucket for exactly this reason, and `other` must never reach this path.
 
-⚠️ **Omarchy is Arch-based, and whether `/etc/os-release` distinguishes it from stock Arch is
-UNMEASURED.** `shared/engine/installer._detect_distro` reads `ID=`/`ID_LIKE=` and is the shape to
-follow, but if Omarchy reports `ID=arch` then a second signal is required. Measure on a real Omarchy
-box before implementing; do not infer it.
+**RESOLVED 2026-09-03 (issue 04): Omarchy writes its own `/etc/os-release`, so `ID=omarchy` is the
+signal — and `ID_LIKE=` must stay out of it.** The `omarchy-settings` package generates the file
+(`ID=omarchy`, `ID_LIKE=arch`) and its `post_install`/`post_upgrade` scriptlet `rm -f`s the system's
+copy and `cp -f`s that one over `/etc/os-release` on every install and upgrade. Identical in
+`omarchy-settings-dev`, the edge channel. Stock Arch is `ID=arch` with no `ID_LIKE`.
+
+⚠️ **`shared/engine/installer._detect_distro` is no longer the shape to follow, and this decision is
+the reason.** It reads `ID=` and `ID_LIKE=` into ONE list and matches either. Every Arch derivative
+ships `ID_LIKE=arch` — EndeavourOS, CachyOS, Manjaro — so copied here it would put all of them on the
+Omarchy grid: the exact mis-sorting the closed set exists to prevent. `ID=` is an identity, `ID_LIKE=`
+is a lineage, and only the first one names a community. `shared/system/os_grid._distro_id` reads `ID=`
+alone, and `tests/test_local_cli.py` names those three distributions so that re-merging the two fields
+fails.
+
+⚠️ **The evidence is a SOURCE read of Omarchy's packaging, not a `cat` on a live machine**, and is
+held to the same lower standard as this ADR's hostname sweep below. It is stronger than the
+documentation this decision refused to infer from — it is the code that writes the file — but a live
+reading has still not been taken. The fail direction is the safe one: anything that is not
+`ID=omarchy` still resolves to `linux`, so a wrong reading costs Omarchy users their own grid rather
+than putting Arch users on it. Older Omarchy installs that predate `omarchy-settings` (the
+`boot.sh`-onto-Arch era) do not write the file and land on the general Linux grid for the same reason.
+
+**An Omarchy machine is NOT also on the Linux grid.** `os=` carries one value and the gate is an
+equality test against one grid's own token, so claiming `omarchy` is precisely what takes the machine
+off `linux`. That is the decision and not a gap — "Omarchy is built on Linux, so it should see both"
+is the reading to rule out, and the wire cannot express it anyway.
+
+⚠️ **This gives the token set a rollout order the `os-community` literal does not have, and it points
+the OTHER WAY: the control plane rolls out BEFORE the CLI.** A CLI that has learnt a token the control
+plane does not serve claims it, stops claiming `linux`, and is handed nothing — a machine that was on
+the Linux grid yesterday. Loud (D-k's absence line fires on `os_served: false`) but wrong. Pinned
+across the boundary by `tests/test_os_grid_type_lockstep.py`, which compares
+`shared/system/os_grid.OS_TOKENS` against grid-apis' `DEFAULT_SERVED_OS_TOKENS` — as a SUBSET, so that
+deploying the control plane first is not itself a failure.
 
 `platform_kind()` was rejected as the vocabulary even though it already exists and is already on the
 wire (`remote/serve.py` heartbeat `load["platform"]`). It answers *"which binaries run here"* — a
@@ -170,6 +200,17 @@ and the partial unique index that makes the auto-provision claim atomic sits on 
 `private-domain` makes `name` do two jobs, and `store.domain_gate_for` exists only to hide the fact
 that the two domain types keep their gate in different places. Not repeating that here means a user who
 names their own grid `macos` collides with nothing.
+
+**DECIDED 2026-09-03 (issue 04): the Omarchy grid is named `Omagrid`, and its token stays `omarchy`.**
+`os_networks._OS_LABELS` is a map of **grid names**, not of operating-system names, and this is where
+the two part company: three entries happening to spell their own OS (`macos` → `macOS`) is a
+coincidence of those three, not a rule.
+
+⚠️ It is also the decision that makes the two-values split load-bearing rather than tidy. Until now a
+reviewer could look at `macos`/`macOS` and see one value prettied up; **no derivation from `omarchy`
+produces `Omagrid`**, and one written to try would have to move the gate to do it — which is exactly
+what `create_pending_os_network`'s own warning says must never happen. Nothing compares a grid's name:
+every reader of this value prints it.
 
 ## D-g — Inference on an `os-community` grid is free, and stays free
 

--- a/shared/system/os_grid.py
+++ b/shared/system/os_grid.py
@@ -28,24 +28,35 @@ cannot verify ``device_id`` (a ``uuid4`` this CLI writes to ``~/.grid/device.tom
 stops *mistakes*, not *intent*, and nothing downstream may be justified by "only macOS machines are on
 the macOS grid" (ADR 0039 D-b).
 
-``omarchy`` is the fourth token in ADR 0039 D-c and is deliberately **absent here**: it is Arch-based
-and whether ``/etc/os-release`` distinguishes it from stock Arch is UNMEASURED. Adding it on an
-unverified signal would silently sort every Arch user into the Omarchy grid — the exact mis-sorting the
-closed set exists to prevent. `.scratch/os-grid-type/issues/04-omarchy-gets-its-own-grid.md` owns it,
-and owns taking the measurement first; that is also where the ``/etc/os-release`` read arrives (see
-``shared.engine.installer._detect_distro`` for the shape it will follow).
+``omarchy`` is the fourth token (ADR 0039 D-c, issue 04) and the only one ``platform.system()`` cannot
+answer: Omarchy reports ``Linux`` like every other distribution, so it is resolved from ``ID=`` in
+``/etc/os-release``, one step further down and only for a machine that already resolved to ``linux``.
+
+⚠️ **``ID=``, and never ``ID_LIKE=``.** Omarchy writes ``ID=omarchy`` *and* ``ID_LIKE=arch``, and so
+does every other Arch derivative — EndeavourOS, CachyOS, Manjaro. ``shared.engine.installer
+._detect_distro`` is the read this docstring used to point at as "the shape to follow", and it reads
+the two fields into ONE list and matches either; copied here it would put every Arch derivative on the
+Omarchy grid, which is the exact mis-sorting the closed set exists to prevent. ``ID=`` is an identity,
+``ID_LIKE=`` is a lineage, and only the first one names a community.
+
+⚠️ **Omarchy is NOT also on the Linux grid, and that is the decision rather than a gap.** ``os=`` is a
+single value and the far end's gate is an equality test against one grid's own token, so claiming
+``omarchy`` is precisely what takes the machine off the general Linux grid. A reading that has it join
+both sounds generous — Omarchy *is* Linux — and the wire cannot express it.
 """
 
 from __future__ import annotations
 
 import platform
+from pathlib import Path
 
 OS_MACOS = "macos"
 OS_WINDOWS = "windows"
 OS_LINUX = "linux"
+OS_OMARCHY = "omarchy"
 
 #: Every token this CLI can emit. Closed by decision (ADR 0039 D-c) — see the module docstring.
-OS_TOKENS: tuple[str, ...] = (OS_MACOS, OS_WINDOWS, OS_LINUX)
+OS_TOKENS: tuple[str, ...] = (OS_MACOS, OS_WINDOWS, OS_LINUX, OS_OMARCHY)
 
 # `platform.system()` → OS token. Only the systems that HAVE a grid appear; everything else — a BSD, a
 # Java runtime, the empty string a frozen build can report — is absent and resolves to None.
@@ -54,6 +65,46 @@ _BY_SYSTEM = {
     "Windows": OS_WINDOWS,
     "Linux": OS_LINUX,
 }
+
+#: Where a Linux machine names its distribution. Read only when `_BY_SYSTEM` already said `linux`.
+#:
+#: ⚠️ `/usr/lib/os-release` — the freedesktop fallback — is deliberately NOT consulted. Omarchy's
+#: `omarchy-settings` package `rm -f`s `/etc/os-release` and copies its own over it on every install
+#: AND upgrade, so this path is where its claim lands; and on a machine that has only the `/usr/lib`
+#: copy the answer would be some other distribution's `ID`, which resolves to `linux` either way.
+_OS_RELEASE = Path("/etc/os-release")
+
+#: How much of `/etc/os-release` is read. It is a root-owned file of a few hundred bytes everywhere,
+#: so this is a bound and not a threat model: it keeps an unbounded read off a path this CLI does not
+#: own. Truncation can only LOSE the `ID=` line, and a lost signal lands on `linux`.
+_MAX_OS_RELEASE_BYTES = 64 * 1024
+
+#: Distribution ``ID`` → OS token, for the distributions that have a grid of their own. A second
+#: closed set, and everything absent from it is an ordinary Linux machine (see `os_token`).
+_BY_DISTRO_ID = {
+    "omarchy": OS_OMARCHY,
+}
+
+
+def _distro_id() -> str:
+    """The lowercased ``ID=`` of ``/etc/os-release``, or ``""`` when there is nothing to read.
+
+    Every failure is the empty string, never an exception: this runs inside ``grid login`` on a
+    machine whose only fault might be a mis-encoded system file, and a traceback there would be about
+    the OS grid — the one part of a sign-in nobody asked for. ``errors="replace"`` rather than a bare
+    ``read_text`` because ``UnicodeDecodeError`` is a ``ValueError`` that no ``except OSError`` sees.
+
+    ⚠️ Reads ``ID=`` alone. See the module docstring for why ``ID_LIKE=`` must stay out of it.
+    """
+    try:
+        with _OS_RELEASE.open("rb") as handle:
+            text = handle.read(_MAX_OS_RELEASE_BYTES).decode("utf-8", errors="replace")
+    except OSError:
+        return ""
+    for line in text.splitlines():
+        if line.startswith("ID="):
+            return line.split("=", 1)[1].strip().strip("\"'").strip().lower()
+    return ""
 
 
 def system_name() -> str:
@@ -79,11 +130,21 @@ def os_token() -> str | None:
     ``None`` is an ordinary answer, not a failure: a machine outside the closed set simply has no OS
     grid, keeps every other grid it belongs to, and sends no ``os`` parameter at all.
 
-    Every Linux resolves to ``linux``, including a distribution nobody has heard of — an unusual
-    choice of distribution must not exclude somebody from the general Linux grid.
+    Every Linux resolves to ``linux`` **except** one that names itself ``omarchy`` — a distribution
+    nobody has heard of still lands on the general Linux grid, and so does a machine with no
+    ``/etc/os-release`` to read. The distro lookup narrows nothing: it is an exception TO the ``linux``
+    answer, taken after it, so a new entry in ``_BY_DISTRO_ID`` can only ever move machines that
+    already matched that entry's own ``ID``.
 
     Resolved from :func:`system_name` rather than from its own ``platform.system()`` call, so the two
     answers this module gives are one reading. The trim that comes with it is free: a padded system
     name matched nothing before and matches its grid now.
+
+    ⚠️ The distro read hangs off the ``linux`` answer and nothing else. ``/etc/os-release`` is not
+    Linux's alone — a container image or a hand-rolled script can leave one on a Mac — and consulting
+    it before the system is known would move that machine's grid.
     """
-    return _BY_SYSTEM.get(system_name())
+    token = _BY_SYSTEM.get(system_name())
+    if token != OS_LINUX:
+        return token
+    return _BY_DISTRO_ID.get(_distro_id(), OS_LINUX)

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -11710,13 +11710,28 @@ def test_control_plane_fetch_tokens_defaults_missing_networks_to_empty(monkeypat
 # machine of a given system ends up sending, and the parameter is what the control plane gates on.
 
 
-def _fetch_tokens_query(monkeypatch, system):
-    """The query string `fetch_tokens` builds on a machine whose ``platform.system()`` is ``system``."""
+def _fetch_tokens_query(monkeypatch, tmp_path, system, os_release=None):
+    """The query string `fetch_tokens` builds on a machine whose ``platform.system()`` is ``system``.
+
+    ``os_release`` is that machine's ``/etc/os-release``, or ``None`` for a machine that has none.
+
+    ⚠️ **Both are stubbed on every call, and the second is not optional decoration.** Since `omarchy`
+    landed (issue 04) a Linux machine's token is read off that file, so a test that left the real one
+    alone would be asking whatever host the suite runs on what the answer is — green on this Mac,
+    green on an Ubuntu runner, and quietly wrong the day somebody runs it on Omarchy. Pointing the
+    module at a path that does not exist is the deterministic *no distro signal* case, and it is what
+    keeps `("Linux", "linux")` a statement about the code rather than about the machine.
+    """
     import platform
 
     from remote import control_plane
+    from shared.system import os_grid
 
     monkeypatch.setattr(platform, "system", lambda: system)
+    os_release_path = tmp_path / "os-release"
+    if os_release is not None:
+        os_release_path.write_text(os_release, encoding="utf-8")
+    monkeypatch.setattr(os_grid, "_OS_RELEASE", os_release_path)
     seen = {}
 
     def handler(request):
@@ -11735,7 +11750,7 @@ def test_fetch_tokens_sends_the_os_token_of_the_machine_it_runs_on(
     monkeypatch, tmp_path, system, expected
 ):
     monkeypatch.setenv("GRID_HOME", str(tmp_path))
-    params = _fetch_tokens_query(monkeypatch, system)
+    params = _fetch_tokens_query(monkeypatch, tmp_path, system)
     assert params["os"] == expected
     assert params["device_id"] == "dev-1"  # the OS rides ALONGSIDE the device id, never instead of it
 
@@ -11752,9 +11767,179 @@ def test_fetch_tokens_sends_no_os_parameter_when_the_system_resolves_to_nothing(
     grid still has every other grid it belongs to.
     """
     monkeypatch.setenv("GRID_HOME", str(tmp_path))
-    params = _fetch_tokens_query(monkeypatch, system)
+    params = _fetch_tokens_query(monkeypatch, tmp_path, system)
     assert "os" not in params
     assert params["device_id"] == "dev-1"
+
+
+# --- Omarchy is its own grid, and Arch is not it (ADR 0039 D-c, issue 04) --------------------------
+# The fourth token is the only one a machine cannot answer from `platform.system()`: Omarchy reports
+# `Linux` like every other distribution, so the signal is `ID=` in `/etc/os-release`, which its
+# `omarchy-settings` package writes and `cp -f`s over the file on every install and upgrade.
+#
+# ⚠️ **`ID=`, and NEVER `ID_LIKE=`.** Omarchy writes `ID=omarchy` AND `ID_LIKE=arch`, and every other
+# Arch derivative writes that same `ID_LIKE`. `shared/engine/installer._detect_distro` — the shape
+# ADR 0039 D-c pointed at — reads the two fields into ONE list and matches either, and copying that
+# here is the mis-sorting the closed set exists to prevent: EndeavourOS, CachyOS and Manjaro would
+# all land on the Omarchy grid. The tests below are written so that copying it fails.
+
+_OMARCHY_OS_RELEASE = (
+    'NAME="Omarchy"\n'
+    'PRETTY_NAME="Omarchy"\n'
+    "ID=omarchy\n"
+    "ID_LIKE=arch\n"
+    'HOME_URL="https://omarchy.org/"\n'
+)
+
+_ARCH_OS_RELEASE = 'NAME="Arch Linux"\nID=arch\nBUILD_ID=rolling\n'
+
+
+def test_fetch_tokens_sends_omarchy_from_a_machine_whose_os_release_says_so(monkeypatch, tmp_path):
+    """The whole point of the fourth token: people running Omarchy meet each other."""
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    params = _fetch_tokens_query(
+        monkeypatch, tmp_path, "Linux", os_release=_OMARCHY_OS_RELEASE)
+    assert params["os"] == "omarchy"
+
+
+def test_a_machine_on_omarchy_does_not_also_claim_the_linux_grid(monkeypatch, tmp_path):
+    """One claim per request, and on Omarchy that claim is NOT `linux`.
+
+    Written as its own case because it is the behaviour somebody is most likely to "fix" back:
+    Omarchy is built on Linux, so a reading that has it join both grids sounds generous. The wire
+    cannot express it — `os=` is a single value — and the gate is an equality test against one grid's
+    own token, so claiming `omarchy` is exactly what takes this machine off the Linux grid. That is
+    the decision (ADR 0039 D-c), not a gap.
+    """
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    params = _fetch_tokens_query(
+        monkeypatch, tmp_path, "Linux", os_release=_OMARCHY_OS_RELEASE)
+    assert params["os"] != "linux"
+
+
+@pytest.mark.parametrize(
+    "label,os_release",
+    [
+        ("stock Arch", _ARCH_OS_RELEASE),
+        # ⚠️ The three below all carry `ID_LIKE=arch`. Read the way `_detect_distro` reads it — ID and
+        # ID_LIKE merged into one list — every one of them would be an Omarchy machine.
+        ("EndeavourOS", 'NAME="EndeavourOS"\nID=endeavouros\nID_LIKE=arch\n'),
+        ("CachyOS", 'NAME="CachyOS"\nID=cachyos\nID_LIKE="arch"\n'),
+        ("Manjaro", 'NAME="Manjaro Linux"\nID=manjaro\nID_LIKE=arch\n'),
+        ("Ubuntu", 'NAME="Ubuntu"\nID=ubuntu\nID_LIKE=debian\n'),
+        ("a distribution nobody has heard of", "ID=serenity\n"),
+        ("a file with no ID at all", 'NAME="Something"\nVERSION_ID="1"\n'),
+        ("an empty file", ""),
+        ("no /etc/os-release at all", None),
+    ])
+def test_every_other_linux_still_claims_the_linux_grid(monkeypatch, tmp_path, label, os_release):
+    """The new branch narrows NOTHING — issue 04's third acceptance criterion.
+
+    An unusual choice of distribution must not exclude somebody from the general Linux grid, and a
+    machine that says nothing about its distribution is an ordinary Linux machine, not a machine with
+    no OS grid. `linux` is the fallback for every Linux; `omarchy` is the one exception to it.
+    """
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    params = _fetch_tokens_query(monkeypatch, tmp_path, "Linux", os_release=os_release)
+    assert params["os"] == "linux", label
+
+
+@pytest.mark.parametrize(
+    "label,line",
+    [
+        ("double-quoted", 'ID="omarchy"'),
+        ("single-quoted", "ID='omarchy'"),
+        ("trailing whitespace", "ID=omarchy   "),
+        ("shouted", "ID=OMARCHY"),
+    ])
+def test_the_id_is_read_the_way_os_release_is_actually_written(monkeypatch, tmp_path, label, line):
+    """os-release values may be quoted, and the file is written by hand as often as by a package.
+
+    Not defensive padding: the same normalisation `installer._detect_distro` already applies, plus a
+    case fold. The cost of missing one of these is a machine silently sorted into the wrong grid, and
+    the cost of applying them is nothing — none of these spellings names any other distribution.
+    """
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    params = _fetch_tokens_query(
+        monkeypatch, tmp_path, "Linux", os_release=f"NAME=x\n{line}\nID_LIKE=arch\n")
+    assert params["os"] == "omarchy", label
+
+
+@pytest.mark.parametrize("system,expected", [("Darwin", "macos"), ("Windows", "windows")])
+def test_a_machine_that_is_not_linux_never_consults_os_release(
+    monkeypatch, tmp_path, system, expected
+):
+    """A Mac with a stray `/etc/os-release` is still a Mac.
+
+    The distro read hangs off the `linux` answer and nothing else. Written down because the file is
+    not Linux's alone — a container image, a Homebrew package or a hand-rolled script can leave one
+    on macOS — and a lookup done before the system is known would move that machine's grid.
+    """
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    params = _fetch_tokens_query(
+        monkeypatch, tmp_path, system, os_release=_OMARCHY_OS_RELEASE)
+    assert params["os"] == expected
+
+
+@pytest.mark.parametrize(
+    "label,content",
+    [("not UTF-8", b"ID=omarchy\n\xff\xfe\x00rubbish\n"), ("a lone NUL", b"\x00\x00\x00")])
+def test_an_unreadable_os_release_never_takes_the_sign_in_down(
+    monkeypatch, tmp_path, label, content
+):
+    """A file this cannot decode is *no signal*, never an exception.
+
+    `installer._detect_distro` guards `OSError` only, and `Path.read_text` on a file that is not
+    UTF-8 raises `UnicodeDecodeError` — a `ValueError`, which no `except OSError` sees. On that path
+    it would surface as a traceback out of `grid login`, on a machine whose only fault is a
+    mis-encoded system file. The first case still holds a readable `ID=omarchy` before the bad bytes
+    and is deliberately NOT required to find it: what is pinned is that the sign-in completes.
+    """
+    from shared.system import os_grid
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    path = tmp_path / "os-release"
+    path.write_bytes(content)
+    monkeypatch.setattr(os_grid, "_OS_RELEASE", path)
+
+    import platform
+
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    assert os_grid.os_token() in ("linux", "omarchy"), label
+
+
+def test_a_gigantic_os_release_is_not_read_into_memory(monkeypatch, tmp_path):
+    """The read is bounded, so a pathological file cannot be turned into a crash by reading it.
+
+    `/etc/os-release` is root-owned and a few hundred bytes in every real deployment, so this is a
+    bound and not a threat model. It matters because the alternative — an unbounded `read_text` on a
+    path chosen by somebody else's package manager — is the shape that has to be argued about later.
+    Truncation can only LOSE the signal, and losing it lands on `linux`, the safe direction.
+    """
+    from shared.system import os_grid
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    path = tmp_path / "os-release"
+    path.write_text("#" + " " * (os_grid._MAX_OS_RELEASE_BYTES * 2) + "\nID=omarchy\n")
+    monkeypatch.setattr(os_grid, "_OS_RELEASE", path)
+
+    import platform
+
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    assert os_grid.os_token() == "linux"
+
+
+def test_omarchy_is_one_of_the_tokens_this_cli_can_emit():
+    """The closed set grew, and three things read it rather than writing the members out again.
+
+    `cli/os_grid_notice` names it in the sentence a machine outside the set is shown, and
+    `tests/test_os_grid_type_lockstep` pins it against what the control plane will serve. A token
+    that resolves but is absent from `OS_TOKENS` would be claimable and unmentionable.
+    """
+    from shared.system import os_grid
+
+    assert os_grid.OS_OMARCHY == "omarchy"
+    assert os_grid.OS_OMARCHY in os_grid.OS_TOKENS
 
 
 # --- `os_served`, the answer to "why is there no OS grid in my list" (ADR 0039 D-k) ---------------

--- a/tests/test_os_grid_type_lockstep.py
+++ b/tests/test_os_grid_type_lockstep.py
@@ -632,6 +632,70 @@ def test_the_fetch_and_the_renewal_agree_with_each_other(monkeypatch, tmp_path):
         f"a machine would be admitted to an OS grid and then silently unable to renew on it")
 
 
+# --- the TOKEN SET itself: what this CLI can claim vs what the control plane will serve ------------
+# Every pin above is about a value's SPELLING. This one is about its MEMBERSHIP, and it arrived with
+# `omarchy` (issue 04) because that is the first token added since the two lists were written.
+#
+# `shared/system/os_grid.OS_TOKENS` is everything a machine running this CLI can claim.
+# `os_networks.DEFAULT_SERVED_OS_TOKENS` is everything the control plane provisions a grid for when
+# `GRID_OS_GRID_TOKENS` is unset — and it is unset on the dev VM and on prod, so that default is not
+# a fallback in practice, it is the served list.
+#
+# ⚠️ **A token this CLI claims and the control plane does not serve is a machine with NO OS grid, not
+# a machine that falls back to another one.** That is the whole point of the claim being single-valued
+# (ADR 0039 D-c): an Omarchy machine claims `omarchy`, so it is no longer claiming `linux`, so an
+# unserved `omarchy` costs it the Linux grid it used to be on. The degrade is at least LOUD — D-k's
+# absence line fires on `os_served: false` — which is why this is an ordering rather than a fail-open.
+#
+# ⚠️ **Roll the CONTROL PLANE out BEFORE the CLI for this value, the REVERSE of the `os-community`
+# literal at the top of this file.** That one goes grid-src first because the control plane shells out
+# to grid-src's argparse; this one goes control plane first because the CLI is what starts making the
+# new claim. Same feature, opposite answers, and inferring either from the other gets it backwards.
+#
+# ⚠️ Deliberately NOT compared against `_OS_LABELS`. The label map is the GRID'S NAME per token
+# (`omarchy` → `Omagrid`) and lives only in grid-apis; nothing in this repository reads a grid's name
+# for anything but printing it, so it has no half here and no lockstep to keep.
+
+_APIS_OS_NETWORKS = "grid_networks/os_networks.py"
+_SERVED_TOKENS = "DEFAULT_SERVED_OS_TOKENS"
+
+#: The token that predates this slice on both sides — the positive control, so a helper that has
+#: quietly stopped reading the tuple fails as a HARNESS fault rather than as "the seam is fine".
+_TOKEN_CONTROL_VALUE = "macos"
+
+
+def test_every_token_this_cli_can_claim_is_one_the_control_plane_serves():
+    """Membership, compared list against list — neither repository can see this alone.
+
+    This repository's suite is right that `os_token()` resolves `omarchy` on an Omarchy machine.
+    grid-apis' suite is right that `served_os_tokens()` answers exactly what its default tuple holds.
+    Both stay green while an Omarchy machine signs in, claims a token nobody serves, and is handed
+    nothing — which is a REGRESSION for that machine, because it was on the Linux grid the day before.
+
+    Asserted as a subset rather than as equality: the control plane may legitimately serve a token no
+    shipped CLI claims yet (that is how a token gets deployed FIRST, per the ordering above), and
+    calling that a failure would make the safe rollout order the one that fails the test.
+    """
+    from shared.system import os_grid
+
+    served = _collection(
+        _apis_module(_APIS_OS_NETWORKS), _SERVED_TOKENS, _APIS_OS_NETWORKS)
+
+    assert _TOKEN_CONTROL_VALUE in served, (
+        f"positive control: even {_TOKEN_CONTROL_VALUE!r} is missing from grid-apis' "
+        f"{_SERVED_TOKENS}, so this check is reading the wrong thing — fix the harness")
+    assert _TOKEN_CONTROL_VALUE in os_grid.OS_TOKENS, (
+        f"positive control: even {_TOKEN_CONTROL_VALUE!r} is missing from this repository's "
+        f"OS_TOKENS, so this check is reading the wrong thing — fix the harness")
+
+    unserved = sorted(set(os_grid.OS_TOKENS) - served)
+    assert not unserved, (
+        f"this CLI can claim {unserved} and grid-apis' {_SERVED_TOKENS} serves {sorted(served)}, so a "
+        f"machine of that system claims a token nobody provisions a grid for — and because the claim "
+        f"is single-valued it has stopped claiming the one it used to get (ADR 0039 D-c). Add the "
+        f"token to BOTH, and roll the control plane out FIRST")
+
+
 # --- the ANSWER's key, this slice's FOURTH cross-repo value ----------------------------------------
 # Everything above pins what the CLI SAYS. `os_served` is the one value on this seam that travels the
 # other way: `GET /v1/grid/tokens` reports whether this call was handed an OS grid, so the three


### PR DESCRIPTION
Closes issue 04 of the OS-grid feature — the fourth and last token of ADR 0039 D-c's taxonomy, unblocked by the measurement it had been waiting on since the ADR was written.

## What changes

A machine running **Omarchy** now claims `omarchy` instead of `linux`, and lands on a grid named **`Omagrid`**. Everything else about the feature is unchanged.

| | before | after |
|---|---|---|
| Omarchy machine | `os=linux` → the Linux grid | `os=omarchy` → **Omagrid** |
| stock Arch, EndeavourOS, CachyOS, Manjaro, Ubuntu, anything else | `os=linux` | `os=linux` — unchanged |
| macOS / Windows | unchanged | unchanged, and they never read `/etc/os-release` |

The control-plane half (the served-token list and the grid's name) is `autonomous-ai/autonomous-grid-be@7ead370`, already on that repo's `main`.

## The measurement this was blocked on

Omarchy writes its own `/etc/os-release`. `omacom/omarchy-pkgs`' `omarchy-settings` PKGBUILD generates `ID=omarchy` / `ID_LIKE=arch`, and its `post_install`/`post_upgrade` scriptlet `rm -f`s the system copy and `cp -f`s that one over the file — on every install **and** every upgrade. Identical in `omarchy-settings-dev`, the edge channel. Stock Arch is `ID=arch` with no `ID_LIKE`.

⚠️ **This is a SOURCE read of the packaging, not a `cat` on a live machine**, and is held to the same lower standard as ADR 0039's hostname sweep. It is stronger than the documentation D-c refused to infer from — it is the code that writes the file — but a live reading is still worth taking, and is recorded as a follow-up. The fail direction is the safe one: anything that is not `ID=omarchy` still resolves to `linux`, so a wrong reading costs Omarchy users their own grid rather than putting Arch users on it. Installs predating `omarchy-settings` land on `linux` for the same reason.

## ⚠️ `installer._detect_distro` is no longer the shape to follow

ADR 0039 D-c originally pointed at it. It reads `ID=` and `ID_LIKE=` into **one list** and matches either — and every Arch derivative ships `ID_LIKE=arch`, so copied here it would put EndeavourOS, CachyOS and Manjaro on the Omarchy grid: the exact mis-sorting the closed token set exists to prevent. `ID=` is an identity, `ID_LIKE=` is a lineage, and only the first names a community. The tests name those three distributions by hand so that re-merging the two fields fails.

## ⚠️ An Omarchy machine is NOT also on the Linux grid

`os=` carries one value and the gate is an equality test against one grid's own token, so claiming `omarchy` is precisely what takes the machine off `linux`. That is the decision, not a gap — and it is the behaviour most likely to be "fixed" back on the grounds that Omarchy *is* Linux, so it has its own named test on each side of the seam.

## ⚠️ Rollout: the control plane goes out BEFORE the CLI

That single-valued claim gives the token **set** a rollout order the `os-community` **literal** does not have, and it points the **other way**. A CLI that has learnt `omarchy` against a control plane that does not serve it is handed nothing, and it is no longer claiming `linux` to fall back on — so a machine that was on the Linux grid yesterday has no grid today. Loud (D-k's absence line fires on `os_served: false`), never silent, which is what makes it an ordering rather than a fail-open.

Three answers now live in this one feature, and inferring any from its neighbour is wrong:

| value | order |
|---|---|
| the `os-community` type literal | grid-src → control plane |
| the `os=` parameter **name** | none, either direction |
| the OS **token set** (this PR) | **control plane → CLI** |

Pinned across the boundary by `tests/test_os_grid_type_lockstep.py` as a **subset**, so that deploying the control plane first is not itself a failure.

## Notes on the implementation

- The distro read hangs off the `linux` answer and nothing else — `/etc/os-release` is not Linux's alone.
- The read is bounded and decodes with `errors="replace"`. A file that is not UTF-8 raises `UnicodeDecodeError`, a `ValueError` that `_detect_distro`'s `except OSError` does not see; a traceback out of `grid login` about the one part of a sign-in nobody asked for is not an acceptable failure. Every failure, and truncation, land on `linux`.
- The grid's name is `Omagrid` while the token stays `omarchy` (ADR 0039 D-f). This is what makes the label/token split load-bearing rather than tidy: no derivation from the token produces `Omagrid`, and one written to try would have to move the gate to do it.

## Test plan

- [x] `pytest tests/` — full suite, 0 failures (re-run after merging `main`, which also touched `tests/test_local_cli.py`)
- [x] `ruff check` clean
- [x] grid-apis `pytest tests/` — 1158 passed, 0 failed
- [x] Cross-repo lockstep run locally with all three worktrees present (it skips in CI)
- [x] Mutation-checked: reverting grid-apis' `DEFAULT_SERVED_OS_TOKENS` to three tokens fails the new pin with the right sentence
- [ ] A live `cat /etc/os-release` on a real Omarchy box, to raise the source read to a measurement
- [ ] E2E on a real Omarchy machine: sign in, confirm `Omagrid` is provisioned and the machine is not on the Linux grid. ⚠️ `GET /v1/grid/tokens?os=omarchy` is a WRITE — it provisions the grid — so do it deliberately, not as a probe

⚠️ `_fetch_tokens_query` now stubs `_OS_RELEASE` on **every** call, including the macOS cases. Without it `("Linux", "linux")` stops being a statement about the code and becomes one about whatever machine runs the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXNAadpsFfETXENbie3p91