### PR TITLE
cli: list Brute Force + Feedback Loop when the grid routes

### DIFF
--- a/cli/remote_overview.py
+++ b/cli/remote_overview.py
@@ -204,13 +204,19 @@ def cmd_remote_models(args: argparse.Namespace) -> int:
         capable = _node_responses_models(node)  # resolved once per node, not per served model
         for model in _node_models(node, overview):
             rows.append((model, engine, name, model in capable))
-    # When auto routing is enabled, advertise the reserved `auto` model FIRST — same as the relay's
-    # /relay/v1/models endpoint (owner `grid-router`), so it shows even when zero engines are joined.
-    # An older master whose overview lacks the field reports falsy → no auto row (graceful degradation).
+    # When auto routing is enabled, advertise the reserved router family FIRST — mirroring the
+    # relay's /relay/v1/models endpoint (owner `grid-router`), so it shows even when zero engines
+    # are joined. The relay lists the three effort modes under their display names
+    # (`effort_router.EFFORT_DISPLAY_NAMES`: "Auto", "Brute Force", "Feedback Loop"); the standard
+    # one is the bare `auto` row the grid has always shown (both spellings parse the same), and
+    # these two extra names are accepted request ids too — without them the CLI hid two working
+    # models behind the one listing (an older master whose overview lacks router_enabled reports
+    # falsy → no router rows at all: graceful degradation).
     # `responses` is False for `auto`: dialect-reachability is a per-request routing outcome, not a
     # static property of the reserved model (no AC covers it) — a real model's badge is its engine's.
     if overview.get("router_enabled"):
         rows.insert(0, ("auto", "grid-router", "", False))
+        rows[1:1] = [(name, "grid-router", "", False) for name in ("Brute Force", "Feedback Loop")]
 
     if getattr(args, "json", False):
         # Derived view (not a raw passthrough like engines): new API fields on a model entry
@@ -227,11 +233,11 @@ def cmd_remote_models(args: argparse.Namespace) -> int:
         return 0
 
     seen = list(dict.fromkeys(model for model, *_ in rows))  # order-preserving dedup
-    # Prefer a real model over the reserved `auto` here: `auto` is always inserted first when
-    # routing is on, and a newcomer who just joined an engine wants to see THAT model chat-tested,
-    # not the router alias. Mirrors the local `cmd_models`' closing-the-loop hint (issue: `grid
-    # join`'s own "still loading" message can't yet promise a working model — this can).
-    target = next((m for m in seen if m != "auto"), seen[0])
+    # Prefer a real model over the reserved router family here: the router rows are always inserted
+    # first when routing is on, and a newcomer who just joined an engine wants to see THAT model
+    # chat-tested, not a router alias. Mirrors the local `cmd_models`' closing-the-loop hint (issue:
+    # `grid join`'s own "still loading" message can't yet promise a working model — this can).
+    target = next((m for m in seen if m not in ("auto", "Brute Force", "Feedback Loop")), seen[0])
 
     if getattr(args, "verbose", False):
         mwidth = max(len("MODEL"), *(len(model) for model, _, _, _ in rows))

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -23049,7 +23049,9 @@ def test_remote_models_prepends_auto_when_router_enabled(monkeypatch, tmp_path, 
     _mock_overview(monkeypatch, {**_OVERVIEW_2NODES, "router_enabled": True})
     assert cli.main(["models"]) == 0
     lines = [ln for ln in capsys.readouterr().out.splitlines() if ln.strip()]
-    assert lines == ["auto", "glm-5.2", "qwen-3"]  # auto first (mirrors /relay/v1/models), then engine models
+    # The router family first (mirrors /relay/v1/models: auto + the two effort display names),
+    # then engine models.
+    assert lines == ["auto", "Brute Force", "Feedback Loop", "glm-5.2", "qwen-3"]
 
 
 def test_remote_models_omits_auto_when_router_disabled(monkeypatch, tmp_path, capsys):
@@ -23058,6 +23060,7 @@ def test_remote_models_omits_auto_when_router_disabled(monkeypatch, tmp_path, ca
     assert cli.main(["models"]) == 0
     lines = [ln for ln in capsys.readouterr().out.splitlines() if ln.strip()]
     assert lines == ["glm-5.2", "qwen-3"] and "auto" not in lines
+    assert "Brute Force" not in lines and "Feedback Loop" not in lines
 
 
 def test_remote_models_omits_auto_when_field_absent(monkeypatch, tmp_path, capsys):
@@ -23084,14 +23087,39 @@ def test_remote_models_json_includes_auto_first_when_router_enabled(monkeypatch,
     payload = json.loads(capsys.readouterr().out)
     assert payload[0] == {"model": "auto", "engine": "grid-router", "node": "", "responses": False}
 
-
 def test_remote_models_shows_auto_even_with_zero_nodes_when_enabled(monkeypatch, tmp_path, capsys):
-    # Mirrors /relay/v1/models: auto is advertised whenever routing is on, independent of engines.
+    # Mirrors /relay/v1/models: the router family is advertised whenever routing is on,
+    # independent of engines.
     _seed_running_remote_grid(monkeypatch, tmp_path)
     _mock_overview(monkeypatch, {"nodes": [], "router_enabled": True})
     assert cli.main(["models"]) == 0
     lines = [ln for ln in capsys.readouterr().out.splitlines() if ln.strip()]
-    assert lines == ["auto"]
+    assert lines == ["auto", "Brute Force", "Feedback Loop"]
+
+
+def test_remote_models_json_lists_effort_rows_after_auto(monkeypatch, tmp_path, capsys):
+    # The two effort display names are rows of their own (each independently chat-addressable),
+    # owned by grid-router with no node — exactly what the relay advertises.
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_overview(monkeypatch, {**_OVERVIEW_2NODES, "router_enabled": True})
+    assert cli.main(["models", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload[1:3] == [
+        {"model": "Brute Force", "engine": "grid-router", "node": "", "responses": False},
+        {"model": "Feedback Loop", "engine": "grid-router", "node": "", "responses": False},
+    ]
+
+
+def test_remote_models_hint_skips_effort_names(monkeypatch, tmp_path, capsys):
+    # Zero engines + router on: every listed name is a router alias — the hint must fall back to
+    # `auto`, never suggest chat-testing an effort alias as if it were the newcomer's own model.
+    # The hint rides stderr behind a tty check (print_models_hint), so fake the tty.
+    _seed_running_remote_grid(monkeypatch, tmp_path)
+    _mock_overview(monkeypatch, {"nodes": [], "router_enabled": True})
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+    assert cli.main(["models"]) == 0
+    err = capsys.readouterr().err
+    assert "-m auto" in err and "Brute Force" not in err and "Feedback Loop" not in err
 
 
 # ── responses dialect annotation on the live listing (issue 10) ──


### PR DESCRIPTION
## What
`grid models` (remote) inserted one `auto` row when `router_enabled`, while the relay's `/relay/v1/models` advertises the whole reserved family (`auto` + the two effort display names, owned_by `grid-router`). Two working, chat-addressable models (`Brute Force`, `Feedback Loop`) were hidden from the one listing users actually read — observed live on autonomous.ai.

- Mirror the relay: three `grid-router` rows (`auto`, `Brute Force`, `Feedback Loop`), still first.
- The chat hint skips every router alias, not just `auto`.

## Verification
- `tests/test_local_cli.py -k remote_models`: 17 passed (3 existing assertions updated to the new listing; 2 new tests: JSON rows after auto, hint falls back to `auto` with zero engines).