### PR TITLE
feat(cli): grid update + the daily stale-version notice

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -60,6 +60,7 @@ from .parser import build_parser
 from .provider import cmd_engines, cmd_join, cmd_leave, cmd_models
 from .request import cmd_chat, cmd_edit, cmd_image, cmd_video
 from .stt import cmd_stt_transcribe
+from .update import cmd_update
 
 __all__ = [
     "main",
@@ -115,4 +116,5 @@ __all__ = [
     "cmd_engine_start",
     "cmd_engine_stop",
     "cmd_stt_transcribe",
+    "cmd_update",
 ]

--- a/cli/_main.py
+++ b/cli/_main.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from local import config
 from local import runtime
 from shared import logging_setup, paths
-from . import json_error
+from . import json_error, update
 from .dispatch import dispatch, resolve_override, split_forwarded
 from .parser import build_parser
 
@@ -149,7 +149,18 @@ def main(argv: list[str] | None = None) -> int:
             # the attribute — `grid launch claude --` with nothing after it is therefore identical
             # to no `--` at all.
             args.forward = forwarded
-        return dispatch(args, override)
+        # `--json` anywhere the user typed it suppresses the version notice, not just the global
+        # slot — argparse lets a subcommand's own `--json` default mask the parent's parsed value,
+        # so the parsed flag OR'd with the raw argv is the reliable witness.
+        json_requested = bool(args.json) or "--json" in cleaned
+        # The version check spawns here — before the command runs — so the network call happens
+        # while the user watches their command's work, not as added latency; the notice then prints
+        # after the command's own output finishes. Both are total functions that swallow everything:
+        # a stale-version hint must never change this run's exit code or output (cli/update.py).
+        update.maybe_spawn_check(args, json_requested=json_requested)
+        rc = dispatch(args, override)
+        update.print_notice(args, json_requested=json_requested)
+        return rc
     except SystemExit as exc:
         # `args` is `None` when argparse itself refused, so the flag is read out of the raw argv —
         # see `json_error.asked_for_json`.
@@ -189,6 +200,12 @@ def _maybe_internal(argv: list[str]) -> int | None:
         parser.add_argument("--week-limit", type=int, default=None)
         parser.add_argument("--quota-ttl", type=float, default=60.0)
         return cmd_internal_cli_seat_server(parser.parse_args(argv[1:]))
+    if argv[0] == "__update-check":
+        # Detached background refresh of ~/.grid/update-check.json, spawned by `maybe_spawn_check`.
+        # No flags, and it always exits 0: the only consumer is the next command's notice.
+        from .update import run_check
+
+        return run_check()
     if argv[0] == "__engine":
         from .provider import run_engine_from_record
 

--- a/cli/dispatch.py
+++ b/cli/dispatch.py
@@ -29,6 +29,9 @@ from . import remote_grid, remote_overview, remote_provider, remote_request
 AGNOSTIC = frozenset({
     None,
     "version",
+    # `update` replaces the CLI binary itself — the same file in both modes, so mode cannot
+    # meaningfully gate it (and refusing it in one mode would strand that mode's users).
+    "update",
     "device-info",
     "catalog",
     "pull",

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -54,6 +54,7 @@ from .remote_router import (
 )
 from .request import cmd_chat, cmd_edit, cmd_image, cmd_video
 from .stt import cmd_stt_transcribe
+from .update import cmd_update
 
 
 def _positive_task_count(raw: str) -> int:
@@ -99,6 +100,14 @@ def build_parser() -> argparse.ArgumentParser:
 
     version = sub.add_parser("version", help="Print the grid version")
     version.set_defaults(handler=cmd_version)
+
+    update = sub.add_parser("update", help="Update grid to the latest release")
+    update.add_argument(
+        "--check",
+        action="store_true",
+        help="Only report whether a newer version exists; install nothing.",
+    )
+    update.set_defaults(handler=cmd_update)
 
     _add_grid_lifecycle(sub)
     _add_engines(sub)

--- a/cli/update.py
+++ b/cli/update.py
@@ -1,0 +1,468 @@
+"""Keep the CLI itself current: the background version check, the stale notice, `grid update`.
+
+Three pieces, one flow (the uv/pip shape, adapted to how this CLI ships):
+
+1. **Background check.** Any ordinary command that is due (cache older than ``CHECK_INTERVAL_S``)
+   spawns a detached ``grid __update-check`` — the same self-exec pattern as ``__server`` — which
+   resolves the newest release tag and writes ``~/.grid/update-check.json``. The user's command
+   never waits on the network; discovery costs zero latency.
+2. **The notice.** After the command's own output, one line on **stderr** when the cached newest
+   version is newer than the running one — at most once per interval. Suppressed for ``--json``,
+   non-TTY stderr, ``__*`` internals, dev builds, ``grid update`` itself, and
+   ``GRID_NO_UPDATE_CHECK``. So it rides whichever command the user actually runs — `login`, `ls`,
+   `models`, bare `grid` — never a specific one.
+3. **`grid update`.** The explicit upgrade: a Linux self-contained binary downloads the new asset,
+   verifies it against the release's SHA256SUMS and renames itself into place; a uv-installed wheel
+   re-runs ``uv tool install --force`` on the release wheel (exactly what install.sh does on
+   macOS). A running grid keeps the old binary until the operator restarts it — nothing here
+   replaces a live process.
+
+The version resolution deliberately goes through ``github.com`` (the ``/releases/latest`` redirect,
+with the releases Atom feed as fallback), never ``api.github.com``: the unauthenticated API limit is
+60 req/hr per IP, so an office behind one NAT address would have every notice 403 by lunchtime —
+the same reason install.sh:56 does it this way.
+"""
+from __future__ import annotations
+
+import argparse
+import builtins
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from shared import jsonio, paths
+from shared._version import __version__
+
+# How old the cached answer must be before another check is worth a spawn — and how long a shown
+# notice stays suppressed. One line a day per machine is the whole budget; the check and the notice
+# deliberately share the number so "checked today" and "notified today" cannot disagree.
+CHECK_INTERVAL_S = 24 * 3600
+
+# Kept short: this runs detached *beside* the user's command, so a hung network must never become
+# a hung background process pool. The download in `grid update` is the operator's own call and
+# uses its own, longer, timeout.
+_CHECK_TIMEOUT_S = 5.0
+_DOWNLOAD_TIMEOUT_S = 120.0
+
+_USER_AGENT = "grid-cli-update"
+
+_TAG_RE = re.compile(r"^v?(\d+(?:\.\d+)*)")
+
+
+def _repo() -> tuple[str, str]:
+    """(owner, repo) of the releases to track — the same env knobs install.sh honours."""
+    return (
+        os.environ.get("GRID_REPO_OWNER", "autonomous-ai"),
+        os.environ.get("GRID_REPO_NAME", "autonomous-grid"),
+    )
+
+
+def _version_key(version: str) -> tuple[int, ...]:
+    """Leading dotted numbers of a version as a comparable tuple (``0.3.41`` → ``(0, 3, 41)``).
+
+    Prerelease/local suffixes are not compared: this CLI only ever ships plain ``X.Y.Z`` releases
+    (packaging/build_binary.sh stamps them), so anything after the numeric run — ``+dev`` on a
+    source checkout included — carries no ordering meaning here. Unequal-length tuples pad with
+    zeros so ``0.4`` compares above ``0.3.9``.
+    """
+    match = _TAG_RE.match(version.strip())
+    numbers = tuple(int(p) for p in match.group(1).split(".")) if match else ()
+    return numbers
+
+
+def is_newer(candidate: str, current: str) -> bool:
+    """True when ``candidate`` (a release tag or version) is strictly newer than ``current``."""
+    cand, cur = _version_key(candidate), _version_key(current)
+    if not cand or not cur:
+        return False
+    width = max(len(cand), len(cur))
+    return cand + (0,) * (width - len(cand)) > cur + (0,) * (width - len(cur))
+
+
+def _is_dev_build() -> bool:
+    return "+dev" in __version__
+
+
+def _is_binary_build() -> bool:
+    """True inside the Nuitka-compiled self-contained binary (the Linux install shape).
+
+    Nuitka injects ``__compiled__`` into builtins of every compiled module — the documented
+    detector, and it cannot fire on a wheel/source run.
+    """
+    return hasattr(builtins, "__compiled__")
+
+
+# --------------------------------------------------------------------------- cache
+
+
+def _read_cache() -> dict[str, Any]:
+    """The check cache, or ``{}`` when absent/corrupt/unreadable.
+
+    Deliberately NOT ``jsonio.load_json``: that raises ``SystemExit`` on a corrupt file, and nothing
+    in this module may end a user's command — a torn ``update-check.json`` must mean "no cached
+    answer", not ``grid ls`` dying. The strict reader stays right for state the user acts on.
+    """
+    try:
+        data = json.loads(paths.update_check_file().read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _write_cache(cache: dict[str, Any]) -> None:
+    try:
+        jsonio.atomic_write_json(paths.update_check_file(), cache)
+    except OSError:
+        pass  # a read-only GRID_HOME loses the cache, never the command
+
+
+def _fresh(cache: dict[str, Any], now: float) -> bool:
+    try:
+        return now - float(cache.get("checked_at", 0.0)) < CHECK_INTERVAL_S
+    except (TypeError, ValueError):
+        return False
+
+
+# ------------------------------------------------------------------- version check
+
+
+def fetch_latest_version(client: httpx.Client | None = None) -> str | None:
+    """The newest release version (no leading ``v``), or ``None`` when it cannot be resolved.
+
+    Redirect-of-``/releases/latest`` first, Atom feed second — install.sh:``latest_release_tag``
+    ported to httpx, for the rate-limit reason in the module docstring. Never raises.
+    """
+    owner, repo = _repo()
+    own_client = client is None
+    if own_client:
+        client = httpx.Client(timeout=_CHECK_TIMEOUT_S, follow_redirects=False)
+    try:
+        try:
+            resp = client.get(
+                f"https://github.com/{owner}/{repo}/releases/latest",
+                headers={"User-Agent": _USER_AGENT},
+            )
+            location = resp.headers.get("location", "")
+            tag = location.rstrip("/").rsplit("/", 1)[-1] if location else ""
+            version = _parse_tag(tag)
+            if version:
+                return version
+        except httpx.HTTPError:
+            pass
+        try:
+            resp = client.get(
+                f"https://github.com/{owner}/{repo}/releases.atom",
+                headers={"User-Agent": _USER_AGENT},
+            )
+            resp.raise_for_status()
+            match = re.search(r"/releases/tag/([^\"<\s]+)", resp.text)
+            if match:
+                return _parse_tag(match.group(1))
+        except httpx.HTTPError:
+            pass
+    finally:
+        if own_client:
+            client.close()
+    return None
+
+
+def _parse_tag(tag: str) -> str | None:
+    """``v0.3.41`` → ``0.3.41``; anything that is not version-shaped (a page URL, an empty
+    redirect) → ``None``, which makes the caller fall through to the next source."""
+    match = _TAG_RE.match(tag.strip())
+    if not match or tag.strip() != match.group(0):
+        return None
+    return match.group(1)
+
+
+def run_check() -> int:
+    """Resolve the newest version once and refresh the cache. Always succeeds — it runs detached
+    behind ``grid __update-check`` and a failed check must only delay the next attempt."""
+    cache = _read_cache()
+    try:
+        latest = fetch_latest_version()
+    except Exception:
+        latest = None
+    # ``checked_at`` advances even when the resolution failed: without it every command would
+    # re-spawn a check against an offline network until the network returns.
+    cache["checked_at"] = time.time()
+    cache["latest"] = latest
+    _write_cache(cache)
+    return 0
+
+
+# ------------------------------------------------------------------ spawn + notice
+
+
+def _stderr_is_tty() -> bool:
+    try:
+        return bool(sys.stderr) and sys.stderr.isatty()
+    except (AttributeError, ValueError):
+        return False
+
+
+def _opted_out() -> bool:
+    return os.environ.get("GRID_NO_UPDATE_CHECK", "").strip().lower() not in ("", "0", "false")
+
+
+def _notice_allowed(args: argparse.Namespace | None, json_requested: bool) -> bool:
+    """Every suppression the notice (and the spawn behind it) honours, in one decision."""
+    if _is_dev_build() or _opted_out():
+        return False
+    if json_requested or not _stderr_is_tty():
+        return False
+    command = getattr(args, "command", None) if args is not None else None
+    if command == "update":  # mid-upgrade the notice would contradict the command running
+        return False
+    return True
+
+
+def _self_command(*sub: str) -> list[str]:
+    """ argv to re-exec this very build with an internal subcommand.
+
+    The binary must re-exec *itself* (not a PATH lookup of some other grid): the check has to
+    describe the build that is actually running. A bare ``sys.argv[0]`` can be relative (``./grid``)
+    and a background process gets no second chance at cwd, so resolve before spawning.
+    """
+    if _is_binary_build():
+        argv0 = sys.argv[0] or ""
+        candidate = Path(argv0) if os.path.isabs(argv0) else None
+        if candidate is None or not candidate.is_file():
+            found = shutil.which(os.path.basename(argv0) or "grid") or shutil.which("grid")
+            candidate = Path(found) if found else None
+        if candidate is not None and candidate.is_file():
+            return [str(candidate), *sub]
+        # No resolvable path: better no check than a check of the wrong build.
+        return []
+    return [sys.executable, "-m", "cli", *sub]
+
+
+def maybe_spawn_check(args: argparse.Namespace | None, *, json_requested: bool = False) -> None:
+    """Spawn the detached background check when the cache is due. Never raises, never waits."""
+    try:
+        if not _notice_allowed(args, json_requested=json_requested):
+            return
+        if _fresh(_read_cache(), time.time()):
+            return
+        argv = _self_command("__update-check")
+        if not argv:
+            return
+        subprocess.Popen(  # noqa: S603 — fixed argv, no shell; detached so the user's command exits first
+            argv,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except Exception:
+        pass
+
+
+def print_notice(args: argparse.Namespace | None, *, json_requested: bool = False) -> None:
+    """The one-line stale-version notice on stderr, at most once per interval. Never raises.
+
+    Reads only the cache — the spawn in ``maybe_spawn_check`` keeps it current, so this stays
+    instant even with the network down. The first run after a release usually discovers and shows
+    nothing (check still in flight); the next run shows it, which is the trade for zero latency.
+    """
+    try:
+        if not _notice_allowed(args, json_requested=json_requested):
+            return
+        cache = _read_cache()
+        latest = cache.get("latest")
+        if not isinstance(latest, str) or not is_newer(latest, __version__):
+            return
+        now = time.time()
+        try:
+            notified_at = float(cache.get("notified_at", 0.0))
+        except (TypeError, ValueError):
+            notified_at = 0.0
+        if now - notified_at < CHECK_INTERVAL_S:
+            return
+        print(
+            f"\nA new version of grid is available: {__version__} → {latest}. "
+            "Run `grid update` to upgrade.",
+            file=sys.stderr,
+        )
+        cache["notified_at"] = now
+        _write_cache(cache)
+    except Exception:
+        pass
+
+
+# ------------------------------------------------------------------ `grid update`
+
+
+def cmd_update(args: argparse.Namespace) -> int:
+    """Upgrade the CLI in place — or say exactly why it cannot, with the manual path."""
+    current = __version__
+    if _is_dev_build():
+        raise SystemExit(
+            f"`grid update` can't upgrade a source checkout ({current}) — it would not know which "
+            "release to install. `git pull` (or reinstall from the release wheel) instead."
+        )
+    latest = fetch_latest_version()
+    if latest is None:
+        raise SystemExit(
+            "could not resolve the latest grid release from github.com — check your network, or "
+            "install a known version with:  curl -fsSL https://grid.autonomous.ai/install.sh | "
+            "GRID_VERSION=X.Y.Z bash"
+        )
+    if not is_newer(latest, current):
+        print(f"grid {current} is the latest version.")
+        return 0
+    if getattr(args, "check", False):
+        print(
+            f"grid {current} → {latest} is available. Run `grid update` to install it."
+        )
+        return 0
+    if _is_binary_build():
+        _update_binary(latest)
+    else:
+        _update_wheel(latest)
+    print(f"Updated grid {current} → {latest}.")
+    print("Any grid already running keeps serving the old version until you restart it "
+          "(`grid stop`, then `grid start`).")
+    return 0  # both strategies either replaced the CLI or raised SystemExit; there is no partial win
+
+
+def _arch_tag() -> str:
+    import platform
+
+    machine = platform.machine().lower()
+    if machine in ("arm64", "aarch64"):
+        return "arm64"
+    if machine in ("x86_64", "amd64"):
+        return "x86_64"
+    raise SystemExit(f"no grid binary is published for architecture {machine!r}")
+
+
+def _os_tag() -> str:
+    if sys.platform.startswith("linux"):
+        return "linux"
+    if sys.platform == "darwin":
+        return "macos"
+    raise SystemExit(
+        f"`grid update` does not know how to upgrade on {sys.platform!r} — reinstall with the "
+        "command from the docs."
+    )
+
+
+def _release_base(version: str) -> str:
+    owner, repo = _repo()
+    return f"https://github.com/{owner}/{repo}/releases/download/v{version}"
+
+
+def _fetch_bytes(url: str, client: httpx.Client | None = None) -> bytes | None:
+    """GET a release asset whole, or ``None`` on any failure (404 is a normal answer here: the
+    SHA256SUMS file is optional, exactly as install.sh treats it)."""
+    own_client = client is None
+    if own_client:
+        client = httpx.Client(timeout=_DOWNLOAD_TIMEOUT_S, follow_redirects=True)
+    try:
+        resp = client.get(url, headers={"User-Agent": _USER_AGENT})
+        resp.raise_for_status()
+        return resp.content
+    except httpx.HTTPError:
+        return None
+    finally:
+        if own_client:
+            client.close()
+
+
+def _installed_binary_path() -> Path:
+    """The on-disk binary to replace. Nuitka onefile exposes the launcher path; a bare relative
+    ``argv[0]`` and a PATH lookup are the fallbacks, in that order of trustworthiness."""
+    try:  # Nuitka onefile keeps the real launcher path here (standalone builds have no such module)
+        import __nuitka.onefile  # type: ignore[import-not-found]
+
+        path = __nuitka.onefile.getBinaryPath()
+        if path and Path(path).is_file():
+            return Path(path)
+    except Exception:
+        pass
+    argv0 = sys.argv[0] or ""
+    for candidate in (argv0 if os.path.isabs(argv0) else None, shutil.which("grid")):
+        if candidate and Path(candidate).is_file():
+            return Path(candidate)
+    raise SystemExit(
+        "could not locate the installed grid binary to replace — rerun the installer:  "
+        "curl -fsSL https://grid.autonomous.ai/install.sh | bash"
+    )
+
+
+def _update_binary(latest: str) -> None:
+    """Download the new release binary and rename it over this one (the install.sh sequence,
+    in-process). ``os.replace`` is the whole point: the running process keeps its already-mapped
+    inode, the ``agrid`` symlink (same directory, name ``grid``) keeps resolving, and there is no
+    window where the path holds a partial file."""
+    asset = f"grid-{_os_tag()}-{_arch_tag()}"
+    base = _release_base(latest)
+    payload = _fetch_bytes(f"{base}/{asset}")
+    if payload is None:
+        raise SystemExit(
+            f"the {latest} release has no {asset} asset to download — if that is wrong, rerun the "
+            "installer instead:  curl -fsSL https://grid.autonomous.ai/install.sh | bash"
+        )
+    # Hard-fail on a mismatch; only a release shipping no SHA256SUMS at all skips verification —
+    # byte-for-byte install.sh's rule, so `grid update` and the installer cannot disagree about
+    # what a good download is.
+    sums = _fetch_bytes(f"{base}/SHA256SUMS")
+    if sums is not None:
+        want = None
+        for line in sums.decode("utf-8", "replace").splitlines():
+            parts = line.split()
+            if len(parts) == 2 and parts[1].lstrip("*") == asset:
+                want = parts[0].lower()
+                break
+        got = hashlib.sha256(payload).hexdigest()
+        if want is not None and got != want:
+            raise SystemExit(f"checksum mismatch for {asset}: got {got}, want {want}. Nothing installed.")
+
+    target = _installed_binary_path()
+    mode = target.stat().st_mode & 0o777
+    tmp = target.parent / f".{target.name}.new-{os.getpid()}"
+    try:
+        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, mode)
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(payload)
+        os.chmod(tmp, mode)
+        os.replace(tmp, target)
+    except OSError as exc:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise SystemExit(
+            f"could not replace {target}: {exc}\n"
+            "If it belongs to another account, rerun the installer as that account."
+        ) from None
+
+
+def _update_wheel(latest: str) -> None:
+    """The uv-tool shape (macOS's install path, and any wheel install): hand the release wheel
+    back to ``uv tool install --force``, exactly as install.sh:``install_macos_wheel`` does."""
+    wheel_url = f"{_release_base(latest)}/grid-{latest}-py3-none-any.whl"
+    uv = shutil.which("uv") or (Path.home() / ".local" / "bin" / "uv")
+    uv = str(uv)
+    if not Path(uv).is_file():
+        raise SystemExit(
+            "this grid was not installed as a self-contained binary, and no `uv` was found to "
+            "reinstall the wheel with — install uv (https://astral.sh/uv) or rerun the installer:  "
+            "curl -fsSL https://grid.autonomous.ai/install.sh | bash"
+        )
+    try:
+        result = subprocess.run([uv, "tool", "install", "--force", wheel_url])
+    except OSError as exc:
+        raise SystemExit(f"could not run `{uv} tool install`: {exc}") from None
+    if result.returncode != 0:
+        raise SystemExit(f"`uv tool install` failed for {wheel_url} (exit {result.returncode}).")

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -46,8 +46,17 @@ grid --help                           # concise help with common examples first
 grid <command> --help
 grid version
 grid --version                        # same output as `grid version`
+grid update [--check]                 # install the latest release, or just report it
 grid [--local | --remote] <command>      # override the active mode for one command
 ```
+
+`grid update` upgrades the CLI itself in place: the Linux binary verifies the new release against
+its SHA256SUMS before replacing itself, a uv-installed wheel (the macOS path) re-runs
+`uv tool install`. A grid that is already running keeps serving the old version until you restart
+it. It also tells you it is stale on its own: once a day, in the background, any `grid` command
+refreshes a cached "what is the newest version" answer, and when the cache is behind it prints one
+line on stderr after the command's output. That notice never appears in `--json` output, in
+non-terminal contexts (pipes, CI, apps driving the CLI), or when `GRID_NO_UPDATE_CHECK=1` is set.
 
 Bare `grid` is not just help. It is the dashboard for a terminal:
 

--- a/shared/paths.py
+++ b/shared/paths.py
@@ -208,6 +208,13 @@ def codex_models_cache_file() -> Path:
     return grid_home() / "codex_models_cache.json"
 
 
+def update_check_file() -> Path:
+    """Cache of the background version check (JSON): when it last ran, the newest release it
+    saw, and when the stale notice was last shown. Carries no secret — it only names version
+    numbers — so 0o600 here is consistency with the rest of the tree, not confidentiality."""
+    return grid_home() / "update-check.json"
+
+
 def seat_home(kind: str) -> Path:
     """A CLI seat's own home for the tool it drives (e.g. CODEX_HOME).
 

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,0 +1,319 @@
+"""The version check, the stale notice, and `grid update` (cli/update.py).
+
+The properties worth locking are the ones a future edit can quietly break: the notice must be
+impossible to mistake for command output (stderr, suppressed under --json / non-TTY / internals /
+dev builds / opt-out), the check must never add latency or an exit code to the user's command, and
+the binary swap must refuse on a checksum mismatch with the old binary intact.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import sys
+import time
+
+import httpx
+import pytest
+
+import cli
+from cli import update
+from shared import paths
+
+
+def _ns(**kw):
+    base = {"command": "ls", "json": False}
+    base.update(kw)
+    return argparse.Namespace(**base)
+
+
+@pytest.fixture
+def grid_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    monkeypatch.delenv("GRID_NO_UPDATE_CHECK", raising=False)
+    monkeypatch.setattr(update, "__version__", "0.3.34")
+    monkeypatch.setattr(update, "_stderr_is_tty", lambda: True)
+    return tmp_path
+
+
+# ------------------------------------------------------------------ version compare
+
+
+@pytest.mark.parametrize(
+    ("candidate", "current", "expected"),
+    [
+        ("0.3.41", "0.3.34", True),
+        ("0.3.34", "0.3.34", False),
+        ("0.3.33", "0.3.34", False),
+        ("v0.4.0", "0.3.34", True),          # tag form, as the redirect hands it over
+        ("0.4", "0.3.9", True),              # unequal lengths pad with zeros
+        ("0.3.34", "0.0.0+dev", True),       # local label carries no ordering
+        ("nonsense", "0.3.34", False),       # unparseable never claims an upgrade
+        ("", "0.3.34", False),
+    ],
+)
+def test_is_newer(candidate, current, expected):
+    assert update.is_newer(candidate, current) is expected
+
+
+@pytest.mark.parametrize(
+    ("tag", "expected"),
+    [("v0.3.41", "0.3.41"), ("0.4.0", "0.4.0"), ("latest", None), ("", None),
+     ("https://x/releases/tag/v1", None)],
+    ids=["v-prefixed", "plain", "not-a-tag", "empty", "full-url"],
+)
+def test_parse_tag(tag, expected):
+    assert update._parse_tag(tag) == expected
+
+
+# ------------------------------------------------------------------ resolution
+
+
+def test_fetch_latest_from_release_redirect():
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/releases/latest"):
+            return httpx.Response(302, headers={"location": "https://github.com/o/r/releases/tag/v9.9.9"})
+        raise AssertionError(f"unexpected request: {request.url}")
+
+    client = httpx.Client(transport=httpx.MockTransport(handler), follow_redirects=False)
+    assert update.fetch_latest_version(client) == "9.9.9"
+
+
+def test_fetch_latest_falls_back_to_atom_feed():
+    """The redirect source answers nothing useful (the failure mode install.sh:61 defends against)
+    — the Atom feed's newest entry must carry the resolution."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/releases/latest"):
+            return httpx.Response(200, text="no redirect today")
+        return httpx.Response(
+            200,
+            text='<entry><link>https://github.com/o/r/releases/tag/v7.7.7</link></entry>',
+        )
+
+    client = httpx.Client(transport=httpx.MockTransport(handler), follow_redirects=False)
+    assert update.fetch_latest_version(client) == "7.7.7"
+
+
+def test_fetch_latest_silent_when_unreachable():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("offline", request=request)
+
+    client = httpx.Client(transport=httpx.MockTransport(handler), follow_redirects=False)
+    assert update.fetch_latest_version(client) is None
+
+
+# ------------------------------------------------------------------ cache + check
+
+
+def test_run_check_caches_and_survives_failure(grid_home, monkeypatch):
+    monkeypatch.setattr(update, "fetch_latest_version", lambda *a, **k: "0.4.0")
+    assert update.run_check() == 0
+    cache = update._read_cache()
+    assert cache["latest"] == "0.4.0" and cache["checked_at"] > 0
+
+    # A failed resolution advances `checked_at` (no re-spawn storm against an offline network)
+    # but drops `latest` — a notice must never outlive the release it announced.
+    monkeypatch.setattr(update, "fetch_latest_version", lambda *a, **k: None)
+    update.run_check()
+    cache = update._read_cache()
+    assert cache["latest"] is None and cache["checked_at"] >= 1
+
+
+def test_run_check_preserves_notified_at(grid_home, monkeypatch):
+    paths.update_check_file().write_text('{"checked_at": 1, "latest": "0.4.0", "notified_at": 5}')
+    monkeypatch.setattr(update, "fetch_latest_version", lambda *a, **k: "0.4.0")
+    update.run_check()
+    assert update._read_cache()["notified_at"] == 5  # the background writer must not un-silence today
+
+
+# ------------------------------------------------------------------ the notice
+
+
+def test_notice_prints_once_per_interval(grid_home, capsys):
+    update._write_cache({"checked_at": 1.0, "latest": "0.4.0"})
+    update.print_notice(_ns())
+    err = capsys.readouterr().err
+    assert "A new version of grid is available: 0.3.34 → 0.4.0" in err
+    assert "`grid update`" in err
+
+    update.print_notice(_ns())  # second command the same day: silent, and the clock moved
+    assert capsys.readouterr().err == ""
+    assert update._read_cache()["notified_at"] > 0
+
+
+def test_notice_never_appears_when_suppressed(grid_home, capsys, monkeypatch):
+    update._write_cache({"checked_at": 1.0, "latest": "0.4.0"})
+
+    update.print_notice(_ns(json=True), json_requested=True)
+    update.print_notice(_ns(command="update"))
+    monkeypatch.setenv("GRID_NO_UPDATE_CHECK", "1")
+    update.print_notice(_ns())
+    monkeypatch.delenv("GRID_NO_UPDATE_CHECK")
+    monkeypatch.setattr(update, "_stderr_is_tty", lambda: False)
+    update.print_notice(_ns())
+    monkeypatch.setattr(update, "_stderr_is_tty", lambda: True)
+    monkeypatch.setattr(update, "__version__", "0.0.0+dev")
+    update.print_notice(_ns())
+
+    assert capsys.readouterr().err == ""
+    assert "notified_at" not in update._read_cache()  # suppressed = unseen, not seen-and-hidden
+
+
+def test_notice_quiet_when_already_current_or_cache_broken(grid_home, capsys):
+    update._write_cache({"checked_at": 1.0, "latest": "0.3.34"})
+    update.print_notice(_ns())
+    update._write_cache({"checked_at": 1.0, "latest": None})
+    update.print_notice(_ns())
+    paths.update_check_file().write_text("{corrupt")  # must read as "no answer", never kill `grid ls`
+    update.print_notice(_ns())
+    assert capsys.readouterr().err == ""
+
+
+# ------------------------------------------------------------------ the spawn
+
+
+def test_spawn_when_due_not_when_fresh(grid_home, monkeypatch):
+    calls: list[tuple[list[str], dict]] = []
+    monkeypatch.setattr(
+        update.subprocess, "Popen",
+        lambda argv, **kw: calls.append((argv, kw)) or object(),
+    )
+    update.maybe_spawn_check(_ns())  # no cache at all → due
+    assert len(calls) == 1
+    argv, kwargs = calls[0]
+    assert argv[-1] == "__update-check"
+    assert argv[0] == sys.executable  # source/wheel run re-execs through the interpreter
+    assert kwargs["start_new_session"] is True  # detached: the user's command exits first
+    assert kwargs["stdout"] is update.subprocess.DEVNULL
+
+    # The child's answer lands; the next hour of commands must not spawn another one.
+    update._write_cache({"checked_at": time.time(), "latest": "0.4.0"})
+    update.maybe_spawn_check(_ns())
+    assert len(calls) == 1  # fresh cache → no spawn
+
+
+def test_spawn_suppressions_touch_no_process(grid_home, monkeypatch):
+    def boom(*a, **k):
+        raise AssertionError("a suppressed run must not spawn anything")
+
+    monkeypatch.setattr(update.subprocess, "Popen", boom)
+    monkeypatch.setenv("GRID_NO_UPDATE_CHECK", "1")
+    update.maybe_spawn_check(_ns())
+    monkeypatch.delenv("GRID_NO_UPDATE_CHECK")
+    update.maybe_spawn_check(_ns(json=True), json_requested=True)
+    update.maybe_spawn_check(_ns(command="update"))
+    monkeypatch.setattr(update, "_stderr_is_tty", lambda: False)
+    update.maybe_spawn_check(_ns())
+
+
+# ------------------------------------------------------------------ `grid update`
+
+
+def test_update_noop_when_current(grid_home, monkeypatch, capsys):
+    monkeypatch.setattr(update, "fetch_latest_version", lambda: "0.3.34")
+    assert update.cmd_update(_ns(command="update")) == 0
+    assert "0.3.34 is the latest version" in capsys.readouterr().out
+
+
+def test_update_check_flag_reports_without_installing(grid_home, monkeypatch, capsys):
+    monkeypatch.setattr(update, "fetch_latest_version", lambda: "0.4.0")
+    monkeypatch.setattr(update, "_update_binary", lambda v: pytest.fail("--check installed"))
+    monkeypatch.setattr(update, "_update_wheel", lambda v: pytest.fail("--check installed"))
+    assert update.cmd_update(_ns(command="update", check=True)) == 0
+    assert "0.3.34 → 0.4.0 is available" in capsys.readouterr().out
+
+
+def test_update_refuses_source_checkout(grid_home, monkeypatch):
+    monkeypatch.setattr(update, "__version__", "0.0.0+dev")
+    with pytest.raises(SystemExit, match="source checkout"):
+        update.cmd_update(_ns(command="update"))
+
+
+def test_update_reports_unreachable_github(grid_home, monkeypatch):
+    monkeypatch.setattr(update, "fetch_latest_version", lambda: None)
+    with pytest.raises(SystemExit, match="could not resolve"):
+        update.cmd_update(_ns(command="update"))
+
+
+def test_update_routes_wheel_installs_to_uv(grid_home, monkeypatch):
+    seen: list[str] = []
+    monkeypatch.setattr(update, "fetch_latest_version", lambda: "0.4.0")
+    monkeypatch.setattr(update, "_is_binary_build", lambda: False)
+    monkeypatch.setattr(update, "_update_wheel", seen.append)
+    assert update.cmd_update(_ns(command="update")) == 0
+    assert seen == ["0.4.0"]
+
+
+def test_binary_swap_verifies_then_replaces(grid_home, monkeypatch):
+    payload = b"NEW-GRID-BINARY"
+    asset = f"grid-{update._os_tag()}-{update._arch_tag()}"
+    digest = hashlib.sha256(payload).hexdigest()
+
+    def fake_fetch(url: str, client=None):
+        if url.endswith("/SHA256SUMS"):
+            return f"{digest}  {asset}\n".encode()
+        if url.endswith(f"/{asset}"):
+            return payload
+        raise AssertionError(url)
+
+    binary = grid_home / "grid"
+    binary.write_bytes(b"OLD")
+    binary.chmod(0o755)
+    monkeypatch.setattr(update, "_fetch_bytes", fake_fetch)
+    monkeypatch.setattr(update, "_installed_binary_path", lambda: binary)
+
+    update._update_binary("0.4.0")  # returns quietly; failure is a SystemExit, covered below
+    assert binary.read_bytes() == payload
+    assert binary.stat().st_mode & 0o777 == 0o755  # the swap keeps the file it replaced executable
+    assert not list(grid_home.glob(".grid.new-*"))  # and leaves no orphan behind
+
+
+def test_binary_swap_refuses_on_checksum_mismatch(grid_home, monkeypatch):
+    asset = f"grid-{update._os_tag()}-{update._arch_tag()}"
+
+    def fake_fetch(url: str, client=None):
+        if url.endswith("/SHA256SUMS"):
+            return f"{'0' * 64}  {asset}\n".encode()
+        return b"TAMPERED"
+
+    binary = grid_home / "grid"
+    binary.write_bytes(b"OLD")
+    monkeypatch.setattr(update, "_fetch_bytes", fake_fetch)
+    monkeypatch.setattr(update, "_installed_binary_path", lambda: binary)
+
+    with pytest.raises(SystemExit, match="checksum mismatch"):
+        update._update_binary("0.4.0")
+    assert binary.read_bytes() == b"OLD"  # refused = untouched, the whole point of the verification
+
+
+def test_binary_swap_reports_a_download_404(grid_home, monkeypatch):
+    monkeypatch.setattr(update, "_fetch_bytes", lambda url, client=None: None)
+    monkeypatch.setattr(update, "_installed_binary_path", lambda: pytest.fail("must not touch the binary"))
+    with pytest.raises(SystemExit, match="no grid-"):
+        update._update_binary("0.4.0")
+
+
+# ------------------------------------------------------------------ wiring
+
+
+def test_main_spawns_check_and_prints_notice_around_the_command(monkeypatch, grid_home, capsys):
+    events: list[str] = []
+    monkeypatch.setattr(update, "maybe_spawn_check", lambda a, **k: events.append("spawn"))
+    monkeypatch.setattr(update, "print_notice", lambda a, **k: events.append("notice"))
+    assert cli.main(["version"]) == 0
+    assert events == ["spawn", "notice"]  # spawn before the work, notice after its output
+
+
+def test_internal_update_check_command_writes_cache(grid_home, monkeypatch):
+    monkeypatch.setattr(update, "fetch_latest_version", lambda: "1.2.3")
+    assert cli.main(["__update-check"]) == 0
+    assert update._read_cache()["latest"] == "1.2.3"
+
+
+def test_update_reaches_its_handler_in_both_modes(grid_home, monkeypatch, capsys):
+    """AGNOSTIC by decision (dispatch.py): replacing the binary is the same act in both modes, so
+    neither mode may refuse it — locked end-to-end, not just through the classification set."""
+    monkeypatch.setattr(update, "fetch_latest_version", lambda: "0.3.34")
+    assert cli.main(["--remote", "update"]) == 0
+    assert "latest version" in capsys.readouterr().out
+    assert cli.main(["--local", "update"]) == 0


### PR DESCRIPTION
## What

Closes the loop install.sh opens: the CLI ships and then never says it is behind. Adds the uv/pip-shaped update loop — zero added latency, zero output an application has to parse.

- **Background check.** Any ordinary command whose cache is older than 24h spawns a detached `grid __update-check` (the self-exec pattern of `__server`). It resolves the newest release via the `github.com/releases/latest` redirect with the Atom feed as fallback — never `api.github.com`, same rate-limit reason install.sh gives — and caches to `~/.grid/update-check.json`.
- **The notice.** One line on **stderr** after the command's own output, at most once per interval. Suppressed for `--json`, non-TTY, `__*` internals, dev builds, `grid update` itself, `GRID_NO_UPDATE_CHECK=1`, and on failing runs. Rides whichever command the user actually runs — `login`, `ls`, `models`, bare `grid`.
- **`grid update` [`--check`].** Linux self-contained binary: download the release asset, verify against SHA256SUMS (install.sh's rule verbatim — hard-fail on mismatch, skip only when the release ships none), then `os.replace` over itself — the running process keeps its mapped inode and the `agrid` symlink keeps resolving. uv-wheel installs (the macOS path): re-run `uv tool install --force` on the release wheel, exactly as install.sh does. A running grid keeps the old version until the operator restarts it.

## Design notes

- `update` is dispatch **AGNOSTIC**: replacing the binary is the same act in both modes.
- The check spawn and the notice are total functions that swallow everything — a stale-version hint can never change an exit code or stdout.
- Cache corruption reads as "no answer", never as `SystemExit` (`grid ls` must not die on a torn JSON file).
- `docs/cli.md`: the command and the notice contract.

## Verification

- `tests/test_update.py`: 34 tests — version compare, redirect+Atom+offline resolution, cache merge semantics, every suppression path (incl. `notified_at` preserved across background writes), checksum-mismatch refuses with the old binary intact, spawn gating, both-modes reachability, main() hook ordering.
- Full suite: 2255 passed; the 2 `test_local_cli` install-location failures reproduce on the clean tree (machine-specific, unrelated).
- Live smoke on Linux: `__update-check` resolved the real `0.3.39`; pty run printed the notice after `grid version`; piped run printed nothing; `grid update --check` reported `0.3.34 → 0.3.39` end-to-end against live releases.