### PR TITLE
feat(cli): grid stats / grid usage — the app's grid panels in the ter…

### DIFF
--- a/README.md
+++ b/README.md
@@ -670,6 +670,12 @@ grid engines
 
 # Every model, and which computer answers for it
 grid models --verbose
+
+# The grid's uptime, memory pool and answered tokens (--verbose adds a card per computer)
+grid stats
+
+# Who spent them — also --by model / --by engine
+grid usage --by member
 ```
 
 `engines` lists what each computer serves and how many requests it takes at once; `models` lists

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -23,6 +23,7 @@ from .remote_grid import (
 )
 from .remote_price import cmd_remote_price
 from .remote_project import cmd_remote_project
+from .remote_stats import cmd_remote_stats, cmd_remote_usage
 from .remote_task import cmd_remote_task
 from .remote_request import (
     cmd_remote_chat,
@@ -92,7 +93,9 @@ __all__ = [
     "cmd_remote_members",
     "cmd_remote_price",
     "cmd_remote_project",
+    "cmd_remote_stats",
     "cmd_remote_task",
+    "cmd_remote_usage",
     "cmd_remote_router",
     "cmd_remote_chat",
     "cmd_remote_image",

--- a/cli/_format.py
+++ b/cli/_format.py
@@ -1,0 +1,120 @@
+"""Display formatters for the live-grid readouts (`grid stats`, `grid usage`).
+
+Ported field-for-field from the desktop app's own helpers — `formatCount` /
+`formatVram` / `formatVramShare` / `formatShare` / `answeredWindowLabel` in
+`autonomous-grid-app` (`lib/features/network/logic/node_metrics.dart`,
+`grid_power_provider.dart`, `model_usage.dart`). The two surfaces read the *same*
+relay payload, so a grid whose panel says "0.9 / 1.4 TB" and whose terminal says
+something else is a bug the eye catches immediately; keeping the rounding rules
+identical is what stops that drifting.
+
+Pure and stdlib-only: no `cli` sibling imports, so this stays safe to import at module
+top from a module `cli.dispatch` pulls in while the package is still initialising.
+"""
+from __future__ import annotations
+
+import math
+
+
+def round_half_up(value: float) -> int:
+    """``value`` rounded with .5 going away from zero — Dart's ``num.round()``.
+
+    Not ``round()``: Python's is banker's rounding, so ``round(0.5)`` is 0 and ``round(2.5)``
+    is 2. Every figure here is a token count or a percentage read against the app's, and a
+    number that disagrees with the panel beside it in the last digit is the kind of difference
+    nobody can explain and everybody reports.
+    """
+    return -int(math.floor(-value + 0.5)) if value < 0 else int(math.floor(value + 0.5))
+
+
+def metric_number(value: float) -> str:
+    """A figure with at most one decimal and no trailing ``.0`` — ``3755``, ``121.7``."""
+    rounded = round_half_up(value * 10) / 10
+    return f"{rounded:.0f}" if rounded == int(rounded) else f"{rounded:.1f}"
+
+
+def count(value: int) -> str:
+    """A count shortened to something a column can hold — ``940``, ``12.3K``, ``1.2M``, ``1.3B``.
+
+    Token counts span nine orders of magnitude between a quiet machine and a busy grid's daily
+    input, so a raw ``1285402913`` would break every table it lands in. The unit steps up while
+    the figure would otherwise print four digits (at 999.5, before the rounding below could
+    expose a ``1000K``), rather than on fixed thresholds.
+    """
+    if value < 0:
+        return "0"
+    scaled = float(value)
+    suffix = ""
+    for unit in ("K", "M", "B"):
+        if scaled < 999.5:
+            break
+        scaled /= 1000
+        suffix = unit
+    digits = metric_number(scaled) if scaled < 100 else str(round_half_up(scaled))
+    return f"{digits}{suffix}"
+
+
+def _trim(value: float) -> str:
+    """Drop a trailing ``.0`` (``48.0`` → ``48``), keep one decimal otherwise (``47.5``)."""
+    return str(int(value)) if value == int(value) else f"{value:.1f}"
+
+
+def memory(gb: float) -> str:
+    """A memory figure — ``192 GB``, ``1.4 TB``.
+
+    Switches to TB past 1024 so a large grid reads as "1.4 TB" rather than a four-digit GB
+    number that no longer scans.
+    """
+    return f"{_trim(gb / 1024)} TB" if gb >= 1024 else f"{_trim(gb)} GB"
+
+
+def memory_share(used_gb: float, total_gb: float) -> str:
+    """``0.9/1.4 TB`` — memory in use against the pool it is drawn from, sharing one unit.
+
+    The unit is written once and chosen from the **total**: two figures either side of a slash
+    are being compared, and a comparison written in two different units is a puzzle. Under
+    100 GB both halves keep a decimal (on a 63.7 GB card a tenth is a twentieth of the total);
+    from three digits up both drop it, because ``276.9/382.4`` spends ten characters on a tenth
+    of a gigabyte nobody is acting on.
+    """
+    if total_gb >= 1024:
+        return f"{_trim(used_gb / 1024)}/{_trim(total_gb / 1024)} TB"
+    if total_gb < 100:
+        return f"{_trim(used_gb)}/{_trim(total_gb)} GB"
+    return f"{round_half_up(used_gb)}/{round_half_up(total_gb)} GB"
+
+
+def share(fraction: float) -> str:
+    """A fraction as a percentage, never rounded to a lie.
+
+    A model at 0.4% of the grid would round to ``0%`` under plain integer rounding, which reads
+    as "did nothing" against a row plainly showing 24.6K tokens. Below 1% the figure keeps a
+    decimal, and anything that would still round to zero says ``<0.1%``.
+    """
+    pct = fraction * 100
+    if pct >= 9.95:
+        return f"{round_half_up(pct)}%"
+    if pct >= 0.95:
+        return f"{metric_number(pct)}%"
+    if pct >= 0.05:
+        return f"{pct:.1f}%"
+    return "<0.1%" if pct > 0 else "0%"
+
+
+def window(seconds: int) -> str:
+    """The span a rollup covers, as short as it can honestly be said — ``24h``, ``7d``, ``30m``.
+
+    Derived from what the relay sent rather than hardcoded: the window is an operator knob, and
+    a label reading "24h" while the master counted six would be wrong in the one way a figure
+    must never be. Days only from two up — a day is "24h" to anyone talking about what a machine
+    did today, and 86400 is the default, so that is the string almost every readout carries.
+    """
+    if seconds <= 0:
+        return ""
+    if seconds % 86400 == 0 and seconds >= 172800:
+        return f"{seconds // 86400}d"
+    if seconds % 3600 == 0:
+        return f"{seconds // 3600}h"
+    if seconds % 60 == 0:
+        return f"{seconds // 60}m"
+    return f"{seconds}s"

--- a/cli/dispatch.py
+++ b/cli/dispatch.py
@@ -138,6 +138,16 @@ REMOTE_ONLY: dict[str, str | None] = {
     # not the control plane's — and the repository they name is served by the relay's git plane. A
     # local grid has none of it.
     "project": None,
+    # Two more whose reason is not sign-in: uptime, the memory pool, per-engine telemetry and the
+    # answered-token rollup are all computed by the hosted relay. A local grid serves models and
+    # keeps no such books, so there is nothing for a local handler to print — see cli/remote_stats.py.
+    "stats": (
+        "to read a hosted grid's live rollup — uptime, its memory pool and the tokens it has "
+        "answered — which a local grid does not compute."
+    ),
+    "usage": (
+        "to read a hosted grid's token rollup, which a local grid does not compute."
+    ),
     # The one command whose reason is not sign-in (ADR 0028): a local grid serves chat/completions,
     # completions, models and media — never Anthropic Messages, which is the only dialect Claude Code
     # speaks. Naming the dialect is what stops this being filed as a bug.

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -44,6 +44,7 @@ from .provider import cmd_engines, cmd_join, cmd_leave, cmd_models
 from .remote_grid import cmd_remote_members
 from .remote_price import cmd_remote_price
 from .remote_project import cmd_remote_project
+from .remote_stats import USAGE_DIMENSIONS, cmd_remote_stats, cmd_remote_usage
 from .remote_task import cmd_remote_task
 from .remote_router import (
     MAX_ADVISORS,
@@ -101,6 +102,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     _add_grid_lifecycle(sub)
     _add_engines(sub)
+    _add_stats(sub)
     _add_models(sub)
     _add_use(sub)
     _add_state(sub)
@@ -369,6 +371,31 @@ def _add_engines(sub) -> None:
                          help="Grid name or id (ag-…). Omit for the active grid.")
     engines.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
     engines.set_defaults(handler=cmd_engines)
+
+
+def _add_stats(sub) -> None:
+    """`grid stats` / `grid usage` — the live readouts of a hosted grid (remote-only).
+
+    Both read the relay's own rollup, which is the same source the desktop app's grid panels
+    read, so the two surfaces report one grid identically. A local grid computes no such
+    figures, which is why `cli.dispatch` gates these with a reason of their own rather than
+    the sign-in default.
+    """
+    stats = sub.add_parser("stats", help="A remote grid's live capacity and answered tokens")
+    stats.add_argument("grid", nargs="?", default=None,
+                       help="Grid name or id (ag-…). Omit for the active grid.")
+    stats.add_argument("--verbose", action="store_true",
+                       help="Also print a card per engine: memory, telemetry, storage and its own tokens.")
+    stats.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    stats.set_defaults(handler=cmd_remote_stats)
+
+    usage = sub.add_parser("usage", help="Tokens a remote grid answered, by model, member or engine")
+    usage.add_argument("grid", nargs="?", default=None,
+                       help="Grid name or id (ag-…). Omit for the active grid.")
+    usage.add_argument("--by", choices=USAGE_DIMENSIONS, default="model",
+                       help="What to split the tokens by (default: model).")
+    usage.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    usage.set_defaults(handler=cmd_remote_usage)
 
 
 def _add_models(sub) -> None:

--- a/cli/remote_stats.py
+++ b/cli/remote_stats.py
@@ -1,0 +1,1013 @@
+"""Remote-mode `grid stats` / `grid usage`: the live rollup a hosted grid's relay reports.
+
+The terminal equivalent of the desktop app's grid panels. Both read the *same* two relay
+endpoints, through the same rules, so the two surfaces cannot disagree about one grid:
+
+* ``GET /relay/v1/grid/overview`` (public) — the grid's state and uptime, its advertised
+  models, and every live engine with its hardware, telemetry and answered-token rollup. The
+  app parses it in ``lib/infrastructure/api/models/grid_overview.dart`` and folds it in
+  ``grid_power_provider.dart`` / ``node_groups.dart`` / ``model_usage.dart``.
+* ``GET /relay/v1/grid/members/usage`` (per-grid token) — what each person on the grid ran in
+  the same window. The app's ``member_usage_provider.dart``.
+
+``grid usage --by member`` additionally merges the control-plane roster
+(``cli.remote_grid``'s member list) so someone who has *not* used the grid still gets a row,
+exactly as the app's members panel does. That call is owner-only, so it degrades to
+usage-only rows with a note on stderr rather than failing the command.
+
+Three rules are ported deliberately and are the reason this is not a thinner wrapper:
+
+* **Absent is not zero.** A relay too old to compute a rollup sends no ``answered`` object at
+  all, and a ``0`` printed there would report a busy fleet as dead. Unmeasured prints ``—``.
+* **Cached input is *part of* input, never additional to it.** Settlement bills
+  ``(in − cached)·input + cached·cache + out·output``, so the ``input`` this prints is the
+  *fresh* leg — the three legs then add up to what actually passed through. ``--json`` carries
+  the relay's raw ``tokens_in`` alongside it, so nothing is redefined on the wire.
+* **A subscription seat brings a plan, not memory.** A node with a ``plan_type`` relays to a
+  hosted model, so its host's RAM never runs anything for the grid and is left out of the pool.
+
+Import rule mirrors `cli/remote_overview.py`: `remote.*` and the remote-specific `cli` siblings
+are imported lazily inside the helpers, because `cli.dispatch` imports this module while the
+`cli` package is still initialising. `cli._format` is a leaf (stdlib only) and safe at top.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any
+
+import httpx
+
+from . import _format
+
+
+# Both reads are small; neither parser carries a `--timeout`, and the relay client requires the
+# kwarg — so bound them with a constant, like `remote_overview._OVERVIEW_TIMEOUT`.
+_TIMEOUT = 30.0
+
+# Printed in place of a figure the grid did not report. An em dash, not `0`, `N/A` or a blank:
+# it reads as "nothing here" without looking like a measurement or like a bug.
+UNMEASURED = "—"
+
+USAGE_DIMENSIONS = ("model", "member", "engine")
+
+# How many machines `grid stats --verbose` prints a card for, however many the relay returns.
+#
+# A card is eleven lines, so a large grid would otherwise scroll its own summary off the screen —
+# the rollup at the top is the part every run is read for. The list is sorted strongest-first
+# (see [engine_cards]), so the cap keeps the machines actually carrying the grid and drops the
+# tail. Nothing is hidden: the `nodes=` line above states the real count, and `--json` is
+# uncapped, so a script never sees a truncated fleet.
+MAX_NODE_CARDS = 20
+
+
+# ---------------------------------------------------------------------------
+# resolution
+# ---------------------------------------------------------------------------
+
+def _resolve(args: argparse.Namespace) -> tuple[str, dict[str, Any], str, str, str, str]:
+    """``(session, record, network_id, label, relay base, token)`` for the grid these commands act on.
+
+    Same gates, in the same order, as every other remote read: signed in → a grid resolves → it
+    is up. The token is passed along for the ride and ignored by the public overview route, which
+    is what lets `grid stats` work on a grid whose token `grid sync` has not stored yet;
+    `_require_token` adds the real gate for the one dimension that names people.
+    """
+    from remote import credentials
+
+    from . import remote_grid
+
+    session = credentials.require_session()
+    rec = remote_grid._select(getattr(args, "grid", None))
+    network_id = remote_grid._network_id(rec)
+    label = str(rec.get("name") or network_id)
+    base, _status = remote_grid.resolve_relay_base(session, rec, network_id, label)
+    return session, rec, network_id, label, base, str(rec.get("access_token") or "")
+
+
+def _require_token(rec: dict[str, Any], label: str) -> str:
+    from . import remote_grid
+
+    return remote_grid.require_access_token(rec, label)
+
+
+def fetch_member_usage(base: str, token: str, label: str) -> dict[str, Any] | None:
+    """``/relay/v1/grid/members/usage`` for the grid at ``base``, or ``None`` when it can't say.
+
+    ``None`` covers every "this grid has no answer for us" case and is rendered as such, never as
+    zeros: a master that predates the endpoint (404), a caller who may not ask (401/403), and a
+    relay whose ``members`` is explicitly null — no rollup has landed yet. A grid that *did*
+    measure and found nobody sends an empty list, which is a different and true statement.
+
+    Anything else — a transport failure, a 500, a non-JSON body — is a clean ``SystemExit``: those
+    are not facts about how much anyone used, and silently reading them as "no data" would put a
+    broken relay on screen as an idle grid.
+    """
+    from remote import relay
+
+    try:
+        with relay.open_consumer_client(base, token, timeout=_TIMEOUT) as client:
+            resp = client.get("/relay/v1/grid/members/usage")
+    except httpx.RequestError as exc:
+        raise SystemExit(f"Could not reach grid {label}: {exc}") from exc
+    if resp.status_code in (401, 403, 404):
+        return None
+    if resp.status_code >= 400:
+        raise SystemExit(f"Grid {label} member usage failed ({resp.status_code}): {resp.text[:200]}")
+    try:
+        data = resp.json()
+    except ValueError as exc:
+        raise SystemExit(f"Grid {label} returned a non-JSON member usage: {resp.text[:200]}") from exc
+    if not isinstance(data, dict) or data.get("members") is None:
+        return None
+    if not isinstance(data.get("members"), list):
+        raise SystemExit(f"Grid {label} returned an unexpected member usage shape.")
+    return data
+
+
+def _try_roster(session: str, network_id: str) -> tuple[list[dict[str, Any]], str | None]:
+    """``(members, None)`` from the control plane, or ``([], reason)`` when this caller may not ask.
+
+    The roster is owner-only, so a member running this gets a 403 — which must not fail the
+    command: usage the relay *did* report is still worth printing. Mirrors
+    ``remote_grid._try_status``: for a display path that should degrade, never fail.
+    """
+    from remote import control_plane
+
+    try:
+        return list(control_plane.list_members(session, network_id)), None
+    except SystemExit as exc:
+        return [], str(exc) or "the control plane refused"
+
+
+# ---------------------------------------------------------------------------
+# defended readers — the relay body crosses a trust boundary
+# ---------------------------------------------------------------------------
+
+def _number(value: Any) -> float | None:
+    """A JSON number as a float, or ``None`` for anything else.
+
+    ``bool`` is an ``int`` subclass, so it is excluded explicitly: ``vram_gb: true`` must read as
+    "this node didn't say", not as one gigabyte.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def _count(value: Any) -> int:
+    """A JSON number as a non-negative int; ``0`` for anything else. For figures *inside* an
+    object the relay did send, where a missing key is genuinely zero."""
+    number = _number(value)
+    return int(number) if number is not None and number > 0 else 0
+
+
+def _text(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _gb(value: float | None) -> float | None:
+    """A GB figure rounded to the tenth these commands print.
+
+    The relay reports memory in megabytes, so every GB figure here is a division and carries the
+    float noise of one (``105.24374999999998``). Rounding at the projection — not at the render —
+    is what keeps ``--json`` and the human line quoting the same number rather than one being the
+    exact remainder of the other.
+    """
+    return None if value is None else round(value, 1)
+
+
+def read_answered(raw: Any) -> dict[str, int] | None:
+    """One ``answered`` object as four honest figures, or ``None`` when the relay sent none.
+
+    ``tokens_cached`` is clamped to the ``tokens_in`` it is a share of — the way the relay stores
+    it. An old row or a provider bug would otherwise hand the caller a negative fresh-input leg.
+    """
+    if not isinstance(raw, dict):
+        return None
+    tokens_in = _count(raw.get("tokens_in"))
+    return {
+        "window_seconds": _count(raw.get("window_seconds")),
+        "tokens_in": tokens_in,
+        "tokens_cached": min(_count(raw.get("tokens_cached")), tokens_in),
+        "tokens_out": _count(raw.get("tokens_out")),
+        "requests": _count(raw.get("requests")),
+    }
+
+
+def _fresh(answered: dict[str, int]) -> int:
+    """Input that was not served from a prompt cache — the leg that, with cache and output, adds
+    up to what passed through."""
+    return answered["tokens_in"] - answered["tokens_cached"]
+
+
+def _online(nodes: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """The engines currently serving. ``online`` is read strictly (``is True``), the same way the
+    app reads it: a machine that is asleep contributes no memory and no throughput, and counting
+    one would overstate what the grid can do right now."""
+    return [node for node in nodes if node.get("online") is True]
+
+
+def node_memory_gb(node: dict[str, Any]) -> float | None:
+    """GPU memory this engine contributes to the grid pool, in GB, or ``None`` when it brings none.
+
+    Prefers the relay's ``vram_gb``, falling back to ``vram_total_mb / 1024``. A subscription seat
+    (a non-empty ``plan_type``) returns ``None`` however much its host reports: it relays to a
+    hosted model, so that memory never runs a model for the grid, and pooling it would advertise
+    capacity nobody on the grid can use.
+    """
+    if _text(node.get("plan_type")):
+        return None
+    gb = _number(node.get("vram_gb"))
+    if gb is None:
+        total_mb = _number(node.get("vram_total_mb"))
+        gb = None if total_mb is None else total_mb / 1024
+    return gb if gb is not None and gb > 0 else None
+
+
+def node_memory_used_gb(node: dict[str, Any]) -> float | None:
+    """Memory this engine currently has in use, in GB, or ``None``. Gated on [node_memory_gb] so
+    the used share is summed over exactly the machines the total is: a ratio counted over two
+    different sets is quietly wrong rather than obviously missing."""
+    if node_memory_gb(node) is None:
+        return None
+    used_mb = _number(node.get("vram_used_mb"))
+    return used_mb / 1024 if used_mb is not None and used_mb > 0 else None
+
+
+def node_memory_kind(node: dict[str, Any]) -> str:
+    """What this engine's memory should be *called*: ``RAM`` on Apple Silicon, which shares one
+    unified pool, and ``VRAM`` on a discrete GPU that has its own."""
+    return "RAM" if _text(node.get("platform")).lower().startswith("macos-arm") else "VRAM"
+
+
+def _platform_label(platform: Any) -> str:
+    """``macos-arm64`` → ``macOS``. The arch half is dropped: ``x86_64`` beside ``M3 Ultra`` tells
+    nobody anything they can act on, and the hardware line already names the chip."""
+    value = _text(platform).lower()
+    for prefix, label in (("macos", "macOS"), ("linux", "Linux"), ("windows", "Windows")):
+        if value.startswith(prefix):
+            return label
+    return ""
+
+
+def _model_key(model: Any) -> str:
+    """One model id in the form everything here compares by.
+
+    Ids arrive from two directions that disagree on case — the grid's catalog entry keeps its own
+    (``DeepSeek-V4-Flash-0731``) while a node advertises the relay's normalised, lowercased id —
+    and a raw ``==`` misses every model on the grid *silently*, as "this model reports nothing".
+    """
+    return str(model).strip().lower()
+
+
+# ---------------------------------------------------------------------------
+# rollups — pure, so every rule below is testable without a relay
+# ---------------------------------------------------------------------------
+
+def grid_rollup(overview: dict[str, Any]) -> dict[str, Any]:
+    """What the grid brings and what it has answered, from an already-fetched overview.
+
+    Each hardware total stays ``None`` unless at least one online engine reported that field, so a
+    grid where nobody advertises memory shows none rather than claiming "0 GB".
+
+    **There is deliberately no grid-level throughput.** Each engine's ``throughput_tok_s`` is its
+    own decode estimate, measured whenever it last answered something, so adding them up produces a
+    rate no single request ever sees and no two engines were ever measured at the same moment. Speed
+    is a property of the machine that answers you; it is reported per engine (``--verbose``) and
+    nowhere else.
+
+    ``parallel`` prefers the relay's own ``stats.concurrent_capacity``: the relay is the authority
+    on how much work it will actually dispatch, and may cap or oversubscribe what the engines
+    individually advertise. Summing ``max_concurrency`` is the fallback for a relay that is silent.
+
+    ``answered`` prefers the grid-wide rollup over summing the engines, and the difference is not
+    cosmetic: an engine is listed only while its heartbeat is live, so a machine that served all
+    morning and then went offline takes its tokens out of a summed total — and the relay's
+    per-node rollup separately drops rows it cannot attribute to a machine. The sum is only what a
+    relay too old to send a grid total leaves us.
+    """
+    from . import remote_overview
+
+    nodes = remote_overview._nodes_from(overview)
+    online = _online(nodes)
+    stats = overview.get("stats") if isinstance(overview.get("stats"), dict) else {}
+    models = overview.get("models")
+
+    memory = memory_used = None
+    summed_parallel: int | None = None
+    node_total: dict[str, int] | None = None
+    for node in online:
+        gb = node_memory_gb(node)
+        if gb is not None:
+            memory = (memory or 0.0) + gb
+            used = node_memory_used_gb(node)
+            if used is not None:
+                memory_used = (memory_used or 0.0) + used
+
+        parallel = _number(node.get("max_concurrency"))
+        if parallel is not None and parallel > 0:
+            summed_parallel = (summed_parallel or 0) + int(parallel)
+
+        answered = read_answered(node.get("answered"))
+        if answered is not None:
+            node_total = _add_answered(node_total, answered)
+
+    capacity = _number(stats.get("concurrent_capacity"))
+    pool = _gb(memory)
+    # Clamped to the pool it is a share of (see below), then rounded like every other GB figure —
+    # so the percentage and the two numbers it sits between are computed from the same values.
+    used_pool = _gb(None if memory is None or memory_used is None else min(memory_used, memory))
+    return {
+        "status": _state(overview),
+        "uptime_pct": _number(stats.get("uptime_pct")),
+        "engines_online": len(online),
+        "engines_total": len(nodes),
+        "models": len(models) if isinstance(models, list) and models else _count(stats.get("models")),
+        "memory_gb": pool,
+        # Never above the pool it is a share of: an engine reporting more used than it advertises
+        # as total (a driver rounding, a seat counted twice) would otherwise show over 100%.
+        "memory_used_gb": used_pool,
+        "memory_used_pct": None if not pool or used_pool is None else round(used_pool / pool * 100, 1),
+        "parallel": int(capacity) if capacity is not None and capacity > 0 else summed_parallel,
+        "answered": read_answered(overview.get("answered")) or node_total,
+    }
+
+
+def _add_answered(running: dict[str, int] | None, extra: dict[str, int]) -> dict[str, int]:
+    """Fold one rollup into a running total. The window is one setting on one relay, so every row
+    agrees; the first one seen is the one reported."""
+    if running is None:
+        return dict(extra)
+    return {
+        "window_seconds": running["window_seconds"] or extra["window_seconds"],
+        "tokens_in": running["tokens_in"] + extra["tokens_in"],
+        "tokens_cached": running["tokens_cached"] + extra["tokens_cached"],
+        "tokens_out": running["tokens_out"] + extra["tokens_out"],
+        "requests": running["requests"] + extra["requests"],
+    }
+
+
+def _state(overview: dict[str, Any]) -> str:
+    grid = overview.get("grid")
+    return _text(grid.get("state")) if isinstance(grid, dict) else ""
+
+
+def engine_cards(overview: dict[str, Any]) -> list[dict[str, Any]]:
+    """One projected card per engine, strongest first — the shape `-v` prints and `--json` emits.
+
+    A derived view, not the raw passthrough `grid engines --json` already gives: a new field on a
+    node object shows up there, not here. Ordered by memory rather than left in relay order,
+    because the machine carrying most of the grid is the one worth seeing first and relay order
+    buried a 382 GB box under a 32 GB laptop. Engines bringing no memory sort last, by name, so
+    the order stays stable between refreshes instead of shuffling.
+    """
+    from . import remote_overview
+
+    cards = [_engine_card(node, overview) for node in remote_overview._nodes_from(overview)]
+    cards.sort(key=lambda card: (
+        card["memory_gb"] is None, -(card["memory_gb"] or 0.0), card["engine"]
+    ))
+    return cards
+
+
+def _engine_card(node: dict[str, Any], overview: dict[str, Any]) -> dict[str, Any]:
+    from . import remote_overview
+
+    total = node_memory_gb(node)
+    used = node_memory_used_gb(node)
+    capabilities = node.get("model_capabilities")
+    capabilities = capabilities if isinstance(capabilities, dict) else {}
+    # Two readings of one list, in the same order. A node advertises the relay's *lowercased* id
+    # and that is what its `model_capabilities` is keyed by — but the lowercased form is never what
+    # should render, so the displayed name comes from the overview-corrected reading, which restores
+    # the catalog's true case (`deepseek-v4-flash-0731` → `DeepSeek-V4-Flash-0731`). Both lists are
+    # built from the same `node["models"]`, so zipping them cannot misalign.
+    keys = remote_overview._node_models(node)
+    shown = remote_overview._node_models(node, overview)
+    models = []
+    for key, name in zip(keys, shown):
+        entry = capabilities.get(key)
+        window = _number(entry.get("context_length")) if isinstance(entry, dict) else None
+        models.append({"model": name, "context_length": int(window) if window else None})
+    return {
+        "engine": _text(node.get("name")),
+        "online": node.get("online") is True,
+        "owner": _text(node.get("provider_email")),
+        "hardware": _text(node.get("chip")) or _text(node.get("device")),
+        "platform": _platform_label(node.get("platform")),
+        "kind": _text(node.get("engine")),
+        "plan_type": _text(node.get("plan_type")) or None,
+        "models": models,
+        "parallel": int(_number(node.get("max_concurrency")) or 0) or None,
+        "throughput_tok_s": _number(node.get("throughput_tok_s")),
+        "memory_kind": node_memory_kind(node),
+        "memory_gb": _gb(total),
+        "memory_used_gb": _gb(used),
+        # Only when the node reported BOTH halves: subtracting an absent figure from a present one
+        # would invent headroom nobody measured.
+        "memory_free_gb": _gb(None if total is None or used is None else total - used),
+        "gpu_temp_c": _number(node.get("gpu_temp_c")),
+        "gpu_util_pct": _number(node.get("gpu_util_pct")),
+        "gpu_power_w": _number(node.get("gpu_power_w")),
+        "gpu_power_limit_w": _number(node.get("gpu_power_limit_w")),
+        "disk_total_gb": _number(node.get("disk_total_gb")),
+        "disk_used_gb": _number(node.get("disk_used_gb")),
+        "answered": read_answered(node.get("answered")),
+    }
+
+
+def model_rows(overview: dict[str, Any], grid_total: dict[str, int] | None) -> list[dict[str, Any]]:
+    """What every model on the grid answered, busiest first.
+
+    A model is usually served by more than one engine and the relay reports the rollup per engine,
+    so the grid-level figure exists nowhere in the payload and is added up here (keyed by
+    [_model_key], since the catalog entry and the node's advertisement disagree on case).
+
+    Rows come from the grid's advertised model list *and* from anything the rollup measured that
+    the list doesn't carry: a model the catalog has since dropped still did the work it did, and
+    silently omitting it would leave the column adding up to less than its own header.
+
+    A model with no rows of its own is ambiguous, and [grid_total] settles it — non-null exactly
+    when at least one engine reported a rollup. On a measured grid such a model gets a real zero,
+    because a model nobody used today is a fact worth seeing and a blank row reads as one the CLI
+    forgot to ask about; on a grid nothing measured it stays unmeasured, because printing zeros
+    against every model there would report a busy fleet as dead.
+
+    Ordered by output, then requests, then id — so the position itself carries information, and a
+    grid whose models have all answered nothing keeps a stable order across polls.
+    """
+    from . import remote_overview
+
+    nodes = remote_overview._nodes_from(overview)
+    online = _online(nodes)
+    measured, serving = _measured_by_model(nodes), _serving_counts(online)
+    idle = None if grid_total is None else {
+        "window_seconds": grid_total["window_seconds"],
+        "tokens_in": 0, "tokens_cached": 0, "tokens_out": 0, "requests": 0,
+    }
+
+    rows: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for entry in _catalog_models(overview):
+        key = _model_key(entry)
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        rows.append({
+            # Membership, not truthiness: a measured row is a dict and never empty today, but an
+            # `or` here would silently fall through to the zero row if that ever changed — and the
+            # difference between "measured" and "assumed idle" is exactly what this line decides.
+            "model": entry,
+            "answered": measured[key] if key in measured else idle,
+            "engines": serving.get(key, 0),
+        })
+    for key, answered in measured.items():
+        if key not in seen:
+            rows.append({"model": key, "answered": answered, "engines": serving.get(key, 0)})
+    rows.sort(key=lambda row: (
+        -(row["answered"] or {}).get("tokens_out", 0),
+        -(row["answered"] or {}).get("requests", 0),
+        _model_key(row["model"]),
+    ))
+    return rows
+
+
+def _catalog_models(overview: dict[str, Any]) -> list[str]:
+    """The ids in the overview's ``models`` list, defended against a non-list field and entries
+    that aren't objects — a malformed catalog costs its own rows, never the whole table."""
+    models = overview.get("models")
+    if not isinstance(models, list):
+        return []
+    return [_text(m.get("id")) for m in models if isinstance(m, dict) and _text(m.get("id"))]
+
+
+def _measured_by_model(nodes: list[dict[str, Any]]) -> dict[str, dict[str, int]]:
+    """Every engine's ``answered.by_model`` folded into one total per model. A model no engine
+    reported on is **absent**, never a zero entry: the caller has to be able to tell "answered
+    nothing" from "nothing measured it", and only the missing key carries the second meaning."""
+    totals: dict[str, dict[str, int]] = {}
+    for node in nodes:
+        answered = node.get("answered")
+        by_model = answered.get("by_model") if isinstance(answered, dict) else None
+        if not isinstance(by_model, list):
+            continue
+        window = _count(answered.get("window_seconds"))
+        for entry in by_model:
+            if not isinstance(entry, dict):
+                continue
+            key = _model_key(entry.get("model", ""))
+            row = read_answered(entry)
+            if not key or row is None:
+                continue
+            row["window_seconds"] = row["window_seconds"] or window
+            totals[key] = _add_answered(totals.get(key), row)
+    return totals
+
+
+def _serving_counts(online: list[dict[str, Any]]) -> dict[str, int]:
+    """How many online engines advertise each model. A node's primary ``model`` counts too — an
+    older provider fills that and leaves ``models`` empty, and reading only the list would report
+    such a machine as serving nothing."""
+    from . import remote_overview
+
+    counts: dict[str, int] = {}
+    for node in online:
+        # Uncorrected on purpose: every id here goes through [_model_key], which lowercases, so
+        # restoring the catalog's case would be work undone on the next line.
+        advertised = {_model_key(m) for m in remote_overview._node_models(node)}
+        primary = _model_key(node.get("model") or "")
+        if primary:
+            advertised.add(primary)
+        for key in advertised:
+            if key:
+                counts[key] = counts.get(key, 0) + 1
+    return counts
+
+
+def engine_usage_rows(overview: dict[str, Any]) -> list[dict[str, Any]]:
+    """What each engine answered in the window, busiest first. Engines the relay measured and
+    found idle keep their row (a real zero); one it never measured carries ``None``."""
+    from . import remote_overview
+
+    rows = [
+        {"engine": _text(node.get("name")), "answered": read_answered(node.get("answered"))}
+        for node in remote_overview._nodes_from(overview)
+    ]
+    rows.sort(key=lambda row: (-(row["answered"] or {}).get("tokens_out", 0), row["engine"]))
+    return rows
+
+
+def member_rows(
+    members: list[Any] | None, roster: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Who used the grid, biggest reader first, with everyone the roster names but the relay has
+    no figure for listed after them, alphabetically.
+
+    **The roster only adds rows; the usage decides the order.** A member who has never sent a
+    request is still a member and keeps a row (unmeasured, so it prints as such); a consumer the
+    relay counted but could not name is still counted, which is why a row with no email survives
+    rather than being dropped — usage nobody can name is still usage.
+
+    Matched case-insensitively: the control plane stores what the user typed and the relay stores
+    what the token carried, so an address differing only in case would show a busy person as
+    having done nothing.
+    """
+    rows: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for raw in members or []:
+        if not isinstance(raw, dict):
+            continue
+        email = _text(raw.get("email"))
+        answered = read_answered(raw)
+        if answered is None:
+            continue
+        if email:
+            seen.add(email.lower())
+        rows.append({"email": email, "answered": answered, "roles": []})
+    for entry in roster:
+        email = _text(entry.get("email"))
+        if not email or email.lower() in seen:
+            continue
+        seen.add(email.lower())
+        rows.append({"email": email, "answered": None, "roles": _roles(entry)})
+    for row in rows:  # the roster is the only place roles come from; usage rows borrow them
+        if not row["roles"]:
+            row["roles"] = _roles_for(roster, row["email"])
+    rows.sort(key=lambda row: (
+        # −1 for "no figure", so an unmeasured member sorts below a measured zero: someone the
+        # grid counted and found idle is a different fact from someone it never heard from.
+        -(_fresh(row["answered"]) if row["answered"] else -1),
+        row["email"].lower(),
+    ))
+    return rows
+
+
+def _roles(entry: dict[str, Any]) -> list[str]:
+    roles = entry.get("roles")
+    return [str(role) for role in roles] if isinstance(roles, list) else []
+
+
+def _roles_for(roster: list[dict[str, Any]], email: str) -> list[str]:
+    if not email:
+        return []
+    for entry in roster:
+        if _text(entry.get("email")).lower() == email.lower():
+            return _roles(entry)
+    return []
+
+
+# ---------------------------------------------------------------------------
+# rendering
+# ---------------------------------------------------------------------------
+
+def _token_pairs(
+    answered: dict[str, int] | None, *, include_window: bool = True
+) -> list[tuple[str, str]]:
+    """The window and the three legs plus requests, as name/value pairs.
+
+    Every name is present whether or not the grid reported one — a stable set is what lets two runs
+    be compared line for line — with an empty value where nothing measured it. What that emptiness
+    is *rendered* as belongs to the caller: a dash where the values sit in a column, nothing after
+    the `=` where they do not.
+
+    ``include_window`` drops the span for a caller that has already stated it. `grid stats` names it
+    in its heading, where it qualifies the whole readout; repeating it as a row would be the same
+    fact twice on one screen.
+    """
+    window = [("window", "" if answered is None else _format.window(answered["window_seconds"]))]
+    if answered is None:
+        legs = [(name, "") for name in ("input", "cached", "output", "requests")]
+    else:
+        legs = [
+            ("input", _format.count(_fresh(answered))),
+            ("cached", _format.count(answered["tokens_cached"])),
+            ("output", _format.count(answered["tokens_out"])),
+            ("requests", _format.count(answered["requests"])),
+        ]
+    return (window if include_window else []) + legs
+
+
+def _overview_block(rows: list[tuple[str, str]], window: str, *, title: str) -> list[str]:
+    """A heading naming the span, then one aligned column of name/value pairs.
+
+    The shape both commands open with, from one place: `grid stats` fills it with the machines and
+    the day, `grid usage` with the day alone above its breakdown. Two renderings of the same block
+    would drift, and these two are read minutes apart against the same grid.
+
+    ``title`` is each caller's own, and required rather than defaulted so neither can inherit the
+    other's noun by accident. In `grid stats` this block *is* the command's answer and names the
+    thing it describes; in `grid usage` it is a header over a breakdown, and a heavier title there
+    would out-weigh the table it introduces.
+
+    **The span is the relay's, never the literal "24h".** The window is an operator knob
+    (``node_answered_window_seconds``), so a hardcoded label would go quietly wrong the moment
+    someone retuned it — and since no row repeats it, this heading is the only thing saying what the
+    token figures below cover. A grid that reported no rollup names no span and gets the bare noun.
+
+    Anything unreported reads [UNMEASURED]: in a column, a name with nothing after it looks like a
+    rendering failure rather than a fact about the grid.
+    """
+    width = max(len(name) for name, _ in rows)
+    return [
+        f"{window} {title}:" if window else f"{title}:",
+        "",
+        *(f"{name:<{width}}  {value or UNMEASURED}" for name, value in rows),
+    ]
+
+
+def _window_label(answered: dict[str, int] | None) -> str:
+    return _format.window(answered["window_seconds"]) if answered else ""
+
+
+def render_usage_totals(answered: dict[str, int] | None) -> list[str]:
+    """`grid usage`'s header: what the whole grid answered, above whichever split follows."""
+    return _overview_block(
+        _token_pairs(answered, include_window=False), _window_label(answered), title="overview"
+    )
+
+
+def _memory_value(rollup: dict[str, Any]) -> str:
+    """The pool as one figure — ``0.9/1.4 TB (68%)`` — or empty when no engine advertised memory.
+
+    The total alone is still worth printing when nothing reported its occupancy: it is the pool a
+    model has to fit into, so only the missing half degrades.
+    """
+    total, used = rollup["memory_gb"], rollup["memory_used_gb"]
+    if total is None:
+        return ""
+    if used is None:
+        return _format.memory(total)
+    return f"{_format.memory_share(used, total)} ({_format.share(used / total)})"
+
+
+def render_stats(label: str, rollup: dict[str, Any]) -> list[str]:
+    """The grid's own readout: a heading naming the span, then one column of figures under it.
+
+    **The span in the heading is the relay's, never the string "24h".** The window is an operator
+    knob (``node_answered_window_seconds``), so a hardcoded label would go quietly wrong the moment
+    someone retuned it — and it qualifies every token figure below, which is exactly why it belongs
+    in the heading and not in a row of its own. A grid that reported no rollup names no span, and
+    the heading degrades to the bare noun rather than to an empty one.
+
+    Anything the grid did not report reads [UNMEASURED] — the same dash the engine cards use,
+    because in a column a name with nothing after it looks like a rendering failure rather than a
+    fact about the grid.
+
+    No speed among them: see [grid_rollup] for why a summed tok/s is not a rate the grid can
+    deliver. Each machine's own is on its card.
+    """
+    uptime = rollup["uptime_pct"]
+    answered = rollup["answered"]
+    capacity = [
+        ("grid", label),
+        ("status", rollup["status"]),
+        ("uptime", f"{_format.metric_number(uptime)}%" if uptime is not None else ""),
+        # `nodes`, not `engines`, and deliberately at odds with the Output Contract's vocabulary
+        # (docs/cli.md): this readout is the terminal form of the app's NODES panel, and a machine
+        # here is a *node* while `engine` is the software running on it — a distinction the card
+        # below makes on its own `engine` line ("external · 16 parallel"). One word could not carry
+        # both. The `--json` keys stay `engines_online` / `engines_total` / `engines`, which is a
+        # split worth knowing about; renaming those is a contract change, not a display one.
+        ("nodes", str(rollup["engines_online"])),
+        ("models", str(rollup["models"])),
+        ("memory", _memory_value(rollup)),
+        ("parallel", "" if rollup["parallel"] is None else str(rollup["parallel"])),
+    ]
+    return _overview_block(
+        capacity + _token_pairs(answered, include_window=False), _window_label(answered),
+        title="Grid Overview",
+    )
+
+
+def _card_lines(card: dict[str, Any]) -> list[str]:
+    """One engine as a block of labelled readings.
+
+    **Every reading gets its line, whether or not the machine reported it** — rows that come and
+    go make two machines impossible to compare, because the eye has to re-read the labels on each
+    before it can read the numbers. A reading the engine never sent prints [UNMEASURED], which is
+    what keeps "measured at zero" (an online, idle GPU) apart from "never measured" (a Mac, which
+    reports no temperature at all because macOS exposes it only to a root `powermetrics`).
+    """
+    hardware = " · ".join(part for part in (card["hardware"], card["platform"]) if part)
+    kind = " · ".join(part for part in (
+        card["kind"], f"{card['parallel']} parallel" if card["parallel"] else "",
+        f"{card['plan_type']} plan" if card["plan_type"] else "",
+    ) if part)
+    models = ", ".join(
+        entry["model"] + (f" ({_format.count(entry['context_length'])} ctx)" if entry["context_length"] else "")
+        for entry in card["models"]
+    )
+    rate = card["throughput_tok_s"]
+    answered = card["answered"]
+    rows = [
+        ("owner", card["owner"]),
+        ("hardware", hardware),
+        ("engine", kind),
+        ("models", models),
+        (card["memory_kind"], _pair_gb(card["memory_used_gb"], card["memory_gb"], card["memory_free_gb"])),
+        ("temperature", f"{_format.metric_number(card['gpu_temp_c'])}°C" if card["gpu_temp_c"] is not None else UNMEASURED),
+        ("usage", f"{_format.round_half_up(card['gpu_util_pct'])}%" if card["gpu_util_pct"] is not None else UNMEASURED),
+        ("power", _pair_w(card["gpu_power_w"], card["gpu_power_limit_w"])),
+        ("storage", _pair_gb(card["disk_used_gb"], card["disk_total_gb"], None)),
+        ("throughput", f"~{_format.round_half_up(rate)} tok/s" if rate else UNMEASURED),
+        (
+            f"tokens {_format.window(answered['window_seconds']) or 'total'}" if answered else "tokens",
+            _answered_phrase(answered),
+        ),
+    ]
+    header = card["engine"] + ("" if card["online"] else "  (offline)")
+    width = max(len(name) for name, _ in rows)
+    return [header, *(f"  {name:<{width}}  {value or UNMEASURED}" for name, value in rows)]
+
+
+def _pair_gb(used: float | None, total: float | None, free: float | None) -> str:
+    """Two GB figures against each other — ``277.2/382.4 GB (72%)``.
+
+    One decimal on both halves, which is how the app's own node dashboard writes them, and not the
+    compact rule the grid's pooled `memory=` line uses: a card has the width, and 382.4 is what the
+    machine actually reported. Both rules are the app's, for the two widths it has; keeping them on
+    the same surfaces is what stops one figure reading two ways.
+
+    The total is a real fact worth printing even when the occupancy is missing — it is the pool a
+    model has to fit into — so only the absent half degrades.
+    """
+    if total is None:
+        return UNMEASURED
+    if used is None:
+        return f"{UNMEASURED}/{_format.metric_number(total)} GB"
+    pair = f"{_format.metric_number(used)}/{_format.metric_number(total)} GB"
+    share = f"{pair} ({_format.share(used / total)})" if total > 0 else pair
+    return share if free is None else f"{share} · {_format.metric_number(free)} GB free"
+
+
+def _pair_w(draw: float | None, limit: float | None) -> str:
+    if draw is None:
+        return UNMEASURED
+    drawn = f"{_format.metric_number(draw)}W"
+    return f"{drawn}/{UNMEASURED}" if limit is None or limit <= 0 else f"{drawn}/{_format.metric_number(limit)}W"
+
+
+def _answered_phrase(answered: dict[str, int] | None) -> str:
+    """A rollup in one line — "31.3M input · 526.2M cached · 6.2M output · 8K requests"."""
+    if answered is None:
+        return UNMEASURED
+    return (
+        f"{_format.count(_fresh(answered))} input · {_format.count(answered['tokens_cached'])} cached · "
+        f"{_format.count(answered['tokens_out'])} output · {_format.count(answered['requests'])} requests"
+    )
+
+
+def _table(headers: list[str], rows: list[list[str]]) -> list[str]:
+    """A left-aligned table whose last column is not padded (trailing spaces are noise a pipe
+    keeps). Empty when there are no rows — the caller prints its own empty state."""
+    if not rows:
+        return []
+    widths = [max(len(headers[i]), *(len(row[i]) for row in rows)) for i in range(len(headers))]
+    lines = ["  ".join(h.ljust(widths[i]) for i, h in enumerate(headers)).rstrip()]
+    for row in rows:
+        lines.append("  ".join(cell.ljust(widths[i]) for i, cell in enumerate(row)).rstrip())
+    return lines
+
+
+def _cells(answered: dict[str, int] | None) -> list[str]:
+    """The four token columns for one row — all [UNMEASURED] when nothing measured it."""
+    if answered is None:
+        return [UNMEASURED] * 4
+    return [
+        _format.count(_fresh(answered)),
+        _format.count(answered["tokens_cached"]),
+        _format.count(answered["tokens_out"]),
+        _format.count(answered["requests"]),
+    ]
+
+
+_TOKEN_HEADERS = ["INPUT", "CACHED", "OUTPUT", "REQUESTS"]
+
+
+def render_model_table(rows: list[dict[str, Any]], grid_out: int) -> list[str]:
+    return _table(
+        ["MODEL", *_TOKEN_HEADERS, "SHARE", "ENGINES"],
+        [
+            [
+                str(row["model"]),
+                *_cells(row["answered"]),
+                _format.share((row["answered"] or {}).get("tokens_out", 0) / grid_out) if grid_out > 0 else UNMEASURED,
+                str(row["engines"]),
+            ]
+            for row in rows
+        ],
+    )
+
+
+def render_member_table(rows: list[dict[str, Any]]) -> list[str]:
+    """Who spent the tokens, and nothing else. What each person is *allowed* to do is a different
+    question with its own command (`grid members list`), and a permission column beside four token
+    figures invited the two to be read as one fact about a person."""
+    return _table(
+        ["MEMBER", *_TOKEN_HEADERS],
+        [[row["email"] or "(unnamed)", *_cells(row["answered"])] for row in rows],
+    )
+
+
+def render_engine_table(rows: list[dict[str, Any]]) -> list[str]:
+    return _table(
+        ["ENGINE", *_TOKEN_HEADERS],
+        [[row["engine"], *_cells(row["answered"])] for row in rows],
+    )
+
+
+# ---------------------------------------------------------------------------
+# commands
+# ---------------------------------------------------------------------------
+
+def cmd_remote_stats(args: argparse.Namespace) -> int:
+    """`grid stats [grid] [-v] [--json]` — what the grid brings and what it has answered."""
+    from . import remote_overview
+
+    _session, _rec, _network_id, label, base, token = _resolve(args)
+    overview = remote_overview.fetch_overview(base, token, label)
+    rollup = grid_rollup(overview)
+    cards = engine_cards(overview)
+
+    if getattr(args, "json", False):
+        # A derived view, not a passthrough: `grid engines --json` stays the verbatim node list, so
+        # a new relay field surfaces there rather than silently changing this shape. `--verbose`
+        # deliberately does not move it — a flag that changed the machine-readable output would
+        # make every script depend on how it was invoked.
+        print(json.dumps({
+            "grid": label,
+            **rollup,
+            "answered": _json_answered(rollup["answered"], window=True),
+            "engines": [
+                {**card, "answered": _json_answered(card["answered"], window=True)} for card in cards
+            ],
+        }, indent=2))
+        return 0
+
+    for line in render_stats(label, rollup):
+        print(line)
+    if not getattr(args, "verbose", False):
+        return 0
+    if not cards:
+        print("\n(no nodes — `grid join` one first)")
+        return 0
+    # Fixed wording, so the list always announces the rule it follows rather than only saying so on
+    # the grids large enough to hit it. How many actually exist is the `nodes=` line above.
+    print(f"\nTop {MAX_NODE_CARDS} nodes:")
+    for card in cards[:MAX_NODE_CARDS]:
+        print()
+        for line in _card_lines(card):
+            print(line)
+    return 0
+
+
+def cmd_remote_usage(args: argparse.Namespace) -> int:
+    """`grid usage [grid] [--by model|member|engine] [--json]` — who and what spent the tokens.
+
+    The header totals are the **grid's own** rollup in every dimension, not the sum of the rows
+    below them, so this command and `grid stats` can never print two different figures for one
+    grid and window. The rows can therefore add up to slightly less: a member the relay could not
+    name, or work it could not attribute to a machine, is counted once at the top and nowhere else.
+    """
+    from . import remote_overview
+
+    dimension = getattr(args, "by", "model") or "model"
+    session, rec, network_id, label, base, token = _resolve(args)
+    overview = remote_overview.fetch_overview(base, token, label)
+    rollup = grid_rollup(overview)
+    answered = rollup["answered"]
+
+    rows, note = _usage_rows(dimension, overview, answered, session, rec, network_id, label, base)
+
+    if getattr(args, "json", False):
+        print(json.dumps({
+            "grid": label,
+            "by": dimension,
+            "window_seconds": answered["window_seconds"] if answered else None,
+            "totals": _json_answered(answered),
+            "rows": [_json_row(dimension, row) for row in rows],
+        }, indent=2))
+    else:
+        for line in render_usage_totals(answered):
+            print(line)
+        table = {
+            "model": lambda: render_model_table(rows, (answered or {}).get("tokens_out", 0)),
+            "member": lambda: render_member_table(rows),
+            "engine": lambda: render_engine_table(rows),
+        }[dimension]()
+        print()
+        for line in table or [f"(no {dimension} usage — this grid reported none)"]:
+            print(line)
+    if note:
+        print(note, file=sys.stderr, flush=True)
+    return 0
+
+
+def _usage_rows(
+    dimension: str,
+    overview: dict[str, Any],
+    grid_total: dict[str, int] | None,
+    session: str,
+    rec: dict[str, Any],
+    network_id: str,
+    label: str,
+    base: str,
+) -> tuple[list[dict[str, Any]], str | None]:
+    """The rows for one dimension, and a note for stderr when something had to be left out.
+
+    Only `--by member` leaves the overview: the model and engine splits are already in it, while
+    who-ran-what names *people* and so rides an authenticated endpoint (and, for the members who
+    ran nothing, the owner-only roster).
+    """
+    if dimension == "model":
+        return model_rows(overview, grid_total), None
+    if dimension == "engine":
+        return engine_usage_rows(overview), None
+
+    usage = fetch_member_usage(base, _require_token(rec, label), label)
+    roster, refused = _try_roster(session, network_id)
+    rows = member_rows((usage or {}).get("members"), roster)
+    if usage is None:
+        return rows, (
+            f"Note: grid {label} reports no member usage (its relay may predate the endpoint, or "
+            f"no rollup has landed yet) — rows below carry the roster only."
+        )
+    if refused:
+        return rows, (
+            "Note: only the grid owner can list members, so this shows the people the relay has "
+            "usage for, not the full roster."
+        )
+    return rows, None
+
+
+def _json_answered(answered: dict[str, int] | None, *, window: bool = False) -> dict[str, int] | None:
+    """A rollup as JSON, in one shape wherever one appears — the grid's, an engine's, a row's.
+
+    Carries the relay's raw ``tokens_in`` **and** the fresh leg the human tables print, so nothing
+    on the wire is redefined and no script has to know that cached input is a share of input
+    rather than a fourth kind. ``window`` adds the span, for the places that are not already
+    printed under one.
+    """
+    if answered is None:
+        return None
+    return {
+        **({"window_seconds": answered["window_seconds"]} if window else {}),
+        "tokens_in": answered["tokens_in"],
+        "tokens_in_fresh": _fresh(answered),
+        "tokens_cached": answered["tokens_cached"],
+        "tokens_out": answered["tokens_out"],
+        "requests": answered["requests"],
+    }
+
+
+def _json_row(dimension: str, row: dict[str, Any]) -> dict[str, Any]:
+    key = {"model": "model", "member": "email", "engine": "engine"}[dimension]
+    entry: dict[str, Any] = {key: row[key], **(_json_answered(row["answered"]) or {})}
+    if dimension == "model":
+        entry["engines"] = row["engines"]
+    if dimension == "member":
+        entry["roles"] = row["roles"]
+    entry["measured"] = row["answered"] is not None
+    return entry

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -540,6 +540,150 @@ flat `models` list.
 See [ADR 0012](./adr/0012-api-engines.md) for the decisions behind the CLI-shipped whitelist,
 the `openai:*` namespacing, and the key-store lifecycle.
 
+## Stats
+
+```
+grid stats [grid] [--verbose] [--json]                       # what the grid brings, and what it answered
+grid usage [grid] [--by model|member|engine] [--json]        # who and what spent the tokens
+```
+
+**Remote-only.** These are the terminal form of the desktop app's grid panels, and they read the
+same two relay endpoints the app reads — the public `grid/overview` and the token-authenticated
+`grid/members/usage` — so a grid cannot report one thing in the app and another in a shell. A local
+grid computes none of these figures (no uptime, no memory pool, no answered-token books), which is
+what the local-mode gate says rather than "sign in".
+
+`grid stats` is the grid at a glance:
+
+```text
+24h Grid Overview:
+
+grid      autonomous.ai
+status    running
+uptime    99.9%
+nodes     6
+models    6
+memory    0.9/1.4 TB (68%)
+parallel  59
+input     36.2M
+cached    518M
+output    6.2M
+requests  8.1K
+```
+
+**The span in the heading is the relay's, never the literal string `24h`.** The window is an
+operator knob, so a hardcoded label would go quietly wrong the moment someone retuned it — a grid
+counting six hours reads `6h Grid Overview:`, and one whose relay computes no rollup reads
+`Grid Overview:` with no span at all. It sits in the heading rather than in a row because it
+qualifies every token figure beneath it.
+
+`nodes` counts the machines currently serving. It is the one place this CLI says *node* rather
+than *engine* (the [Output Contract](#output-contract) mandates `engines` elsewhere, and `grid info`
+still prints it): here a machine is a node while `engine` is the software running on it, which each
+card states on its own `engine` line, and one word could not carry both. `--json` keeps
+`engines_online` / `engines_total` / `engines` for the same reason a wire name is never redefined.
+
+`memory` is the GPU-memory pool summed across **online** engines — a machine that is asleep
+contributes nothing, and a subscription seat contributes a plan rather than memory, so neither is
+counted. `parallel` is how many requests the grid will take at once (the relay's own capacity when
+it reports one, else the engines' summed concurrency). Every value is **empty when the grid did not
+report it**, printed as `—` like the readings on the cards below: a `0` standing in for "not
+measured" would libel a working fleet as an idle one.
+
+`grid usage` opens with the same block, built by the same code, under a lighter title — here it is
+a header over a breakdown rather than the answer itself. The grid's totals, then whichever
+breakdown was asked for. Two renderings of one set of figures would drift, and these two are read
+minutes apart against the same grid.
+
+There is deliberately **no grid-level speed**. Each engine's tok/s is its own decode estimate, taken
+whenever it last answered something, so adding them up gives a rate no request ever sees and no two
+engines were measured at the same moment. Speed belongs to the machine that answers you, and is
+reported per engine by `--verbose`.
+
+`--verbose` adds a card per engine — its owner, hardware, the models it serves and their context
+windows, memory and free headroom, temperature, utilisation, power, disk, speed, and its own share
+of the window's tokens. A reading the machine never sent prints `—`, which is what keeps it apart
+from a measured zero (an online, idle GPU). Apple Silicon reports no temperature or power at all, so
+those rows are routinely `—` on a Mac, and its memory is labelled `RAM` rather than `VRAM` because a
+unified pool is not a graphics card's own.
+
+**The list stops at 20 machines**, strongest first, however many the grid has. A card is eleven
+lines, so an uncapped list scrolls the rollup — the part every run is read for — off the screen;
+capping a sorted list drops the tail rather than an arbitrary slice. Nothing is concealed by it:
+`nodes=` above states the real count, and `--json` is never capped, so a script always sees the
+whole fleet. Sleeping machines are listed too, marked `(offline)`, which is why the number of cards
+can exceed `nodes=`.
+
+```text
+Top 20 nodes:
+
+scholes-60001
+  owner        scholes@autonomous.ai
+  hardware     NVIDIA RTX PRO 6000 Blackwell Workstation Edition ×4 · Linux
+  engine       external · 16 parallel
+  models       deepseek-v4-flash-0731 (256K ctx)
+  VRAM         277.2/382.4 GB (72%) · 105.2 GB free
+  temperature  36°C
+  usage        0%
+  power        198.7W/2400W
+  storage      796.1/914.8 GB (87%)
+  throughput   ~162 tok/s
+  tokens 24h   4.2M input · 5.2M cached · 91.5K output · 185 requests
+```
+
+`grid usage` splits the same window three ways — by `model` (the default), by `member`, or by
+`engine`:
+
+```text
+24h overview:
+
+input     35.3M
+cached    520M
+output    6.2M
+requests  8.1K
+
+MODEL                   INPUT  CACHED  OUTPUT  REQUESTS  SHARE  ENGINES
+Qwen3.8-Flash-Next      31M    515M    6.1M    7.9K      98%    1
+DeepSeek-V4-Flash-0731  4.2M   5.2M    91.5K   185       1.5%   1
+Qwen/Qwen3.8-27B        85.4K  0       5.8K    30        0.1%   1
+gemma-4-31B-it          0      0       0       0         0%     2
+```
+
+A `0` and a `—` are different answers and are never interchangeable. A model that answered
+nothing on a grid whose rollup landed reads `0` — nobody used it today, which is a fact worth
+seeing. A `—` means nothing measured it at all: an engine whose master predates the rollup, a
+reading the machine never reported, or a member the grid has no figures for.
+
+**`input` is the fresh leg, not the raw figure.** Cached input is a share *of* input, never
+additional to it — billing settles `(in − cached)·input + cached·cache + out·output` — so `input`,
+`cached` and `output` are three non-overlapping legs that add up to what actually passed through.
+`--json` carries the relay's raw `tokens_in` beside `tokens_in_fresh`, so nothing on the wire is
+redefined.
+
+The header totals are the **grid's own** rollup in every dimension, never the sum of the rows below
+them, so `grid stats` and `grid usage` can never print two different figures for one grid. The rows
+can therefore add up to slightly less: work the relay could not attribute to a machine, or to a
+named person, is counted once at the top and nowhere else.
+
+`--by member` names people, so it rides the authenticated endpoint (the grid's own access token)
+and additionally merges the roster `grid members list` reads — a member who has never sent a
+request still gets a row, printed as unmeasured. That roster is owner-only, so a non-owner sees the
+people the relay has usage for and a note on stderr saying so; stdout stays a clean table either
+way.
+
+```text
+MEMBER                      INPUT  CACHED  OUTPUT  REQUESTS
+scholes@autonomous.ai       26.8M  344M    5.1M    6.3K
+dev@autonomous.ai           4M     3.8M    72.2K   131
+tuan.dev@autonomous.ai      3.9M   171M    972K    1.6K
+accounting@autonomous.ai    —      —       —       —
+```
+
+Ordered by what each person actually read, with everyone the grid has no figure for after them,
+alphabetically — so the list answers "who is using this grid" before it answers "who is on it".
+What each of them is *allowed* to do is a different question, and `grid members list` is where it
+is asked; `--json` still carries their roles for a script that wants both in one call.
+
 ## Use
 
 ```

--- a/docs/draft/wrp-engineering-ready-design.md
+++ b/docs/draft/wrp-engineering-ready-design.md
@@ -1,0 +1,618 @@
+# Design spec — WRP "engineering-ready" features, adapted to the `grid` CLI
+
+Status: draft (proposed)
+Date: 2026-07-06
+Source: *The Workload–Router–Pool Architecture for LLM Inference Optimization* (vLLM Semantic
+Router project, March 2026) — the six opportunities the paper tiers as **engineering-ready**
+(Opp 2, 5, 8, 11, 15, 20), mapped onto what this repo can actually build.
+
+---
+
+## 1. Context and scope
+
+The paper's engineering-ready opportunities all assume a *semantic router with fleet-wide
+visibility*. Grid has two in-repo router surfaces and one out-of-repo one:
+
+| Surface | Where | What it decides today |
+| --- | --- | --- |
+| **Local grid server** | `local/server.py` | model → engine, least-loaded (`_choose_engine`, `_load_score`) |
+| **Provider serve loop** | `remote/serve.py` | relay job → local engine (`_ServeState.route`), N poll workers (`--max-concurrency`, ADR 0009) |
+| **Hosted relay** | *not in this repo* | remote consumer → provider routing, membership, billing, queuing |
+
+Everything relay-side is out of scope (ARCHITECTURE.md: "the hosted backend … stay out of this
+repo"). This spec therefore lands each feature at the local server, the provider serve loop, or
+the consumer CLI — and explicitly parks the parts that need relay changes.
+
+### 1.1 Applicability map (the six features)
+
+| # | Paper opportunity | Grid adaptation | Lands in | Dropped / parked |
+| --- | --- | --- | --- | --- |
+| F1 | Opp 2 — HaluGate model-reputation routing | **Outcome-aware engine routing**: per-(engine, model) success/latency reputation feeding engine choice | `local/server.py`; heartbeat enrichment in `remote/serve.py` | Hallucination/factuality verdicts (no classifier in a thin CLI); semantic domains |
+| F2 | Opp 5 — Runtime token-budget enforcement | **Provider token budgets + per-job clamps**; consumer `--max-tokens` | `remote/serve.py`, `cli/parser.py`, `cli/remote_provider.py` | Tool-catalog shaping, compression, model downgrade (grid doesn't rewrite bodies or pick models for consumers) |
+| F3 | Opp 11 — Follow-the-sun pool rebalancing | **Serve windows + adaptive concurrency**: the one pool-capacity knob grid owns, recomputed from local telemetry | `remote/serve.py` | Pool-boundary (B*) math — pools live relay-side |
+| F4 | Opp 15 — KV-cache retention directives | **Session/prefix affinity routing**: keep a conversation on the engine whose KV cache is warm | `local/server.py` | RetentionDirective API (no engine exposes one); relay-side affinity needs a relay header |
+| F5 | Opp 20 — Governance-as-code | **`grid policy`**: a versioned policy file + `check` (satisfiability-lite), enforced at join/serve/consume | new `shared/policy.py`, `cli/policy.py`, hooks in join/serve/request paths | A DSL/compiler — JSON keys instead |
+| F6 | Opp 8 — Request-level RBAC | **Opt-in local grid keys (admin/app roles)** + provider-side job guards | `local/server.py`, `cli/grid.py`, `cli/provider.py` | Per-caller enforcement on providers — relay jobs carry no caller identity (see §9) |
+
+### 1.2 Non-goals
+
+- No semantic classification, no hallucination detection, no ML in the CLI.
+- No change to the relay wire beyond **additive, optional** fields (feature-flagged; see §8 risks).
+- Local mode stays **default-open, in-memory, LAN-only, stateless** (ARCHITECTURE.md design
+  constraints). Every local-mode addition here is either in-memory or strictly opt-in.
+- No new long-lived daemons; no IPC beyond the existing run-record file channel.
+
+### 1.3 Invariants honored (from ADRs / ARCHITECTURE.md)
+
+1. `local/` and `remote/` never import each other; shared logic goes to `shared/`.
+2. Run records carry **non-secret routing only**; tokens stay in `credentials.toml` (0600).
+3. Every new command is classified in `cli/dispatch.py` (`AGNOSTIC` / `REMOTE_HANDLERS` /
+   `REMOTE_ONLY`) — the classification test must be extended, never bypassed.
+4. Surface vocabulary: **grid / engine / model / app**; `node_id`, `provider`, `consumer` stay
+   internal.
+5. `--max-concurrency` semantics from ADR 0009 (one poll worker per slot, `_MAX_CONCURRENCY=256`
+   cap, bounded drain, main thread a pure waiter) are preserved; F3 only varies N at runtime.
+6. One bad job never kills the serve loop; one dead loop stops the engine loudly (`_supervise`).
+
+---
+
+## 2. Shared foundation
+
+Three small pieces are used by several features. Build these first.
+
+### 2.1 `shared/outcomes.py` — outcome records and rolling stats (pure module)
+
+Used by F1 (routing scores), F2 (token accounting), F3 (controller inputs).
+
+```python
+@dataclass
+class Outcome:
+    ts: float
+    model: str
+    kind: str        # "ok" | "engine_error" | "timeout" | "transport_error" | "rejected"
+    status: int | None
+    ttft_ms: float | None      # streams: first chunk; whole: total duration
+    duration_ms: float
+    tokens_in: int | None      # exact from `usage` when present, else estimate
+    tokens_out: int | None
+    estimated: bool            # True when token counts are estimated
+```
+
+`OutcomeStats` (per `(engine, model)` key) maintains, in memory:
+
+- `ema_err` — EMA (α = 0.2) of `1.0` for *hard* failures, `0.0` otherwise.
+  Hard = transport error, timeout, HTTP 5xx, or 404-model-not-found (a misadvertisement).
+  Other 4xx are **neutral** (the request's fault, not the engine's) — recorded, not penalized.
+- `ema_ttft_ms` — EMA (α = 0.2) of TTFT, streams only.
+- `err_streak` — consecutive hard failures; reset on any success.
+- `last_hard_failure_ts` — for cooldown.
+- `hour_buckets: dict[int, TokenCounts]` — rolling 24 × 1-hour token buckets (F2); pruning on
+  write; `window_tokens()` sums the live buckets.
+- counters: `requests`, `failures`, `p50/p95_duration_ms` (t-digest is overkill — keep a
+  fixed 256-sample reservoir and compute on demand).
+
+Concurrency: the module is lock-free; **owners lock**. The local server mutates from a single
+asyncio loop (no lock needed); the serve loop guards with the existing `_ServeState._lock`
+pattern.
+
+Persistence: none in this module. Owners decide (local server: none, matches the stateless
+registry; serve loop: budget buckets persisted into the run record, §4.3).
+
+Token estimation helper: `estimate_tokens(byte_len: int) -> int` = `max(1, byte_len // 4)`,
+documented as ±30 %. Exact `usage` always wins when present.
+
+### 2.2 Run record as a live config channel
+
+`shared/run_records.update_record` (`shared/run_records.py:55`) already merges fields
+atomically, and the serve loop already owns its record. New convention:
+
+- The serve loop re-reads its record every **control tick** (piggybacked on the heartbeat
+  cadence, `relay.HEARTBEAT_INTERVAL = 30 s`) and applies a whitelisted set of *tunable* fields:
+  `max_concurrency`, `daily_token_budget`, `max_tokens_per_job`, `serve_windows`.
+- `grid tune` (§7.2) is just `update_record` + user feedback; the loop picks changes up within
+  one tick. No sockets, no signals, no new IPC — the record file is the channel.
+- Unknown/malformed tunable values are logged and ignored (a corrupt record must not kill the
+  loop — same posture as `shared/state.read_state`).
+
+### 2.3 `shared/policy.py` — policy load/merge/eval (pure module)
+
+See F5 (§6) for the schema. The module exposes:
+
+```python
+def load() -> Policy                 # ~/.grid/policy.json, lenient like state.read_state
+def effective(grid: str | None) -> dict   # global ∪ grid override (key-wise, grid wins)
+def check(policy, context) -> list[Finding]   # errors + warnings, pure
+```
+
+Precedence everywhere: **CLI flag > per-grid policy > global policy > built-in default.**
+
+---
+
+## 3. F1 — Outcome-aware engine routing (paper Opp 2)
+
+**Paper idea kept:** maintain a per-(model, domain) reputation table from response verdicts;
+route to the best performer; sliding window so stale reputation ages out; "silent drift"
+detection. **Translation:** grid can't judge factuality, but it *observes* every forward's
+transport outcome, status, and latency at `_proxy_openai` — enough for a reputation table keyed
+`(engine, model)` where "verdict" = did the engine actually serve the request well.
+
+### 3.1 Behaviour
+
+`local/server.py` today sorts candidates by `(active_tasks, last_heartbeat)`
+(`_active_engines`, `local/server.py:322`) and takes the head (`_choose_engine`,
+`local/server.py:326`). New selection:
+
+```
+score(engine) = active_tasks
+              + W_ERR  * ema_err            # W_ERR  = 4.0
+              + W_TTFT * min(ema_ttft_ms / 5000, 1.0)   # W_TTFT = 1.0, streams only
+```
+
+plus a **cooldown gate**: an engine with `err_streak >= 3` is skipped for
+`COOLDOWN_SECONDS = 30` after its last hard failure — *unless* it is the only candidate for the
+model (degraded service beats no service; the paper's "route around, don't block").
+
+Weights are constants in v1 (no config surface). Rationale: `W_ERR = 4.0` means a fully
+failing engine (ema_err → 1.0) scores as if it had 4 extra in-flight tasks — enough to lose to
+any healthy peer, small enough that one blip (ema_err ≈ 0.2 after a single failure) only
+tie-breaks.
+
+### 3.2 Recording
+
+`_proxy_openai` (`local/server.py:187`) and `_proxy_media` wrap the forward:
+
+- t0 before send; streams: stamp TTFT at the first chunk of `aiter_raw()`; whole: TTFT = total.
+- Outcome classification exactly as §2.1; recorded in `app.state.stats` keyed
+  `(node_id, model)`.
+- Token counts: parse `usage` from whole JSON responses; streams: count `data:` payload bytes
+  in passing (the generator already touches every chunk) and estimate. Never buffer, never
+  delay chunks.
+
+In-memory only — a grid restart forgets stats, exactly like it forgets nodes. This is the
+documented local-mode posture, not a limitation to fix.
+
+### 3.3 Surfacing
+
+- `/nodes/discover` gains per-engine `"stats": {"requests": n, "success_rate": s,
+  "err_streak": k, "p50_ms": …, "p95_ms": …, "cooldown": bool}` (computed, not stored on
+  `Node`).
+- `grid engines` prints one extra detail per engine:
+  `health: 98% ok · p50 412ms · 1.2k reqs` and marks `DEGRADED (cooldown)` when gated.
+  `grid engines --json` carries the raw object. No new verb.
+
+### 3.4 Remote slice (minimal)
+
+The provider loop cannot re-route (the relay picked it), but it already assembles heartbeat
+`load` in `_ServeState.load()` (`remote/serve.py:498`). Add, behind env flag
+`GRID_HEARTBEAT_STATS=1` (default off until verified against the relay, §8):
+
+```json
+"outcomes": {"<model>": {"requests": n, "success_rate": s, "p50_ms": m}}
+```
+
+This is the paper's "feed per-model quality back into routing policy" — the routing policy
+lives relay-side, so grid's job is only to *emit the signal*.
+
+### 3.5 Acceptance
+
+- Two engines serve `m`; engine A returns three consecutive 5xx → the next request routes to B
+  even when A is less loaded; after 30 s + one success, A is eligible again.
+- 4xx responses do not change routing order.
+- Sole engine failing → still selected (with `DEGRADED` visible in `grid engines`).
+- No measurable added latency on the proxy hot path (stats update is O(1), no I/O).
+
+---
+
+## 4. F2 — Token budgets and job guards (paper Opp 5)
+
+**Paper idea kept:** the router is the natural budget-enforcement point because it sees actual
+token flow; graduated response; P90-style headroom so legitimate long jobs survive.
+**Translation:** the serve loop is where a provider's GPU gets spent (and, on priced grids,
+billed via `grid price set`) — today it forwards without reading `usage` at all. The graduated
+response compresses to what a proxy that must not rewrite results *can* do: **clamp → warn →
+pause claiming** (never kill in-flight work).
+
+### 4.1 CLI surface
+
+New remote-only `grid join` flags (added to `cli/parser.py` `_add_engines`, mirrored into the
+run record in `cli/remote_provider.py:_build_record`, and appended to
+`_REMOTE_ONLY_JOIN_FLAGS` in `cli/provider.py:35` so local mode rejects them):
+
+```
+--max-tokens-per-job N    Clamp each job's max_tokens to N before forwarding (default: none)
+--daily-token-budget N    Stop claiming new jobs after N tokens (in+out) in a rolling 24h (default: none)
+```
+
+Consumer side, both modes: `grid chat --max-tokens N` → body `max_tokens` (today
+`cli/remote_request.py:75` builds `{model, messages}` only; local `cli/request.py` likewise).
+
+### 4.2 Enforcement in `handle_job` (`remote/serve.py:608`)
+
+Ordered, before `enter_inference`:
+
+1. **Reject oversized bodies**: serialized `body` > `MAX_JOB_BODY_BYTES` (default 10 MB, text
+   endpoints only — media already streams files) → `_try_submit_error(state, txn,
+   "request too large for this engine")`. (Also part of F6's guard story.)
+2. **Clamp**: if `max_tokens_per_job` is set → `forward_body["max_tokens"] =
+   min(cap, body.get("max_tokens") or cap)`. The engine enforces; the consumer sees a standard
+   `finish_reason: "length"`. This is the only body mutation, and it follows the existing
+   precedent (the loop already rewrites `model` for `--advertise-as`, `remote/serve.py:653`).
+3. **Budget gate** is *not* per-job — exhaustion pauses claiming (§4.4), so a claimed job is
+   always served. No job is half-punished.
+
+### 4.3 Accounting
+
+- `_forward_whole` (`remote/serve.py:701`): parse the engine's JSON for
+  `usage.prompt_tokens` / `usage.completion_tokens`; fall back to `estimate_tokens(len(bytes))`.
+- `_forward_stream` (`remote/serve.py:717`): wrap `engine_resp.iter_bytes()` in a counting
+  generator (bytes flow through untouched); estimate tokens from cumulative `data:` payload
+  size; if a final SSE chunk carries `usage` (llama.cpp with `include_usage`, vLLM), prefer it.
+  Counts are marked `estimated`.
+- Buckets: 24 rolling hour buckets per engine identity (§2.1), aggregate across models
+  (budgets protect the *box*, not a model).
+- Persistence: buckets flushed into the run record (`update_record(..., budget_buckets={...},
+  budget_updated_at=ts)`) every control tick and on clean shutdown; reloaded on start. A
+  restart therefore cannot reset a budget — the paper's enforcement survives the trivial
+  bypass.
+
+### 4.4 Graduated response
+
+| Budget state | Trigger | Action |
+| --- | --- | --- |
+| `ok` | < 90 % of window budget | — |
+| `low` | ≥ 90 % | serve-loop log line; heartbeat `load["budget"] = {"state": "low", "used": u, "limit": l}` |
+| `exhausted` | ≥ 100 % | **pause claiming** (§4.5); heartbeat `budget.state = "exhausted"`; resume automatically when the rolling window frees ≥ 5 % headroom |
+
+### 4.5 Pause/resume mechanics (shared with F3)
+
+Pausing must tell the relay to stop routing here, not just stop polling (else jobs queue
+against a dead slot). Grid already has the primitive: `unregister_node`
+(`remote/relay.py:88`) flips the node to `role: "consumer"`, which the relay treats as drain.
+
+- `_ServeState` gains `desired_role: "provider" | "consumer"` and `pause(reason)` /
+  `resume()`; `register(state)` (`remote/serve.py:570`) sends `role=state.desired_role`.
+- Workers check a `state.paused` event between polls: paused workers park on
+  `resume_event.wait(5)` instead of long-polling.
+- `heartbeat_once` (`remote/serve.py:594`) keeps running while paused (keeps the node fresh
+  and the budget state visible); its 404 → `register(state)` path re-registers **with the
+  current desired role**, so a prune during a pause cannot resurrect a claiming provider.
+- In-flight jobs always finish and submit (drain semantics of ADR 0009 untouched).
+
+### 4.6 Acceptance
+
+- Whole + streamed jobs both count; `grid engines --json` (remote) shows
+  `budget: {used, limit, state}` read from the run record.
+- Set a 1 000-token budget, run chat jobs until exhausted → relay-visible role flips to
+  consumer, no new jobs claimed, in-flight job completes and submits; window rolls → provider
+  role restored without operator action.
+- `--max-tokens-per-job 64` → engine receives `max_tokens ≤ 64` even when the consumer sent
+  4 096 or nothing.
+- Kill -9 the serve loop mid-window, rejoin → budget usage carries over (record reload).
+
+---
+
+## 5. F3 — Serve windows and adaptive concurrency (paper Opp 11)
+
+**Paper idea kept:** capacity should track the workload's clock — recompute periodically from a
+sliding window of telemetry and reassign capacity *in software*; hysteresis against
+oscillation (the paper cites Autopilot's). **Translation:** grid owns exactly one pool-capacity
+knob — how many poll workers a provider runs (`max_concurrency`, ADR 0009) and whether it
+serves at all. Provider boxes are often workstations: "follow the sun" here literally means
+*serve hard at night, lightly at 2pm*.
+
+### 5.1 CLI surface
+
+```
+--serve-window "22:00-08:00"     Serve only inside these local-time windows (repeatable).
+--max-concurrency auto[:F-C]     Adapt worker count between floor F and ceiling C (defaults 1–8).
+```
+
+`--max-concurrency N` keeps its exact ADR 0009 meaning. `auto` ceiling is clamped by
+`_MAX_CONCURRENCY` (`remote/serve.py:40`). Both are run-record tunables (§2.2), so
+`grid tune --serve-window …` retunes a live engine within one tick.
+
+### 5.2 Windows
+
+- Parse `HH:MM-HH:MM`, local time, midnight-crossing allowed; several windows OR-ed.
+- Evaluated each control tick: outside → `pause("window")`, inside → `resume()` — the same
+  §4.5 machinery (role flip + park). Window edges therefore *drain, never kill*.
+
+### 5.3 Adaptive controller (AIMD)
+
+Runs on the control tick (30 s), only when mode is `auto`:
+
+- **State:** `target` (current worker target), `best_p95` (min windowed p95 job duration seen,
+  floor 1 s), last-tick outcome window from `OutcomeStats`.
+- **Increase** `target += 1` (up to ceiling) iff the last tick had ≥ 1 completion, zero hard
+  failures, and windowed p95 ≤ 1.5 × `best_p95`.
+- **Decrease** `target = max(floor, ceil(target / 2))` on any timeout, any engine 5xx, or
+  p95 > 2 × `best_p95`; then hold (no increase) for a 90 s cooldown.
+- Rationale: the congestion signal is *job latency degradation at the engine* — GPU-utilization
+  telemetry is confounded (our own jobs pin the GPU; that's healthy, not overload).
+
+Worker scaling mechanics (extends `_serve_loop`, `remote/serve.py:793`):
+
+- Workers get indices; each checks `self.index < state.target_workers` at the top of its poll
+  iteration and exits cleanly when above target (shrink latency ≤ one 35 s poll cycle).
+- Growth spawns fresh threads under `_supervise` (unchanged supervision semantics).
+- On any target change: re-register (`PUT /nodes/{id}` is idempotent and already re-sent on
+  heartbeat-404) so the relay's advertised `max_concurrency` tracks reality; heartbeat gains
+  `load["capacity"] = {"target": t, "limit": c}`.
+
+### 5.4 Acceptance
+
+- `--serve-window "22:00-08:00"` at 14:00 → engine registers, immediately pauses (role
+  consumer), logs `outside serve window — paused`; at 22:00 (simulated clock) resumes.
+- `auto:1-8` against a healthy fast engine → target climbs one step per tick to 8; inject
+  timeouts → halves and holds ≥ 90 s; N never exceeds the ceiling nor `_MAX_CONCURRENCY`.
+- ADR 0009 suite stays green with `--max-concurrency N` (fixed mode byte-identical).
+
+---
+
+## 6. F4 — Session/prefix affinity routing (paper Opp 15)
+
+**Paper idea kept:** the router should use zero-cost identity signals (system-prompt
+fingerprint, session continuation) to protect KV-cache locality — the engine can't infer this
+from the token stream, the router can. **Translation:** grid can't emit retention directives
+(no engine API), but it *chooses the engine*, and today it re-rolls that choice every turn:
+turn 2 of a conversation can land on a different engine than turn 1, cold-starting the entire
+prefix. llama.cpp (`cache_prompt`, on by default) and vLLM (automatic prefix caching) both
+reward stickiness with large TTFT wins — grid just has to stop defeating them.
+
+### 6.1 Behaviour (`local/server.py` only, v1)
+
+- Compute a **conversation fingerprint** in `_proxy_openai` after the body parse (no extra
+  parse): `sha256(model + "\0" + system_message_content + "\0" +
+  first_user_message_content).hexdigest()[:16]`. Multi-part content is serialized with
+  `json.dumps(..., sort_keys=True)`; missing messages hash as empty. Turns 2..n of one
+  conversation repeat their first messages verbatim, so the fingerprint is stable per
+  conversation without any client cooperation — the paper's "system-prompt fingerprint,
+  zero classification cost".
+- `app.state.affinity`: LRU `{fingerprint: (node_id, ts)}`, cap 1 024, TTL 900 s.
+- Selection (extends `_choose_engine`): among the F1-scored candidates, pick the affinity
+  engine iff it (a) is a live candidate for the model, (b) is not in cooldown, and
+  (c) `active_tasks ≤ min_active + SLACK` (SLACK = 2). Otherwise take the score head and
+  update the map. The slack term is the paper's sunk-cost-vs-queueing trade, reduced to a
+  constant: a warm cache is worth waiting behind ≤ 2 tasks, not behind a pile-up.
+- The forwarded body stays byte-identical (affinity only *reads*), preserving the documented
+  "raw body forwarded unchanged" contract.
+
+### 6.2 Explicitly parked
+
+Remote-mode affinity requires the relay to accept a session hint and the consumer response to
+identify the serving engine; neither exists on the wire this repo sees. If/when the relay
+exposes them, the consumer slice is small: persist `{session → provider}` client-side and set
+the existing `X-Target-Provider` header (`remote/relay.py:287`) on follow-up turns. Parked in
+§9, not designed further here.
+
+### 6.3 Acceptance
+
+- Two engines serve `m`, both idle: three consecutive requests sharing a system+first-user
+  prefix land on the same engine; a request with a different prefix may land elsewhere.
+- Affinity engine loaded with `min_active + 3` tasks → conversation moves (slack exceeded).
+- Affinity engine in F1 cooldown → conversation moves; map updates to the new engine.
+- TTL expiry (fake clock) → entry dropped, no stale node_id ever returned to a dead engine.
+
+---
+
+## 7. F5 — Governance-as-code: `grid policy` (paper Opp 20)
+
+**Paper idea kept:** operator constraints as reviewable *code*, validated for satisfiability
+before they bite at runtime, then enforced at dispatch. **Translation:** JSON policy keys
+instead of a DSL — the repo already speaks versioned JSON everywhere (`state.json`, run
+records); the enforcement points already exist as hardcoded guards (`_ALLOWED_ENDPOINTS`,
+`_REMOTE_ONLY_JOIN_FLAGS`) that this feature generalizes without replacing.
+
+### 7.1 Policy file
+
+`~/.grid/policy.json` — atomic writes via `shared/jsonio`, 0600, lenient reads
+(corrupt → `{}` + warning, self-heals on next `set`; same posture as `shared/state.py`).
+
+```json
+{
+  "version": 1,
+  "global": {
+    "serve.models": ["qwen3*", "llama3*"],
+    "serve.media": false,
+    "serve.max_tokens_per_job": 4096,
+    "serve.daily_token_budget": 5000000,
+    "serve.windows": ["22:00-08:00"],
+    "serve.require_price": true,
+    "consume.models": ["*"],
+    "consume.max_price_per_mtok": 2.0,
+    "local.require_key": false
+  },
+  "grids": {
+    "home":     {"serve.media": true},
+    "<network_id-or-name>": {"serve.daily_token_budget": 20000000}
+  }
+}
+```
+
+Key semantics (v1 — the complete set; anything else is a `check` error):
+
+| Key | Type | Enforced at |
+| --- | --- | --- |
+| `serve.models` / `serve.models_deny` | globs (`fnmatch`) | join-time: filters the advertised set (empty result = error); serve-time: `handle_job` re-checks (defense in depth, policy may have tightened since join) |
+| `serve.media` | bool | join-time: rejects `--media` / detected media |
+| `serve.max_tokens_per_job` | int | default for the F2 flag |
+| `serve.daily_token_budget` | int | default for the F2 flag |
+| `serve.windows` | list | default for the F3 flag |
+| `serve.require_price` | bool | remote join-time: `relay.list_model_prices` must cover every advertised model, else refuse with the missing list ("don't serve for free by accident") |
+| `consume.models` | globs | `grid chat/image/edit/video`: reject a disallowed `-m` before any network call |
+| `consume.max_price_per_mtok` | float | remote consume: fetch the grid's price table (only when the key is set), refuse when the model's `input_rate` or `output_rate` exceeds the ceiling |
+| `local.require_key` | bool | default for `grid up --require-key` (F6) |
+
+### 7.2 CLI surface
+
+```
+grid policy show [--json]                 # effective global + per-grid table
+grid policy set <key> <value> [--grid G]  # typed parse per key; unknown key = error
+grid policy unset <key> [--grid G]
+grid policy check [grid]                  # satisfiability pass; exit 1 on errors
+
+grid tune [grid] --engine <id> [--max-concurrency N|auto[:F-C]]
+          [--daily-token-budget N] [--max-tokens-per-job N] [--serve-window W]...
+```
+
+- `policy` is **AGNOSTIC** in `cli/dispatch.py` (file edits work in either mode; remote-only
+  keys simply don't fire locally). `tune` is **REMOTE_ONLY** v1 (its knobs are all remote);
+  it writes run-record tunables (§2.2) and prints what the live loop will pick up.
+- Both added to the dispatch classification sets *and* the classification test.
+
+### 7.3 `grid policy check` — satisfiability-lite
+
+Pure evaluation in `shared/policy.check` over a context assembled by the CLI:
+
+- **Errors:** unknown key; type mismatch; unparseable window; `serve.models` ∩ (advertised or
+  detected models) = ∅; `consume.models` = ∅; `require_price` true with unpriced advertised
+  models (remote, needs the grid reachable); per-job cap > daily budget.
+- **Warnings:** windows cover 0 h or 24 h (likely a mistake); price ceiling below every live
+  model's price (nothing consumable); deny-glob shadowing an allow-glob.
+- Output mirrors the paper's compile-time gate: every finding names the key, the scope
+  (global/grid), and the fix.
+
+### 7.4 Enforcement wiring (exact hook points)
+
+| Hook | File anchor | Check |
+| --- | --- | --- |
+| local join | `cli/provider.py:cmd_join` (52) | `serve.models` filter, `serve.media` |
+| remote join | `cli/remote_provider.py:cmd_remote_join` (37) | same + `serve.require_price`; resolved defaults written into the record so the detached loop needs no policy read on the hot path |
+| serve loop | `remote/serve.py:handle_job` (608) | model allow re-check; §4.2 guards |
+| local consume | `cli/request.py` handlers | `consume.models` |
+| remote consume | `cli/remote_request.py:_resolve` callers (71, 136) | `consume.models`, `consume.max_price_per_mtok` |
+| server start | `local/runtime.py` → `create_app` | `local.require_key` (F6) |
+
+---
+
+## 8. F6 — Request-level auth for the local grid (paper Opp 8)
+
+**Paper idea kept:** "the model is both decision-maker and enforcer" → put an independent
+authorization check at the unique point that sees identity + intent *before execution*, in
+block/rewrite duality, defaulting to the narrowest role. **Translation:** grid proxies chat
+rather than executing tools, so the enforcement point is the **grid server's API surface** —
+which today is fully open on the LAN: any peer can consume every model *and* silently
+`DELETE /nodes/{id}` your engines or register a rogue engine that then receives everyone's
+prompts. Remote mode already has membership roles relay-side; the local server has nothing.
+
+### 8.1 Design (strictly opt-in)
+
+`grid up --require-key` (local-only flag; remote `up` rejects it, mirroring the
+`_reject_local_only_flags` pattern):
+
+- On create, generate two keys (`secrets.token_urlsafe(32)`): `admin_key`, `app_key`; store in
+  the grid's `config.json` (`local/config.py:13`; `jsonio` already writes 0600) under
+  `"auth": {"required": true, "admin_key": …, "app_key": …}`.
+- FastAPI middleware in `create_app` when auth is on — role matrix:
+
+| Endpoint | open (auth off) | `app_key` | `admin_key` |
+| --- | --- | --- | --- |
+| `/`, `/grid/info` | ✓ | ✓ | ✓ (always open; `auth_required` is reported here so clients can self-diagnose) |
+| `/v1/*`, `/nodes/discover` | ✓ | ✓ | ✓ |
+| `POST/PUT/DELETE /nodes*`, `/nodes/heartbeat` | ✓ | ✗ 403 | ✓ |
+
+- 401 (missing/garbled) vs 403 (wrong role) with OpenAI-shaped error bodies
+  (`_openai_error` reused).
+- Key distribution: same-box commands read `config.json` transparently; cross-box `grid join`
+  / `grid chat --grid <url>` accept `--key` or `GRID_API_KEY` env. `grid info --env` prints
+  `OPENAI_API_KEY=<app_key>` when auth is on — the dummy key becomes a real one, and existing
+  OpenAI SDK apps work unchanged.
+- Engine heartbeat loop (`cli/provider.py:_run_engine`) sends
+  `Authorization: Bearer <admin_key>` from its record-resolved config; the run record itself
+  stays secret-free (the key is read from `config.json` at loop start — same box; cross-box
+  external engines pass `--key`, stored nowhere, exported into the child's env).
+
+### 8.2 Provider-side guards (what RBAC means without caller identity)
+
+Relay jobs carry `{transaction_id, endpoint_path, body, is_stream, inference_timeout_seconds}`
+— **no caller identity**, so per-caller rules are impossible here (parked, §9). What ships:
+the F2/F5 `handle_job` guards (endpoint allowlist — already present as `_ALLOWED_ENDPOINTS` —
+plus model allowlist, body-size cap, `max_tokens` clamp). This is the paper's "rewrite mode":
+strip/clamp before the engine ever sees it, fail the job cleanly otherwise.
+
+### 8.3 Acceptance
+
+- Default `grid up`: byte-identical behaviour, `auth_required: false` in `/grid/info`.
+- `--require-key`: unauthenticated `DELETE /nodes/x` → 401; app-key → 403; admin-key → 200.
+- `OPENAI_API_KEY` from `grid info --env` works against `/v1/chat/completions` with a stock
+  OpenAI SDK.
+- ARCHITECTURE.md "local is unauthenticated" paragraph updated to "unauthenticated by
+  default; `--require-key` opts a grid into key auth".
+
+---
+
+## 9. Parked — relay-dependent (explicit, so nobody designs against a wall)
+
+| Idea | Missing wire piece |
+| --- | --- |
+| Remote session affinity (F4) | relay support for a session-hint header + serving-engine identity in responses |
+| Per-caller RBAC / budgets / reputation on providers (Opp 8/9 full form) | caller identity claim in the poll job payload |
+| Relay-side reputation routing on F1 signals | relay reading `load.outcomes` (grid only emits, flagged) |
+| KV retention directives proper (Opp 15 full form) | any engine exposing a retention API |
+
+Each is additive to this design: the emit points (`heartbeat`, `consumer_headers`) and the
+stats/policy stores are already where those extensions would plug in.
+
+---
+
+## 10. Delivery plan
+
+**Phase 1 — foundations + pure-CLI wins (no wire changes)**
+`shared/outcomes.py`, `shared/policy.py` · F1 local routing (score + cooldown + `grid engines`
+health) · F4 affinity · `grid chat --max-tokens` · `grid policy show/set/unset/check` with
+consume gates and join-time serve gates · F2 `--max-tokens-per-job` clamp.
+
+**Phase 2 — provider guardrails**
+F2 accounting + budgets + run-record persistence + pause/resume role flip · F3 serve windows ·
+`grid tune` (record channel) · budget/window state in `grid engines`.
+
+**Phase 3 — adaptive + auth**
+F3 AIMD `auto` concurrency + capacity heartbeat field · F1 heartbeat outcome enrichment
+(flagged) · F6 `--require-key` + middleware + key plumbing.
+
+Suggested ADRs: `0010-outcome-aware-local-routing`, `0011-provider-budgets-and-pause`,
+`0012-adaptive-serve-capacity`, `0013-policy-and-local-auth`.
+
+## 11. Testing strategy
+
+- **Unit (pure):** outcome EMA/streak/buckets math; token estimator; window parser
+  (midnight-crossing, overlaps); AIMD controller against a scripted timeline (fake clock);
+  policy merge/precedence/check findings; fingerprint stability across turns and content
+  forms.
+- **Local server (FastAPI TestClient, extends `tests/test_local_cli.py` patterns):** routing
+  prefers healthy engine after 3 hard failures; cooldown expiry; 4xx neutrality; affinity
+  stickiness / slack eviction / TTL; auth matrix (401/403/200 per role per endpoint);
+  default-open regression.
+- **Serve loop (mocked relay, extends the ADR 0009 suite):** clamp applied to
+  `forward_body`; whole + streamed token counting (usage present / absent); budget exhaustion
+  → role-flip PUT observed, workers park, in-flight job still submits; window pause/resume;
+  record-tunable pickup within one tick; auto mode scale-up/down + re-register; corrupt
+  record/policy never kills the loop.
+- **Dispatch:** classification test extended for `policy` (AGNOSTIC) and `tune` (REMOTE_ONLY);
+  wrong-mode flag rejections (`--require-key` in remote, new remote-only join flags in local).
+- **e2e smoke:** extend `test_remote_mode_e2e.sh` with a budgeted join and a `grid tune`
+  round-trip.
+
+## 12. Risks and mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Relay rejects unknown register/heartbeat fields | all new wire fields behind `GRID_HEARTBEAT_STATS` / omitted-when-unset; verify against staging before defaulting on |
+| Streamed token estimates off by ±30 % | exact `usage` preferred whenever present; counts flagged `estimated`; budgets are provider self-protection, not billing |
+| Pause role-flip races heartbeat re-register | single `desired_role` source of truth in `_ServeState`; `register()` always reads it |
+| AIMD oscillation | one step per 30 s tick, 90 s post-decrease hold, `best_p95` floor |
+| Affinity herds a conversation onto a hot engine | slack bound (≤ min_active + 2) + cooldown gate always win over affinity |
+| Policy foot-gun (allow-list matches nothing) | `grid policy check` + join-time error naming the key; lenient loads never brick unrelated commands |
+| Local auth breaks existing LAN apps | strictly opt-in; `/grid/info` always open and reports `auth_required`; `grid info --env` hands out the working key |
+
+## 13. Open questions
+
+1. Should F2 budgets also count *input* tokens of failed jobs (engine 5xx after a long
+   prefill)? Proposed: yes — the GPU did the work (prefill cost is real).
+2. `grid tune` in local mode (heartbeat interval, future local knobs) — defer until a local
+   tunable exists, or classify GATED now with a local stub?
+3. Does the relay tolerate frequent `PUT /nodes/{id}` re-registers from the auto controller
+   (worst case every 30 s)? If not: only re-register on target *changes*, which the design
+   already does — confirm rate limits with the relay team.
+4. `consume.max_price_per_mtok` adds one price-table fetch per consume when set — cache it
+   (`~/.grid/cache/`, 10-min TTL) or accept the latency? Proposed: accept in v1 (opt-in key).

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -22640,6 +22640,618 @@ def test_local_edit_and_video_reject_remote_only_flags(monkeypatch, tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Remote `grid stats` / `grid usage` (cli/remote_stats.py + cli/_format.py)
+#
+# The terminal form of the desktop app's grid panels, off the same two relay reads. The rules under
+# test are the ones ported from it deliberately — absent is not zero, cached input is a share of
+# input, a subscription seat brings a plan rather than memory — because those are what make the two
+# surfaces agree about one grid, and each is invisible when it breaks (a wrong figure, not an error).
+# ---------------------------------------------------------------------------
+
+# One busy GPU box, one idle Mac, one asleep machine and one subscription seat: between them they
+# exercise every membership and every "the relay didn't say" branch in one payload.
+_OVERVIEW_STATS = {
+    "grid": {"state": "running"},
+    "stats": {"models": 2, "nodes": 3, "concurrent_capacity": 20, "uptime_pct": 99.9},
+    "answered": {"window_seconds": 86400, "tokens_in": 1_200_000, "tokens_cached": 200_000,
+                 "tokens_out": 90_000, "requests": 400},
+    "models": [{"id": "GLM-5.2"}, {"id": "Qwen-3"}],
+    "nodes": [
+        {"name": "gpu-box", "provider_email": "ana@example.com", "device": "NVIDIA RTX 5090 ×2",
+         "platform": "linux", "engine": "vllm", "models": ["glm-5.2"],
+         "model_capabilities": {"glm-5.2": {"context_length": 256000}},
+         "vram_gb": 64.0, "vram_total_mb": 65536.0, "vram_used_mb": 32768.0,
+         "gpu_util_pct": 55.0, "gpu_temp_c": 61.0, "gpu_power_w": 300.0, "gpu_power_limit_w": 600.0,
+         "disk_total_gb": 900.0, "disk_used_gb": 450.0,
+         "throughput_tok_s": 120.0, "max_concurrency": 16, "online": True,
+         "answered": {"window_seconds": 86400, "tokens_in": 1_000_000, "tokens_cached": 200_000,
+                      "tokens_out": 80_000, "requests": 300,
+                      "by_model": [{"model": "glm-5.2", "tokens_in": 1_000_000,
+                                    "tokens_cached": 200_000, "tokens_out": 80_000,
+                                    "requests": 300}]}},
+        {"name": "mac-studio", "provider_email": "bo@example.com", "chip": "Apple M2 Ultra",
+         "platform": "macos-arm64", "engine": "llama.cpp", "models": ["qwen-3"],
+         "vram_gb": 192.0, "vram_total_mb": 196608.0, "vram_used_mb": 49152.0,
+         "throughput_tok_s": 20.0, "max_concurrency": 1, "online": True,
+         "answered": {"window_seconds": 86400, "tokens_in": 0, "tokens_cached": 0,
+                      "tokens_out": 0, "requests": 0, "by_model": []}},
+        {"name": "asleep-box", "vram_gb": 999.0, "throughput_tok_s": 500.0,
+         "max_concurrency": 8, "online": False},
+        {"name": "codex-seat", "plan_type": "pro", "vram_gb": 128.0, "engine": "codex",
+         "models": ["codex:gpt-5.5"], "max_concurrency": 4, "online": True},
+    ],
+}
+
+
+def _mock_member_usage(monkeypatch, payload, *, status=200, seen=None):
+    """Serve both relay reads `grid usage` makes: the overview, then `/grid/members/usage`."""
+    def handler(request):
+        if seen is not None:
+            seen.setdefault("paths", []).append(request.url.path)
+            seen["auth"] = request.headers.get("authorization")
+        if request.url.path.endswith("/members/usage"):
+            return httpx.Response(status, json=payload)
+        return httpx.Response(200, json=_OVERVIEW_STATS)
+
+    _mock_relay(monkeypatch, handler)
+
+
+def _lines(capsys):
+    return [ln for ln in capsys.readouterr().out.splitlines()]
+
+
+def _overview(lines):
+    """The aligned overview block as a dict — what `grid stats` and `grid usage` both open with.
+
+    A pair is identified by its column gap, so the heading (single-spaced prose) is skipped without
+    this having to know what it says, and the block ends at the first line that is not a pair — the
+    blank before the node cards or the breakdown table.
+    """
+    out = {}
+    for line in lines:
+        if "  " in line and not line.startswith(" "):
+            name, _, value = line.partition("  ")
+            out[name.strip()] = value.strip()
+        elif out:
+            break
+    return out
+
+
+def _heading(lines):
+    """The first line `grid stats` prints — the span-qualified title."""
+    return lines[0]
+
+
+# -- `grid stats` ----------------------------------------------------------
+
+def test_stats_and_usage_are_classified_remote_only_with_their_own_reason():
+    """Neither has a local handler to fall back to, and neither is gated for sign-in — so both must
+    carry a reason of their own rather than inheriting "to sign in."."""
+    assert {"stats", "usage"} <= set(dispatch.REMOTE_ONLY)
+    assert not (set(dispatch.AGNOSTIC) & {"stats", "usage"})
+    assert not (set(dispatch.REMOTE_HANDLERS) & {"stats", "usage"})
+    assert all(dispatch.REMOTE_ONLY[command] for command in ("stats", "usage"))
+
+
+def test_stats_in_local_mode_says_a_local_grid_computes_none_of_it(monkeypatch, tmp_path):
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    state.set_mode("local")  # the default for a fresh home is `remote` (ADR 0001 D-2, amended)
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["stats"])
+    message = str(exc.value)
+    assert message.startswith("`grid stats` is a remote-mode command.")
+    assert "does not compute" in message and "sign in" not in message
+
+
+def test_remote_stats_prints_the_grid_rollup(monkeypatch, tmp_path, capsys):
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    seen = {}
+    _mock_overview(monkeypatch, _OVERVIEW_STATS, seen)
+    assert cli.main(["stats"]) == 0
+    values = _overview(_lines(capsys))
+    assert seen["path"] == "/relay/v1/grid/overview"
+    assert values["grid"] == "team" and values["status"] == "running"
+    assert values["uptime"] == "99.9%"
+    assert values["nodes"] == "3"  # online only — the sleeping box is not serving
+    assert values["models"] == "2"
+    assert values["parallel"] == "20"  # the relay's own capacity wins over the engines' summed 21
+    # Speed is a property of the machine that answers, not of the grid: each engine's figure is its
+    # own decode estimate taken at its own moment, so there is no summed rate here to read.
+    assert "throughput" not in values
+
+
+def test_remote_stats_opens_with_a_span_qualified_heading_over_one_column(monkeypatch, tmp_path, capsys):
+    """The block's shape is the contract here: a heading naming the span, then one column of
+    figures. No `window` row — the heading already qualifies every token figure under it."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_overview(monkeypatch, _OVERVIEW_STATS)
+    assert cli.main(["stats"]) == 0
+    assert capsys.readouterr().out == (
+        "24h Grid Overview:\n"
+        "\n"
+        "grid      team\n"
+        "status    running\n"
+        "uptime    99.9%\n"
+        "nodes     3\n"
+        "models    2\n"
+        "memory    80/256 GB (31%)\n"
+        "parallel  20\n"
+        "input     1M\n"
+        "cached    200K\n"
+        "output    90K\n"
+        "requests  400\n"
+    )
+
+
+def test_remote_stats_heading_names_the_relays_span_not_a_hardcoded_day(monkeypatch, tmp_path, capsys):
+    """The window is an operator knob (`node_answered_window_seconds`). A heading reading "24h"
+    while the master counted six would be wrong in the one way a figure must never be — and with
+    the `window` row gone, this heading is the only thing saying what the figures cover."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    six_hours = {**_OVERVIEW_STATS,
+                 "answered": {**_OVERVIEW_STATS["answered"], "window_seconds": 21600}}
+    _mock_overview(monkeypatch, six_hours)
+    assert cli.main(["stats"]) == 0
+    lines = _lines(capsys)
+    assert _heading(lines) == "6h Grid Overview:"
+    assert "window" not in _overview(lines)
+
+
+def test_remote_stats_heading_drops_the_span_when_nothing_measured_one(monkeypatch, tmp_path, capsys):
+    """A grid whose relay computes no rollup names no span — the bare noun, not an empty one, and
+    certainly not a day it never counted."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_overview(monkeypatch, {"grid": {"state": "running"}, "stats": {}, "nodes": []})
+    assert cli.main(["stats"]) == 0
+    assert _heading(_lines(capsys)) == "Grid Overview:"
+
+
+def test_remote_usage_opens_with_the_shared_block_under_its_own_title(monkeypatch, tmp_path, capsys):
+    """One shape from one place — but each command names it for itself. Here the block is a header
+    over a breakdown, so it stays light; in `grid stats` it *is* the answer and says so."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_overview(monkeypatch, _OVERVIEW_STATS)
+    assert cli.main(["usage"]) == 0
+    assert _lines(capsys)[:7] == [
+        "24h overview:",
+        "",
+        "input     1M",
+        "cached    200K",
+        "output    90K",
+        "requests  400",
+        "",
+    ]
+
+
+def test_remote_usage_heading_names_the_relays_span(monkeypatch, tmp_path, capsys):
+    """Same rule as `grid stats`: with no `window` row under it, this heading is the only thing
+    saying what the figures cover, so it cannot be a hardcoded day."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_overview(monkeypatch, {**_OVERVIEW_STATS,
+                                 "answered": {**_OVERVIEW_STATS["answered"], "window_seconds": 21600}})
+    assert cli.main(["usage"]) == 0
+    lines = _lines(capsys)
+    assert _heading(lines) == "6h overview:"
+    assert "window" not in _overview(lines)
+
+
+def test_remote_stats_memory_pool_excludes_offline_boxes_and_subscription_seats(
+    monkeypatch, tmp_path, capsys
+):
+    """64 + 192 GB of hardware, not 999 (asleep — it can run nothing now) and not 128 (a seat, which
+    relays to a hosted model, so its host's memory never runs anything for the grid)."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_overview(monkeypatch, _OVERVIEW_STATS)
+    assert cli.main(["stats"]) == 0
+    # 32 GB used of 256 GB pooled. Used is summed over exactly the machines the total is.
+    assert _overview(_lines(capsys))["memory"] == "80/256 GB (31%)"
+
+
+def test_remote_stats_prints_the_fresh_input_leg_not_the_raw_one(monkeypatch, tmp_path, capsys):
+    """Cached prefill is a share OF input, never additional to it — so the three legs printed here
+    add up to what passed through. Raw `tokens_in` would show 1.2M and a total larger than the grid."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_overview(monkeypatch, _OVERVIEW_STATS)
+    assert cli.main(["stats"]) == 0
+    lines = _lines(capsys)
+    values = _overview(lines)
+    assert _heading(lines) == "24h Grid Overview:"  # the span is stated once, above the figures
+    assert values["input"] == "1M"  # 1_200_000 read − 200_000 from cache
+    assert values["cached"] == "200K" and values["output"] == "90K" and values["requests"] == "400"
+
+
+def test_remote_stats_marks_an_unmeasured_field_rather_than_printing_zero(monkeypatch, tmp_path, capsys):
+    """A relay too old to compute a rollup sends none, and a `0` there would report a busy fleet as
+    dead. The name still prints — the block is the same shape either way — with a dash where the
+    figure would be, which in a column is what keeps it from reading as a rendering failure."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_overview(monkeypatch, {"grid": {"state": "running"}, "stats": {}, "nodes": [
+        {"name": "quiet-box", "online": True},
+    ]})
+    assert cli.main(["stats"]) == 0
+    lines = _lines(capsys)
+    values = _overview(lines)
+    assert _heading(lines) == "Grid Overview:"  # no span to name
+    assert values["uptime"] == "—" and values["memory"] == "—" and values["parallel"] == "—"
+    assert [values[key] for key in ("input", "cached", "output", "requests")] == ["—"] * 4
+
+
+def test_remote_stats_prefers_the_grids_own_rollup_over_summing_engines(monkeypatch, tmp_path, capsys):
+    """An engine is listed only while its heartbeat is live, and the relay's per-node rollup drops
+    rows it cannot attribute — so a summed total is quietly low by an amount that moves as machines
+    come and go. The grid's own figure is authoritative wherever it sends one."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_overview(monkeypatch, _OVERVIEW_STATS)
+    assert cli.main(["stats"]) == 0
+    # The one engine that answered reports 80K out; the grid says 90K. The grid's figure wins.
+    assert _overview(_lines(capsys))["output"] == "90K"
+
+
+def test_remote_stats_falls_back_to_the_engine_sum_when_the_grid_sends_no_rollup(
+    monkeypatch, tmp_path, capsys
+):
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_overview(monkeypatch, {k: v for k, v in _OVERVIEW_STATS.items() if k != "answered"})
+    assert cli.main(["stats"]) == 0
+    lines = _lines(capsys)
+    assert _overview(lines)["output"] == "80K" and _overview(lines)["requests"] == "300"
+    assert _heading(lines) == "24h Grid Overview:"  # span taken from the engines, not assumed
+
+
+def test_remote_stats_verbose_prints_a_card_per_engine(monkeypatch, tmp_path, capsys):
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_overview(monkeypatch, _OVERVIEW_STATS)
+    assert cli.main(["stats", "--verbose"]) == 0
+    out = capsys.readouterr().out
+    card = out.split("gpu-box\n", 1)[1]
+    assert "owner        ana@example.com" in card
+    assert "NVIDIA RTX 5090 ×2 · Linux" in card
+    assert "vllm · 16 parallel" in card
+    # The catalog's case, not the lowercased id the node advertises — a name copied off a card has
+    # to be one `grid chat -m` will answer to.
+    assert "models       GLM-5.2 (256K ctx)" in card
+    assert "VRAM         32/64 GB (50%) · 32 GB free" in card
+    assert "temperature  61°C" in card and "usage        55%" in card
+    assert "power        300W/600W" in card and "storage      450/900 GB (50%)" in card
+    assert "throughput   ~120 tok/s" in card
+    assert "tokens 24h   800K input · 200K cached · 80K output · 300 requests" in card
+    assert "asleep-box  (offline)" in out  # listed, and marked, rather than dropped
+    # The heading stands off the rollup on both sides — a `key=value` block running straight into a
+    # prose heading read as a fourteenth key rather than as the start of a new section.
+    assert "\nrequests  400\n\nTop 20 nodes:\n\n" in out
+
+
+def test_remote_stats_verbose_caps_the_node_list_and_keeps_the_strongest(monkeypatch, tmp_path, capsys):
+    """A card is eleven lines, so an uncapped list would scroll the rollup — the part every run is
+    read for — off the screen. Sorted strongest-first, the cap drops the tail rather than an
+    arbitrary slice, and the `nodes=` line still states how many there really are."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_overview(monkeypatch, {"grid": {"state": "running"}, "stats": {}, "nodes": [
+        {"name": f"box-{i:02d}", "vram_gb": float(i), "online": True} for i in range(1, 26)
+    ]})
+    assert cli.main(["stats", "--verbose"]) == 0
+    out = capsys.readouterr().out
+    headers = [ln for ln in out.splitlines() if ln.startswith("box-")]
+    assert _overview(out.splitlines())["nodes"] == "25"  # the real count is never hidden
+    assert "Top 20 nodes:" in out
+    assert len(headers) == 20
+    assert headers[0] == "box-25" and headers[-1] == "box-06"  # biggest kept, smallest dropped
+    assert "box-05" not in out and "box-01" not in out
+
+
+def test_remote_stats_json_is_never_capped(monkeypatch, tmp_path, capsys):
+    """The cap is a reading aid, not a filter. A script asking for the fleet must get the fleet."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_overview(monkeypatch, {"grid": {"state": "running"}, "stats": {}, "nodes": [
+        {"name": f"box-{i:02d}", "vram_gb": float(i), "online": True} for i in range(1, 26)
+    ]})
+    assert cli.main(["stats", "--verbose", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert len(payload["engines"]) == 25 and payload["engines_online"] == 25
+
+
+def test_remote_stats_verbose_keeps_a_measured_zero_apart_from_an_unmeasured_reading(
+    monkeypatch, tmp_path, capsys
+):
+    """The Mac reports memory and speed but no temperature or power — macOS exposes neither outside a
+    root `powermetrics` — while its token figures are real zeros the relay did measure. A `0` in the
+    first pair would libel a working machine; a `—` in the second would hide a true fact."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_overview(monkeypatch, _OVERVIEW_STATS)
+    assert cli.main(["stats", "--verbose"]) == 0
+    card = capsys.readouterr().out.split("mac-studio\n", 1)[1].split("\n\n", 1)[0]
+    assert "temperature  —" in card and "power        —" in card and "usage        —" in card
+    assert "tokens 24h   0 input · 0 cached · 0 output · 0 requests" in card
+    assert "RAM          48/192 GB (25%)" in card  # unified memory is RAM, not VRAM
+
+
+def test_remote_stats_json_carries_the_engines_whether_verbose_or_not(monkeypatch, tmp_path, capsys):
+    """`--verbose` must not change the machine-readable shape, or every script would depend on how
+    it was invoked."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_overview(monkeypatch, _OVERVIEW_STATS)
+    assert cli.main(["stats", "--json"]) == 0
+    plain = json.loads(capsys.readouterr().out)
+    _mock_overview(monkeypatch, _OVERVIEW_STATS)
+    assert cli.main(["stats", "--verbose", "--json"]) == 0
+    assert json.loads(capsys.readouterr().out) == plain
+
+    assert plain["grid"] == "team" and plain["engines_online"] == 3 and plain["engines_total"] == 4
+    assert plain["memory_gb"] == 256.0 and plain["memory_used_gb"] == 80.0
+    assert plain["memory_used_pct"] == 31.2 and "throughput_tok_s" not in plain
+    assert next(e for e in plain["engines"] if e["engine"] == "gpu-box")["throughput_tok_s"] == 120.0
+    assert plain["answered"]["tokens_in"] == 1_200_000  # the relay's own name keeps its own meaning
+    assert plain["answered"]["tokens_in_fresh"] == 1_000_000
+    seat = next(e for e in plain["engines"] if e["engine"] == "codex-seat")
+    assert seat["plan_type"] == "pro" and seat["memory_gb"] is None  # a plan, not memory
+
+
+# -- `grid usage` ----------------------------------------------------------
+
+def test_remote_usage_by_model_ranks_by_output_and_counts_serving_engines(
+    monkeypatch, tmp_path, capsys
+):
+    """Ordered by what each model did, not by catalog order — the position itself carries
+    information. A model the grid lists but nothing answered on keeps its row, unmeasured."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_overview(monkeypatch, _OVERVIEW_STATS)
+    assert cli.main(["usage"]) == 0
+    lines = _lines(capsys)
+    header = next(ln for ln in lines if ln.startswith("MODEL"))
+    rows = [ln for ln in lines[lines.index(header) + 1:] if ln.strip()]
+    assert header.split() == ["MODEL", "INPUT", "CACHED", "OUTPUT", "REQUESTS", "SHARE", "ENGINES"]
+    # Catalog casing is what prints, though the node advertises `glm-5.2` — matched case-insensitively.
+    assert rows[0].split() == ["GLM-5.2", "800K", "200K", "80K", "300", "89%", "1"]
+    # A real zero, not a dash: the grid's rollup landed, so "nobody used this model today" is a
+    # measured fact — see the third branch in `model_rows`.
+    assert rows[1].split() == ["Qwen-3", "0", "0", "0", "0", "0%", "1"]
+
+
+def test_remote_usage_by_model_stays_unmeasured_when_nothing_measured_the_grid(
+    monkeypatch, tmp_path, capsys
+):
+    """The other side of the same rule. An older master computes no rollup at all, and printing
+    `0 requests` against every model on such a grid would report a busy fleet as dead — so with
+    nothing measured anywhere the rows stay silent rather than claiming an idle day."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_overview(monkeypatch, {
+        "models": [{"id": "GLM-5.2"}],
+        "nodes": [{"name": "old-box", "models": ["glm-5.2"], "online": True}],
+    })
+    assert cli.main(["usage"]) == 0
+    lines = _lines(capsys)
+    row = next(ln for ln in lines if ln.startswith("GLM-5.2"))
+    assert row.split() == ["GLM-5.2", "—", "—", "—", "—", "—", "1"]
+
+
+def test_remote_usage_by_model_keeps_a_model_the_catalog_no_longer_lists(monkeypatch, tmp_path, capsys):
+    """Work that happened is printed whatever the catalog says now — dropping it would leave the
+    column adding up to less than its own header with nothing to show why."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_overview(monkeypatch, {**_OVERVIEW_STATS, "models": []})
+    assert cli.main(["usage"]) == 0
+    assert any(ln.startswith("glm-5.2 ") for ln in _lines(capsys))
+
+
+def test_remote_usage_by_engine_lists_every_engine_busiest_first(monkeypatch, tmp_path, capsys):
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_overview(monkeypatch, _OVERVIEW_STATS)
+    assert cli.main(["usage", "--by", "engine"]) == 0
+    lines = _lines(capsys)
+    rows = [ln.split() for ln in lines[lines.index(next(ln for ln in lines if ln.startswith("ENGINE"))) + 1:]
+            if ln.strip()]
+    assert rows[0] == ["gpu-box", "800K", "200K", "80K", "300"]
+    assert ["mac-studio", "0", "0", "0", "0"] in rows       # measured, and idle
+    assert ["codex-seat", "—", "—", "—", "—"] in rows       # never measured
+
+
+def test_remote_usage_by_member_merges_the_roster_and_ranks_by_fresh_input(
+    monkeypatch, tmp_path, capsys
+):
+    """The roster decides who is listed, the usage decides the order. Someone who has never sent a
+    request is still a member and keeps a row; someone the relay counted but the roster has since
+    dropped is not one any more and must not reappear."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    seen = {}
+    _mock_member_usage(monkeypatch, {"window_seconds": 86400, "members": [
+        {"email": "Ana@example.com", "requests": 12, "tokens_in": 900_000,
+         "tokens_cached": 400_000, "tokens_out": 5_000},
+        {"email": "bo@example.com", "requests": 3, "tokens_in": 100_000,
+         "tokens_cached": 10_000, "tokens_out": 900},
+    ]}, seen=seen)
+    _mock_members(monkeypatch, members=[
+        {"email": "ana@example.com", "roles": ["admin"]},
+        {"email": "bo@example.com", "roles": ["both"]},
+        {"email": "cy@example.com", "roles": ["consumer"]},
+    ])
+    assert cli.main(["usage", "--by", "member"]) == 0
+    lines = _lines(capsys)
+    rows = [ln.split() for ln in lines[lines.index(next(ln for ln in lines if ln.startswith("MEMBER"))) + 1:]
+            if ln.strip()]
+    assert "/relay/v1/grid/members/usage" in seen["paths"]
+    assert seen["auth"] == "Bearer AT"  # this one names people, so it is authenticated
+    # 500K fresh (900K read − 400K cached) beats 90K; the member with no figure sorts last. The
+    # roster is what puts `cy` on the list at all — what each of them may *do* is `grid members list`.
+    assert rows[0] == ["Ana@example.com", "500K", "400K", "5K", "12"]
+    assert rows[1] == ["bo@example.com", "90K", "10K", "900", "3"]
+    assert rows[2] == ["cy@example.com", "—", "—", "—", "—"]
+
+
+def test_remote_usage_by_member_matches_the_roster_case_insensitively(monkeypatch, tmp_path, capsys):
+    """The control plane stores what the user typed and the relay what the token carried, so an
+    address differing only in case would list one person twice — once busy, once as never having
+    sent a request."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_member_usage(monkeypatch, {"window_seconds": 86400, "members": [
+        {"email": "Ana@Example.com", "requests": 1, "tokens_in": 10, "tokens_out": 2},
+    ]})
+    _mock_members(monkeypatch, members=[{"email": "ana@example.com", "roles": ["both"]}])
+    assert cli.main(["usage", "--by", "member"]) == 0
+    assert len([ln for ln in _lines(capsys) if "ana@example.com" in ln.lower()]) == 1
+
+
+def test_remote_usage_by_member_degrades_when_the_roster_is_owner_only(
+    monkeypatch, tmp_path, capsys
+):
+    """A member gets a 403 from the owner-only roster. Usage the relay *did* report is still worth
+    printing, so the table stands and the caveat goes to stderr — stdout stays a clean table."""
+    from remote import control_plane
+
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_member_usage(monkeypatch, {"window_seconds": 86400, "members": [
+        {"email": "ana@example.com", "requests": 12, "tokens_in": 900_000, "tokens_out": 5_000},
+    ]})
+
+    def _refuse(session_token, network_id, api_url=None):
+        raise control_plane.ControlPlaneError("forbidden", status=403)
+
+    monkeypatch.setattr(control_plane, "list_members", _refuse)
+    assert cli.main(["usage", "--by", "member"]) == 0
+    captured = capsys.readouterr()
+    assert "ana@example.com" in captured.out
+    assert "only the grid owner can list members" in captured.err.lower()
+
+
+def test_remote_usage_by_member_reports_no_rollup_rather_than_zeros(monkeypatch, tmp_path, capsys):
+    """404 is a master that predates the endpoint — the common case mid-rollout — and 401/403 is a
+    caller who may not ask. Neither is a fact about how much anyone used, so neither may print as a
+    figure; the roster still gets its rows, unmeasured."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_member_usage(monkeypatch, {"detail": "not found"}, status=404)
+    _mock_members(monkeypatch, members=[{"email": "ana@example.com", "roles": ["both"]}])
+    assert cli.main(["usage", "--by", "member"]) == 0
+    captured = capsys.readouterr()
+    assert "ana@example.com" in captured.out and "—" in captured.out
+    assert "reports no member usage" in captured.err
+
+
+def test_remote_usage_totals_are_the_grids_own_in_every_dimension(monkeypatch, tmp_path, capsys):
+    """One grid, one window, one set of totals — whichever way the rows are split. Summing the rows
+    instead would make `--by member` and `grid stats` print two different figures for one grid."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    totals = {}
+    for dimension in ("model", "engine"):
+        _mock_overview(monkeypatch, _OVERVIEW_STATS)
+        assert cli.main(["usage", "--by", dimension]) == 0
+        totals[dimension] = _overview(_lines(capsys))
+    _mock_member_usage(monkeypatch, {"window_seconds": 86400, "members": []})
+    _mock_members(monkeypatch, members=[])
+    assert cli.main(["usage", "--by", "member"]) == 0
+    totals["member"] = _overview(_lines(capsys))
+    assert len({tuple(sorted(v.items())) for v in totals.values()}) == 1
+    assert totals["model"]["input"] == "1M" and totals["model"]["output"] == "90K"
+
+
+def test_remote_usage_json_carries_the_raw_and_the_fresh_input(monkeypatch, tmp_path, capsys):
+    """`tokens_in` keeps the relay's own meaning (cached included) so nothing on the wire is
+    redefined; `tokens_in_fresh` is the leg the human table prints."""
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_overview(monkeypatch, _OVERVIEW_STATS)
+    assert cli.main(["usage", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["by"] == "model" and payload["window_seconds"] == 86400
+    assert payload["totals"] == {
+        "tokens_in": 1_200_000, "tokens_in_fresh": 1_000_000, "tokens_cached": 200_000,
+        "tokens_out": 90_000, "requests": 400,
+    }
+    served, idle = payload["rows"][0], payload["rows"][1]
+    assert served["model"] == "GLM-5.2" and served["engines"] == 1 and served["measured"] is True
+    assert idle["model"] == "Qwen-3" and idle["measured"] is True and idle["tokens_out"] == 0
+
+
+def test_remote_usage_rejects_an_unknown_dimension(monkeypatch, tmp_path):
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    with pytest.raises(SystemExit):
+        cli.main(["usage", "--by", "planet"])
+
+
+def test_remote_stats_requires_a_started_grid(monkeypatch, tmp_path):
+    """A stopped grid has no relay to read, and the message points at the lifecycle verb that fixes
+    it — `grid start`, which replaced `grid up`."""
+    _seed_remote(monkeypatch, tmp_path,
+                networks=[{"network_id": "n1", "name": "team", "access_token": "AT"}], active="team")
+    _mock_lifecycle(monkeypatch, status={"state": "stopped"})
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["stats"])
+    assert "grid start" in str(exc.value).lower()
+
+
+def test_remote_stats_works_without_an_access_token(monkeypatch, tmp_path, capsys):
+    """The overview route is public, so the rollup must read before `grid sync` stores a token."""
+    _seed_remote(monkeypatch, tmp_path,
+                networks=[{"network_id": "n1", "name": "team"}], active="team")  # no access_token
+    _mock_lifecycle(monkeypatch, status={"state": "running", "signaling_url": "https://relay.example"})
+    _mock_overview(monkeypatch, _OVERVIEW_STATS)
+    assert cli.main(["stats"]) == 0
+    assert _overview(_lines(capsys))["nodes"] == "3"
+
+
+def test_remote_usage_by_member_needs_the_grids_own_token(monkeypatch, tmp_path):
+    """Unlike the overview beside it, this endpoint names people — so a grid whose token has not
+    been synced gets the familiar `grid login` guidance rather than an opaque 401."""
+    _seed_remote(monkeypatch, tmp_path,
+                networks=[{"network_id": "n1", "name": "team"}], active="team")  # no access_token
+    _mock_lifecycle(monkeypatch, status={"state": "running", "signaling_url": "https://relay.example"})
+    _mock_overview(monkeypatch, _OVERVIEW_STATS)
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["usage", "--by", "member"])
+    assert "grid login" in str(exc.value)
+
+
+def test_relay_client_omits_the_bearer_when_there_is_no_token():
+    """`Bearer ` with nothing after it is not a legal header value: h11 refuses to write it, so a
+    public read on a tokenless grid died as `Illegal header value` before leaving the machine. The
+    header is omitted instead — which MockTransport cannot catch, hence this direct check."""
+    from remote import relay
+
+    with relay.open_consumer_client("https://relay.example", "", timeout=1.0) as client:
+        assert "authorization" not in client.headers
+    with relay.open_consumer_client("https://relay.example", "AT", timeout=1.0) as client:
+        assert client.headers["authorization"] == "Bearer AT"
+
+
+# -- the shared formatters (cli/_format.py) --------------------------------
+
+def test_format_count_steps_units_before_a_four_digit_figure_appears():
+    """`1000K` and `1285M` are the same numbers as `1M` and `1.3B` but read as a unit that was never
+    carried — the one thing a shortened figure must not do. The step is at 999.5, before the
+    rounding below it could expose one."""
+    from cli import _format
+
+    assert [_format.count(n) for n in (0, 940, 999, 1000, 12_345)] == ["0", "940", "999", "1K", "12.3K"]
+    assert [_format.count(n) for n in (999_499, 999_500)] == ["999K", "1M"]
+    assert [_format.count(n) for n in (1_000_000, 1_285_402_913)] == ["1M", "1.3B"]
+
+
+def test_format_memory_share_writes_one_unit_chosen_from_the_total():
+    """Two figures either side of a slash are being compared, and a comparison written in two units
+    is a puzzle — so the unit is the total's, written once."""
+    from cli import _format
+
+    assert _format.memory_share(950.6, 1404.3) == "0.9/1.4 TB"   # a terabyte grid, both halves in TB
+    assert _format.memory_share(276.9, 382.4) == "277/382 GB"    # three digits: the tenth is noise
+    assert _format.memory_share(31.8, 63.7) == "31.8/63.7 GB"    # under 100 the decimal is a 20th
+
+
+def test_format_share_never_rounds_a_working_model_to_nothing():
+    """A model at 0.4% of the grid rounding to `0%` reads as "did nothing" against a row plainly
+    showing tokens."""
+    from cli import _format
+
+    assert [_format.share(f) for f in (0.98, 0.0145, 0.004, 0.0004, 0.0)] == \
+        ["98%", "1.5%", "0.4%", "<0.1%", "0%"]
+
+
+def test_format_window_says_the_span_the_relay_actually_reported():
+    """The window is an operator knob; a label hardcoded to 24h would go quietly wrong the moment
+    someone retuned it. A day stays "24h" — that is how people talk about what a machine did today."""
+    from cli import _format
+
+    assert [_format.window(s) for s in (86400, 172800, 604800, 21600, 1800, 45, 0)] == \
+        ["24h", "2d", "7d", "6h", "30m", "45s", ""]
+
+
+# ---------------------------------------------------------------------------
 # Remote membership — `grid members add|remove|list` (cli/remote_grid.py + control_plane)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Support 2 new commands:

    grid stats [grid] [--verbose] [--json]
    grid usage [grid] [--by model|member|engine] [--json]

`stats` prints the grid at a glance under a span-qualified heading, and with `--verbose` a card per machine — owner, hardware, models and their context windows, memory and headroom, temperature, utilisation, power, disk, speed, and its own share of the window's tokens. The card list stops at the 20 strongest; `nodes=` states the real count and `--json` is never capped.

Three rules are ported field-for-field from the app rather than paraphrased, because each is invisible when it breaks — a wrong figure, not an error:

- Absent is not zero. A relay too old to compute a rollup sends no `answered` object at all, and a `0` there would report a busy fleet as dead. Unmeasured reads `—`; a measured idle reads `0`.
- Cached input is part of input, never additional to it. Settlement bills `(in − cached)·input + cached·cache + out·output`, so the `input` printed is the fresh leg and the three legs add up. `--json` carries the relay's raw `tokens_in` beside `tokens_in_fresh`, so no wire name is redefined.
- A subscription seat brings a plan, not memory. Its host's RAM never runs a model for the grid, so it stays out of the pool.

The rounding rules (`cli/_format.py`) are the app's own, for the same reason: a grid whose panel says "0.9 / 1.4 TB" and whose terminal says something else is a bug the eye catches immediately. The span in the heading is likewise the relay's own `window_seconds`, never the literal "24h" — the window is an operator knob, and with no `window` row under it that heading is the only thing saying what the token figures cover.

Purely additive: no existing command, output or JSON shape changes.


Claude-Session: https://claude.ai/code/session_01CrAMJRVgirHN246sanb7BJ