### PR TITLE
fix(os-grid): find Omarchy on a Mac, where ID=omarchy is never written

### DIFF
--- a/docs/adr/0039-a-grid-can-be-keyed-on-an-os.md
+++ b/docs/adr/0039-a-grid-can-be-keyed-on-an-os.md
@@ -72,6 +72,60 @@ signal — and `ID_LIKE=` must stay out of it.** The `omarchy-settings` package 
 copy and `cp -f`s that one over `/etc/os-release` on every install and upgrade. Identical in
 `omarchy-settings-dev`, the edge channel. Stock Arch is `ID=arch` with no `ID_LIKE`.
 
+**AMENDED 2026-09-09: that `cp -f` is x86-only, so `ID=` alone was never going to find a Mac. The
+INSTALL on disk is a second signal — `/usr/share/omarchy/version` (`os_grid._BY_MARKER`).** The
+paragraph above says "on every install and upgrade"; it is true on x86 and false on Apple Silicon,
+and the difference cost the whole Mac population their grid silently. Found because a user running
+`omarchy-mac` reported seeing **Linux** and not Omagrid — no test failed, no signal was missing, and
+the machine had a real grid, so nothing anywhere said so.
+
+Both Apple Silicon routes miss the identity, for unrelated reasons, and neither is an accident to be
+waited out:
+
+- **Bare metal** (`omacom/omarchy-mac`: Asahi + Arch Linux ARM, the m1n1 → u-boot → GRUB chain). The
+  package IS installed, but `omarchy-settings.install` opens with
+  `_apple_silicon() { [[ $(uname -m) == aarch64 ]] && grep -aq 'apple,' /proc/device-tree/compatible; }`
+  and returns EARLY on a Mac, having symlinked `/etc/os-release` back to Arch Linux ARM's own
+  (`ID=archarm`, `ID_LIKE=arch`). The `cp -f` that writes the identity sits on the far side of that
+  `return 0`. Deliberate and shipped — omarchy-pkgs PR #275 (`4ed5f14`, 2026-09-02, *one day before
+  this ADR resolved the signal*): "Apple Silicon installs run on Arch Linux ARM's base with the Asahi
+  packages, and keep that system identity."
+- **The VM** (`omacom/try-omarchy`, ~9.8k `.dmg` downloads in its first fortnight). It never installs
+  `omarchy-settings` at all: `guest/packages.lock.json` carries only `omarchy-keyring`, the guest is a
+  plain Arch Linux ARM `pacstrap` (`guest/Containerfile:26`), and `materialize-omarchy.sh` *copies*
+  the Omarchy source tree to `/usr/share/omarchy`. A repository-wide search for `os-release` there
+  returns zero hits.
+
+⚠️ **The marker is `/usr/share/omarchy/version`, and NOT the nearer-looking
+`/usr/share/omarchy/etc-overrides/os-release`.** The latter carries a real `ID=omarchy` line and is
+staged even on Apple Silicon — the early return skips only the copy into `/etc`, never the packaging
+— so it looks like the better match for a rule written about `ID=`. It is written by
+`omarchy-settings` alone, and the VM route installs no package, so it is absent exactly where the
+larger population is. `version` is written by BOTH producers: `pkgbuilds/omarchy/PKGBUILD:161`
+(`arch=('x86_64' 'aarch64')`) and `try-omarchy` `guest/scripts/materialize-omarchy.sh:130`. Two
+independent producers, one path, every layout.
+
+⚠️ **It is read as a FILE, on a SYSTEM path, and only after `ID=` has failed to name a
+distribution.** A file rather than the directory, because `pacman -R omarchy` can leave
+`/usr/share/omarchy` behind and an uninstall is precisely when a machine stops being an Omarchy
+machine. A system path rather than `~/.local/share/omarchy` (where Omarchy 3.x kept its tree, which
+is why that layout still resolves to `linux`), because a per-user path is writable by anything the
+person runs and this decides which grid a machine joins. And after `ID=`, because a distribution
+stating its own identity is the stronger claim wherever it survives — the marker speaks only where
+that read came back with a distribution this product has no grid for.
+
+⚠️ **This widens who claims `omarchy`; it narrows nothing.** A machine with neither signal is still
+`linux`. The direction that changes is Mac users moving OFF the Linux grid and onto Omagrid, which is
+D-c's own rule (`os=` is single-valued) working as decided, now on the machines it always meant.
+There is **no cross-repo half and no rollout order**: the token set is unchanged and the control
+plane has served `omarchy` since 2026-09-03 — only this CLI's reading of its own disk moves.
+
+⚠️ **Upstream has no plan to change it.** `omarchy-settings.install` has three commits in its whole
+history, none since #275, and that PR's own offer to narrow the behaviour ("If you would rather
+narrow it to just os-release, that is a one-line change and I am happy to make it") was never taken
+up. No issue or PR in `omarchy-pkgs`, `omarchy-mac` or `try-omarchy` discusses distro identity on
+Apple Silicon. So this is not a workaround waiting on a fix upstream; it is the shape of the signal.
+
 ⚠️ **`shared/engine/installer._detect_distro` is no longer the shape to follow, and this decision is
 the reason.** It reads `ID=` and `ID_LIKE=` into ONE list and matches either. Every Arch derivative
 ships `ID_LIKE=arch` — EndeavourOS, CachyOS, Manjaro — so copied here it would put all of them on the

--- a/shared/system/os_grid.py
+++ b/shared/system/os_grid.py
@@ -42,6 +42,17 @@ the two fields into ONE list and matches either; copied here it would put every 
 Omarchy grid, which is the exact mis-sorting the closed set exists to prevent. ``ID=`` is an identity,
 ``ID_LIKE=`` is a lineage, and only the first one names a community.
 
+⚠️ **On a Mac, Omarchy does not write that file, so a second signal is needed** — the INSTALL on
+disk (:data:`_BY_MARKER`). Read at source 2026-09-08, after a user on ``omarchy-mac`` reported
+landing on the Linux grid. Both Apple Silicon routes miss ``ID=omarchy``, for unrelated reasons:
+``omarchy-settings``' scriptlet opens with an ``_apple_silicon()`` test and returns EARLY on a Mac
+after symlinking ``/etc/os-release`` back to Arch Linux ARM's own (``ID=archarm``) — the ``cp -f``
+that writes the identity is on the far side of that ``return`` — while ``omacom/try-omarchy``, the VM
+most people meet Omarchy through on a Mac, never installs that package at all and copies the source
+tree in instead. Neither is an accident to be waited out: the first is upstream's stated intent
+(omarchy-pkgs PR #275, *"keep that system identity"*), and the second has no os-release handling
+anywhere in its repository.
+
 ⚠️ **Omarchy is NOT also on the Linux grid, and that is the decision rather than a gap.** ``os=`` is a
 single value and the far end's gate is an equality test against one grid's own token, so claiming
 ``omarchy`` is precisely what takes the machine off the general Linux grid. A reading that has it join
@@ -93,6 +104,28 @@ _BY_DISTRO_ID = {
     "omarchy": OS_OMARCHY,
 }
 
+#: What a distribution's INSTALL leaves on disk → OS token. A third closed set, read only when
+#: `_BY_DISTRO_ID` did not answer, for a distribution whose own `/etc/os-release` identity does not
+#: survive on every platform it ships for. See the module docstring for why Omarchy needs one.
+#:
+#: ⚠️ **`/usr/share/omarchy/version` rather than the nearer-looking
+#: `/usr/share/omarchy/etc-overrides/os-release`.** That one really does carry an `ID=omarchy` line
+#: and really is staged even on Apple Silicon (the scriptlet's early return skips only the copy INTO
+#: `/etc`, never the packaging), so it looks like the better match for a module that reads `ID=`
+#: everywhere else. It is written by `omarchy-settings` alone — and the VM route installs no package
+#: at all, so it is absent there. `version` is written by BOTH producers: the `omarchy` package
+#: installs it (`pkgbuilds/omarchy/PKGBUILD:161`, `arch=('x86_64' 'aarch64')`) and the VM image
+#: copies it (`try-omarchy` `guest/scripts/materialize-omarchy.sh:130`). Two independent producers,
+#: one path, every layout.
+#:
+#: ⚠️ **A system path, never one under `$HOME`.** Omarchy 3.x kept its tree in
+#: `~/.local/share/omarchy`, which is why that layout resolves to `linux` and must stay that way:
+#: a per-user path is writable by anything the person runs, and this map decides which grid a machine
+#: joins. `/usr/share/omarchy` is created by the Quattro upgrade and owned by a package.
+_BY_MARKER = {
+    Path("/usr/share/omarchy/version"): OS_OMARCHY,
+}
+
 
 def _distro_id() -> str:
     """The lowercased ``ID=`` of ``/etc/os-release``, or ``""`` when there is nothing to read.
@@ -113,6 +146,23 @@ def _distro_id() -> str:
         if line.startswith("ID="):
             return line.split("=", 1)[1].strip().strip("\"'").strip().lower()
     return ""
+
+
+def _marker_token() -> str | None:
+    """The token of the first install marker present on this machine, or ``None`` for no marker.
+
+    ``is_file`` and never ``exists``: `pacman -R omarchy` removes the files it owns and can leave
+    `/usr/share/omarchy` behind, and an uninstall is precisely when a machine stops being an Omarchy
+    machine — keyed on the directory it would go on claiming `omarchy` for good.
+
+    Needs no guard of its own, unlike :func:`_distro_id`: ``Path.is_file`` answers ``False`` for
+    every way the path can be missing or unreadable rather than raising, so there is no failure here
+    to keep out of ``grid login``.
+    """
+    for path, token in _BY_MARKER.items():
+        if path.is_file():
+            return token
+    return None
 
 
 def system_name() -> str:
@@ -151,8 +201,18 @@ def os_token() -> str | None:
     ⚠️ The distro read hangs off the ``linux`` answer and nothing else. ``/etc/os-release`` is not
     Linux's alone — a container image or a hand-rolled script can leave one on a Mac — and consulting
     it before the system is known would move that machine's grid.
+
+    ⚠️ **So does the marker read, for the same reason one level down.** ``/usr/share`` is not Linux's
+    alone either, and `try-omarchy` ships a 1.3 GB image containing this very path whose ``.dmg`` is
+    opened *on a Mac*. The order of the two is the design: ``ID=`` is an identity a distribution
+    states about itself and still decides wherever it survives, and the marker speaks only where that
+    read came back with a distribution this CLI has no grid for. Neither narrows the Linux grid — a
+    machine with neither signal is an ordinary Linux machine.
     """
     token = _BY_SYSTEM.get(system_name())
     if token != OS_LINUX:
         return token
-    return _BY_DISTRO_ID.get(_distro_id(), OS_LINUX)
+    distro = _BY_DISTRO_ID.get(_distro_id())
+    if distro is not None:
+        return distro
+    return _marker_token() or OS_LINUX

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -12116,10 +12116,11 @@ def test_control_plane_fetch_tokens_defaults_missing_networks_to_empty(monkeypat
 # machine of a given system ends up sending, and the parameter is what the control plane gates on.
 
 
-def _fetch_tokens_query(monkeypatch, tmp_path, system, os_release=None):
+def _fetch_tokens_query(monkeypatch, tmp_path, system, os_release=None, *, marker=False):
     """The query string `fetch_tokens` builds on a machine whose ``platform.system()`` is ``system``.
 
     ``os_release`` is that machine's ``/etc/os-release``, or ``None`` for a machine that has none.
+    ``marker`` is whether an Omarchy install is present on its disk (`os_grid._BY_MARKER`).
 
     ⚠️ **Both are stubbed on every call, and the second is not optional decoration.** Since `omarchy`
     landed (issue 04) a Linux machine's token is read off that file, so a test that left the real one
@@ -12127,6 +12128,10 @@ def _fetch_tokens_query(monkeypatch, tmp_path, system, os_release=None):
     green on an Ubuntu runner, and quietly wrong the day somebody runs it on Omarchy. Pointing the
     module at a path that does not exist is the deterministic *no distro signal* case, and it is what
     keeps `("Linux", "linux")` a statement about the code rather than about the machine.
+
+    The marker map is stubbed for the same reason and is the same trap one level down: it names a
+    path under ``/usr/share``, so a suite that left it alone would answer `omarchy` for every one of
+    these cases the day somebody runs it on a machine that has Omarchy installed.
     """
     import platform
 
@@ -12138,6 +12143,10 @@ def _fetch_tokens_query(monkeypatch, tmp_path, system, os_release=None):
     if os_release is not None:
         os_release_path.write_text(os_release, encoding="utf-8")
     monkeypatch.setattr(os_grid, "_OS_RELEASE", os_release_path)
+    marker_path = tmp_path / "omarchy-version"
+    if marker:
+        marker_path.write_text("4.0.2\n", encoding="utf-8")
+    monkeypatch.setattr(os_grid, "_BY_MARKER", {marker_path: os_grid.OS_OMARCHY})
     seen = {}
 
     def handler(request):
@@ -12336,6 +12345,122 @@ def test_a_gigantic_os_release_is_not_read_into_memory(monkeypatch, tmp_path):
 
     monkeypatch.setattr(platform, "system", lambda: "Linux")
     assert os_grid.os_token() == "linux"
+
+
+# --- Omarchy on a Mac never writes `ID=omarchy`, so the install on disk is the second signal -------
+# `/etc/os-release` carries Omarchy's identity on x86 and NOWHERE ELSE. Both Apple Silicon routes
+# were read at source on 2026-09-08, and they miss it for two unrelated reasons:
+#
+# - **Bare metal** (`omacom/omarchy-mac`, Asahi + Arch Linux ARM): the package IS installed, but
+#   `omarchy-pkgs/pkgbuilds/omarchy-settings/omarchy-settings.install` opens with an
+#   `_apple_silicon()` test (aarch64 AND `apple,` in `/proc/device-tree/compatible`) and returns
+#   EARLY, after symlinking `/etc/os-release` back to Arch Linux ARM's own. The `cp -f` that would
+#   write `ID=omarchy` sits on the far side of that `return 0`. Deliberate and shipped — omarchy-pkgs
+#   PR #275: "Apple Silicon installs run on Arch Linux ARM's base with the Asahi packages, and keep
+#   that system identity".
+# - **The VM** (`omacom/try-omarchy`, ~10k `.dmg` downloads in its first fortnight): never installs
+#   `omarchy-settings` at all. Its guest is a plain Arch Linux ARM pacstrap and
+#   `guest/scripts/materialize-omarchy.sh` COPIES the Omarchy source tree in; a repository-wide
+#   search for `os-release` there finds nothing.
+#
+# Both therefore answer `ID=archarm`, and keying on that file alone left the entire Apple Silicon
+# population on the Linux grid — found because a user reported it, not because a test did.
+#
+# ⚠️ **The second signal is a MARKER, and it is deliberately not a second `os-release` to parse.**
+# `/usr/share/omarchy/version` is written by BOTH producers — the `omarchy` package installs it
+# (`pkgbuilds/omarchy/PKGBUILD:161`, `arch=('x86_64' 'aarch64')`) and the VM image copies it
+# (`materialize-omarchy.sh:130`) — so one path covers every layout there is. The nearer-looking
+# `/usr/share/omarchy/etc-overrides/os-release` really does carry an `ID=omarchy` line and really is
+# staged on Apple Silicon, but `omarchy-settings` alone writes it, so it is absent in the VM.
+
+_ALARM_OS_RELEASE = 'NAME="Arch Linux ARM"\nID=archarm\nID_LIKE=arch\n'
+
+
+def test_fetch_tokens_sends_omarchy_when_only_the_install_on_disk_says_so(monkeypatch, tmp_path):
+    """The Apple Silicon case, at the wire: ALARM's identity in the file, Omarchy on the disk.
+
+    This is what every Mac running Omarchy looks like — bare metal and VM alike — and before the
+    marker it claimed `linux`, which is a real grid, so nothing failed and nobody was told.
+    """
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    params = _fetch_tokens_query(
+        monkeypatch, tmp_path, "Linux", os_release=_ALARM_OS_RELEASE, marker=True)
+    assert params["os"] == "omarchy"
+
+
+@pytest.mark.parametrize(
+    "label,os_release",
+    [
+        ("Arch Linux ARM, which is what a Mac answers", _ALARM_OS_RELEASE),
+        ("stock Arch, for the x86 machine whose scriptlet has not run yet", _ARCH_OS_RELEASE),
+        ("a machine with no /etc/os-release at all", None),
+    ])
+def test_the_marker_decides_whatever_the_distro_id_failed_to_say(
+    monkeypatch, tmp_path, label, os_release
+):
+    """The marker is consulted after `ID=` and answers for every way `ID=` can fail to name Omarchy.
+
+    Written as its own parametrize because the ORDER is the whole design: `ID=omarchy` is still read
+    first and still decides on x86, and the marker only speaks where that read came back with a
+    distribution this CLI has no grid for. Nothing here narrows the Linux grid — a machine with
+    neither signal is still `linux`, which the parametrize above pins.
+    """
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    params = _fetch_tokens_query(
+        monkeypatch, tmp_path, "Linux", os_release=os_release, marker=True)
+    assert params["os"] == "omarchy", label
+
+
+@pytest.mark.parametrize("system,expected", [("Darwin", "macos"), ("Windows", None)])
+def test_a_machine_that_is_not_linux_never_consults_the_marker_either(
+    monkeypatch, tmp_path, system, expected
+):
+    """The marker hangs off the `linux` answer, exactly as the `/etc/os-release` read does.
+
+    Same reason, one level down: `/usr/share` is not Linux's alone. A Mac can mount, sync or unpack
+    one — `try-omarchy` ships an image containing this very path, and its `.dmg` is opened ON a Mac —
+    and a lookup done before the system is known would move that machine's grid.
+    """
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    params = _fetch_tokens_query(monkeypatch, tmp_path, system, marker=True)
+    assert params.get("os") == expected
+
+
+def test_an_emptied_omarchy_directory_is_not_an_omarchy_machine(monkeypatch, tmp_path):
+    """The marker is the FILE. A directory of that name is no signal, and this is why.
+
+    `pacman -R omarchy` removes the files it owns and can leave `/usr/share/omarchy` behind — an
+    uninstall is exactly when a machine stops being an Omarchy machine, and keying on the directory
+    would have it claim `omarchy` for good. `Path.is_file` also answers False rather than raising for
+    every way the path can be unreadable, so nothing here can take a sign-in down.
+    """
+    import platform
+
+    from shared.system import os_grid
+
+    monkeypatch.setenv("GRID_HOME", str(tmp_path))
+    marker = tmp_path / "omarchy-version"
+    marker.mkdir()
+    monkeypatch.setattr(os_grid, "_BY_MARKER", {marker: os_grid.OS_OMARCHY})
+    monkeypatch.setattr(os_grid, "_OS_RELEASE", tmp_path / "no-such-os-release")
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+
+    assert os_grid.os_token() == "linux"
+
+
+def test_the_marker_map_is_the_path_both_omarchy_layouts_actually_write():
+    """Pins the literal path and the fact that it is the ONLY one.
+
+    Not decoration: this path is an unwritten contract with a repository nobody here controls, and
+    the two producers agree on it by coincidence of layout rather than by any promise. A test that
+    only exercised the map through a stub would keep passing if the real path were mistyped, which is
+    the one mistake that costs the whole Apple Silicon population again and says nothing when it does.
+    """
+    from pathlib import Path
+
+    from shared.system import os_grid
+
+    assert os_grid._BY_MARKER == {Path("/usr/share/omarchy/version"): os_grid.OS_OMARCHY}
 
 
 def test_windows_is_not_a_system_this_cli_has_a_grid_for(monkeypatch, tmp_path):
@@ -41682,7 +41807,9 @@ def _refresh_body(monkeypatch, tmp_path, system, os_release=None):
     ``/etc/os-release`` is stubbed here for the same reason `_fetch_tokens_query` stubs it: since
     `omarchy` landed, a Linux machine's token is read off that file, and leaving the real one in place
     would make a `("Linux", "linux")` case a statement about the host running the suite rather than
-    about the code.
+    about the code. The install marker is stubbed to a path that does not exist for that same reason
+    — this helper's cases are all *no Omarchy on this machine*, and saying so is what keeps them true
+    on a machine that has one.
     """
     import json as _json
     import platform
@@ -41695,6 +41822,8 @@ def _refresh_body(monkeypatch, tmp_path, system, os_release=None):
     if os_release is not None:
         os_release_path.write_text(os_release, encoding="utf-8")
     monkeypatch.setattr(os_grid, "_OS_RELEASE", os_release_path)
+    monkeypatch.setattr(
+        os_grid, "_BY_MARKER", {tmp_path / "no-omarchy-install": os_grid.OS_OMARCHY})
     seen = {}
 
     def handler(request):


### PR DESCRIPTION
## The bug

`/etc/os-release` carries Omarchy's identity on x86 and **nowhere else**, so every Apple Silicon
machine running Omarchy claimed `linux` and sat on the Linux grid instead of Omagrid.

Found because a user on `omarchy-mac` reported it — not by a test. Nothing failed: the claim was a
real token, the machine got a real grid, and no signal anywhere said the wrong one.

## Why both Mac routes miss it

- **Bare metal** (`omacom/omarchy-mac`, Asahi + Arch Linux ARM). The package *is* installed, but
  `omarchy-settings`' scriptlet opens with
  `_apple_silicon() { [[ $(uname -m) == aarch64 ]] && grep -aq 'apple,' /proc/device-tree/compatible; }`
  and returns **early**, after symlinking `/etc/os-release` back to Arch Linux ARM's own
  (`ID=archarm`). The `cp -f` that writes `ID=omarchy` is on the far side of that `return 0`.
  Deliberate and shipped — omarchy-pkgs PR #275 (`4ed5f14`, 2026-09-02), *"Apple Silicon installs run
  on Arch Linux ARM's base with the Asahi packages, and keep that system identity"* — merged **one day
  before** we shipped the signal.
- **The VM** (`omacom/try-omarchy`, ~9.8k `.dmg` downloads in its first fortnight). Never installs
  that package at all: `guest/packages.lock.json` carries only `omarchy-keyring`, the guest is a plain
  Arch Linux ARM `pacstrap`, and `materialize-omarchy.sh` *copies* the source tree in. A
  repository-wide search for `os-release` there returns zero hits.

Upstream has no plan to change either: `omarchy-settings.install` has three commits in its whole
history, none since #275, and that PR's own offer of a narrower fix was never taken up.

## The fix

A third closed map in `shared/system/os_grid.py`, read **after** `ID=` and only on a machine that
already resolved to `linux`:

```python
_BY_MARKER = {Path("/usr/share/omarchy/version"): OS_OMARCHY}
```

**Why `version` and not the nearer-looking `etc-overrides/os-release`** — that one carries a real
`ID=omarchy` line and *is* staged even on Apple Silicon (the early return skips only the copy into
`/etc`, never the packaging), so it looks like the better match for a module that reads `ID=`
everywhere else. But `omarchy-settings` alone writes it, so it is absent exactly where the larger
population is. `version` has **two independent producers**: `omarchy/PKGBUILD:161`
(`arch=('x86_64' 'aarch64')`) and `try-omarchy` `materialize-omarchy.sh:130`. One path, every layout.

- `is_file()` and never `exists()` — `pacman -R omarchy` can leave `/usr/share/omarchy` behind, and an
  uninstall is precisely when a machine stops being an Omarchy machine.
- A **system** path and never `~/.local/share/omarchy` (Omarchy 3.x's per-user tree), so 3.x
  deliberately stays `linux`: a per-user path is writable by anything the person runs, and this
  decides which grid a machine joins.

## Blast radius

Widens who claims `omarchy`; narrows nothing. A machine with neither signal is still `linux`. Mac
users move **off** the Linux grid and onto Omagrid, which is ADR 0039 D-c working as decided (`os=` is
single-valued), now on the machines it always meant.

**No cross-repo half and no rollout order.** The token set is unchanged and the control plane has
served `omarchy` since 2026-09-03 — only this CLI's reading of its own disk moves.

## Test plan

- [x] TDD: 16 red → green. New cases cover the ALARM-identity machine, the marker deciding wherever
      `ID=` failed to name a distribution, the marker being ignored on a non-Linux system, an emptied
      `/usr/share/omarchy` directory, and the literal marker path itself.
- [x] Both `os=` carriers stub the marker (`_fetch_tokens_query`, `_refresh_body`) — without that the
      suite answers `omarchy` for every case the day it runs on a machine that has Omarchy installed.
- [x] `pytest tests/` on the merged tree — see below.
- [x] `ruff check .` clean.
- [ ] **Live confirmation still open**: every fact here is a source read. A user on `omarchy-mac` has
      been sent a script that prints the token this build would produce; expected
      `grid today: linux` → `grid patched: omarchy`. If the marker turns out to be absent on a real
      Apple Silicon install, the line to change is `_BY_MARKER` and nothing else.

ADR 0039 D-c amended with the evidence, including the corrected claim that the `cp -f` runs "on every
install and upgrade".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
