### PR TITLE
chore(release): v0.3.43

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "grid"
-version = "0.3.42"
+version = "0.3.43"
 description = "Grid: one private OpenAI-compatible endpoint for the AI engines you already run."
 requires-python = ">=3.11"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -814,7 +814,7 @@ wheels = [
 
 [[package]]
 name = "grid"
-version = "0.3.42"
+version = "0.3.43"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
v0.3.42 was cut before the --parallel↔max-concurrency fix (#102) landed. That fix ships under 0.3.43.