### PR TITLE
feat: default to remote mode on a machine with no local grids

### DIFF
--- a/cli/grid.py
+++ b/cli/grid.py
@@ -340,6 +340,9 @@ def _overview_remote(as_json: bool) -> int:
     print(f"active grid: {active}" if active else "active grid: (none)")
     print("\nSign in with `grid login`, then manage your remote grids with `grid start`/`ls`/`info`, "
           "serve models with `grid join`, and use them with `grid chat -m <model> \"…\"`.")
+    # `remote` is the default for a new install (ADR 0001 D-2, amended), so this screen is the first
+    # thing a new user sees — and without this line the local mode has no signpost anywhere.
+    print("Or run a grid on this machine alone, no account needed: `grid mode local`.")
     return 0
 
 

--- a/docs/adr/0001-mode-state-and-dispatch.md
+++ b/docs/adr/0001-mode-state-and-dispatch.md
@@ -1,6 +1,7 @@
 # ADR 0001 — Mode state, `grid mode` / `grid use`, and mode-aware dispatch
 
-Status: accepted (2026-06-27)
+Status: accepted (2026-06-27); amended 2026-09-04 — the default mode for a machine with no
+state file is now `remote`, derived rather than constant (D-2, D-4).
 
 ## Context
 
@@ -12,6 +13,8 @@ grid is selected per mode, and how command handlers become mode-aware while remo
 stub.
 
 Hard invariant: an existing local user with no state file must behave **exactly** as before.
+This invariant **survives the 2026-09-04 amendment** — it is what that amendment is built around,
+and it is now carried by evidence on disk rather than by the constant.
 
 ## Decisions
 
@@ -26,14 +29,44 @@ Hard invariant: an existing local user with no state file must behave **exactly*
    A missing file ⇒ mode `local` and no active selection (today's `home`/sole-grid fallback). The
    mode/state kernel is shared infrastructure and lives in `shared/state.py`.
 
+   > **Amended 2026-09-04 — the default is `remote`, and it is DERIVED, not a constant.**
+   > A missing/invalid mode now resolves through `shared/state._default_mode()`: `remote` for a
+   > new install, `local` when `~/.grid/grids/*/config.json` matches at least one grid. The
+   > product wants a new user pointed at a hosted grid; the hard invariant above forbids taking a
+   > working local grid out of an existing user's sight to get there, so the presence of a local
+   > grid *is* the opt-out and no migration step or state write is needed.
+   >
+   > Three properties bind, each a way this has already been got wrong once in review:
+   > - **`_normalized()` derives the same default.** `grid use <name>` writes `state.json`, so a
+   >   plain `DEFAULT_MODE` there would persist `remote` for a local user as a *side effect* of
+   >   selecting a grid — flipping them without a `grid mode` in sight.
+   > - **The evidence is a `config.json`, never a bare directory.** A leftover empty
+   >   `grids/<id>/` is not a grid.
+   > - **Unreadable ⇒ `local`.** A new install has no `grids` directory and globs clean, so an
+   >   `OSError` means the directory exists and only the read failed. "Cannot tell" must answer
+   >   the way that leaves a user where they were.
+   >
+   > Accepted sharp edge: the default is *derived on every read*, never written, so a user who
+   > removes their last local grid moves to `remote` — a mode change caused by an unrelated action.
+   > It was preferred to the alternative (stamping `state.json` at first run), which trades this for
+   > a write side effect on a machine the user has not configured yet. With no local grid left there
+   > is nothing the flip can take away, and `grid mode local` is on the overview screen.
+   >
+   > `shared/state.GRID_CONFIG_FILE` hand-duplicates `local.config.CONFIG_FILE` — `local.config`
+   > imports this module, so the dependency runs one way only and the kernel stays pure. Renamed
+   > on one side alone, the glob matches nothing and every existing local user is silently moved
+   > onto `remote`.
+
 3. **`grid use <name>` sets the per-mode active grid**, consulted inside `local/config.py:select_grid()`
    so it applies to every grid-targeting command. Precedence: explicit positional `[grid]` > active
    selection > sole/`home` fallback. local validates the grid exists at set-time (`raise SystemExit`);
    a stored active that was later deleted is ignored at resolve-time (fall back, never crash).
    `grid use --none` clears; `grid use` with no argument prints the current active.
 
-4. **Per-invocation override `--local` / `--remote` > persisted mode > default `local`.** The flags are
+4. **Per-invocation override `--local` / `--remote` > persisted mode > derived default.** The flags are
    stripped from `argv` before parsing so they work in any position; specifying both is an error.
+   *(Amended 2026-09-04: the tail of that chain was the constant `local`; it is now
+   `_default_mode()` — see D-2.)*
 
 5. **Remote is a clear stub this slice.** `grid mode remote` switches and persists (per the issue's
    acceptance criteria) with a one-line "not available yet" note. Mode-gated commands fail with a
@@ -47,7 +80,8 @@ Hard invariant: an existing local user with no state file must behave **exactly*
 
 ## Consequences
 
-- local behavior is unchanged when `state.json` is absent; the existing test suite stays green.
+- local behavior is unchanged when `state.json` is absent **and local grids exist on disk**; a
+  machine with neither starts in `remote` (amended 2026-09-04).
 - The dispatch table is the single seam later remote slices plug real handlers into.
 - `select_grid()` becomes the one chokepoint where the active selection takes effect, so `chat` /
   `info` / `stop` / `models` / `engines` / `join` / `leave` all honor `grid use` for free.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -108,9 +108,11 @@ grid use --none                       # clear the active grid for the current mo
 grid [--local | --remote] <command>      # override the mode for a single command
 ```
 
-The mode is persisted in `~/.grid/state.json` (default `local`); each mode remembers its own
-active grid. Which mode a command runs in is resolved as `--local`/`--remote` (one command) > the
-persisted mode > `local`. `grid use <name>` sets the persistent default grid, so `grid chat` /
+The mode is persisted in `~/.grid/state.json`; each mode remembers its own active grid. Which mode
+a command runs in is resolved as `--local`/`--remote` (one command) > the persisted mode > the
+default. With no state file the default is `remote`, except on a machine that already holds local
+grids (`~/.grid/grids/*/config.json`), which stays `local` until you run `grid mode remote` — so an
+upgrade never takes a running local grid out of sight. `grid use <name>` sets the persistent default grid, so `grid chat` /
 `grid info` / `grid models` target it without naming it — naming a grid explicitly still wins (the
 `[grid]` positional on `info`/`models`/`engines`, `--grid` on `chat`/`image`/`edit`/`video`), and a
 stale selection (its grid was removed) is ignored.

--- a/install.sh
+++ b/install.sh
@@ -145,5 +145,8 @@ esac
 
 ver="$("$grid_bin" --version 2>&1)" || die "installed but failed to run: $ver"
 ok "$ver"
-info "Next:  grid login   # sign in, then pick from the grids you can use"
-info "  or:  grid start   # create your own grid on this computer"
+info "Next:  grid login       # sign in, then pick from the grids you can use"
+# A new install starts in remote mode (ADR 0001 D-2, amended), where 'grid start' means "start my
+# hosted grid" and asks for a sign-in. So the local path has to name the mode, or this line sends
+# someone who wants no account into 'You are not signed in.'
+info "  or:  grid mode local  # then 'grid start' creates your own grid on this computer"

--- a/shared/state.py
+++ b/shared/state.py
@@ -2,11 +2,13 @@
 
 State lives at ``~/.grid/state.json`` (``GRID_HOME`` overrides the base)::
 
-    {"version": 1, "mode": "local", "active": {"local": <name|null>, "remote": <name|null>}}
+    {"version": 1, "mode": "remote", "active": {"local": <name|null>, "remote": <name|null>}}
 
-A missing file means mode ``local`` with no active selection — so an existing local user
-behaves exactly as before. This module is pure: it imports only ``shared.paths`` and
-``shared.jsonio`` (never ``local``/``remote``), because mode is shared by both modes.
+A missing file means no active selection and the *derived* default mode (``_default_mode``):
+``remote`` for a new install, ``local`` for a machine that already holds local grids — so an
+existing local user who never ran ``grid mode`` still behaves exactly as before (ADR 0001 D-2,
+amended). This module is pure: it imports only ``shared.paths`` and ``shared.jsonio`` (never
+``local``/``remote``), because mode is shared by both modes.
 """
 from __future__ import annotations
 
@@ -18,9 +20,16 @@ from shared import jsonio, paths
 
 
 VALID_MODES = ("local", "remote")
-DEFAULT_MODE = "local"
+DEFAULT_MODE = "remote"
+LEGACY_DEFAULT_MODE = "local"
 STATE_VERSION = 1
 STATE_FILE = "state.json"
+
+# Hand-duplicated from ``local.config.CONFIG_FILE``. It cannot be imported: ``local.config``
+# imports *this* module, so the dependency runs one way only and this module stays pure. Kept in
+# lockstep by editing both sides — renamed there with no edit here, ``_has_local_grids`` sees an
+# empty directory and every existing local user is silently moved onto the remote default.
+GRID_CONFIG_FILE = "config.json"
 
 
 def state_path() -> Path:
@@ -50,9 +59,33 @@ def validate_mode(mode: str) -> str:
     return mode
 
 
+def _has_local_grids() -> bool:
+    """Whether this machine already holds at least one local grid's config on disk.
+
+    The evidence ``_default_mode`` reads. Unreadable ⇒ ``True``: a new install has no ``grids``
+    directory at all and ``glob`` yields nothing *without* raising, so an ``OSError`` means the
+    directory is there and only unreadable — and "cannot tell" must answer the way that leaves an
+    existing local user where they were, never the way that takes their grids out of sight.
+    """
+    try:
+        return any(paths.grids_dir().glob(f"*/{GRID_CONFIG_FILE}"))
+    except OSError:
+        return True
+
+
+def _default_mode() -> str:
+    """The mode for a machine that has never persisted a choice (ADR 0001 D-2, amended).
+
+    ``remote`` is the default the product wants for a new install. A machine that already has
+    local grids keeps ``local`` until its owner opts in with ``grid mode remote`` — ADR 0001's
+    invariant that an existing local user with no state file behaves exactly as before.
+    """
+    return LEGACY_DEFAULT_MODE if _has_local_grids() else DEFAULT_MODE
+
+
 def get_mode() -> str:
     mode = read_state().get("mode")
-    return mode if mode in VALID_MODES else DEFAULT_MODE
+    return mode if mode in VALID_MODES else _default_mode()
 
 
 def resolve_mode(override: str | None) -> str:
@@ -86,6 +119,6 @@ def _normalized(data: dict[str, Any]) -> dict[str, Any]:
     mode = data.get("mode")
     return {
         "version": STATE_VERSION,
-        "mode": mode if mode in VALID_MODES else DEFAULT_MODE,
+        "mode": mode if mode in VALID_MODES else _default_mode(),
         "active": {m: (active.get(m) or None) for m in VALID_MODES},
     }

--- a/tests/test_install_sh.py
+++ b/tests/test_install_sh.py
@@ -99,6 +99,24 @@ def test_no_hint_when_local_bin_already_on_users_path(tmp_path):
     )
 
 
+def test_installer_local_path_names_the_mode(tmp_path):
+    """The installer's two on-ramps must both work on a machine that has just run it.
+
+    A new install is in remote mode (ADR 0001 D-2, amended), where `grid start` is the hosted
+    lifecycle verb and answers `You're not signed in.` — so an installer that offers a bare
+    `grid start` as the "your own grid on this computer" option hands the reader a command that
+    refuses. Driven through the real script rather than grepped, because the banner is what a user
+    actually sees.
+    """
+    res = _run_installer(tmp_path, local_bin_on_path=True)
+    assert res.returncode == 0, f"installer failed:\n{res.stdout}\n{res.stderr}"
+    assert "grid login" in res.stdout, f"the hosted on-ramp must be named:\n{res.stdout}"
+    assert "grid mode local" in res.stdout, (
+        "the local on-ramp must name the mode, or `grid start` refuses on a fresh install; "
+        f"output was:\n{res.stdout}"
+    )
+
+
 def _code_lines(text: str) -> list[tuple[int, str]]:
     """(lineno, code) for each line, with comments stripped.
 

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -4983,6 +4983,7 @@ def test_engine_ls_accepts_grid_and_json():
 
 def test_engine_ls_local_delegates_to_cmd_engines(monkeypatch, tmp_path):
     monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    state.set_mode("local")  # the default for a fresh home is `remote` (ADR 0001 D-2, amended)
     seen = {}
 
     def fake_engines(args):
@@ -5015,6 +5016,7 @@ def test_looks_like_grid_id_detector():
 
 def test_start_rejects_unknown_grid_id_without_creating(monkeypatch, tmp_path):
     monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    state.set_mode("local")  # the default for a fresh home is `remote` (ADR 0001 D-2, amended)
     with pytest.raises(SystemExit) as exc:
         cli.main(["start", "ag-home-deadbeef"])
     assert "grid ls" in str(exc.value)
@@ -5024,6 +5026,7 @@ def test_start_rejects_unknown_grid_id_without_creating(monkeypatch, tmp_path):
 
 def test_start_creates_for_human_name(monkeypatch, tmp_path):
     monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    state.set_mode("local")  # the default for a fresh home is `remote` (ADR 0001 D-2, amended)
     monkeypatch.setattr(cli.grid.runtime, "start_grid", lambda cfg: None)
     assert cli.main(["start", "workshop"]) == 0
     from local import config as local_config
@@ -7047,13 +7050,72 @@ def test_scan_engine_children_reports_an_unreadable_table_as_none(monkeypatch):
 # Mode state kernel (shared/state.py)
 # ---------------------------------------------------------------------------
 
-def test_state_defaults_to_local_with_no_active_when_absent(monkeypatch, tmp_path):
+def _write_local_grid(home, grid_id="home"):
+    """The on-disk evidence of an existing local install: one grid's config."""
+    path = home / "grids" / grid_id / "config.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"grid_id": grid_id, "name": grid_id}))
+    return path
+
+
+def test_state_defaults_to_remote_with_no_active_when_absent(monkeypatch, tmp_path):
     monkeypatch.setenv("GRID_HOME", str(tmp_path))
 
-    assert state.get_mode() == "local"
+    assert state.get_mode() == "remote"
     assert state.get_active("local") is None
     assert state.get_active("remote") is None
     assert not state.state_path().exists()
+
+
+def test_state_defaults_to_local_when_local_grids_already_exist(monkeypatch, tmp_path):
+    """ADR 0001's invariant: an existing local user with no state file is untouched."""
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    _write_local_grid(tmp_path)
+
+    assert state.get_mode() == "local"
+    assert not state.state_path().exists()  # derived, never written behind the user's back
+
+
+def test_state_default_ignores_a_grid_dir_with_no_config(monkeypatch, tmp_path):
+    """A bare directory is not a grid — only a ``config.json`` is the evidence."""
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    (tmp_path / "grids" / "leftover").mkdir(parents=True)
+
+    assert state.get_mode() == "remote"
+
+
+def test_state_default_keeps_local_when_the_grids_dir_is_unreadable(monkeypatch, tmp_path):
+    """Cannot tell ⇒ local: the reading that never takes a working grid out of sight."""
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+
+    class _Unreadable:
+        def glob(self, _pattern):
+            raise OSError("permission denied")
+
+    monkeypatch.setattr(state.paths, "grids_dir", lambda: _Unreadable())
+
+    assert state._has_local_grids() is True
+    assert state._default_mode() == "local"
+    assert state.get_mode() == "local"
+
+
+def test_set_active_does_not_flip_an_existing_local_user_to_remote(monkeypatch, tmp_path):
+    """``grid use <name>`` writes state.json; the mode it stamps must be the derived one."""
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    _write_local_grid(tmp_path)
+
+    state.set_active("local", "home")
+
+    assert json.loads(state.state_path().read_text())["mode"] == "local"
+    assert state.get_mode() == "local"
+
+
+def test_set_active_stamps_remote_for_a_new_install(monkeypatch, tmp_path):
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+
+    state.set_active("remote", "team")
+
+    assert json.loads(state.state_path().read_text())["mode"] == "remote"
 
 
 def test_state_set_mode_persists_and_preserves_active(monkeypatch, tmp_path):
@@ -7107,9 +7169,9 @@ def test_state_recovers_from_malformed_file(monkeypatch, tmp_path):
     state.state_path().parent.mkdir(parents=True, exist_ok=True)
     state.state_path().write_text("{ this is not json")
 
-    assert state.get_mode() == "local"  # lenient: corrupt file => defaults
-    state.set_mode("remote")           # self-heals on next write
-    assert state.get_mode() == "remote"
+    assert state.get_mode() == "remote"  # lenient: corrupt file => defaults
+    state.set_mode("local")             # self-heals on next write
+    assert state.get_mode() == "local"
 
 
 # ---------------------------------------------------------------------------
@@ -7118,6 +7180,7 @@ def test_state_recovers_from_malformed_file(monkeypatch, tmp_path):
 
 def test_grid_mode_reads_and_persists(monkeypatch, tmp_path, capsys):
     monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    _write_local_grid(tmp_path)  # start on the derived `local` so the switch below is a real one
 
     assert cli.cmd_mode(cli.build_parser().parse_args(["mode"])) == 0
     assert capsys.readouterr().out.strip() == "local"
@@ -11334,7 +11397,8 @@ def test_dispatch_runs_agnostic_command_in_remote(monkeypatch, tmp_path, capsys)
 
 
 def test_override_sets_remote_active_without_persisting_mode(monkeypatch, tmp_path, capsys):
-    monkeypatch.setenv("GRID_HOME", str(tmp_path))  # persisted mode stays local
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    state.set_mode("local")  # load-bearing: with a `remote` default this assertion could not fail
 
     assert cli.main(["--remote", "use", "team"]) == 0  # G1: --remote reaches cmd_use
     capsys.readouterr()
@@ -11345,6 +11409,7 @@ def test_override_sets_remote_active_without_persisting_mode(monkeypatch, tmp_pa
 
 def test_mode_query_ignores_override(monkeypatch, tmp_path, capsys):
     monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    state.set_mode("local")  # load-bearing: with a `remote` default this assertion could not fail
 
     assert cli.main(["--remote", "mode"]) == 0
     assert capsys.readouterr().out.strip() == "local"  # prints persisted mode, not the override
@@ -11371,7 +11436,8 @@ def test_local_gate_message_is_byte_for_byte_for_a_command_with_no_reason(monkey
     "to sign in." is their reason and the message must not move by a byte. A command whose reason
     is *not* sign-in registers its own and is covered by its own test instead.
     """
-    monkeypatch.setenv("GRID_HOME", str(tmp_path))  # default mode is local
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    state.set_mode("local")  # the default for a fresh home is `remote` (ADR 0001 D-2, amended)
     argvs = {
         "login": ["login"],
         "logout": ["logout"],
@@ -11408,7 +11474,8 @@ def test_local_gate_prints_a_commands_own_reason_when_it_registers_one(monkeypat
     Messages dialect, is a later slice). The `grid mode remote` signpost lives in the fixed part of
     the sentence, so it must survive a custom reason.
     """
-    monkeypatch.setenv("GRID_HOME", str(tmp_path))  # default mode is local
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    state.set_mode("local")  # the default for a fresh home is `remote` (ADR 0001 D-2, amended)
     monkeypatch.setattr(dispatch, "REMOTE_ONLY", {**dispatch.REMOTE_ONLY, "price": "to reach Mars."})
 
     with pytest.raises(SystemExit) as exc:
@@ -11478,10 +11545,26 @@ def test_overview_remote_is_stub_without_network(monkeypatch, tmp_path, capsys):
     assert "grid login" in out  # accurate remote guidance, still no network call
     assert "grid chat" in out  # consume has shipped — overview points at it
     assert "later release" not in out  # the stale "chatting comes later" line is gone
+    assert "grid mode local" in out  # local mode keeps a signpost now that `remote` is the default
+
+
+def test_bare_grid_on_a_new_install_lands_in_remote_and_names_the_local_way_out(
+        monkeypatch, tmp_path, capsys):
+    """The screen a brand-new user sees. It must not be a dead end for someone who wants no account."""
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))  # no state file, no grids: a new install
+    monkeypatch.setattr(cli.grid, "_live_engines",
+                        lambda url: (_ for _ in ()).throw(AssertionError("no network on a bare grid")))
+
+    assert cli.main([]) == 0
+    out = capsys.readouterr().out
+    assert out.splitlines()[0] == "mode: remote"
+    assert "grid login" in out
+    assert "grid mode local" in out
 
 
 def test_overview_json_local_no_grids_has_stable_keys(monkeypatch, tmp_path, capsys):
     monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    state.set_mode("local")  # the default for a fresh home is `remote` (ADR 0001 D-2, amended)
 
     assert cli.main(["--json"]) == 0
     payload = json.loads(capsys.readouterr().out)
@@ -19940,7 +20023,8 @@ def test_login_logout_classified_remote_only():
 
 
 def test_login_logout_gated_in_local_mode(monkeypatch, tmp_path):
-    monkeypatch.setenv("GRID_HOME", str(tmp_path))  # default mode is local
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    state.set_mode("local")  # the default for a fresh home is `remote` (ADR 0001 D-2, amended)
     for command in ("login", "logout"):
         with pytest.raises(SystemExit) as exc:
             cli.main([command])
@@ -20849,7 +20933,8 @@ def test_sync_classified_remote_only():
 def test_sync_gated_in_local_mode(monkeypatch, tmp_path):
     from remote import control_plane
 
-    monkeypatch.setenv("GRID_HOME", str(tmp_path))  # default mode is local
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    state.set_mode("local")  # the default for a fresh home is `remote` (ADR 0001 D-2, amended)
     called = []
     monkeypatch.setattr(control_plane, "fetch_tokens",
                         lambda *a, **k: called.append(1) or control_plane.TokenFetch([], None))
@@ -22482,21 +22567,24 @@ def test_remote_info_env_requires_access_token(monkeypatch, tmp_path):
 
 
 def test_local_chat_rejects_remote_only_flags(monkeypatch, tmp_path):
-    monkeypatch.setenv("GRID_HOME", str(tmp_path))  # default local mode
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    state.set_mode("local")  # the default for a fresh home is `remote` (ADR 0001 D-2, amended)
     with pytest.raises(SystemExit) as exc:
         cli.main(["chat", "-m", "m", "hi", "--target-provider", "e1"])
     assert "remote mode" in str(exc.value).lower()
 
 
 def test_local_image_rejects_allow_self_provider(monkeypatch, tmp_path):
-    monkeypatch.setenv("GRID_HOME", str(tmp_path))  # default local mode
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    state.set_mode("local")  # the default for a fresh home is `remote` (ADR 0001 D-2, amended)
     with pytest.raises(SystemExit) as exc:
         cli.main(["image", "a cat", "-m", "comfyui:image_generation", "--allow-self-provider"])
     assert "remote mode" in str(exc.value).lower()
 
 
 def test_local_edit_and_video_reject_remote_only_flags(monkeypatch, tmp_path):
-    monkeypatch.setenv("GRID_HOME", str(tmp_path))  # default local mode
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    state.set_mode("local")  # the default for a fresh home is `remote` (ADR 0001 D-2, amended)
     img = tmp_path / "a.png"
     img.write_bytes(b"x")
     with pytest.raises(SystemExit) as exc:  # reject runs before the >3-image check / file reads
@@ -22669,7 +22757,8 @@ def test_remote_members_grid_not_found(monkeypatch, tmp_path):
 
 
 def test_remote_members_gated_in_local_mode(monkeypatch, tmp_path):
-    monkeypatch.setenv("GRID_HOME", str(tmp_path))  # default local mode
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    state.set_mode("local")  # the default for a fresh home is `remote` (ADR 0001 D-2, amended)
     with pytest.raises(SystemExit) as exc:
         cli.main(["members", "list"])
     assert "remote" in str(exc.value).lower()
@@ -23204,7 +23293,8 @@ def test_router_classified_remote_only():
 
 
 def test_router_gated_in_local_mode(monkeypatch, tmp_path):
-    monkeypatch.setenv("GRID_HOME", str(tmp_path))  # default local mode
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    state.set_mode("local")  # the default for a fresh home is `remote` (ADR 0001 D-2, amended)
     with pytest.raises(SystemExit) as exc:
         cli.main(["router", "status"])
     assert "remote" in str(exc.value).lower()
@@ -31215,7 +31305,8 @@ def test_launch_claude_targets_a_named_grid_and_defaults_to_the_active_one(monke
 def test_launch_in_local_mode_refuses_naming_the_dialect_and_the_mode_switch(monkeypatch, tmp_path):
     """A local grid serves chat/completions, never Anthropic Messages — so the refusal must name the
     dialect (or the user files a bug) *and* the command that moves them (or it is a dead end)."""
-    monkeypatch.setenv("GRID_HOME", str(tmp_path))  # default mode is local
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    state.set_mode("local")  # the default for a fresh home is `remote` (ADR 0001 D-2, amended)
     _capture_launch(monkeypatch)  # if the gate leaked, the spawn below would be reached
 
     with pytest.raises(SystemExit) as exc:

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -11439,7 +11439,11 @@ def test_local_gate_message_is_byte_for_byte_for_a_command_with_no_reason(monkey
     monkeypatch.setenv("GRID_HOME", str(tmp_path))
     state.set_mode("local")  # the default for a fresh home is `remote` (ADR 0001 D-2, amended)
     argvs = {
-        "login": ["login"],
+        # `login` is `dispatch.SELF_SWITCHING`: in plain local mode it no longer meets this gate at
+        # all — it signs in and moves the mode — so only an explicit `--local` still refuses. Driven
+        # without the flag this test runs the REAL device flow against the live control plane: CI
+        # fails it on the sign-in timeout, and on a developer's machine it can actually sign in.
+        "login": ["--local", "login"],
         "logout": ["logout"],
         "sync": ["sync"],
         "members": ["members", "list"],
@@ -11456,6 +11460,12 @@ def test_local_gate_message_is_byte_for_byte_for_a_command_with_no_reason(monkey
     defaulted = {c for c, reason in dispatch.REMOTE_ONLY.items() if reason is None}
     assert defaulted, "nothing takes the default reason any more: delete this lock, don't let it pass vacuously"
     assert defaulted <= set(argvs), f"no argv here for defaulted command(s): {defaulted - set(argvs)}"
+    # The lock above cannot see the difference between a gate that refused and a handler that ran, so
+    # it is stated separately: a self-switching command reaches its REAL handler without `--local`.
+    unflagged = sorted(c for c in dispatch.SELF_SWITCHING & defaulted if "--local" not in argvs[c])
+    assert not unflagged, (
+        f"self-switching command(s) {unflagged} must be driven with an explicit --local here, or "
+        "this test calls the real handler and reaches the live control plane")
 
     for command in sorted(defaulted):
         with pytest.raises(SystemExit) as exc:


### PR DESCRIPTION
## What

A new install now starts in **remote** mode. The default is *derived*, not a constant:
`shared/state._default_mode()` answers `local` whenever `~/.grid/grids/*/config.json` matches at
least one grid, so an existing local user who never ran `grid mode` is untouched. That is ADR 0001's
hard invariant, which this change is built around rather than retiring.

ADR 0001 is amended (status, D-2, D-4, invariant, consequences); `docs/cli.md` updated.

## Relationship to #dee0251 (v0.3.31)

`dee0251` solved the same problem from the other end — `grid login` runs in local mode and moves the
mode itself. The two compose rather than compete: that self-switch is now what an **existing local
user** meets, and it is what carries them across once they sign in. What this branch adds is the
case that path cannot reach — someone who types `grid`, `grid ls` or `grid chat` *before*
`grid login` and, until now, landed in local mode with no account and no hosted grid.

Upstream's two new login tests are updated accordingly: their premise ("a fresh install is in local
mode") is no longer true, and left implicit `switched` would be False, so
`test_login_in_local_mode_runs_and_switches_the_mode` would have stopped exercising the self-switch
entirely.

## Three properties that bind

- **`_normalized()` derives the same default.** A plain `DEFAULT_MODE` there would persist `remote`
  for a local user as a side effect of `grid use <name>`, with no `grid mode` in sight.
- **The evidence is a `config.json`, never a bare directory.** A leftover empty `grids/<id>/` is not
  a grid.
- **Unreadable ⇒ `local`.** A new install has no `grids` directory and globs clean without raising,
  so an `OSError` means the directory exists and only the read failed; "cannot tell" must answer the
  way that leaves a user where they were.

`shared/state.GRID_CONFIG_FILE` hand-duplicates `local.config.CONFIG_FILE` because `local.config`
imports that module — the dependency runs one way only and the kernel stays pure. Renamed on one
side alone, the glob matches nothing and every existing local user moves silently onto `remote`.

## Two fixes that came with it

**`e621317` — main's CI is red and this fixes it.** Not from this branch: CI has failed on
3.11/3.12/3.13 since `dee0251` with
``assert 'Sign-in time...to try again.' == '`grid login`...) to sign in.'``. That commit made `login`
`dispatch.SELF_SWITCHING`, so in plain local mode it reaches the real `cmd_login` — and
`test_local_gate_message_is_byte_for_byte_for_a_command_with_no_reason` still drove it as a bare
`["login"]`. The test therefore performs an **actual device-login against the live control plane**:
on CI it fails on the sign-in timeout (~13 min of polling), and on a developer's machine it can
complete and print a real account with its grids. It is now driven as `--local login`, which still
refuses with the same sentence, so `login`'s byte-for-byte coverage is kept rather than dropped.

**`5db40ec` — the installer's local on-ramp.** This branch breaks `install.sh`'s second suggestion:
in remote mode `grid start` asks for a sign-in, so "create your own grid on this computer" handed the
reader a command that refuses. It now names `grid mode local`. Nothing in the suite covered those two
lines, which is why it was invisible.

## Known sharp edge

The default is derived on every read and never written, so a user who removes their **last** local
grid moves to `remote` — a mode change caused by an unrelated action. Documented in the ADR
amendment. It was preferred to stamping `state.json` at first run, which trades this for a write side
effect on a machine the user has not configured yet; with no local grid left there is nothing the
flip can take away, and bare `grid` in remote mode now names `grid mode local`.

## Testing

- `.venv/bin/pytest tests/` — **3342 passed, 9 skipped, 0 failed** on the merged tree.
- `.venv/bin/ruff check .` — clean.
- 16 tests that relied on "empty `GRID_HOME` ⇒ local" now declare `state.set_mode("local")`.
  Two of them (`test_mode_query_ignores_override`,
  `test_override_sets_remote_active_without_persisting_mode`) would have lost **all** discriminating
  power had the assertion simply been flipped to `remote` — with a `remote` default they could no
  longer tell an ignored override from an honoured one.
- New coverage for the carve-out: the derived default both ways, a bare directory not counting as a
  grid, `OSError ⇒ local`, and `grid use` not flipping an existing local user.
- The new installer test is mutation-checked (restored to the old wording, it fails).

## Not addressed here

`tests/conftest.py` opens with *"Everything here exists to stop a test reaching something real"* but
has **no network guard** — which is why the live-login above ran at all. Worth its own change.
