### PR TITLE
docs(cli): Codex cancels MCP tool calls under its read-only sandbox

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -902,6 +902,14 @@ Each harness spells the credential differently, so the command prints all three:
 Web tools need a hosted grid: in local mode the command refuses, because the server it points at is
 the control plane's and a local grid has no account behind it.
 
+> **Codex cancels MCP tool calls under its read-only sandbox, and blames nobody for it.** Run
+> non-interactively as `codex exec …`, a search prints `mcp: grid_web/web_search (failed)` followed
+> by `user cancelled MCP tool call` — which reads like the grid refused it. It did not: the call is
+> stopped inside Codex and never reaches the server, so nothing shows up in your allowance either.
+> That is Codex's own approval policy (`approval: never` with `sandbox: read-only` denies anything
+> that would need approving), not a grid problem. Interactive `codex` asks you instead; a scripted
+> run needs a policy that permits the call. Measured on Codex 0.144.6.
+
 See [ADR 0041](./adr/0041-a-coding-agent-reaches-the-web-through-the-control-plane.md).
 
 ## Training


### PR DESCRIPTION
One warning in `docs/cli.md`'s **Web tools over MCP** section, for a failure that points at the
wrong system.

Run non-interactively, Codex prints:

```
mcp: grid_web/web_search started
mcp: grid_web/web_search (failed)
user cancelled MCP tool call
```

That reads like the grid refused the search. It did not — the call is stopped **inside Codex** and
never reaches the server, so it leaves no ledger row either, which is precisely the shape that sends
somebody debugging the grid.

Measured on **Codex 0.144.6** while checking all three harnesses against production: the identical
prompt with `--dangerously-bypass-approvals-and-sandbox` answers `(completed)` and the ledger row
appears. So the difference is Codex's approval policy (`approval: never` with `sandbox: read-only`
denies anything needing approval), not anything on this side.

## Context — the three harnesses are now verified end to end

Each with the exact block `grid mcp config` prints, unmodified, against prod:

| harness | result |
|---|---|
| Claude Code 2.1.263 | `✔ Connected` |
| opencode 1.18.29 | `✓ grid-web connected`, called `grid-web_web_search`, real result |
| Codex 0.144.6 | `mcp: grid_web/web_search (completed)`, real result |

Proof they went **through the grid** rather than each CLI's own web tool: the account's `web_search`
ledger rows went 1 → 2 → 3, one `webmcp:…` row per call.

## Test plan

- [x] Docs only
- [x] The claim is measured, both directions, on the versions named

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AkSRxxSVi97wtt7UpyU4br