### PR TITLE
grid mcp config takes a --harness and renews the token it prints

### DIFF
--- a/cli/grid_credential.py
+++ b/cli/grid_credential.py
@@ -44,11 +44,44 @@ def ensure_usable(rec: dict[str, Any], label: str, token: str, base: str) -> str
     return _prove(rec, label, token, base, refreshed=refreshed, expiry_note=expiry_note)
 
 
+def refresh_if_stale(
+    rec: dict[str, Any],
+    label: str,
+    token: str,
+    *,
+    margin_seconds: int = LAUNCH_EXPIRY_MARGIN_SECONDS,
+    proceeding: str = "using it anyway",
+) -> str:
+    """The offline half of :func:`ensure_usable`, for a caller that has nothing to probe.
+
+    `grid launch` can afford to be lenient about a stale token because a relay round-trip is one
+    line away and authoritative. A caller that only *prints* the credential — `grid mcp config`,
+    whose server is the control plane's rather than the grid's — has no such second opinion, and a
+    different deadline to protect: what it hands over is pasted into a file and left there, so the
+    margin is its own to choose.
+
+    Returns the token to use, having persisted a renewed one; raises ``SystemExit`` only when the
+    token has already expired **and** the exchange failed, which is the one state no caller can make
+    anything of.
+    """
+    token, _refreshed, _expiry_note = _repair_if_stale(
+        rec, label, token, margin=margin_seconds, proceeding=proceeding
+    )
+    return token
+
+
 # ---------------------------------------------------------------------------
 # Layer 1 + 2: what the token says about itself, and the repair
 # ---------------------------------------------------------------------------
 
-def _repair_if_stale(rec: dict[str, Any], label: str, token: str) -> tuple[str, bool, str | None]:
+def _repair_if_stale(
+    rec: dict[str, Any],
+    label: str,
+    token: str,
+    *,
+    margin: int = LAUNCH_EXPIRY_MARGIN_SECONDS,
+    proceeding: str = "launching anyway",
+) -> tuple[str, bool, str | None]:
     """``(token, refreshed, expiry_note)`` after the offline check has had its say.
 
     ``expiry_note`` is what we learned and could not act on — carried forward so that if the probe
@@ -62,7 +95,7 @@ def _repair_if_stale(rec: dict[str, Any], label: str, token: str) -> tuple[str, 
     """
     exp = _token_expiry(token)
     now = time.time()
-    if exp is None or exp - now > LAUNCH_EXPIRY_MARGIN_SECONDS:
+    if exp is None or exp - now > margin:
         return token, False, None
 
     phrase = _expiry_phrase(exp, now)
@@ -78,9 +111,12 @@ def _repair_if_stale(rec: dict[str, Any], label: str, token: str) -> tuple[str, 
         fresh = _refresh(rec, label)
     except _RefreshFailed as failure:
         if not expired:
-            # It still works. A control-plane hiccup must not cost a launch that would have succeeded.
+            # It still works. A control-plane hiccup must not cost a launch — or a config — that
+            # would have succeeded. ⚠️ `proceeding` is the caller's word because this sentence is
+            # shared: "launching anyway" printed by `grid mcp config`, which launches nothing, is a
+            # message about a command the user did not run.
             _warn(f"couldn't renew grid {label}'s access token ({failure.reason}); it {phrase}, "
-                  f"launching anyway.")
+                  f"{proceeding}.")
             return token, False, phrase
         raise SystemExit(failure.refusal(label, phrase)) from None
     _note(f"Refreshed grid {label}'s access token (it {phrase}).")

--- a/cli/mcp_config.py
+++ b/cli/mcp_config.py
@@ -1,20 +1,31 @@
-"""`grid mcp config` / `grid mcp token` — pointing a coding agent's harness at the grid's web tools.
+"""`grid mcp config` — pointing a coding agent's harness at the grid's web tools.
 
 ADR 0041. The server is the control plane's (`/v1/grid/web-mcp`); this half exists so nobody has to
 open `~/.grid/credentials.toml` and pick a token out of it by hand. That file holds one bundle per
 grid, so "by hand" means choosing between them correctly, and teaching people to open their own
 credential store is a habit worth not starting.
 
-**Three harnesses, three spellings, one credential.** Measured 2026-09-07 against Claude Code 2.1.263
-and Codex 0.144.6, with a header-logging listener rather than vendor documentation:
+**Six harnesses, six spellings, one credential.** Measured 2026-09-08 against Claude Code 2.1.263,
+Codex 0.153.4, GitHub Copilot CLI 1.0.83, opencode 1.18.29, Hermes 0.21.1 and pi 0.84.1 — each
+binary run against a throwaway home so the file it writes could be read back, then the header proven
+to arrive with a header-logging listener (positive control included). Not from vendor documentation:
+the flag set moves per release and does not cover every supported field.
 
-- Claude Code takes `--header` on `claude mcp add`, so it gets a command.
-- ⚠️ **Codex has no `--header` flag** — `codex mcp add` offers only `--bearer-token-env-var` and the
-  OAuth options. It nonetheless honours `http_headers` in `config.toml` (proven on the wire; `codex
-  mcp get` shows the field and masks its value, which it never does for a key it does not know), so
-  Codex gets a **block to paste**, not a command. An environment variable was rejected: a 365-day
-  credential in a shell is readable by every child process of that shell.
-- opencode takes `headers` in its JSON config.
+- **Claude Code**, **Copilot** and **opencode** take a command *and* a config file, so both are
+  printed — a person who keeps their config in git wants the file, not a command that edits it.
+- ⚠️ **Codex has no `--header` flag** — still true on 0.153.4, which offers only
+  `--bearer-token-env-var` and the OAuth options. It nonetheless honours `http_headers` in
+  `config.toml` (proven on the wire; `codex mcp get` shows the field and masks its value, which it
+  never does for a key it does not know), so Codex gets a **block to paste**, not a command. An
+  environment variable was rejected: a 365-day credential in a shell is readable by every child
+  process of that shell.
+- ⚠️ **opencode's `--header` takes `KEY=VALUE`**, not the `Key: value` every other harness takes.
+- ⚠️ **Hermes's block is YAML, so its indentation is load-bearing** — it is printed at column zero
+  while the shell commands are indented. Its own `mcp mcp add` is interactive (it asks for the token
+  and probes the server), which is why the block leads.
+- ⚠️ **pi ships no MCP client at all**, by design. It is a listed target anyway: argparse's "invalid
+  choice" would read as an oversight in this command, and the refusal is decided before a grid is
+  resolved so it never turns into "run `grid login`".
 
 ⚠️ **The URL carries its trailing slash.** Without it the mount answers **307**; Claude Code follows
 it, and nothing here should depend on every client doing the same.
@@ -28,6 +39,7 @@ from __future__ import annotations
 import argparse
 import json
 import shlex
+import time
 
 # ↔ grid-apis `grid_networks/web_mcp.MOUNT_PATH`. Roll the CONTROL PLANE out before this CLI: a
 # `grid mcp config` against an older control plane prints a URL that answers a bare 404, which the
@@ -35,14 +47,81 @@ import shlex
 MOUNT_PATH = "/v1/grid/web-mcp"
 
 # What the tools are called in the harness's own listing — an agent sees `mcp__grid-web__web_search`.
+# The hyphen survives every harness, Codex included: `codex mcp add` writes `[mcp_servers.grid-web]`
+# itself (measured), so spelling it `grid_web` there would rename the tools for that one harness.
 SERVER_NAME = "grid-web"
 
+# How close to `exp` still counts as "renew it before printing". Deliberately not
+# `grid_credential.LAUNCH_EXPIRY_MARGIN_SECONDS`' one day: a launch protects a work session that
+# starts now, while what this command prints is pasted into a config file and left there for months.
+# A token with 25 hours left passes a one-day margin and gives somebody a harness that dies tomorrow.
+# Thirty days is 8% of a grid token's 365-day life, so it cannot cause a renewal that would not have
+# happened within the month anyway.
+EXPIRY_MARGIN_SECONDS = 30 * 24 * 3600
 
-def _session(args: argparse.Namespace) -> tuple[str, str, str]:
+#: Harness key → what to print for it. The listing view and argparse's `choices` both read this, so
+#: a new harness is one entry rather than three places to keep in step.
+_HARNESS_ORDER = ("claude", "codex", "copilot", "hermes", "opencode", "pi")
+
+#: Harnesses with no MCP client at all, and the sentence that says so. Keyed like the renderers so
+#: `--harness` accepts them and answers in words rather than argparse's "invalid choice".
+NO_MCP_CLIENT = {
+    "pi": (
+        "pi ships no MCP client — by design (\"No MCP.\" in its own README, 0.84.1).\n"
+        "The grid's web tools are an MCP server, so there is nothing here to configure for it.\n"
+        "A third-party pi extension can add MCP support; pi itself has none to point at."
+    ),
+}
+
+HARNESS_CHOICES = _HARNESS_ORDER
+
+
+def cmd_mcp_config(args: argparse.Namespace) -> int:
+    """Print how to point one harness — or list the harnesses — at this grid's web tools."""
+    harness = getattr(args, "harness", None)
+    if harness in NO_MCP_CLIENT:
+        # Before any credential is touched: this refusal is about the harness, not about this
+        # machine's sign-in, and resolving a grid first would let it fail with the wrong sentence.
+        raise SystemExit(NO_MCP_CLIENT[harness])
+
+    wants_credential = bool(harness) or bool(getattr(args, "json", False))
+    url, token, label = _session(args, renew=wants_credential)
+
+    if getattr(args, "json", False):
+        # The same three values, for something assembling a config itself — and the replacement for
+        # the `grid mcp token` this command used to sit beside. No postcondition to guard: the
+        # command reports what is already true locally.
+        print(json.dumps({"server": SERVER_NAME, "url": url, "authorization": f"Bearer {token}"},
+                         indent=2))
+        return 0
+
+    if not harness:
+        _print_listing(url, label, getattr(args, "grid", None))
+        return 0
+
+    print(f"Web tools for grid {label}.\n")
+    print(_RENDERERS[harness](url, token))
+    print(
+        "\nThis prints your grid's access token. Anyone who has it can search the web on your "
+        "account's allowance."
+    )
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# The grid, and the credential it is about to hand over
+# ---------------------------------------------------------------------------
+
+def _session(args: argparse.Namespace, *, renew: bool) -> tuple[str, str, str]:
     """`(url, token, label)` for the grid this command names, or a clean `SystemExit`.
 
-    Nothing here is a network call. The control-plane base comes from the same `credentials.api_url`
-    every other command uses, so a home signed in against dev prints a dev URL without being told.
+    The control-plane base comes from the same `credentials.api_url()` every other command uses, so
+    a home signed in against dev prints a dev URL without being told.
+
+    ``renew`` is false for the listing view, and that is the whole of this command's network
+    behaviour: it reaches the control plane **only when it is about to print the credential**. An
+    arg-less `grid mcp config` prints no token, so it needs no fresh one — and must not rotate this
+    machine's refresh credential to draw a menu.
     """
     from remote import credentials
 
@@ -51,49 +130,175 @@ def _session(args: argparse.Namespace) -> tuple[str, str, str]:
     rec = remote_grid._select(getattr(args, "grid", None))
     label = str(rec.get("name") or rec.get("network_id") or "?")
     token = remote_grid.require_access_token(rec, label)
+    if renew:
+        token = _renewed(rec, label, token)
     url = credentials.api_url().rstrip("/") + MOUNT_PATH + "/"
     return url, token, label
 
 
-def cmd_mcp_token(args: argparse.Namespace) -> int:
-    """Print the grid's access token and nothing else, for a script that builds its own config."""
-    _url, token, _label = _session(args)
-    print(token)
-    return 0
+def _renewed(rec: dict, label: str, token: str) -> str:
+    """The token to print: renewed when it is inside the margin, refused when it is already dead.
 
+    ⚠️ The refusal is this command's own, and it is the one place it must be **less** forgiving than
+    `grid launch`. That command warns about an unrepairable token and lets its relay probe decide,
+    because the probe is authoritative and a wrong local clock must not cost somebody a launch that
+    works. There is no probe here — the web-tools server is the control plane's, not the grid's — so
+    the alternative is printing a credential that is certainly dead into a file, where the 401 that
+    follows tells the user to re-run the very command that gave it to them.
 
-def cmd_mcp_config(args: argparse.Namespace) -> int:
-    """Print how to point each harness at this grid's web tools."""
-    url, token, label = _session(args)
+    It runs **before** the shared repair rather than checking its result, so this state is described
+    once: the repair's own warning ("no refresh credential is stored for it") would otherwise be
+    printed first and then contradicted by a refusal saying the same thing in different words. Every
+    other unrepairable state still belongs to the repair, whose refusals name the remedy the control
+    plane's status implies — `grid login` for a 401, `grid sync` for a 403.
+    """
+    from remote import credentials
 
-    if getattr(args, "json", False):
-        # The same three values, for something assembling a config itself. No postcondition to
-        # guard: this command reports what is already true locally and writes nothing.
-        print(json.dumps({"server": SERVER_NAME, "url": url, "authorization": f"Bearer {token}"},
-                         indent=2))
-        return 0
+    from . import grid_credential
 
-    header = f"Authorization: Bearer {token}"
-    print(f"Web tools for grid {label}.\n")
-    print("Claude Code — run this:")
-    print(
-        f"  claude mcp add --transport http --scope user {SERVER_NAME} {shlex.quote(url)} "
-        f"--header {shlex.quote(header)}\n"
+    exp = credentials.token_expiry(token)
+    if exp is not None and exp <= time.time() and not str(rec.get("refresh_token") or ""):
+        raise SystemExit(
+            f"Grid {label}'s access token has expired and there is no refresh credential stored "
+            f"for it.\nRun `grid login` to renew it — a harness configured with this token would "
+            f"be refused."
+        )
+    return grid_credential.refresh_if_stale(
+        rec, label, token,
+        margin_seconds=EXPIRY_MARGIN_SECONDS,
+        # Not the default "launching anyway": this command launches nothing.
+        proceeding="printing it anyway",
     )
+
+
+# ---------------------------------------------------------------------------
+# The listing view — the arg-less command, which prints no credential
+# ---------------------------------------------------------------------------
+
+def _print_listing(url: str, label: str, grid: str | None) -> None:
+    """Name the server and every harness that can be pointed at it — and no token.
+
+    The token is left out on purpose: this is the invocation people run first and run on a shared
+    screen, and it would otherwise put a live 365-day credential there to answer a question about
+    which harnesses are supported.
+    """
+    suffix = f" {shlex.quote(grid)}" if grid else ""
+    print(f"Web tools for grid {label}.")
+    print(f"  server: {SERVER_NAME}")
+    print(f"  url:    {url}\n")
+    print("Pick your harness:")
+    for key in _HARNESS_ORDER:
+        if key in NO_MCP_CLIENT:
+            continue
+        print(f"  grid mcp config --harness {key}{suffix}")
+    print(
+        "\nEach of those prints your grid's access token — a live credential, so treat the output "
+        "like a password."
+    )
+    # Why a harness somebody has installed is missing from the list above. Its own first line names
+    # it, so this generalises to any later addition without a second sentence to keep in step.
+    for sentence in NO_MCP_CLIENT.values():
+        print(sentence.splitlines()[0])
+
+
+# ---------------------------------------------------------------------------
+# One renderer per harness. Commands are indented by two; file blocks start at column zero, because
+# they exist to be pasted and YAML's leading whitespace is part of the document.
+# ---------------------------------------------------------------------------
+
+def _header(token: str) -> str:
+    return f"Authorization: Bearer {token}"
+
+
+def _claude(url: str, token: str) -> str:
     # `--scope user` on purpose: `--scope project` writes `.mcp.json`, which Claude Code holds for
     # interactive approval — measured. Web search is not a per-repository capability anyway.
-    print("Codex — add this to ~/.codex/config.toml (it has no --header flag):")
-    print(f"  [mcp_servers.{SERVER_NAME.replace('-', '_')}]")
-    print(f'  url = "{url}"')
-    print(f'  http_headers = {{ Authorization = "Bearer {token}" }}\n')
-    print("opencode — add this to your opencode.json:")
-    print(json.dumps(
-        {"mcp": {SERVER_NAME: {"type": "remote", "url": url, "enabled": True,
+    command = (
+        f"  claude mcp add --transport http --scope user {SERVER_NAME} {shlex.quote(url)} "
+        f"--header {shlex.quote(_header(token))}"
+    )
+    block = json.dumps(
+        {"mcpServers": {SERVER_NAME: {"type": "http", "url": url,
+                                      "headers": {"Authorization": f"Bearer {token}"}}}},
+        indent=2,
+    )
+    return (
+        f"Claude Code — run this:\n{command}\n\n"
+        f"…or merge this into ~/.claude.json yourself (what that command writes):\n{block}"
+    )
+
+
+def _codex(url: str, token: str) -> str:
+    return (
+        "Codex — add this to ~/.codex/config.toml (it has no --header flag):\n"
+        f"[mcp_servers.{SERVER_NAME}]\n"
+        f'url = "{url}"\n'
+        f'http_headers = {{ Authorization = "Bearer {token}" }}'
+    )
+
+
+def _copilot(url: str, token: str) -> str:
+    # Flag order as measured: `copilot mcp add --transport http --header … <name> <url>`.
+    command = (
+        f"  copilot mcp add --transport http --header {shlex.quote(_header(token))} "
+        f"{SERVER_NAME} {shlex.quote(url)}"
+    )
+    # `"tools": ["*"]` is what its own `mcp add` writes. Omitting it defaults to all tools today
+    # (measured), but printing what the harness itself writes leaves nothing to a default that moves.
+    block = json.dumps(
+        {"mcpServers": {SERVER_NAME: {"tools": ["*"], "type": "http", "url": url,
+                                      "headers": {"Authorization": f"Bearer {token}"}}}},
+        indent=2,
+    )
+    return (
+        f"GitHub Copilot CLI — run this:\n{command}\n\n"
+        f"…or merge this into ~/.copilot/mcp-config.json:\n{block}"
+    )
+
+
+def _opencode(url: str, token: str) -> str:
+    # ⚠️ `KEY=VALUE`, not `Key: value`. Spelled with a colon the header is accepted and wrong.
+    command = (
+        f"  opencode mcp add {SERVER_NAME} --url {shlex.quote(url)} "
+        f"--header {shlex.quote(f'Authorization=Bearer {token}')}"
+    )
+    block = json.dumps(
+        {"mcp": {SERVER_NAME: {"type": "remote", "url": url,
                                "headers": {"Authorization": f"Bearer {token}"}}}},
         indent=2,
-    ))
-    print(
-        "\nThis prints your grid's access token. Anyone who has it can search the web on your "
-        "account's allowance."
     )
-    return 0
+    return (
+        f"opencode — run this:\n{command}\n\n"
+        f"…or merge this into ~/.config/opencode/opencode.json:\n{block}"
+    )
+
+
+def _hermes(url: str, token: str) -> str:
+    # The block leads because `hermes mcp add` is interactive: it asks for the token at a prompt and
+    # probes the server before it will save anything. That prompt is the better path for somebody at
+    # a terminal — the token never reaches their shell history — so it is offered second.
+    block = (
+        "mcp_servers:\n"
+        f"  {SERVER_NAME}:\n"
+        f'    url: "{url}"\n'
+        "    headers:\n"
+        f'      Authorization: "Bearer {token}"\n'
+        "    enabled: true"
+    )
+    command = (
+        f"  hermes mcp add {SERVER_NAME} --url {shlex.quote(url)} --auth header"
+    )
+    return (
+        f"Hermes — add this at the top level of ~/.hermes/config.yaml:\n{block}\n\n"
+        f"…or run this, which asks for the token instead of putting it in your shell history:\n"
+        f"{command}"
+    )
+
+
+_RENDERERS = {
+    "claude": _claude,
+    "codex": _codex,
+    "copilot": _copilot,
+    "hermes": _hermes,
+    "opencode": _opencode,
+}

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -37,7 +37,7 @@ from .grid import (
 )
 from .credential import cmd_credential
 from .launch import cmd_launch
-from .mcp_config import cmd_mcp_config, cmd_mcp_token
+from .mcp_config import HARNESS_CHOICES, cmd_mcp_config
 from .mode import cmd_mode, cmd_use
 from .models import cmd_catalog, cmd_ctx, cmd_pull, cmd_rm
 from . import project_arg
@@ -1624,14 +1624,15 @@ def _add_launch(sub) -> None:
 
 
 def _add_mcp(sub) -> None:
-    """`grid mcp config|token` — point a coding agent's harness at this grid's web tools (ADR 0041).
+    """`grid mcp config` — point a coding agent's harness at this grid's web tools (ADR 0041).
 
     Nested subcommands rather than one positional with `choices=`: `grid mcp myteam` would otherwise
-    be an "invalid choice" error about a word the user meant as a grid name.
+    be an "invalid choice" error about a word the user meant as a grid name. The harness is a
+    **flag** for the same reason — `grid mcp config myteam` has to keep naming a grid.
     """
     mcp = sub.add_parser(
         "mcp",
-        help="Point Claude Code / Codex / opencode at this grid's web tools",
+        help="Point a coding agent's harness at this grid's web tools",
         description=(
             "Print the MCP configuration a coding agent's harness needs to search and read the\n"
             "web through your grid. The server runs on the control plane, so it keeps working\n"
@@ -1640,16 +1641,19 @@ def _add_mcp(sub) -> None:
     mcp_sub = mcp.add_subparsers(dest="mcp_command", required=True)
 
     config = mcp_sub.add_parser(
-        "config", help="Print the config for each harness (prints your grid's access token)")
+        "config", help="Print the config one harness needs (prints your grid's access token)")
     config.add_argument("grid", nargs="?", default=None,
                         help="Grid name or id (ag-...). Omit for the active grid.")
+    # Mutually exclusive: one asks for a harness's own spelling, the other for the values with no
+    # spelling at all. `--json` is also declared here rather than left to the global `grid --json`,
+    # like every other subcommand's — a subparser's default overrides the parent's value anyway, so
+    # the global spelling would silently stop working the moment this flag existed.
+    target = config.add_mutually_exclusive_group()
+    target.add_argument("--harness", choices=HARNESS_CHOICES,
+                        help="Print the config for one harness. Omit to list them.")
+    target.add_argument("--json", action="store_true",
+                        help="Emit machine-readable JSON: the server name, URL and header.")
     config.set_defaults(handler=cmd_mcp_config)
-
-    token = mcp_sub.add_parser(
-        "token", help="Print just the access token, for a script that builds its own config")
-    token.add_argument("grid", nargs="?", default=None,
-                       help="Grid name or id (ag-...). Omit for the active grid.")
-    token.set_defaults(handler=cmd_mcp_token)
 
 
 def _add_train(sub) -> None:

--- a/docs/adr/0041-a-coding-agent-reaches-the-web-through-the-control-plane.md
+++ b/docs/adr/0041-a-coding-agent-reaches-the-web-through-the-control-plane.md
@@ -142,9 +142,34 @@ listener, not read off vendor documentation:
 
 | harness | where the header goes |
 |---|---|
-| Claude Code | `claude mcp add --transport http … --header "Authorization: Bearer <tok>"` |
+| Claude Code | `claude mcp add --transport http … --header "Authorization: Bearer <tok>"` → `mcpServers.<n>` in `~/.claude.json` |
 | Codex | `http_headers = { Authorization = "Bearer <tok>" }` under `[mcp_servers.<n>]` |
-| opencode | `"headers": {"Authorization": "Bearer <tok>"}`, `type: "remote"` |
+| GitHub Copilot CLI | `copilot mcp add --transport http --header "Authorization: Bearer <tok>" <n> <url>` → `mcpServers.<n>` in `~/.copilot/mcp-config.json` |
+| opencode | `"headers": {"Authorization": "Bearer <tok>"}`, `type: "remote"`; its `mcp add --header` takes ⚠️ `KEY=VALUE`, not `Key: value` |
+| Hermes | `headers: {Authorization: "Bearer <tok>"}` under `mcp_servers.<n>` in `~/.hermes/config.yaml` |
+| pi | ⚠️ **nowhere — pi ships no MCP client at all**, by design ("No MCP." in its own README) |
+
+Extended 2026-09-08 to the three harnesses above, the same way and to the same standard: each binary
+run against a throwaway home so the file *it* writes could be read back, then a header-logging
+listener with a positive control proving what actually goes on the wire (Copilot 1.0.83, opencode
+1.18.29, Hermes 0.21.1 all send the literal header; Codex 0.153.4 still has no `--header`). The
+Hermes and opencode configs were then pointed at the **live** control plane with a real per-grid
+token: both connect and discover both tools.
+
+⚠️ **The server name keeps its hyphen everywhere, Codex included.** `codex mcp add` writes
+`[mcp_servers.grid-web]` itself, so a hyphen is a legal TOML bare key here; spelling it `grid_web`
+for Codex alone — which this command did until it was measured — renames the tools for that one
+harness while every other harness sees `grid-web`.
+
+⚠️ **Hermes's block is YAML, so its indentation is part of the document.** TOML and JSON ignore
+leading whitespace and had been printed indented for readability; a `mcp_servers:` printed the same
+way is a block that cannot be pasted. File blocks now start at column zero and only shell commands
+are indented.
+
+**pi is a listed target that refuses.** Leaving it out of `--harness`'s choices would answer
+argparse's "invalid choice", which reads as an oversight in this command rather than a fact about
+pi; and the refusal is decided **before** a grid is resolved, so a signed-out machine is told about
+pi rather than told to run `grid login` for a config that would not exist either way.
 
 ⚠️ **Codex's `mcp add` flags hide the field that works.** It offers only `--bearer-token-env-var`
 and the OAuth flags; there is no `--header`. `http_headers` is nonetheless a first-class field —
@@ -215,3 +240,39 @@ a minute, and Exa's `/search` is capped at ten queries per second across the who
 client in a retry loop makes every other user's search fail. The relay was absorbing that shape.
 Per-process and therefore `limit × workers`, which is right for a stuck client and, as
 `ratelimit.py` says of itself, would not be right as an abuse control.
+
+### D-h — `grid mcp config` renews the credential it is about to print, and only then
+
+The command used to be pure local work: read the store, print. That made D-c's 401 body — *"This
+grid credential was refused. Run `grid mcp config <grid>` to get a fresh one"* — untrue in the case
+it exists for. A refused credential is usually an expired one, and re-running a command that reprints
+the same expired token from the same file is a loop, not a remedy.
+
+So the offline half of ADR 0029's credential check is reused here: read `exp` out of the token, and
+if it is inside the margin exchange the stored refresh credential for a fresh 365-day one, persisting
+**both** halves (⚠️ the control plane rotates the refresh token on every exchange; storing the access
+token alone destroys this machine's ability to renew anything again — silently, and not until some
+later day). One implementation, one place, in `cli/grid_credential.py`.
+
+**The margin is 30 days, not the launch path's 24 hours.** They protect different deadlines. A launch
+protects a work session starting now, so a day of headroom is generous; what this command prints is
+pasted into a config file and left there for months, and a token with 25 hours left passes a one-day
+margin and hands somebody a harness that dies tomorrow. Thirty days is 8% of the token's life, so it
+cannot cause a renewal that would not have happened within the month anyway.
+
+⚠️ **This is the one place that must be LESS forgiving than `grid launch`.** That command warns about
+an unrepairable token and lets its relay probe decide, because the probe is authoritative and a wrong
+local clock must not cost a launch that would have worked. There is no probe here — the web-tools
+server is the control plane's, not the grid's — so an expired token with no refresh credential is
+**refused** rather than printed: the alternative writes a certainly-dead credential into a harness's
+config file, where the 401 that follows tells the user to re-run the command that gave it to them.
+A renewal that *fails* on a token which still works stays a warning on stderr, for the opposite
+reason: nothing was learned, and a control-plane hiccup must not cost somebody a config.
+
+**It reaches the network only when it is about to print the credential.** With no `--harness` the
+command lists the harnesses and prints no token, so it needs no fresh one — and an arg-less
+invocation must not rotate this machine's refresh credential to draw a menu. That listing view also
+exists so the command people run first, often on a shared screen, does not put a live 365-day
+credential on it to answer a question about which harnesses are supported. `grid mcp token`, which
+existed only to print that credential with nothing else around it, is **removed**; `--json` carries
+the same three values in a shape a script can read, and one command fewer can drift from the other.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -868,13 +868,14 @@ Step by step: [Claude Code quickstart](./claude-code-quickstart.md) ·
 ## Web tools over MCP
 
 ```
-grid mcp config [grid]     # print the config each harness needs (prints your access token)
-grid mcp token  [grid]     # print just the access token, for a script that builds its own config
+grid mcp config [grid]                 # list the harnesses; prints NO token
+grid mcp config --harness <name> [grid]  # print that harness's config (prints your access token)
+grid mcp config --json [grid]          # {server, url, authorization} for a script
 ```
 
-`grid mcp config` points a **coding agent's harness** — Claude Code, Codex, opencode — at your grid's
-web search and page reading. It prints a configuration; it changes nothing on your machine and makes
-no network call.
+`grid mcp config` points a **coding agent's harness** at your grid's web search and page reading:
+`claude`, `codex`, `copilot`, `hermes`, `opencode`. With no `--harness` it lists them and the server
+URL and prints **no credential** — the token appears only when you name the harness that needs it.
 
 The server itself runs on the control plane, not on your grid's relay, so it keeps answering whether
 or not the grid is up (ADR 0041). What the harness gets is two tools:
@@ -888,27 +889,42 @@ Both are free to you and bounded by your **account's** daily allowance, not the 
 several grids does not give you several allowances, and it is spent by whichever of your machines
 uses it.
 
-Each harness spells the credential differently, so the command prints all three:
+Each harness spells the credential differently, and every spelling below was measured against the
+binary — run against a throwaway home, the file it wrote read back, and the header watched arriving
+at a listener — never taken from vendor documentation:
 
-- **Claude Code** takes a command with `--header`.
-- **Codex** takes a config block. It has **no `--header` flag** on `codex mcp add`, so the block goes
-  into `~/.codex/config.toml` by hand; `http_headers` is what it honours.
-- **opencode** takes a `headers` object in `opencode.json`.
+| harness | what the command prints |
+|---|---|
+| **Claude Code** | `claude mcp add … --header 'Authorization: …'`, plus the `mcpServers` block it writes into `~/.claude.json` |
+| **Codex** | a `[mcp_servers.grid-web]` block for `~/.codex/config.toml`. It has **no `--header` flag**, so there is no command to print; `http_headers` is what it honours |
+| **GitHub Copilot CLI** | `copilot mcp add --transport http --header 'Authorization: …'`, plus the `~/.copilot/mcp-config.json` block |
+| **opencode** | `opencode mcp add … --header 'Authorization=Bearer …'` — ⚠️ `KEY=VALUE`, not `Key: value` — plus the `~/.config/opencode/opencode.json` block |
+| **Hermes** | the `mcp_servers:` block for `~/.hermes/config.yaml`, plus `hermes mcp add … --auth header`, which asks for the token instead of putting it in your shell history |
+| **pi** | nothing — pi ships no MCP client, by design. The command says so and exits non-zero rather than pretending there is a config |
 
-> `grid mcp config` prints a live credential that lasts a year. Anyone who has it can search the web
-> on your account's allowance. Treat the output like a password, and re-run the command after
-> `grid login` if a harness starts reporting that the server refuses it.
+**The token is renewed before it is printed.** If your grid's access token expires within a month —
+or has expired already — the command exchanges the stored refresh credential for a fresh 365-day one,
+says so on stderr, and prints the new token. So this is the command to run when a harness starts
+reporting that the server refuses it, which is what the server's own 401 tells you to do. It reaches
+the control plane only when it is about to print a credential: the plain listing view is local work.
+A renewal that fails on a token which still works is a warning, not a refusal; an *expired* token
+with no refresh credential stored is refused, because pasting it into a harness config would 401
+forever.
+
+> `grid mcp config --harness …` prints a live credential that lasts a year. Anyone who has it can
+> search the web on your account's allowance. Treat the output like a password.
 
 Web tools need a hosted grid: in local mode the command refuses, because the server it points at is
 the control plane's and a local grid has no account behind it.
 
 > **Codex cancels MCP tool calls under its read-only sandbox, and blames nobody for it.** Run
-> non-interactively as `codex exec …`, a search prints `mcp: grid_web/web_search (failed)` followed
+> non-interactively as `codex exec …`, a search prints `mcp: <server>/web_search (failed)` followed
 > by `user cancelled MCP tool call` — which reads like the grid refused it. It did not: the call is
 > stopped inside Codex and never reaches the server, so nothing shows up in your allowance either.
 > That is Codex's own approval policy (`approval: never` with `sandbox: read-only` denies anything
 > that would need approving), not a grid problem. Interactive `codex` asks you instead; a scripted
-> run needs a policy that permits the call. Measured on Codex 0.144.6.
+> run needs a policy that permits the call. Measured on Codex 0.144.6, when this command spelled the
+> server `grid_web`; it now prints `grid-web`, which is the name that appears in that line.
 
 See [ADR 0041](./adr/0041-a-coding-agent-reaches-the-web-through-the-control-plane.md).
 

--- a/tests/test_mcp_config.py
+++ b/tests/test_mcp_config.py
@@ -1,98 +1,267 @@
-"""`grid mcp config` / `grid mcp token` — the harness-facing half of ADR 0041.
+"""`grid mcp config` — the harness-facing half of ADR 0041.
 
-The command reads only local state and prints. What is worth pinning is therefore not "does it run"
-but the three things that are wrong in a way nobody would notice:
+The command reads local state, renews the credential when it is about to die, and prints. What is
+worth pinning is therefore not "does it run" but the things that are wrong in a way nobody would
+notice:
 
 - **the URL keeps its trailing slash.** Without it the control-plane mount answers 307 (measured).
 - **the base is the signed-in control plane**, not a hardcoded production host — a home logged in
   against dev must print a dev URL, or the config silently points at the wrong fleet.
-- **Codex gets a config BLOCK and not a command.** Measured on codex-cli 0.144.6: `codex mcp add`
-  has no `--header` flag, so a printed `codex mcp add … --header …` would be an invalid-argument
-  error in the user's terminal. This is the assertion that would catch somebody "tidying" the two
-  harnesses into one shape.
+- **each harness's spelling is its own, and one of them takes no command at all.** Measured
+  2026-09-08 against Claude Code 2.1.263, Codex 0.153.4, Copilot 1.0.83, opencode 1.18.29 and
+  Hermes 0.21.1, by running each binary against a throwaway home and reading the file it wrote,
+  then proving the header arrives with a header-logging listener.
+- **the listing view prints no credential**, so the command people run with no arguments does not
+  put a live 365-day token on their screen.
+- **a token inside the expiry margin is renewed before it is printed**, and a config that has just
+  been pasted into a harness is not one that dies tomorrow.
+
+⚠️ Every case here goes through the REAL parser (`_invoke`), never a hand-built ``Namespace``. The
+previous version of this suite asserted a `--json` payload by setting ``json=True`` on a namespace
+the `mcp config` parser never produced — the flag existed only as the *global* `grid --json`, which
+is not the spelling the docs give, and the test would have passed just the same had the branch been
+unreachable altogether.
 """
 
 from __future__ import annotations
 
-import argparse
+import base64
 import json
+import time
 
 import pytest
 
 from cli import mcp_config
 
 API_URL = "https://api-grid.example.invalid"
-TOKEN = "eyJ-a-per-grid-access-token"
+NETWORK_ID = "ag-0000000000000001"
+REFRESH = "a-refresh-credential"
+
+_YEAR = 365 * 24 * 3600
 
 
-@pytest.fixture
-def signed_in(monkeypatch, tmp_path):
+def _jwt(claims: dict) -> str:
+    """A JWT-shaped token whose payload carries ``claims``. No signature is checked anywhere in this
+    CLI (``credentials.claims_from_token`` says why), so an unsigned one is a faithful double."""
+    body = base64.urlsafe_b64encode(json.dumps(claims).encode()).decode().rstrip("=")
+    return f"header.{body}.sig"
+
+
+def _token(*, expires_in: float) -> str:
+    return _jwt({"exp": int(time.time() + expires_in)})
+
+
+FRESH = _token(expires_in=_YEAR)
+
+
+def _sign_in(monkeypatch, tmp_path, *, access: str = FRESH, refresh: str | None = REFRESH,
+             name: str = "team") -> None:
     """One grid in the local store, signed in against a non-default control plane."""
     from remote import credentials
 
     monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    record: dict[str, object] = {
+        "network_id": NETWORK_ID,
+        "name": name,
+        "access_token": access,
+        "lan_signaling_url": "https://relay.example.invalid",
+    }
+    if refresh is not None:
+        record["refresh_token"] = refresh
     credentials.save_credentials(
-        {
-            "session_token": "session",
-            "api_url": API_URL,
-            "networks": [
-                {
-                    "network_id": "ag-0000000000000001",
-                    "name": "team",
-                    "access_token": TOKEN,
-                    "lan_signaling_url": "https://relay.example.invalid",
-                }
-            ],
-        }
+        {"session_token": "session", "api_url": API_URL, "networks": [record]}
     )
-    return argparse.Namespace(grid=None, json=False)
 
 
-def test_token_prints_the_access_token_and_nothing_else(signed_in, capsys):
-    assert mcp_config.cmd_mcp_token(signed_in) == 0
-    assert capsys.readouterr().out.strip() == TOKEN
+def _invoke(*argv: str) -> int:
+    """Run `grid mcp …` through the real parser, so a flag that does not exist fails here."""
+    from cli.parser import build_parser
+
+    args = build_parser().parse_args(["mcp", *argv])
+    return args.handler(args)
 
 
-def test_config_url_is_the_signed_in_control_plane_with_a_trailing_slash(signed_in, capsys):
-    assert mcp_config.cmd_mcp_config(signed_in) == 0
+@pytest.fixture
+def signed_in(monkeypatch, tmp_path):
+    _sign_in(monkeypatch, tmp_path)
+
+
+@pytest.fixture
+def no_refresh_calls(monkeypatch):
+    """Fail loudly if anything reaches the control plane. A test that means "this made no network
+    call" has to be able to tell that from "the call was made and quietly succeeded"."""
+    from remote import control_plane
+
+    def _refuse(**kwargs):
+        raise AssertionError(f"the control plane was called: {kwargs}")
+
+    monkeypatch.setattr(control_plane, "refresh_network_token", _refuse)
+
+
+# ---------------------------------------------------------------------------
+# The listing view
+# ---------------------------------------------------------------------------
+
+def test_no_harness_lists_them_all_and_prints_no_credential(signed_in, capsys, no_refresh_calls):
+    """`grid mcp config` with no target is the command people run first. It names the URL and every
+    harness it can configure — and deliberately no token, so the arg-less invocation cannot put a
+    live 365-day credential on a screen somebody is sharing."""
+    assert _invoke("config") == 0
     out = capsys.readouterr().out
-    expected = f"{API_URL}{mcp_config.MOUNT_PATH}/"
-    assert expected in out
-    # The default production host must not appear: a home signed in against dev prints dev.
-    assert "api-grid.autonomous.ai" not in out
+
+    assert FRESH not in out
+    for harness in ("claude", "codex", "copilot", "hermes", "opencode"):
+        assert f"--harness {harness}" in out
+    assert f"{API_URL}{mcp_config.MOUNT_PATH}/" in out
 
 
-def test_config_covers_all_three_harnesses_with_a_literal_header(signed_in, capsys):
-    assert mcp_config.cmd_mcp_config(signed_in) == 0
+def test_the_listing_keeps_the_grid_you_named(monkeypatch, tmp_path, capsys, no_refresh_calls):
+    """The commands it suggests must configure the grid the user asked about, not the active one."""
+    _sign_in(monkeypatch, tmp_path, name="other-team")
+
+    assert _invoke("config", "other-team") == 0
+    assert "--harness claude other-team" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# One harness at a time — every shape measured against the binary, not its documentation
+# ---------------------------------------------------------------------------
+
+def test_claude_gets_the_command_and_the_file_that_command_writes(signed_in, capsys):
+    """Measured on 2.1.263: `--scope user` writes `mcpServers.<n>` into `~/.claude.json` with
+    `type: "http"`. Both spellings are printed because a person who keeps their config in git wants
+    the file, not a command that edits it behind them."""
+    assert _invoke("config", "--harness", "claude") == 0
     out = capsys.readouterr().out
 
-    assert "claude mcp add --transport http" in out
-    assert f"--header 'Authorization: Bearer {TOKEN}'" in out
+    assert "claude mcp add --transport http --scope user" in out
+    assert f"--header 'Authorization: Bearer {FRESH}'" in out
+    assert '"type": "http"' in out
+    assert '"mcpServers"' in out
 
-    # ⚠️ Codex takes a BLOCK, never a command — it has no --header flag (measured, 0.144.6).
-    assert "http_headers = { Authorization = " in out
+
+def test_codex_gets_a_block_and_never_a_command(signed_in, capsys):
+    """⚠️ Codex has no `--header` flag — still true on 0.153.4 — so a printed `codex mcp add …
+    --header …` would be an invalid-argument error in the user's terminal. This is the assertion
+    that catches somebody "tidying" the harnesses into one shape."""
+    assert _invoke("config", "--harness", "codex") == 0
+    out = capsys.readouterr().out
+
     assert "codex mcp add" not in out
-
-    assert '"type": "remote"' in out  # opencode
-    assert out.count(TOKEN) == 3  # one credential, three spellings
+    assert f'http_headers = {{ Authorization = "Bearer {FRESH}" }}' in out
 
 
-def test_config_says_the_output_carries_a_credential(signed_in, capsys):
-    """The command prints a 365-day token to a terminal; somebody pasting it into an issue should
-    have been told what it is."""
-    mcp_config.cmd_mcp_config(signed_in)
+def test_codex_keeps_the_hyphen_in_the_server_name(signed_in, capsys):
+    """`codex mcp add` writes `[mcp_servers.grid-web]` itself — measured — so a hyphen is a legal
+    TOML bare key here. Spelling it `grid_web` would rename the tools this one harness sees
+    (`grid_web__web_search` against everyone else's `grid-web`)."""
+    assert _invoke("config", "--harness", "codex") == 0
+    assert f"[mcp_servers.{mcp_config.SERVER_NAME}]" in capsys.readouterr().out
+
+
+def test_copilot_gets_the_command_and_the_file(signed_in, capsys):
+    """Measured on 1.0.83: `copilot mcp add --transport http --header "K: V"` writes
+    `mcpServers.<n>` into `~/.copilot/mcp-config.json`, and the header reaches the server."""
+    assert _invoke("config", "--harness", "copilot") == 0
+    out = capsys.readouterr().out
+
+    assert "copilot mcp add --transport http" in out
+    assert f"--header 'Authorization: Bearer {FRESH}'" in out
+    assert "~/.copilot/mcp-config.json" in out
+
+
+def test_opencode_headers_are_key_equals_value_on_the_command_line(signed_in, capsys):
+    """⚠️ opencode's `--header` takes `KEY=VALUE`, not the `Key: value` every other harness takes.
+    Printed with a colon it is accepted and the header is silently wrong."""
+    assert _invoke("config", "--harness", "opencode") == 0
+    out = capsys.readouterr().out
+
+    assert f"--header 'Authorization=Bearer {FRESH}'" in out
+    assert '"type": "remote"' in out
+
+
+def test_hermes_yaml_starts_at_column_zero(signed_in, capsys):
+    """⚠️ The one block whose indentation is load-bearing. TOML and JSON ignore leading whitespace;
+    YAML does not, so a `mcp_servers:` printed indented is a block that cannot be pasted."""
+    assert _invoke("config", "--harness", "hermes") == 0
+    out = capsys.readouterr().out
+
+    assert "\nmcp_servers:\n" in out
+    assert f'Authorization: "Bearer {FRESH}"' in out
+
+
+def test_every_harness_that_takes_one_is_told_the_credential_is_live(signed_in, capsys):
+    """A 365-day token on a screen should have been named as one before somebody pastes it into an
+    issue."""
+    assert _invoke("config", "--harness", "claude") == 0
     assert "access token" in capsys.readouterr().out
 
 
-def test_config_json_is_a_machine_readable_triple(signed_in, capsys):
-    signed_in.json = True
-    assert mcp_config.cmd_mcp_config(signed_in) == 0
+# ---------------------------------------------------------------------------
+# pi — a harness with no MCP client at all
+# ---------------------------------------------------------------------------
+
+def test_pi_is_refused_with_the_reason_and_never_reaches_the_credential_store(monkeypatch, tmp_path):
+    """pi ships no MCP client, by design ("No MCP." in its own README, 0.84.1). Answering argparse's
+    "invalid choice" would read as an oversight in this command; answering "run `grid login`" would
+    be worse still, so the refusal is decided **before** a grid is resolved — this case runs with no
+    credential store at all and must still say the same thing."""
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))  # signed out: no grids, no tokens
+
+    with pytest.raises(SystemExit) as refused:
+        _invoke("config", "--harness", "pi")
+
+    message = str(refused.value)
+    assert "pi" in message
+    assert "grid login" not in message
+
+
+# ---------------------------------------------------------------------------
+# The machine-readable triple, and the flag that replaced `grid mcp token`
+# ---------------------------------------------------------------------------
+
+def test_json_is_a_machine_readable_triple(signed_in, capsys):
+    assert _invoke("config", "--json") == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload == {
         "server": mcp_config.SERVER_NAME,
         "url": f"{API_URL}{mcp_config.MOUNT_PATH}/",
-        "authorization": f"Bearer {TOKEN}",
+        "authorization": f"Bearer {FRESH}",
     }
+
+
+def test_json_and_harness_cannot_be_combined(signed_in):
+    """One asks for a harness's own spelling, the other for the values with no spelling at all.
+    Silently ignoring either would hand a script the wrong thing."""
+    from cli.parser import build_parser
+
+    with pytest.raises(SystemExit) as refused:
+        build_parser().parse_args(["mcp", "config", "--json", "--harness", "codex"])
+    assert refused.value.code == 2
+
+
+def test_the_token_subcommand_is_gone(signed_in):
+    """`grid mcp token` was removed: `--json` carries the same value in a shape a script can read
+    without a second command to keep in step."""
+    from cli.parser import build_parser
+
+    with pytest.raises(SystemExit) as refused:
+        build_parser().parse_args(["mcp", "token"])
+    assert refused.value.code == 2
+    assert not hasattr(mcp_config, "cmd_mcp_token")
+
+
+# ---------------------------------------------------------------------------
+# The URL and the control plane behind it
+# ---------------------------------------------------------------------------
+
+def test_url_is_the_signed_in_control_plane_with_a_trailing_slash(signed_in, capsys):
+    assert _invoke("config", "--harness", "claude") == 0
+    out = capsys.readouterr().out
+
+    assert f"{API_URL}{mcp_config.MOUNT_PATH}/" in out
+    # The default production host must not appear: a home signed in against dev prints dev.
+    assert "api-grid.autonomous.ai" not in out
 
 
 def test_a_grid_with_no_token_says_to_sign_in(monkeypatch, tmp_path):
@@ -108,12 +277,131 @@ def test_a_grid_with_no_token_says_to_sign_in(monkeypatch, tmp_path):
         }
     )
     with pytest.raises(SystemExit) as refused:
-        mcp_config.cmd_mcp_config(argparse.Namespace(grid=None, json=False))
+        _invoke("config", "--harness", "claude")
     assert "grid login" in str(refused.value)
 
 
 def test_an_unknown_grid_name_is_refused(signed_in):
-    signed_in.grid = "no-such-grid"
     with pytest.raises(SystemExit) as refused:
-        mcp_config.cmd_mcp_token(signed_in)
+        _invoke("config", "--harness", "claude", "no-such-grid")
     assert "no-such-grid" in str(refused.value)
+
+
+# ---------------------------------------------------------------------------
+# Renewing the credential before it is printed
+# ---------------------------------------------------------------------------
+
+def _capture_refresh(monkeypatch, *, access: str, refresh: str | None = "rotated-refresh") -> list:
+    """Stand in for the control plane's token exchange, recording what it was asked for."""
+    from remote import control_plane
+
+    calls: list[dict] = []
+
+    def _exchange(**kwargs):
+        calls.append(kwargs)
+        bundle = {"access_token": access}
+        if refresh is not None:
+            bundle["refresh_token"] = refresh
+        return bundle
+
+    monkeypatch.setattr(control_plane, "refresh_network_token", _exchange)
+    return calls
+
+
+def test_a_token_inside_the_margin_is_renewed_before_it_is_printed(monkeypatch, tmp_path, capsys):
+    """A config is pasted once and lives in a file for months, so a token with a fortnight left is
+    a harness that stops working in a fortnight. Renewing mints a fresh 365-day one."""
+    stale = _token(expires_in=14 * 24 * 3600)
+    renewed = _token(expires_in=_YEAR)
+    _sign_in(monkeypatch, tmp_path, access=stale)
+    calls = _capture_refresh(monkeypatch, access=renewed)
+
+    assert _invoke("config", "--harness", "codex") == 0
+
+    out = capsys.readouterr().out
+    assert renewed in out
+    assert stale not in out
+    assert calls == [{"network_id": NETWORK_ID, "refresh_token": REFRESH}]
+
+
+def test_the_renewed_pair_is_persisted_so_the_next_run_can_renew_too(monkeypatch, tmp_path, capsys):
+    """⚠️ The control plane rotates the refresh credential on every exchange and the old one stops
+    matching immediately. Storing the access token alone destroys this machine's ability to renew
+    anything ever again — silently, and not until some later day."""
+    from remote import credentials
+
+    _sign_in(monkeypatch, tmp_path, access=_token(expires_in=3600))
+    renewed = _token(expires_in=_YEAR)
+    _capture_refresh(monkeypatch, access=renewed, refresh="rotated-refresh")
+
+    assert _invoke("config", "--harness", "codex") == 0
+
+    stored = credentials.load_credentials()["networks"][0]
+    assert stored["access_token"] == renewed
+    assert stored["refresh_token"] == "rotated-refresh"
+
+
+def test_a_token_with_a_year_left_is_printed_without_a_network_call(signed_in, capsys,
+                                                                    no_refresh_calls):
+    """The margin is what keeps this command cheap: a healthy token is local work only."""
+    assert _invoke("config", "--harness", "codex") == 0
+    assert FRESH in capsys.readouterr().out
+
+
+def test_the_listing_view_never_renews(monkeypatch, tmp_path, capsys, no_refresh_calls):
+    """Nothing is handed out, so nothing needs renewing — and an arg-less command must not rotate a
+    credential (or need the network at all) to print a menu."""
+    _sign_in(monkeypatch, tmp_path, access=_token(expires_in=3600))
+
+    assert _invoke("config") == 0
+    assert "--harness claude" in capsys.readouterr().out
+
+
+def test_a_failed_renewal_of_a_still_valid_token_warns_and_prints_it_anyway(monkeypatch, tmp_path,
+                                                                           capsys):
+    """A control-plane hiccup must not cost somebody a config they could have had: the token still
+    works today. Named on stderr, never swallowed."""
+    from remote import control_plane
+
+    stale = _token(expires_in=2 * 24 * 3600)
+    _sign_in(monkeypatch, tmp_path, access=stale)
+
+    def _fails(**_kwargs):
+        raise control_plane.ControlPlaneError("token refresh failed (503): busy", status=503)
+
+    monkeypatch.setattr(control_plane, "refresh_network_token", _fails)
+
+    assert _invoke("config", "--harness", "codex") == 0
+    captured = capsys.readouterr()
+    assert stale in captured.out
+    assert "couldn't renew" in captured.err
+    # ⚠️ Not "launching anyway": the sentence is shared with `grid launch`, and this command launches
+    # nothing. A message about a command the user did not run is how a shared string goes wrong.
+    assert "printing it anyway" in captured.err
+    assert "launching" not in captured.err
+
+
+def test_an_expired_token_with_nothing_to_renew_it_is_refused(monkeypatch, tmp_path, capsys):
+    """⚠️ The one case that must NOT degrade into printing. `grid launch` prints a warning here and
+    lets its relay probe decide, but this command has no probe — the web-tools server is the control
+    plane's — so an expired token would be pasted into a harness that then 401s forever, with the
+    server's own refusal telling the user to re-run the command that gave it to them."""
+    _sign_in(monkeypatch, tmp_path, access=_token(expires_in=-3600), refresh=None)
+
+    with pytest.raises(SystemExit) as refused:
+        _invoke("config", "--harness", "codex")
+    assert "grid login" in str(refused.value)
+    # Said once. The shared repair warns about this same state in its own words for `grid launch`,
+    # which goes on to ask its relay; printing both leaves the user reading one fact twice.
+    assert "no refresh credential is stored" not in capsys.readouterr().err
+
+
+def test_an_expired_token_that_can_be_renewed_is_renewed(monkeypatch, tmp_path, capsys):
+    """Expiry is not a dead end while a refresh credential is stored — which is what makes the
+    control plane's own 401 sentence ("run `grid mcp config`") true rather than a loop."""
+    renewed = _token(expires_in=_YEAR)
+    _sign_in(monkeypatch, tmp_path, access=_token(expires_in=-3600))
+    _capture_refresh(monkeypatch, access=renewed)
+
+    assert _invoke("config", "--harness", "codex") == 0
+    assert renewed in capsys.readouterr().out


### PR DESCRIPTION
## What

`grid mcp config` knew three harnesses of the six people here run, printed a live 365-day credential
three times to answer "which harnesses can I use", and could not do the thing the web-tools server's
own 401 tells the user to do.

- **`--harness {claude,codex,copilot,hermes,opencode,pi}`** — a flag, so `grid mcp config myteam`
  keeps naming a grid. With no `--harness` the command lists them and the URL and prints **no token**.
- **Claude Code, Copilot and opencode** get the command *and* the config file that command writes;
  **Codex** still gets a block (no `--header` flag on 0.153.4 either); **Hermes** gets its YAML block;
  **pi** is accepted and answered in words — it ships no MCP client, by design — before a grid is
  resolved, so a signed-out machine hears about pi rather than about `grid login`.
- **The token is renewed before it is printed** when it expires within 30 days, reusing ADR 0029's
  offline check rather than copying the rotation rule. That makes the server's 401 (*"run
  `grid mcp config`"*) a remedy rather than a loop. The network is reached only when a credential is
  about to be printed, so the listing view stays local work.
- **`grid mcp token` is removed**; `--json` carries the same three values.

## Measured, not read off documentation

Each binary was run against a throwaway home (`CLAUDE_CONFIG_DIR` / `HOME` / `CODEX_HOME` /
`XDG_CONFIG_HOME` / `HERMES_HOME`) and the file *it* wrote was read back; a header-logging listener
with a positive control then proved Copilot, Hermes and opencode all send the literal `Authorization`
header. The Hermes and opencode configs were pointed at the **live** control plane with a real
per-grid token: `✓ Connected`, both tools discovered.

Three things a doc read would have got wrong:

- ⚠️ **opencode's `--header` takes `KEY=VALUE`**, not `Key: value`. With a colon it is accepted and
  the header is silently wrong.
- ⚠️ **Codex writes `[mcp_servers.grid-web]` itself**, so the hyphen is legal there; this command had
  been spelling it `grid_web`, renaming the tools for that one harness.
- ⚠️ **Hermes's block is YAML**, so the two-space indent every other block carried for readability
  would have made it unpasteable. File blocks now start at column zero; only commands are indented.

## Test plan

- [x] `tests/test_mcp_config.py` — 23 cases, **all through the real parser**. The suite this replaces
      asserted a `--json` payload on a hand-built `Namespace` the `mcp config` parser never produced,
      so it would have passed even had the branch been unreachable.
- [x] Full suite on the merged tree: **3498 passed, 9 skipped, 0 failed**.
- [x] `ruff` clean on every file touched (`cli/parser.py`'s pre-existing I001 is unchanged).
- [x] Live round-trip against production for two harnesses (above).
- [x] `main` merged into the branch first; no conflicts.

Decisions land in ADR 0041 D-d (the six-harness table) and the new **D-h** (renewing the credential
it prints); `docs/cli.md` and the rollout-order note updated to match.