### PR TITLE
feat: grid mcp config points a coding agent's harness at the grid's web tools

### DIFF
--- a/cli/dispatch.py
+++ b/cli/dispatch.py
@@ -138,6 +138,9 @@ REMOTE_ONLY: dict[str, str | None] = {
     # not the control plane's — and the repository they name is served by the relay's git plane. A
     # local grid has none of it.
     "project": None,
+    # The web-tools MCP server is the CONTROL PLANE's (ADR 0041), so this command needs an account
+    # and a per-grid token. A local grid has neither, and there is no local server to point at.
+    "mcp": None,
     # Two more whose reason is not sign-in: uptime, the memory pool, per-engine telemetry and the
     # answered-token rollup are all computed by the hosted relay. A local grid serves models and
     # keeps no such books, so there is nothing for a local handler to print — see cli/remote_stats.py.

--- a/cli/mcp_config.py
+++ b/cli/mcp_config.py
@@ -1,0 +1,99 @@
+"""`grid mcp config` / `grid mcp token` — pointing a coding agent's harness at the grid's web tools.
+
+ADR 0041. The server is the control plane's (`/v1/grid/web-mcp`); this half exists so nobody has to
+open `~/.grid/credentials.toml` and pick a token out of it by hand. That file holds one bundle per
+grid, so "by hand" means choosing between them correctly, and teaching people to open their own
+credential store is a habit worth not starting.
+
+**Three harnesses, three spellings, one credential.** Measured 2026-09-07 against Claude Code 2.1.263
+and Codex 0.144.6, with a header-logging listener rather than vendor documentation:
+
+- Claude Code takes `--header` on `claude mcp add`, so it gets a command.
+- ⚠️ **Codex has no `--header` flag** — `codex mcp add` offers only `--bearer-token-env-var` and the
+  OAuth options. It nonetheless honours `http_headers` in `config.toml` (proven on the wire; `codex
+  mcp get` shows the field and masks its value, which it never does for a key it does not know), so
+  Codex gets a **block to paste**, not a command. An environment variable was rejected: a 365-day
+  credential in a shell is readable by every child process of that shell.
+- opencode takes `headers` in its JSON config.
+
+⚠️ **The URL carries its trailing slash.** Without it the mount answers **307**; Claude Code follows
+it, and nothing here should depend on every client doing the same.
+
+⚠️ `MOUNT_PATH` is hand-duplicated from grid-apis `web_mcp.MOUNT_PATH`. There is deliberately no
+discovery route — its own path would be the same constant one level down. Pinned by
+`tests/test_web_mcp_lockstep.py`, which skips unless grid-apis sits beside this worktree.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+
+# ↔ grid-apis `grid_networks/web_mcp.MOUNT_PATH`. Roll the CONTROL PLANE out before this CLI: a
+# `grid mcp config` against an older control plane prints a URL that answers a bare 404, which the
+# harness reports as a server it cannot reach.
+MOUNT_PATH = "/v1/grid/web-mcp"
+
+# What the tools are called in the harness's own listing — an agent sees `mcp__grid-web__web_search`.
+SERVER_NAME = "grid-web"
+
+
+def _session(args: argparse.Namespace) -> tuple[str, str, str]:
+    """`(url, token, label)` for the grid this command names, or a clean `SystemExit`.
+
+    Nothing here is a network call. The control-plane base comes from the same `credentials.api_url`
+    every other command uses, so a home signed in against dev prints a dev URL without being told.
+    """
+    from remote import credentials
+
+    from . import remote_grid
+
+    rec = remote_grid._select(getattr(args, "grid", None))
+    label = str(rec.get("name") or rec.get("network_id") or "?")
+    token = remote_grid.require_access_token(rec, label)
+    url = credentials.api_url().rstrip("/") + MOUNT_PATH + "/"
+    return url, token, label
+
+
+def cmd_mcp_token(args: argparse.Namespace) -> int:
+    """Print the grid's access token and nothing else, for a script that builds its own config."""
+    _url, token, _label = _session(args)
+    print(token)
+    return 0
+
+
+def cmd_mcp_config(args: argparse.Namespace) -> int:
+    """Print how to point each harness at this grid's web tools."""
+    url, token, label = _session(args)
+
+    if getattr(args, "json", False):
+        # The same three values, for something assembling a config itself. No postcondition to
+        # guard: this command reports what is already true locally and writes nothing.
+        print(json.dumps({"server": SERVER_NAME, "url": url, "authorization": f"Bearer {token}"},
+                         indent=2))
+        return 0
+
+    header = f"Authorization: Bearer {token}"
+    print(f"Web tools for grid {label}.\n")
+    print("Claude Code — run this:")
+    print(
+        f"  claude mcp add --transport http --scope user {SERVER_NAME} {shlex.quote(url)} "
+        f"--header {shlex.quote(header)}\n"
+    )
+    # `--scope user` on purpose: `--scope project` writes `.mcp.json`, which Claude Code holds for
+    # interactive approval — measured. Web search is not a per-repository capability anyway.
+    print("Codex — add this to ~/.codex/config.toml (it has no --header flag):")
+    print(f"  [mcp_servers.{SERVER_NAME.replace('-', '_')}]")
+    print(f'  url = "{url}"')
+    print(f'  http_headers = {{ Authorization = "Bearer {token}" }}\n')
+    print("opencode — add this to your opencode.json:")
+    print(json.dumps(
+        {"mcp": {SERVER_NAME: {"type": "remote", "url": url, "enabled": True,
+                               "headers": {"Authorization": f"Bearer {token}"}}}},
+        indent=2,
+    ))
+    print(
+        "\nThis prints your grid's access token. Anyone who has it can search the web on your "
+        "account's allowance."
+    )
+    return 0

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -37,6 +37,7 @@ from .grid import (
 )
 from .credential import cmd_credential
 from .launch import cmd_launch
+from .mcp_config import cmd_mcp_config, cmd_mcp_token
 from .mode import cmd_mode, cmd_use
 from .models import cmd_catalog, cmd_ctx, cmd_pull, cmd_rm
 from . import project_arg
@@ -114,6 +115,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_router(sub)
     _add_engine_setup(sub)
     _add_launch(sub)
+    _add_mcp(sub)
     _add_train(sub)
     _add_credential(sub)
     _add_stt(sub)
@@ -1619,6 +1621,35 @@ def _add_launch(sub) -> None:
     # two positionals above). The default is what makes `grid launch claude --`, with nothing after
     # it, identical to no `--` at all.
     launch.set_defaults(handler=cmd_launch, forward=())
+
+
+def _add_mcp(sub) -> None:
+    """`grid mcp config|token` — point a coding agent's harness at this grid's web tools (ADR 0041).
+
+    Nested subcommands rather than one positional with `choices=`: `grid mcp myteam` would otherwise
+    be an "invalid choice" error about a word the user meant as a grid name.
+    """
+    mcp = sub.add_parser(
+        "mcp",
+        help="Point Claude Code / Codex / opencode at this grid's web tools",
+        description=(
+            "Print the MCP configuration a coding agent's harness needs to search and read the\n"
+            "web through your grid. The server runs on the control plane, so it keeps working\n"
+            "whether or not the grid itself is up."),
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    mcp_sub = mcp.add_subparsers(dest="mcp_command", required=True)
+
+    config = mcp_sub.add_parser(
+        "config", help="Print the config for each harness (prints your grid's access token)")
+    config.add_argument("grid", nargs="?", default=None,
+                        help="Grid name or id (ag-...). Omit for the active grid.")
+    config.set_defaults(handler=cmd_mcp_config)
+
+    token = mcp_sub.add_parser(
+        "token", help="Print just the access token, for a script that builds its own config")
+    token.add_argument("grid", nargs="?", default=None,
+                       help="Grid name or id (ag-...). Omit for the active grid.")
+    token.set_defaults(handler=cmd_mcp_token)
 
 
 def _add_train(sub) -> None:

--- a/docs/adr/0041-a-coding-agent-reaches-the-web-through-the-control-plane.md
+++ b/docs/adr/0041-a-coding-agent-reaches-the-web-through-the-control-plane.md
@@ -1,0 +1,192 @@
+---
+status: proposed
+---
+
+# A coding agent reaches the web through the control plane, and the relay is not in the path
+
+ADR 0036 put a web search behind the control plane and gave the agents *a grid drives* two scripts
+to run under their Bash tool. That serves the app, which spawns those agents itself and can set
+`GRID_RELAY_URL` + `GRID_RELAY_TOKEN` in their environment.
+
+It serves nothing else. The coding agents people actually run — Claude Code, Codex, opencode — are
+started by the person, not by the app, so nothing puts that pair in their environment; and they do
+not discover capability by reading a guide and shelling out. They discover it over **MCP**. So the
+grid's web access, which is already paid for and already metered, is invisible to every harness
+outside the app.
+
+The obvious implementation is to point an MCP server at the relay's `POST {RELAY_PATH}/web/search`,
+and it is wrong in three ways that only show up later:
+
+- **A relay is per-grid and is a machine that can be down.** An MCP server's URL goes into a config
+  file and stays there. Pointing it at one grid's relay makes web search stop working when that grid
+  stops — for a capability whose answers do not depend on the grid at all.
+- **The relay verifies, but it cannot be the thing a harness talks to.** It answers on the grid's own
+  address, which for a self-hosted grid is a LAN address the harness may not be able to reach.
+- **It buys nothing.** The relay's stated reason for standing in the path (0036 D-b) is *accounting* —
+  making a search attributable to a grid. That attribution survives without it: `network_id` is a
+  claim inside the per-grid access token, so the control plane can read it from the credential the
+  caller already presents.
+
+## Decision
+
+### D-a — The MCP server is the control plane's, and this deliberately overturns 0036 D-b for this caller
+
+`POST /v1/grid/web-mcp` is mounted in the control plane. The relay is **not** in the path.
+
+⚠️ **0036 D-b argues the opposite, and it is still right about the caller it was written for.** Its
+two reasons were attribution and *"per-grid policy has somewhere to live the day it is wanted"*. The
+first is kept — `network_id` rides the token. The second is genuinely **given up on this path**: a
+policy keyed on a grid would have to be enforced in the control plane against the token's claim
+rather than by the grid's own relay. That is the price, it is paid knowingly, and it buys a
+capability that works when the grid is asleep and from a harness that cannot reach a LAN address.
+
+Anyone reading 0036 alone will see an inconsistency and be tempted to route this through the relay
+"for consistency". That change would re-introduce every problem in the section above. This decision
+is the reason not to make it.
+
+### D-b — The credential is the per-grid access token, verified in FULL — and `verify_access_token` is not full
+
+The caller presents `Authorization: Bearer <per-grid access token>` — the RS256 / 365-day token in
+`~/.grid/credentials.toml`, the same one the app hands its own agents. Not the session token: it is
+24 hours, which would mean re-pasting a config every day.
+
+⚠️ **`tokens.verify_access_token` checks signature, `iss`, `aud`, `exp` and scope, and nothing else.**
+It does not read the member row, and it does not compare `member_epoch` or `network_epoch`. In the
+control plane it has exactly one existing caller (the sync snapshot). The checks it is missing are
+not missing by accident — they are the **relay's**, at `grid_auth.py`, and taking the relay out of
+the path takes them out with it.
+
+⚠️ **The missing checks must NOT be copied from the relay.** The relay's are network-type-dependent
+policy — `_requires_allowlist`, `_is_open_consumer`, `DENYLIST_NETWORK_TYPES` — three functions whose
+own comments say that copying one into the other is the failure they exist to prevent. Duplicating
+that trio into the control plane would create a brand-new hand-maintained policy surface between two
+repositories, for a decision the control plane already owns.
+
+Instead this path asks the control plane's **own** authority: `store.member_for_access(network_id,
+email, google_sub)` — the single function every one of the four `issue_access_token` call sites
+consults to decide whether this account may hold a token on this grid *at all*. It already handles
+network status, `member.status`, the owner-without-an-active-row arm, permissionless access,
+domain-restricted admission, and the denylist with the correct per-type cohort. `None` means refuse.
+
+So the check is: verify the signature → `member_for_access` → compare `member_epoch` and
+`network_epoch`, `<` and never `!=`. Nothing about it is a copy, and it can never be stricter or
+looser than the rule that minted the token, because it *is* that rule.
+
+Without it, somebody removed from every grid keeps a working credential for **365 days**. The harm
+is bounded — a web search is free to the member and the allowance is keyed on the account, so they
+spend only their own — but it is the operator's vendor bill, and nothing anywhere reports it.
+⚠️ Removal already bumps `member_epoch` (`store.remove_member`), so the epoch comparison catches it
+even where the row survives as `inactive`; the two checks overlap on purpose.
+
+**No scope is required.** A web search is free to the member (0036 D-c), so every role including
+`consumer` may make one. A new `web:search` scope was rejected outright: `role_scopes()` would have
+to change and **every token in circulation lacks it**, so the day it shipped every existing user
+would be refused with a valid token — a breaking change that verifies, then fails.
+
+### D-c — One gate, at the ASGI layer, and its 401 body is text a person reads
+
+The bearer gate refuses before MCP sees the request. **It is the only credential check, and a
+second one inside each tool was considered and dropped**: the server is stateless, so every
+`tools/call` carries its own header and runs the gate again — an in-tool re-verification would
+re-derive, from the same bytes in the same request, an answer the gate reached microseconds earlier.
+That is not defence in depth, it is a second copy of the rule for the next person to fix only one of.
+
+What the tools *do* check is that a verified caller is present at all (`current_caller`). That fires
+only when the gate is not in front of them — a wiring fault — and it raises rather than falling back
+to an anonymous identity, because the fallback would go on to write a ledger row belonging to nobody.
+
+So the 401 body carries the whole of the user-facing message. Measured: Claude Code reports
+*"Server rejected the configured Authorization header (HTTP 401)"* **and prints the server's own JSON
+body alongside it**. That makes the body the one place a person is told what to do, so it names
+`grid mcp config <grid>` rather than the `{"error": "unauthorized"}` the analytics server answers a
+trusted bot with.
+
+⚠️ **The body must never say *why*.** "You were removed from that grid" and "your token expired" are
+deliberately the same sentence: anyone holding any string can read this reply, and a refusal that
+distinguishes them is an oracle for which credentials are real.
+
+Identity travels from the gate to the tools through a `contextvar`, not an SDK request object: the
+tool functions never see a request, and a `contextvar` is the one mechanism that cannot break under
+an SDK upgrade. ⚠️ If it breaks, a search still returns results and only the **ledger** is wrong —
+so the test for it asserts on the row, never on the reply.
+
+### D-d — Every harness takes a literal `Authorization` header; the token never goes in an environment variable
+
+Measured on the wire 2026-09-07 — Claude Code 2.1.263 and Codex 0.144.6 — against a header-logging
+listener, not read off vendor documentation:
+
+| harness | where the header goes |
+|---|---|
+| Claude Code | `claude mcp add --transport http … --header "Authorization: Bearer <tok>"` |
+| Codex | `http_headers = { Authorization = "Bearer <tok>" }` under `[mcp_servers.<n>]` |
+| opencode | `"headers": {"Authorization": "Bearer <tok>"}`, `type: "remote"` |
+
+⚠️ **Codex's `mcp add` flags hide the field that works.** It offers only `--bearer-token-env-var`
+and the OAuth flags; there is no `--header`. `http_headers` is nonetheless a first-class field —
+`codex mcp get` displays it and *masks the value*, which it never does for a key it does not know —
+and it is sent on every request. `codex mcp add` simply cannot write it, so `grid mcp config` prints
+a TOML block for Codex rather than a command.
+
+An environment variable was the first plan and is now explicitly rejected. `env_http_headers` and
+`bearer_token_env_var` both work, but a long-lived credential in a shell environment is readable by
+every child process of that shell — the hazard the app's own `dropEnvironment` exists to prevent —
+and it buys nothing once a literal header is available everywhere.
+
+⚠️ Two traps for anyone who does reach for the env-var forms: `env_http_headers` holds the **whole
+header value** (`"Bearer <tok>"`) while `bearer_token_env_var` holds a **bare token**, and
+`bearer_token_env_var` sends no header at all during OAuth discovery. Confusing them is a silent 401.
+⚠️ And `codex mcp` **refuses** `--strict-config`; on other subcommands it does not validate keys
+inside `mcp_servers` at all, so a misspelled field there is dropped in silence.
+
+The whole loop was then run against a locally-hosted control plane with a genuinely minted RS256
+per-grid token, rather than asserted: `grid mcp config`'s **printed** Claude Code command, executed
+verbatim, reports `✔ Connected`; its **printed** Codex block, pasted verbatim, is read back with the
+header masked and reaches the server with **no 401** (a 406 on the discovery `GET`, which is content
+negotiation and proves the credential arrived); both tools answer, and the ledger rows land under the
+caller's own `google_sub` and `network_id`. A wrong token is reported by Claude Code with this
+server's own `detail` sentence printed to the user — which is the whole of D-c, observed rather than
+assumed.
+
+### D-e — Its own mount, its own flag, and it never touches the analytics server
+
+`/v1/grid/web-mcp` is a second `FastMCP` instance with its own `GRID_WEB_MCP_ENABLED`, mounted
+beside `/v1/grid/mcp` and sharing no code path with it beyond the shape.
+
+They must not share a switch. The analytics server's tools run read-only SQL against the
+control-plane database and fan out over **every** network's database; it is gated by a single shared
+secret because its caller is a trusted internal bot. Web tools are for end users. One flag turning
+both on is one operator mistake away from exposing the first to the second's audience.
+
+The transport settings are copied verbatim because they are load-bearing and already proven in
+production: `stateless_http=True`, `json_response=True` (no long-lived SSE stream for Cloudflare to
+idle-close) and DNS-rebinding protection off (the app sees the proxied `Host`). Measured against the
+dev control plane through Cloudflare: `initialize` answers **200 in 72 ms**, and `tools/list`
+succeeds immediately afterwards **with no session id**, which is what stateless means in practice.
+
+⚠️ A mount does **not** appear in `openapi.json`. The house recipe for proving a deploy — grepping
+the OpenAPI paths — silently proves nothing here; probe the endpoint itself.
+⚠️ A request to `/v1/grid/web-mcp` without the trailing slash answers **307**. Clients that follow
+it are fine (Claude Code does, measured), but every URL this repo prints carries the slash.
+
+### D-f — Two tools, and the read takes a list
+
+`web_search(query, num_results)` and `web_read(urls, max_chars)` — one per existing control-plane
+route, so `web_search.search()` / `contents()`, `_allowance_refusal` and `_record_web_search` are
+reused unchanged and no new vendor code is written. Exa's other endpoints (`find_similar`, `answer`,
+`research`) are each new vendor code, new cost parsing and, for `research`, a different cost model
+entirely; they are a separate feature, not a bigger tool list.
+
+`web_read` keeps the wire's list rather than the app script's single URL. **The allowance counts
+ledger rows, not pages**, so reading five pages in one call costs one unit where five calls cost
+five — and comparing sources is the ordinary case for a coding agent.
+
+Each page's text is truncated at `max_chars`, default **6000**, matching the app's `read.py`. A tool
+result goes straight into the model's context, where a script's stdout did not.
+
+### D-g — A per-account rate limit, because taking the relay out took one away
+
+A `SlidingWindowLimiter` keyed on `google_sub`. The daily allowance bounds the *day*; nothing bounds
+a minute, and Exa's `/search` is capped at ten queries per second across the whole fleet — so one
+client in a retry loop makes every other user's search fail. The relay was absorbing that shape.
+Per-process and therefore `limit × workers`, which is right for a stuck client and, as
+`ratelimit.py` says of itself, would not be right as an abuse control.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -865,6 +865,45 @@ Step by step: [Claude Code quickstart](./claude-code-quickstart.md) ·
 [ADR 0028](./adr/0028-launch-hands-an-app-the-grid.md) ·
 [ADR 0029](./adr/0029-the-credential-is-checked-before-it-is-handed-over.md).
 
+## Web tools over MCP
+
+```
+grid mcp config [grid]     # print the config each harness needs (prints your access token)
+grid mcp token  [grid]     # print just the access token, for a script that builds its own config
+```
+
+`grid mcp config` points a **coding agent's harness** — Claude Code, Codex, opencode — at your grid's
+web search and page reading. It prints a configuration; it changes nothing on your machine and makes
+no network call.
+
+The server itself runs on the control plane, not on your grid's relay, so it keeps answering whether
+or not the grid is up (ADR 0041). What the harness gets is two tools:
+
+- **`web_search(query, num_results)`** → `{title, url, excerpt}` per result.
+- **`web_read(urls, max_chars)`** → the main text of up to five pages, each truncated at
+  `max_chars` (default 6000). `status` says whether a page could be fetched at all — "the page
+  refused us" is not the same as "the page is empty".
+
+Both are free to you and bounded by your **account's** daily allowance, not the grid's — so being on
+several grids does not give you several allowances, and it is spent by whichever of your machines
+uses it.
+
+Each harness spells the credential differently, so the command prints all three:
+
+- **Claude Code** takes a command with `--header`.
+- **Codex** takes a config block. It has **no `--header` flag** on `codex mcp add`, so the block goes
+  into `~/.codex/config.toml` by hand; `http_headers` is what it honours.
+- **opencode** takes a `headers` object in `opencode.json`.
+
+> `grid mcp config` prints a live credential that lasts a year. Anyone who has it can search the web
+> on your account's allowance. Treat the output like a password, and re-run the command after
+> `grid login` if a harness starts reporting that the server refuses it.
+
+Web tools need a hosted grid: in local mode the command refuses, because the server it points at is
+the control plane's and a local grid has no account behind it.
+
+See [ADR 0041](./adr/0041-a-coding-agent-reaches-the-web-through-the-control-plane.md).
+
 ## Training
 
 ```

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -11601,6 +11601,9 @@ def test_local_gate_message_is_byte_for_byte_for_a_command_with_no_reason(monkey
         "router": ["router", "status"],
         "task": ["task", "get", "T1"],
         "project": ["project", "list"],
+        # ADR 0041. Gated for the ordinary reason: the web-tools MCP server is the control plane's
+        # and the credential is a per-grid access token, so there is nothing here without an account.
+        "mcp": ["mcp", "config"],
     }
     # A reason must be None or real text. An empty one would be masked by the `or` in ``local_stub``
     # *and* skipped by the `is None` filter below — the one state that is invisible in both

--- a/tests/test_mcp_config.py
+++ b/tests/test_mcp_config.py
@@ -1,0 +1,119 @@
+"""`grid mcp config` / `grid mcp token` — the harness-facing half of ADR 0041.
+
+The command reads only local state and prints. What is worth pinning is therefore not "does it run"
+but the three things that are wrong in a way nobody would notice:
+
+- **the URL keeps its trailing slash.** Without it the control-plane mount answers 307 (measured).
+- **the base is the signed-in control plane**, not a hardcoded production host — a home logged in
+  against dev must print a dev URL, or the config silently points at the wrong fleet.
+- **Codex gets a config BLOCK and not a command.** Measured on codex-cli 0.144.6: `codex mcp add`
+  has no `--header` flag, so a printed `codex mcp add … --header …` would be an invalid-argument
+  error in the user's terminal. This is the assertion that would catch somebody "tidying" the two
+  harnesses into one shape.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+import pytest
+
+from cli import mcp_config
+
+API_URL = "https://api-grid.example.invalid"
+TOKEN = "eyJ-a-per-grid-access-token"
+
+
+@pytest.fixture
+def signed_in(monkeypatch, tmp_path):
+    """One grid in the local store, signed in against a non-default control plane."""
+    from remote import credentials
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    credentials.save_credentials(
+        {
+            "session_token": "session",
+            "api_url": API_URL,
+            "networks": [
+                {
+                    "network_id": "ag-0000000000000001",
+                    "name": "team",
+                    "access_token": TOKEN,
+                    "lan_signaling_url": "https://relay.example.invalid",
+                }
+            ],
+        }
+    )
+    return argparse.Namespace(grid=None, json=False)
+
+
+def test_token_prints_the_access_token_and_nothing_else(signed_in, capsys):
+    assert mcp_config.cmd_mcp_token(signed_in) == 0
+    assert capsys.readouterr().out.strip() == TOKEN
+
+
+def test_config_url_is_the_signed_in_control_plane_with_a_trailing_slash(signed_in, capsys):
+    assert mcp_config.cmd_mcp_config(signed_in) == 0
+    out = capsys.readouterr().out
+    expected = f"{API_URL}{mcp_config.MOUNT_PATH}/"
+    assert expected in out
+    # The default production host must not appear: a home signed in against dev prints dev.
+    assert "api-grid.autonomous.ai" not in out
+
+
+def test_config_covers_all_three_harnesses_with_a_literal_header(signed_in, capsys):
+    assert mcp_config.cmd_mcp_config(signed_in) == 0
+    out = capsys.readouterr().out
+
+    assert "claude mcp add --transport http" in out
+    assert f"--header 'Authorization: Bearer {TOKEN}'" in out
+
+    # ⚠️ Codex takes a BLOCK, never a command — it has no --header flag (measured, 0.144.6).
+    assert "http_headers = { Authorization = " in out
+    assert "codex mcp add" not in out
+
+    assert '"type": "remote"' in out  # opencode
+    assert out.count(TOKEN) == 3  # one credential, three spellings
+
+
+def test_config_says_the_output_carries_a_credential(signed_in, capsys):
+    """The command prints a 365-day token to a terminal; somebody pasting it into an issue should
+    have been told what it is."""
+    mcp_config.cmd_mcp_config(signed_in)
+    assert "access token" in capsys.readouterr().out
+
+
+def test_config_json_is_a_machine_readable_triple(signed_in, capsys):
+    signed_in.json = True
+    assert mcp_config.cmd_mcp_config(signed_in) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {
+        "server": mcp_config.SERVER_NAME,
+        "url": f"{API_URL}{mcp_config.MOUNT_PATH}/",
+        "authorization": f"Bearer {TOKEN}",
+    }
+
+
+def test_a_grid_with_no_token_says_to_sign_in(monkeypatch, tmp_path):
+    """The familiar sentence, not an empty bearer pasted into a config that then 401s forever."""
+    from remote import credentials
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    credentials.save_credentials(
+        {
+            "session_token": "session",
+            "api_url": API_URL,
+            "networks": [{"network_id": "ag-0000000000000002", "name": "tokenless"}],
+        }
+    )
+    with pytest.raises(SystemExit) as refused:
+        mcp_config.cmd_mcp_config(argparse.Namespace(grid=None, json=False))
+    assert "grid login" in str(refused.value)
+
+
+def test_an_unknown_grid_name_is_refused(signed_in):
+    signed_in.grid = "no-such-grid"
+    with pytest.raises(SystemExit) as refused:
+        mcp_config.cmd_mcp_token(signed_in)
+    assert "no-such-grid" in str(refused.value)

--- a/tests/test_web_mcp_lockstep.py
+++ b/tests/test_web_mcp_lockstep.py
@@ -1,0 +1,117 @@
+"""The web-tools MCP path, pinned across the repository boundary (ADR 0041).
+
+`grid mcp config` prints a URL a person pastes into a harness config file, and the control plane
+serves that URL from a mount in `app.py`. There is no import path between the two repositories, so
+the path literal is hand-duplicated and kept in step by editing both sides — and by this test.
+
+**The failure is loud but late.** A path that drifts answers a bare 404, which the harness reports
+as a server it cannot reach — in the user's terminal, days after the deploy, and never in either
+suite. Both halves keep compiling and both suites stay green, which is the whole reason this file
+exists.
+
+⚠️ Per this repository's rule for every cross-repo assertion, the grid-apis cases **skip unless that
+worktree sits beside this one** — i.e. they skip in CI, and a green CI proves nothing about them.
+This CLI's own half is pinned unconditionally below, so the canonical path is asserted somewhere on
+every run whichever way round the halves land.
+
+Its own module rather than more of `tests/test_task_lease.py` for the reason
+`tests/test_harness_login_lockstep.py` gives: nothing here is about the task plane. It reads the
+sibling through `tests/grid_src_repo.py` like the other pins do.
+"""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from cli import mcp_config
+from tests.grid_src_repo import grid_apis_root
+
+#: The path, written out rather than imported from either side — a pin that reads one side's
+#: constant and compares it to itself checks nothing.
+CANONICAL_PATH = "/v1/grid/web-mcp"
+
+_APIS_MODULE = "grid_networks/web_mcp.py"
+_APIS_APP = "app.py"
+_MOUNT_CONST = "MOUNT_PATH"
+
+SKIP_NO_APIS = "the grid-apis worktree is not beside this one; the lockstep cannot be checked here"
+
+
+def _apis_source(relative: str) -> ast.Module:
+    """One of grid-apis' modules, parsed rather than imported: separate installs, no import path.
+
+    ⚠️ Only "no such repository at all" skips. The resolver has already proved a `grid_networks`
+    directory exists under that root, so a module missing from it was renamed or moved — which is
+    drift, and reporting it as "grid-apis is not beside this one" would turn the pin off with a
+    message blaming the wrong thing.
+    """
+    root = grid_apis_root()
+    if root is None:
+        pytest.skip(SKIP_NO_APIS)
+    source = root / relative
+    assert source.exists(), (
+        f"grid-apis has no {relative}. The web-tools MCP server moved or was renamed; "
+        f"this pin and `cli/mcp_config.py` both need updating."
+    )
+    return ast.parse(source.read_text(encoding="utf-8"))
+
+
+def _module_constant(tree: ast.Module, name: str) -> str:
+    for node in tree.body:
+        if isinstance(node, (ast.Assign, ast.AnnAssign)):
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            for target in targets:
+                if isinstance(target, ast.Name) and target.id == name:
+                    assert isinstance(node.value, ast.Constant), f"{name} is not a literal"
+                    return node.value.value
+    raise AssertionError(f"no module-level {name} found")
+
+
+def test_this_cli_prints_the_canonical_path():
+    """Unconditional: the half in this repository is pinned on every run, sibling or not."""
+    assert mcp_config.MOUNT_PATH == CANONICAL_PATH
+
+
+def test_the_control_plane_serves_the_path_this_cli_prints():
+    assert _module_constant(_apis_source(_APIS_MODULE), _MOUNT_CONST) == CANONICAL_PATH
+
+
+def test_the_mount_reads_the_constant_rather_than_a_literal():
+    """⚠️ The constant and the `app.py` mount are two places, and only one of them is pinned above.
+
+    A mount written as a bare string would let `MOUNT_PATH` be corrected while the server went on
+    answering somewhere else — this pin would pass and every harness would still 404. So the mount
+    must name the constant.
+    """
+    tree = _apis_source(_APIS_APP)
+    mounts = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "mount"
+        and node.args
+    ]
+    assert mounts, "grid-apis' app.py mounts nothing; the web-tools server is not wired"
+    web_mounts = [
+        call
+        for call in mounts
+        if isinstance(call.args[0], ast.Attribute) and call.args[0].attr == _MOUNT_CONST
+    ]
+    assert web_mounts, (
+        "no `app.mount(web_mcp.MOUNT_PATH, ...)` in grid-apis' app.py — the web-tools server is "
+        "either unmounted or mounted at a path literal that can drift from MOUNT_PATH."
+    )
+
+
+def test_the_printed_url_keeps_its_trailing_slash():
+    """⚠️ Measured: the mount answers **307** without it.
+
+    Claude Code follows that redirect and Codex was not tested on it, so the URL this CLI hands out
+    carries the slash rather than relying on every client to behave the same way. Asserted on the
+    string the command builds, not on the constant, because the slash is added at the join.
+    """
+    url = "https://api.example.invalid".rstrip("/") + mcp_config.MOUNT_PATH + "/"
+    assert url.endswith(CANONICAL_PATH + "/")


### PR DESCRIPTION
`grid mcp config [grid]` prints the MCP configuration Claude Code, Codex and opencode each need to
search and read the web through the grid; `grid mcp token` prints just the credential. Both read
local state only and make no network call.

The server they point at is the **control plane's**, not the grid's relay — so it answers whether or
not the grid is up, and from a machine that cannot reach a LAN address. That overturns ADR 0036 D-b
for this caller, which is why `docs/adr/0041-…` exists: without it the obvious "tidy this to go
through the relay like the app does" PR looks correct.

## Three harnesses, three spellings, measured on the wire

Claude Code 2.1.263 and Codex 0.144.6, against a header-logging listener rather than vendor docs:

- **Claude Code** takes `--header` on `claude mcp add`, so it gets a command. `--scope user`, because
  `--scope project` writes `.mcp.json` and waits for an interactive approval a printed command
  cannot give.
- **Codex has NO `--header` flag** — only `--bearer-token-env-var` and OAuth — but it *does* honour
  `http_headers` in `config.toml`, so it gets a block to paste. An environment variable was rejected:
  a 365-day credential in a shell is readable by every child process of that shell.
- **opencode** takes a `headers` object in its JSON config.

The URL keeps its trailing slash: without it the mount answers 307.

## Cross-repo

`MOUNT_PATH` is hand-duplicated from grid-apis and pinned by `tests/test_web_mcp_lockstep.py`, which
also refuses a mount written as a path *literal* — that would let the constant be corrected while the
server went on answering somewhere else. **Roll the control plane out before this CLI**: a drifted
path is a bare 404 the harness reports as a server it cannot reach, in the user's terminal, days
later, and in neither suite.

Server half: autonomous-ai/autonomous-grid-be `feat/web-tool-base-on-exa`.

## Test plan

- [x] `tests/test_mcp_config.py` (7) + `tests/test_web_mcp_lockstep.py` (4, **0 skipped** — ran
      against the sibling grid-apis worktree)
- [x] Full suite: **3447 passed**, 9 skipped
- [x] Mutation: path renamed on the control-plane side, and mount rewritten as a literal — each
      killed by its own test; restore green
- [x] Live on the deployed dev control plane: the command `grid mcp config` **prints**, run verbatim,
      gets real Claude Code to `✔ Connected` through Cloudflare; `web_search` and `web_read` answer
      from the real vendor; a bad token is reported to the user with this server's own sentence

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AkSRxxSVi97wtt7UpyU4br