### PR TITLE
docs(adr): 0041 said member_for_access was the whole rule; it is not

### DIFF
--- a/docs/adr/0041-a-coding-agent-reaches-the-web-through-the-control-plane.md
+++ b/docs/adr/0041-a-coding-agent-reaches-the-web-through-the-control-plane.md
@@ -69,8 +69,33 @@ network status, `member.status`, the owner-without-an-active-row arm, permission
 domain-restricted admission, and the denylist with the correct per-type cohort. `None` means refuse.
 
 So the check is: verify the signature → `member_for_access` → compare `member_epoch` and
-`network_epoch`, `<` and never `!=`. Nothing about it is a copy, and it can never be stricter or
-looser than the rule that minted the token, because it *is* that rule.
+`network_epoch`, `<` and never `!=`. Nothing about it is a copy.
+
+⚠️ **`member_for_access` alone is NOT equivalent to the rule that minted the token, and this
+decision originally said it was.** That sentence was wrong, and it was wrong in production: the
+function takes an `os_token` — the operating system a CLI claimed at sign-in — and on an
+`os-community` grid that argument is *the only thing* that admits anybody (ADR 0039 D-e).
+Membership there is not row-backed. Nothing stores the OS, no claim carries it, and an MCP caller
+is a harness that never had one, so the call answers `None` for **every OS grid** — which is the
+commonest kind, and includes the grid this was first tried on. Web tools were dead for all of them
+while every test passed.
+
+Where `member_for_access` answers `None`, the fallback is the control plane's own half of the
+cohort rule, `store.denylist_governs` — whose docstring already names grid-src's
+`_is_open_consumer` as the other half and says the two must agree. For a cohort the denylist
+governs, *being un-denied is the membership test*, which is exactly what the relay does with these
+tokens. Nothing is relaxed elsewhere: on every other type `member_for_access` returns `None` only
+when it means to refuse, and the denial check refuses those again. A member with no row also has no
+`member_epoch` to compare, so the network epoch is that cohort's only revocation lever — the same
+division grid-src makes.
+
+⚠️ Two things made this escape. The obvious one: no test used `os-community`. The subtler one, and
+the reason the first fix's tests *also* proved nothing — a test grid created through the API is
+**owned** by its member, and `member_for_access` has an owner arm that admits from the network row
+alone. A precondition asserting `member_for_access(..., google_sub=None) is None` passed while the
+gate, which passes the real `google_sub`, took the owner arm. The fixture must hold a token for
+somebody who is **not** the owner, and its precondition must be asserted with the argument the gate
+actually uses.
 
 Without it, somebody removed from every grid keeps a working credential for **365 days**. The harm
 is bounded — a web search is free to the member and the allowance is keyed on the account, so they


### PR DESCRIPTION
ADR 0041 D-b claimed the web-tools gate *"can never be stricter or looser than the rule that minted
the token, because it **is** that rule"*. That sentence was wrong, and it was wrong in production.

`store.member_for_access` takes an `os_token` — the operating system a CLI claimed at sign-in — and
on an **os-community** grid that argument is the only thing that admits anybody (ADR 0039 D-e).
Membership there is not row-backed: nothing stores the OS, no claim carries it, and an MCP caller is
a harness that never had one. So the call answers `None` for every OS grid — the commonest kind —
and the gate refused all of them. Found against a real token on prod, not by a test.

This PR is the ADR half only. The server fix is autonomous-grid-be `6b58436`, already on `main` and
deployed; `cli/mcp_config.py` is unchanged, so v0.3.38 stands.

## What it now records

- The fallback: `store.denylist_governs` — the control plane's own half of the cohort rule whose
  other half is grid-src's `_is_open_consumer`. For a cohort the denylist governs, being un-denied
  *is* the membership test. A rowless member has no `member_epoch` either, so the network epoch is
  that cohort's only revocation lever.
- **Both reasons it escaped**, because the second is the one worth keeping: no test used
  os-community, *and* the first tests written for the bug proved nothing — a grid created through
  the API is **owned** by its member, `member_for_access` has an owner arm that admits from the
  network row alone, and the precondition asserted `member_for_access(..., google_sub=None) is None`
  while the gate passes the real `google_sub`. A mutant restoring the bug walked past all four
  tests. With a non-owner's token it is killed 4/4.

## Test plan

- [x] Docs only — no code in this PR
- [x] Server fix: grid-apis **1306 passed**, and the mutant restoring the shipped bug is killed by
      all four new os-community tests
- [x] Verified on prod with the real token that was failing: `initialize` 200, `tools/list` both
      tools, a real `web_search` returns real results, and real Claude Code reports `✔ Connected`
      using the exact command `grid mcp config` prints

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AkSRxxSVi97wtt7UpyU4br