### PR TITLE
docs: ADR 0042 — a grid's money is counted in credits

### DIFF
--- a/docs/adr/0042-a-grids-money-is-counted-in-credits.md
+++ b/docs/adr/0042-a-grids-money-is-counted-in-credits.md
@@ -1,0 +1,357 @@
+---
+status: proposed
+---
+
+# A grid's money is counted in credits, and the two places a dollar becomes one are named
+
+A grid can already charge for inference. The rates are a member's own, the deduction is atomic and
+idempotent, and the gate that refuses an empty wallet works. What none of it has is a **unit anybody
+can use**, a **name for the seam where real money meets it**, or a **switch an operator can throw
+without guessing**.
+
+The wallet is denominated in dollars, and one request costs a fraction of a cent. The number a
+member would be shown is `0.0043` — not a quantity anyone budgets against, watches go down, or
+recognises as the thing they bought. Meanwhile the app's own copy for the refusal reads *"You're out
+of credit on this grid — top up your balance"*. The product has been speaking credits while every
+wire and every column said dollars; this decision makes the wire agree with the copy rather than the
+other way round.
+
+Six facts decided the shape, and most of them point away from the obvious implementation.
+
+- **A market reference price and a member's own price share one sort key.** grid-src's
+  `db.GridReferencePricingRow.price_score` says so outright — *"Same scalar and same weighting as
+  `grid_chat_pricing.price_score`, so the two are comparable in one sort key"* — and the reference
+  table is crawled from a vendor in dollars per million tokens. Re-denominate one side alone and
+  engine selection breaks, silently, in a direction no money test can see.
+- **A renamed wire field refuses; a re-denominated one does not.** Measured on the control plane's
+  own schema library (pydantic 2.13.5): a handler requiring `cost_credits`, fed an old relay's
+  `{request_id, cost_usd}`, raises `ValidationError: cost_credits Field required`. The extra old
+  field is ignored — it is the *missing required* one that refuses. Keep the name and change the
+  unit and nothing anywhere notices being wrong by a thousand.
+- **The usage report throws its answer away, and its own sibling does not.** `relay._report_usage`
+  does `await client.post(...)` and discards the result; `httpx` does not raise on 4xx or 5xx.
+  Twenty lines above it, `_fetch_authoritative_balance` checks `r.status_code < 400`. The asymmetry
+  is the whole silent-revenue-loss hole, and closing it is one `if`.
+- **The control plane has no migration framework.** `grid_networks/db.py::init_schema` replays a
+  fixed statement tuple on every startup, in one transaction. Every schema change has to be
+  re-runnable, and PostgreSQL has no `RENAME COLUMN IF EXISTS`.
+- **Two wallets exist in two units, and the bridge between them still compiles.**
+  `grid_auth.apply_sync_snapshot` still reads `snapshot["accounts"]` and writes the control plane's
+  *dollar* balance into `AccountRow.credit_balance`, a column the media path spends at 100 credits
+  per dollar. The loop never runs today only because the control plane stopped sending the key and
+  says so in its own source. It is one restored wire field from a hundred-fold collision.
+- **Nobody can take money out.** `payout|withdraw|cash.?out|payable` matches nothing outside
+  unrelated prose in any of the three repositories. An engine's earnings accumulate and can only
+  ever be spent back inside the grid.
+
+## Decision
+
+### D-a — A credit is a thousandth of a dollar, and the ratio has no runtime writer
+
+`CREDITS_PER_USD = 1000`. One credit is $0.001, so an ordinary request costs single-digit to
+low-double-digit credits — a whole number a member can read, compare and budget with.
+
+*Why a non-currency unit at all.* The product does not present a currency balance to end users, and
+an inference request routinely costs well under a cent. A wallet that reads `$0.0043` is not a
+wallet: there is no meaningful digit in it, nothing to watch move, and no way to tell an expensive
+question from a cheap one.
+
+*Why a constant and not a setting.* This is deliberately the opposite of the platform cut, which is
+**gaining** a runtime writer in D-j. A ratio that can change while the system is running is a number
+that makes two screens disagree with no ledger row to explain the difference: rows written before
+the change and rows written after are in different units, and nothing in either record says which.
+Changing it is a release, on purpose.
+
+### D-b — The ratio applies at exactly two boundaries, and inside the report function rather than at its call site
+
+| boundary | direction | repository |
+|---|---|---|
+| `relay._report_usage` — the cost settlement computed, leaving the grid as `cost_credits` | dollars → credits | grid-src |
+| `store.apply_topup_credit` — dollars actually paid, becoming wallet credit | dollars → credits | grid-apis |
+
+These are not accidental duplication. They are the only two places in the product where real
+currency genuinely meets product credit; everything between them is credits end to end.
+
+⚠️ **The multiplication lives inside `_report_usage`, not at the settle call site in
+`provider_response`.** `_report_usage` is the single point where a cost leaves the grid *and* the
+one function an existing test already drives directly — `test_billing_settle.py` patches
+`httpx.AsyncClient` and calls it. Put the multiplication at the call site and no function-seam test
+can observe it; only a much heavier route test could, in a suite that already carries
+order-sensitive failures. The seam decides where the arithmetic goes.
+
+⚠️ **Settlement arithmetic stays in dollars and the ratio is applied after it**, so every existing
+case asserting what `settle` *computed* stays green **unchanged**. Needing to edit one of those is
+the signal that the conversion went in the wrong place, and it is worth more than a comment.
+
+⚠️ **The report-payload case is the deliberate exception, and reading the rule without it would
+block this change.** `test_billing_settle.py` drives both: it tests settle's arithmetic *and* it
+drives `_report_usage` behind a faked client and asserts `cost_usd == 0.5` on the captured body.
+That one assertion is precisely what D-c renames and this decision re-scales — it becomes
+`cost_credits == 500`, and it is the test that proves the ratio is applied **once**, on the way out.
+Taken as *no case in that file may change*, the rule would push the multiplication back to the call
+site, where nothing can observe it at all.
+
+#### Engine prices, price scores, reference pricing and engine selection stay in dollars per million tokens
+
+`grid price set --input 3.0` keeps meaning $3.00 per million tokens — the unit every model vendor
+publishes, so a member setting a price copies a figure rather than converting one. The public CLI
+therefore gains **no new command** and its price command is untouched.
+
+This is the decision most likely to be "finished" by a later reader, and the reason not to is not a
+matter of taste:
+
+`grid_reference_pricing.price_score` is crawled in dollars per million tokens, and
+`model_catalog.resolve_price_score` falls back to it for any engine that never stated a price of
+its own. grid-src's schema says what that requires — *"Same scalar and same weighting as
+`grid_chat_pricing.price_score`, so the two are comparable in one sort key"*. Re-denominate a
+member's own price into credits while the reference table stays in dollars and **every engine that
+stated a price sorts a thousand times more expensive than every engine that did not**, so the
+least-configured engine wins every request.
+
+⚠️ **That failure lands in routing, not in billing.** Charges stay correct, ledgers balance, and
+every money test in both repositories stays green while traffic quietly stops reaching the engines
+that priced themselves. Nothing in either suite is positioned to see it. This paragraph exists so
+that the next person to notice two units in one system has the reason in front of them before they
+unify them.
+
+### D-c — Every wire field whose unit changes changes its name
+
+| route | old field | new field |
+|---|---|---|
+| `POST /v1/grid/internal/usage` | `cost_usd` | `cost_credits` |
+| `GET /v1/grid/internal/accounts/{sub}/balance` | `balance` | `balance_credits` |
+| `GET /v1/grid/internal/min-balance` | `min_balance_usd` | `min_balance_credits` |
+| `GET /v1/grid/account` | `balance`, `total_spent` | `balance_credits`, `total_spent_credits` |
+| both ledger reads | `amount_usd` | `amount_credits` |
+
+A unit change under a stable field name is exactly the silent thousand-fold failure this ADR exists
+to prevent, and this repository's own lockstep rule already names the asymmetry: **a new key on an
+existing route degrades silently, and a rename is the loud one.** Here the rename is load-bearing in
+both directions of a partial rollout, for two different reasons:
+
+- **The report refuses loudly.** An old relay's body against a handler requiring `cost_credits` is a
+  validation failure — measured, not assumed. ⚠️ It is loud *only because D-h taught the relay to
+  read the status*. Before that change the same 422 was discarded and the grid served free in
+  silence, which is the defect this feature exists to close and would have been reintroduced by its
+  own rollout.
+- **The reads refuse service.** The relay reads each of these with a default, so a field it cannot
+  find yields that default. Zero is below every threshold, so an out-of-step relay **refuses every
+  request** rather than serving free. Fail closed, deliberately: the worst case is a grid that stops,
+  not a grid that gives itself away.
+
+⚠️ **The relay's fallback for the minimum must be the credit figure (500), never the old dollar one
+(0.5).** Carrying `0.5` across leaves the gate at a thousandth of its intended height, and nothing
+anywhere reports it. It is the single most likely copy-paste in this change, and it is the reason
+the minimum has a register row of its own.
+
+⚠️ **The relay's locally cached threshold moves to a NEW column rather than being reinterpreted.** A
+grid that already cached `0.5` dollars would otherwise enforce `0.5` *credits* — the same
+thousand-fold gap, on a grid nobody redeployed. A new column reads as absent and re-fetches.
+
+### D-d — Rollout: the control plane before the relay
+
+Both directions refuse — one loudly, one by refusing service — so the order is a safety convenience
+rather than a correctness requirement. It is this way for two reasons: the wallet's unit and its
+ledger's unit have to change together and they live in one repository, and grid-apis is the *server*
+on every one of these routes, which is the shape every other control-plane ordering in the register
+already takes.
+
+### D-e — The wallet's schema change is destructive and one-way
+
+Per renamed column, two statements, both re-runnable:
+
+```sql
+ALTER TABLE grid_account ADD COLUMN IF NOT EXISTS balance_credits DOUBLE PRECISION NOT NULL DEFAULT 0;
+ALTER TABLE grid_account DROP COLUMN IF EXISTS balance;
+```
+
+Add-then-drop is the *only* idempotent spelling available. `init_schema` replays the whole tuple on
+every startup, and PostgreSQL has no `RENAME COLUMN IF EXISTS` — the file's one rename precedent,
+`ALTER TABLE IF EXISTS grid_member_invite RENAME TO grid_pending_charge`, works only because
+`IF EXISTS` there applies to a *table*.
+
+Old dollar balances are **discarded**. That is authorised because self-serve payment has never
+shipped, so no wallet holds money anyone paid for.
+
+⚠️ **There is no undo.** Rolling back to the previous release re-runs the old
+`ADD COLUMN IF NOT EXISTS balance` and every wallet reads empty. This belongs in the **deployment
+note**, not only here — a rollback is the one operation whose operator will not be reading an ADR.
+
+### D-f — The legacy per-grid wallet stays for media, fenced so it cannot be mistaken for this one
+
+`AccountRow.credit_balance` becomes **`media_credit_balance`**. It keeps serving the media escrow
+path, which is out of scope; the rename is what stops it being read as the wallet this ADR
+introduces.
+
+Three things are **deleted**, and they go together because together they are one restored wire field
+away from writing control-plane dollars into a credits column:
+
+1. **The `snapshot["accounts"]` loop** in `grid_auth.apply_sync_snapshot`. It assigns the control
+   plane's balance verbatim into that column. Today that is a **dollar** figure landing in a column
+   the media path spends at a hundred credits to the dollar; after D-a it is a **credit** figure on
+   a different scale again. Either way the number means something else the moment it is written, and
+   nothing compares the two. It never iterates today only because the control plane's snapshot
+   builder stopped sending the key and records why in its own source — latent, not live, and one
+   restored wire field from firing.
+2. **`grid_auth.resolve_local_rate` and `GridLocalPricingRow`** — the read-only price replica and its
+   resolver, with **zero callers**, superseded by `model_catalog.resolve_chat_rate`.
+3. **The test covering both.** It hand-builds a snapshot and asserts the master writes both
+   replicas; it never speaks to the control plane's actual builder, so it is green over a seam that
+   no longer exists and would stay green whatever anyone did to the wire.
+
+⚠️ The test is deleted **with** the code rather than left behind. A suite that keeps proving a
+contract nothing speaks is worse than no test: it spends review attention and reports confidence
+about a seam that is gone.
+
+### D-g — `_billing_on()` is the sole authority on the inference path, and always was
+
+The media escrow reads an environment variable directly rather than the billing predicate, and that
+reads at first glance like a second switch for one decision. It is not: `hold_escrow_within`'s only
+caller is `_create_media_transaction`. These are **one switch each on two different paths**.
+
+No behaviour changes. What is added is a pin on the **caller count**, so that a future inference
+caller cannot silently inherit the media switch. A second door onto a refusal inherits none of the
+first door's guards, and a count is what a test can assert where there is no behaviour change to
+assert instead.
+
+### D-h — The usage report stops being fire-and-forget
+
+Three layers, in order:
+
+1. **Check the status.** Anything at or above 400 is a failure. This is the single most valuable
+   line in the feature: without it D-c's loud direction is not loud at all.
+2. **Bounded retry with backoff, on server errors and timeouts only — never on a client error.** A
+   4xx is a body the control plane refused, and resending a refused body is a loop that ends when
+   somebody notices the log.
+3. **An outbox row on final failure, logged at error level.** `request_id` is already the control
+   plane's idempotency key, so replay is safe *by construction*: a replayed report that already
+   landed reports itself as not applied and moves nothing.
+
+⚠️ **The member is never blocked.** Their answer is delivered before any of this runs. That property
+is deliberate and is preserved — billing must never be able to slow down or fail a request.
+
+⚠️ **A new module inside the vendored server package must be registered in the application loader's
+ordered module list, leaf-first.** Omit it and every unit test in that repository stays green while
+the live service dies at startup. Two regression tests already guard this, and they must actually be
+run.
+
+### D-i — The engine's share is applied in the same transaction as the member's charge
+
+Today the charge and the share open two separate pooled connections — two transactions — and the
+second sits inside a bare `except Exception` with a single `warning`. When it fails the member is
+charged, the engine is not paid, and nothing exists to reconcile from.
+
+One store operation, one connection, one transaction: the engine is paid **if and only if** the
+member is charged. If it fails, both roll back and D-h's outbox replays the whole report, safely,
+because both halves are idempotent on keys derived from the same `request_id`.
+
+⚠️ **An engine nobody can be paid for is an ordinary branch, not a failure.** An unresolvable engine
+account, or one that resolves to the member's own, means *nobody to pay* — the charge must still
+stand. Only a genuine write error rolls anything back. Reading these as failures would refund
+members for requests they made.
+
+⚠️ **The cut is read before the transaction opens, not inside it.** That read takes its own pooled
+connection; leaving it inside deadlocks against the pool under load.
+
+### D-j — The platform's cut gets a real writer, and it refuses a value meaning "never pay the engine"
+
+A read and a write endpoint on the same operator gate as their administrative neighbours.
+
+- **The write validates the range and refuses outside it.** A cut of `1.0` means the engine is never
+  paid, with nothing anywhere to say so. Today the setter takes a bare string and the reader falls
+  back to the default on anything unparseable — so a typo currently reads as *unset*, which is not
+  the same thing and must stop being spelled the same way.
+- **The read distinguishes "never set, default in force" from "set to exactly the default value."**
+  Through the reader alone those two states are identical, and only one of them means somebody
+  decided.
+- **No CLI and no route in this repository.** The cut is an operator's knob, not a grid member's.
+
+### D-k — Billing stays off by default, a grid's own owner still cannot switch it on, and switching it on where it cannot work is refused
+
+Two things are unchanged and were already right: the default is off, and the report-key gate keeps a
+grid's own creator from flipping it — charging members is a platform decision.
+
+What is added is that turning it **on** now checks two preconditions, and names the one that failed:
+
+1. **The grid is of the one type that can be billed.** Otherwise the relay's own predicate answers
+   false, nobody is ever charged, and the route answers `200` while the operator believes billing is
+   live.
+2. **This control plane has its operator key configured.** Otherwise the usage report *and* the
+   balance read both answer *service unavailable*, the relay's gate falls back to zero, and **every
+   request on that grid is refused for insufficient balance**.
+
+Two opposite disasters — *charges nobody* and *blocks everybody* — that today share one success
+response. Both conditions are knowable where the switch is thrown, which is why the check lives
+there.
+
+⚠️ **The control plane cannot see the relay's own report URL**; that is the relay's environment.
+Condition 2 is the half that *is* observable from here, and it covers the same bricking symptom.
+
+⚠️ **The honest precondition for ever changing the default is a withdrawal path, and there is
+none.** Verified across all three repositories. Everything in this ADR can ship and be correct, and
+a member's engine will earn credits it has no way to take out. Switching billing on before that
+exists promises people money they cannot have.
+
+### D-l — Five values enter the cross-repo lockstep register, and one of them has no half in this repository
+
+The register contains **zero** billing rows today while four live cross-repository contracts run
+through this area, and a fifth was not known to exist. Each row carries its own failure mode,
+because they genuinely differ:
+
+| value | absent ⇒ | order |
+|---|---|---|
+| the usage-report route and `cost_credits` | a loud validation refusal — ⚠️ **but only because D-h made the relay read the status**; before that it was silent and free | control plane first |
+| the balance route and `balance_credits` | the relay's default of zero ⇒ every request refused. Fail closed, deliberately | control plane first |
+| the minimum route and `min_balance_credits` | ⚠️ the relay's fallback must be the credit figure, not the old dollar one | control plane first |
+| `CREDITS_PER_USD` itself | ⚠️ **nothing degrades — the two sides simply disagree.** No missing route, no validation failure, no postcondition to check. The only value here whose failure is pure arithmetic | no order helps |
+| the refusal sentence the app matches | grid-src ↔ the app, **no half in this repository**; a reword makes the app render the relay's raw sentence, ⚠️ which prints the viewer's exact balance and the grid's threshold into their chat window | no order helps |
+
+⚠️ **The last row stays prose, and that is a decision rather than an omission.** The obvious
+"improvement" is to give the refusal a machine-readable code the app can key on. This repository
+deliberately keeps the count of *parsed* refusal codes at three, on the grounds that every relay
+message already names the way forward and a fourth reader is a fourth thing a reworded relay can
+break. What a test pins here is the **phrase**, and the phrase is what must survive this change
+byte for byte — only its numbers become credits.
+
+⚠️ **A green continuous-integration run proves nothing about any of these.** Every cross-repository
+assertion in this repository skips unless the sibling worktree sits beside it, which it never does
+in CI.
+
+## Consequences
+
+- **Two units live in one system on purpose, and one of them is invisible to every money test.**
+  Prices are dollars per million tokens; wallets, ledgers and refusals are credits. D-b is the whole
+  defence, and the failure mode it prevents shows up in *routing*.
+- **Old wallet balances are gone at deploy and cannot come back** (D-e). Acceptable only while no
+  wallet holds paid-for money, which is a property of today, not a property of the design.
+- **A partial rollout stops a grid rather than giving it away** (D-c). That is the intended
+  trade — an operator would rather explain an outage than a month of free inference — but it does
+  mean the deploy order is worth following even though neither direction is silently wrong.
+- **The platform cut becomes changeable at runtime while the ratio does not** (D-a, D-j). The two
+  numbers look alike and are governed opposite ways: a cut applies to future requests and each one
+  records what it used; a ratio would silently re-denominate the meaning of rows already written.
+- **Billing remains off everywhere.** Nothing here switches a grid on. What changes is that turning
+  one on is now a decision an operator can make with the failure modes visible (D-k), instead of a
+  coin flip between two disasters that share a success response.
+- **Engine earnings still cannot be withdrawn.** This ADR makes them countable and honest; it does
+  not make them collectable, and that gap is the reason the default stays where it is.
+
+## Rollout order
+
+- **Control plane before the relay** for the report, the balance read and the minimum read (D-c,
+  D-d). Both directions refuse, so this is a convenience; it is the wallet and its ledger having to
+  move together that fixes which side goes first.
+- ⚠️ **The relay reading the report's status ships BEFORE the field rename** (D-h before D-c). The
+  rename's loud direction is loud only because the relay checks. Landing the rename first swallows
+  every mismatch in the skew window in silence — the exact defect this work exists to close,
+  reintroduced by its own rollout.
+- **No order helps for the ratio** (D-a). Nothing 404s and nothing refuses; the two sides simply
+  disagree, and charges and top-ups run on two scales until somebody reconciles by hand.
+- **No order helps for the refusal sentence** (D-l). Both halves are grid-src and the app, with
+  nothing in this repository in the path; a reword takes effect the moment the relay deploys and no
+  app release sequence brings the matched phrase back.
+- **No order for the wallet fencing, the one transaction, the fee's operator surface, the readiness
+  gate, or the outbox itself** (D-f, D-g, D-i, D-j, D-k, and D-h's second and third layers). Each is
+  internal to one repository and adds no wire value in either direction. ⚠️ **D-h's first layer —
+  reading the report's status — is the exception directly above**, and it is the only hard ordering
+  constraint in this ADR; everything else here is a convenience.

--- a/docs/adr/0042-a-grids-money-is-counted-in-credits.md
+++ b/docs/adr/0042-a-grids-money-is-counted-in-credits.md
@@ -179,13 +179,29 @@ ALTER TABLE grid_account ADD COLUMN IF NOT EXISTS balance_credits DOUBLE PRECISI
 ALTER TABLE grid_account DROP COLUMN IF EXISTS balance;
 ```
 
-Add-then-drop is the *only* idempotent spelling available. `init_schema` replays the whole tuple on
-every startup, and PostgreSQL has no `RENAME COLUMN IF EXISTS` — the file's one rename precedent,
+`init_schema` replays the whole tuple on every startup, and PostgreSQL has no bare
+`RENAME COLUMN IF EXISTS` — the file's one rename precedent,
 `ALTER TABLE IF EXISTS grid_member_invite RENAME TO grid_pending_charge`, works only because
-`IF EXISTS` there applies to a *table*.
+`IF EXISTS` there applies to a *table*. Add-then-drop is the plainest re-runnable spelling of the
+decision below.
+
+⚠️ **Amended 2026-09-08, during issue 04: it is NOT the only spelling available, and this ADR said it
+was.** A `DO $$ … END $$` block testing `information_schema.columns` — the shape `db.py` already uses
+for `ck_grid_networks_os_community_access_os` — can `RENAME COLUMN` and then multiply by the ratio,
+re-runnably and without losing a value. The reason not to is the decision in the next paragraph, not
+the absence of a way; "there is no other way" is a reason a later reader can disprove in one grep,
+and disproving it would reopen a decision that was actually taken on purpose.
 
 Old dollar balances are **discarded**. That is authorised because self-serve payment has never
-shipped, so no wallet holds money anyone paid for.
+shipped, so no wallet holds money anyone *paid* for.
+
+⚠️ **Amended 2026-09-08: that sentence is narrower than what the change discards.** Two paths that
+move balance HAVE shipped — the operator's own top-up (`POST /admin/accounts/{sub}/topup`) and an
+engine's revenue share (the ledger's `earning` rows) — and both are zeroed too. With a 500-credit
+gate, an account that held such a balance is refused on a billing-on grid until somebody credits it
+again. The decision stands (no grid has billing on, and the fleet's wallets are expected to be
+empty), but it is a decision about *real rows*, so the deployment note carries the count-before-you-
+deploy query rather than the assurance.
 
 ⚠️ **There is no undo.** Rolling back to the previous release re-runs the old
 `ADD COLUMN IF NOT EXISTS balance` and every wallet reads empty. This belongs in the **deployment

--- a/docs/adr/0042-a-grids-money-is-counted-in-credits.md
+++ b/docs/adr/0042-a-grids-money-is-counted-in-credits.md
@@ -153,6 +153,12 @@ happen.
 while the media wallet still holds `100.0`, so `100 < 500` refuses *everyone*. One code path, two
 opposite wrong answers, on either side of this ADR's own change.
 
+⚠️ **Amended 2026-09-09 — "refuses *everyone*" is wrong, and the correction is the subject of D-f's
+amendment below.** It holds only for a member whose media wallet still holds the `100.0` signup seed.
+`payments.py` adds to that wallet on a live path, so a member holding `≥ 500` media credits was
+**served free** on the same outage, from the same line. The fault was never a direction: it was
+**data-dependence**. The fallback is deleted as of issue 10 — see D-f.
+
 ⚠️ **The relay's fallback for the minimum must be the credit figure (500), never the old dollar one
 (0.5).** Carrying `0.5` across leaves the gate at a thousandth of its intended height, and nothing
 anywhere reports it. It is the single most likely copy-paste in this change, and it is the reason
@@ -245,6 +251,67 @@ options are to **drop the fallback** — refuse when the authoritative balance i
 the gate fail closed in fact rather than in prose — or to **keep it and say so in D-g**, recording
 that the inference path has a second, media-funded door. What must not stand is the present
 position, in which this ADR asserts a fence the code does not have.
+
+⚠️ **Amended 2026-09-09 (issue 10) — the fence is now closed, and the fault it left open was
+DATA-DEPENDENCE rather than a direction.** The first option above is taken: the fallback is deleted,
+and **a balance that cannot be established refuses the request**. Four things travel with that.
+
+**What the open fence actually cost.** Both this decision and D-c's amendment described the hole as
+having one direction at a time — first "serves free", then, after D-a, "refuses everyone". Neither
+is true, because the number being read belongs to a different product. `auth.py:107` seeds the media
+wallet at `100.0` and `payments.py:24,79` adds more, on a path `server.py:31` imports, so on one
+unreachable control plane:
+
+| the member's media wallet | the gate did |
+|---|---|
+| `100.0` (the signup seed) | refuse |
+| `≥ 500` (bought media credits) | **serve free** |
+
+One line, opposite outcomes, selected by a figure no part of the inference path owns or can see.
+"Serves itself away" was never closed by D-a and D-c; it was **narrowed** to the members who happen
+to have bought media credit — which is the worst shape for the failure to take, because it is
+invisible on every grid where nobody has.
+
+**The refusal is a 503 carrying a sentence, and deliberately not a 402.** Payment is not what is
+required when a grid cannot reach its own authority on money: the member's wallet may be perfectly
+funded, and D-l's `Insufficient balance` sentence would send them to top it up — somewhere that will
+fix nothing. `503` is simply the true statement. It is also free: the public CLI, which is the client
+here, prints any body at or above 400 verbatim and exits 1 (`cli/remote_request.py:103-105`), so the
+status buys no client behaviour and the **sentence is the whole contract**. It is pinned as a
+sentence and not as a refusal `code` — D-l's count of three parsed codes is deliberate, and this is
+not the fourth.
+
+**Two refusals, because there are two remedies.** *This grid was never configured to reach a control
+plane* is fixed on the box in a minute; *the control plane could not be reached* is not fixed there
+at all. `_fetch_authoritative_balance` answers `None` to both — and to a `>= 400`, which leaves it by
+a bare fall-through rather than a `return`, the path a reader misses — so the gate asks the
+configuration question **before** the read, and the `None` that comes back can then mean only one
+thing. The refused-read and dead-socket cases stay one refusal: an operator can act on neither from
+here.
+
+⚠️ **Unchanged, and the reason the rename is safe: a `200` without `balance_credits` still reads
+`0.0`.** That is a number, not a failure, so it falls through to the min-balance gate and its 402
+exactly as D-c specifies. Turning it into this decision's 503 would tell an operator their control
+plane is down while it answers perfectly.
+
+**Rejected: caching the balance locally.** Recorded here so it is not proposed again during the
+first outage. It fails on the architecture, not on cost:
+
+- the wallet is **global per person** — `grid_account`'s primary key is `google_sub`, and the table
+  has no network column — while every grid is a separate master with its own database. A per-grid
+  cache is therefore *N stale copies of one wallet that cannot see each other*, and the over-spend an
+  outage permits stops being one request and becomes one per grid the member is on;
+- the only store that could hold a **shared** copy is the control plane, which is the thing that is
+  down;
+- the relay's local state table (`grid_local_network_state`) already caches `min_balance_credits` and
+  deliberately holds **no** balance column, for the reason written at grid-apis'
+  `store.apply_usage_charge`: the master keeps no balance, so concurrent requests across grids cannot
+  desync a local copy. A cache overturns that, and the reason it was written has not changed.
+
+What a refusal costs is **availability during a control-plane outage**. Measured 2026-09-09: one grid
+on prod has billing on (121 of 122 are `local_free`), so today that is close to nothing. If it ever
+stops being nothing, the answer is a control plane that stays up or a read replica — not a cache at
+the edge.
 
 ### D-g — `_billing_on()` is the sole authority on the inference path, and always was
 
@@ -344,7 +411,7 @@ because they genuinely differ:
 | value | absent ⇒ | order |
 |---|---|---|
 | the usage-report route and `cost_credits` | a loud validation refusal — ⚠️ **but only because D-h made the relay read the status**; before that it was silent and free | control plane first |
-| the balance route and `balance_credits` | the relay's default of zero ⇒ every request refused. Fail closed for the **rename** — ⚠️ but see D-c's amendment: a control plane that *refuses* or is unreachable yields `None`, not zero, and falls through to the media wallet instead | control plane first |
+| the balance route and `balance_credits` | the relay's default of zero ⇒ every request refused. Fail closed for the **rename** — ⚠️ but see D-c's amendment: a control plane that *refuses* or is unreachable yields `None`, not zero, which since issue 10 is a **503 of its own** rather than a fall-through to the media wallet (D-f, amended 2026-09-09) | control plane first |
 | the minimum route and `min_balance_credits` | ⚠️ the relay's fallback must be the credit figure, not the old dollar one | control plane first |
 | `CREDITS_PER_USD` itself | ⚠️ **nothing degrades — the two sides simply disagree.** No missing route, no validation failure, no postcondition to check. The only value here whose failure is pure arithmetic | no order helps |
 | the refusal sentence the app matches | grid-src ↔ the app, **no half in this repository**; a reword makes the app render the relay's raw sentence, ⚠️ which prints the viewer's exact balance and the grid's threshold into their chat window | no order helps |

--- a/docs/adr/0042-a-grids-money-is-counted-in-credits.md
+++ b/docs/adr/0042-a-grids-money-is-counted-in-credits.md
@@ -134,10 +134,24 @@ both directions of a partial rollout, for two different reasons:
   read the status*. Before that change the same 422 was discarded and the grid served free in
   silence, which is the defect this feature exists to close and would have been reintroduced by its
   own rollout.
-- **The reads refuse service.** The relay reads each of these with a default, so a field it cannot
-  find yields that default. Zero is below every threshold, so an out-of-step relay **refuses every
-  request** rather than serving free. Fail closed, deliberately: the worst case is a grid that stops,
-  not a grid that gives itself away.
+- **The reads refuse service — on the rename, and only on the rename.** The relay reads each of
+  these with a default, so a field it cannot find *on a 200* yields that default. Zero is below
+  every threshold, so an out-of-step relay **refuses every request** rather than serving free. Fail
+  closed for a renamed key, deliberately.
+
+⚠️ **Amended 2026-09-08 — "the worst case is a grid that stops, not a grid that gives itself away"
+was wrong as a general claim about the gate, and is corrected here.** It holds for the renamed key,
+because a renamed key still arrives on a `200` and defaults to zero. It does **not** hold when the
+control plane *refuses or is unreachable*: `relay._fetch_authoritative_balance` returns `None` on
+four paths — no configured URL, no subject, any exception, and by fall-through on
+**`status_code >= 400`** — and `relay.py:5476-5478` then falls back to the legacy media wallet,
+which `auth.py:107` seeds at `100.0` "welcome credits" against a `0.5` floor. A grid whose control
+plane is down therefore **serves free**, the exact outcome the original sentence claimed could not
+happen.
+
+⚠️ After D-a and D-c land, that same path **inverts**: the floor becomes the credit figure (500)
+while the media wallet still holds `100.0`, so `100 < 500` refuses *everyone*. One code path, two
+opposite wrong answers, on either side of this ADR's own change.
 
 ⚠️ **The relay's fallback for the minimum must be the credit figure (500), never the old dollar one
 (0.5).** Carrying `0.5` across leaves the gate at a thousandth of its intended height, and nothing
@@ -202,6 +216,19 @@ away from writing control-plane dollars into a credits column:
 ⚠️ The test is deleted **with** the code rather than left behind. A suite that keeps proving a
 contract nothing speaks is worse than no test: it spends review attention and reports confidence
 about a seam that is gone.
+
+⚠️ **Amended 2026-09-08 — the fence is incomplete, and this ADR did not say so.** The rename stops
+the *snapshot writer* (deletion 1 above) and D-g pins the *escrow caller*, but a third reader was
+never enumerated: the inference path's own balance gate. `relay.py:5477` calls `credits.get_balance`,
+which after the rename returns `account.media_credit_balance` (`credits.py:29`) — so the media
+wallet is still consulted **on the inference path**, as the fallback taken whenever the authoritative
+read yields `None`. Renaming the column did not stop that; it renamed the column being read.
+
+Closing it changes money behaviour and belongs to its own ticket rather than to this prefactor. The
+options are to **drop the fallback** — refuse when the authoritative balance is unavailable, making
+the gate fail closed in fact rather than in prose — or to **keep it and say so in D-g**, recording
+that the inference path has a second, media-funded door. What must not stand is the present
+position, in which this ADR asserts a fence the code does not have.
 
 ### D-g — `_billing_on()` is the sole authority on the inference path, and always was
 
@@ -301,7 +328,7 @@ because they genuinely differ:
 | value | absent ⇒ | order |
 |---|---|---|
 | the usage-report route and `cost_credits` | a loud validation refusal — ⚠️ **but only because D-h made the relay read the status**; before that it was silent and free | control plane first |
-| the balance route and `balance_credits` | the relay's default of zero ⇒ every request refused. Fail closed, deliberately | control plane first |
+| the balance route and `balance_credits` | the relay's default of zero ⇒ every request refused. Fail closed for the **rename** — ⚠️ but see D-c's amendment: a control plane that *refuses* or is unreachable yields `None`, not zero, and falls through to the media wallet instead | control plane first |
 | the minimum route and `min_balance_credits` | ⚠️ the relay's fallback must be the credit figure, not the old dollar one | control plane first |
 | `CREDITS_PER_USD` itself | ⚠️ **nothing degrades — the two sides simply disagree.** No missing route, no validation failure, no postcondition to check. The only value here whose failure is pure arithmetic | no order helps |
 | the refusal sentence the app matches | grid-src ↔ the app, **no half in this repository**; a reword makes the app render the relay's raw sentence, ⚠️ which prints the viewer's exact balance and the grid's threshold into their chat window | no order helps |

--- a/tests/grid_apis_routes.py
+++ b/tests/grid_apis_routes.py
@@ -1,4 +1,4 @@
-"""grid-apis' POST routes, read out of its source — the one derivation, for every pin here.
+"""grid-apis' routes, read out of its source — the one derivation, for every pin here.
 
 Two lockstep suites need the same answer to the same question: *what whole paths does the control
 plane actually serve?* The path is a concatenation — `APIRouter(prefix="/v1/grid")` in one place, a
@@ -21,6 +21,13 @@ from tests.grid_src_repo import grid_apis_root
 
 HANDLER = "grid_networks/handler.py"
 ROUTER = "router"
+
+#: The decorator names `APIRouter` hangs a route off. A method outside this set is a typo, never an
+#: answer — see `decorated_paths`. FastAPI also exposes `api_route(path, methods=[…])`; grid-apis
+#: uses none, and the day it does this reader must be taught about it rather than quietly missing
+#: those routes, which is why the vocabulary is written down instead of inferred.
+HTTP_METHODS = frozenset(
+    {"get", "post", "put", "patch", "delete", "head", "options", "trace"})
 
 SKIP_NO_APIS = "the grid-apis worktree is not beside this one; the lockstep cannot be checked here"
 
@@ -73,8 +80,17 @@ def router_prefix(tree: ast.Module) -> str:
         f"renamed or moved, so teach this check where it went rather than deleting it")
 
 
-def posted_paths(tree: ast.Module) -> list[str]:
-    """Every literal path grid-apis hangs a POST handler off, decorator by decorator.
+def _reject_unknown_method(method: str) -> None:
+    """One membership check, so the two readers cannot disagree about what a method is."""
+    if method not in HTTP_METHODS:
+        raise AssertionError(
+            f"{method!r} is not a route decorator grid-apis' router carries — the known ones are "
+            f"{sorted(HTTP_METHODS)}, all lowercase. Reading it would answer an empty list, which "
+            f"is spelled the same as a route that was renamed")
+
+
+def decorated_paths(tree: ast.Module, method: str) -> list[str]:
+    """Every literal path grid-apis hangs a handler for `method` off, decorator by decorator.
 
     Matched on the decorator rather than the handler name so that renaming a handler — an ordinary
     refactor that moves no route — does not read as drift.
@@ -82,7 +98,14 @@ def posted_paths(tree: ast.Module) -> list[str]:
     ⚠️ BOTH function kinds: `async def` is an `ast.AsyncFunctionDef` and is NOT a subclass of
     `ast.FunctionDef`, and that module already spells many of its routes that way. Matching only the
     sync kind would make converting one handler look like a deleted route.
+
+    ⚠️ **A method this reader does not know RAISES rather than answering `[]`.** `"POST"` is the
+    natural spelling everywhere else in this repository, it matches no decorator, and an empty list
+    is spelled exactly like *the route was renamed* — so a pin fed one either reports drift that is
+    not there or, worse, counts nothing and reports an agreement it never checked. Both readings
+    are wrong and neither is loud, which is why the vocabulary is a set rather than a comment.
     """
+    _reject_unknown_method(method)
     return [
         decorator.args[0].value
         for node in tree.body
@@ -90,7 +113,7 @@ def posted_paths(tree: ast.Module) -> list[str]:
         for decorator in node.decorator_list
         if isinstance(decorator, ast.Call)
         and isinstance(decorator.func, ast.Attribute)
-        and decorator.func.attr == "post"
+        and decorator.func.attr == method
         and getattr(decorator.func.value, "id", None) == ROUTER
         and decorator.args
         and isinstance(decorator.args[0], ast.Constant)
@@ -98,9 +121,31 @@ def posted_paths(tree: ast.Module) -> list[str]:
     ]
 
 
-def served_post_paths() -> list[str]:
-    """The whole paths grid-apis answers POSTs on — prefix and decorator, joined the way it serves
-    them. Skips only when grid-apis is not beside this worktree."""
+def posted_paths(tree: ast.Module) -> list[str]:
+    """`decorated_paths(tree, "post")` — the POST-only spelling this module shipped with.
+
+    Kept rather than replaced: it is part of this module's existing surface, and taking a public
+    name out of shared test infrastructure is a different change from adding one to it.
+    """
+    return decorated_paths(tree, "post")
+
+
+def served_paths(method: str) -> list[str]:
+    """The whole paths grid-apis answers `method` on — prefix and decorator, joined the way it
+    serves them. Skips only when grid-apis is not beside this worktree.
+
+    ⚠️ **The method is checked BEFORE `handler_tree()`, and the order is the point.** `handler_tree`
+    skips when the sibling worktree is absent, which is what happens in CI — so validating after it
+    would report a typo'd method as *"grid-apis is not beside this one"* everywhere the typo could
+    still be caught cheaply. A programming error must not be reachable only on a developer's laptop.
+    """
+    _reject_unknown_method(method)
     tree = handler_tree()
     prefix = router_prefix(tree)
-    return [prefix + path for path in posted_paths(tree)]
+    return [prefix + path for path in decorated_paths(tree, method)]
+
+
+def served_post_paths() -> list[str]:
+    """`served_paths("post")` — the accessor `test_session_revoke_lockstep.py` and
+    `test_harness_login_lockstep.py` already call, kept by that name so neither had to change."""
+    return served_paths("post")

--- a/tests/grid_src_repo.py
+++ b/tests/grid_src_repo.py
@@ -121,6 +121,22 @@ def harness_root() -> pathlib.Path | None:
     return _sibling_root(pathlib.Path("cli") / "src", "autonomous-harness", "HARNESS_REPO")
 
 
+def app_root() -> pathlib.Path | None:
+    """autonomous-grid-app's checkout — the FLUTTER APP — or ``None`` when it is not beside this one.
+
+    The fifth repository, and the only one that reaches the lockstep with **no half in this
+    repository at all**: ADR 0042 D-l's refusal sentence runs grid-src → the app, and this checkout
+    is in the path of neither. It is resolved here anyway because the pin that compares those two
+    halves has to live somewhere, and this repository is the hub.
+
+    ⚠️ The app deliberately has **no worktree** for the billing-activation feature, so the mirror
+    candidate never exists and the derivation lands on the main checkout. That is the intended
+    answer, not a fallback that went wrong: the app's half of this seam is one substring in one file
+    and it does not move per feature branch. `GRID_APP_REPO` overrides the derivation.
+    """
+    return _sibling_root(pathlib.Path("lib"), "autonomous-grid-app", "GRID_APP_REPO")
+
+
 def grid_src_root() -> pathlib.Path | None:
     """grid-src's checkout, or ``None`` when this machine does not have one beside this worktree.
 

--- a/tests/grid_src_repo.py
+++ b/tests/grid_src_repo.py
@@ -17,6 +17,52 @@ from __future__ import annotations
 import os
 import pathlib
 
+FEATS_DIR_NAME = "autonomous-grid-feats"
+
+#: The directory suffix the `new-grid-worktree` skill gives a feature's parallel-ticket root
+#: (`<repo>-feats/<feat>_parallel/<ticket>`). Hand-duplicated with that skill's
+#: `scripts/parallel-worktree.sh` (`PARALLEL_SUFFIX`), and kept in step by editing both: renamed on
+#: one side alone, every ticket worktree still resolves its exact mirror and only the fallback to
+#: the feature worktree is lost -- silently, as a skip.
+PARALLEL_SUFFIX = "_parallel"
+
+
+def _mirror_candidates(here: pathlib.Path, repo: str) -> list[pathlib.Path]:
+    """Where a checkout of ``repo`` could sit beside the checkout at ``here``, best guess first.
+
+    Split out of `_sibling_root` so the layouts can be pinned as data: this function is the whole
+    of the derivation, and the derivation is what decides whether the lockstep suites run at all.
+
+    Three layouts, and the fallbacks are ordered by how close they are to the code this checkout
+    is actually working on:
+
+    * a MAIN checkout (`<projects>/autonomous-grid`) looks for `<projects>/<repo>`;
+    * a FEATURE worktree (`<projects>/autonomous-grid-feats/<slug>`) mirrors the slug into
+      `<projects>/<repo>-feats/<slug>`, then falls back to the main checkout;
+    * a PARALLEL TICKET worktree (`…-feats/<slug>_parallel/<ticket>`) mirrors the WHOLE path below
+      the feats directory, so ticket `t12` reads ticket `t12`. Only then does it fall back to the
+      feature worktree the ticket was cut from, and last to the main checkout. The exact mirror has
+      to come first: two agents working two tickets have moved the same seam in two different
+      directions, and reading the sibling's feature branch would compare against neither.
+
+    The middle candidate is the one piece of the parallel layout this module knows about; a nested
+    directory that is not `<something>_parallel` gets the exact mirror and the main checkout only,
+    because inventing a checkout out of an arbitrary directory name is how a resolver starts
+    answering confidently about the wrong tree.
+    """
+    for ancestor in here.parents:
+        if ancestor.name != FEATS_DIR_NAME:
+            continue
+        projects = ancestor.parent
+        rel = here.relative_to(ancestor)
+        candidates = [projects / f"{repo}-feats" / rel]
+        feature = rel.parts[0][: -len(PARALLEL_SUFFIX)]
+        if len(rel.parts) > 1 and rel.parts[0].endswith(PARALLEL_SUFFIX) and feature:
+            candidates.append(projects / f"{repo}-feats" / feature)
+        candidates.append(projects / repo)
+        return candidates
+    return [here.parent / repo]
+
 
 def _sibling_root(
     marker: pathlib.Path, repo: str, env_var: str, *, hint: str = ""
@@ -27,7 +73,8 @@ def _sibling_root(
     worktree they are checked out into instead of skipping everywhere but one. The convention is
     `<repo>-feats/<slug>` beside `<repo>`, so a worktree of `autonomous-grid` at
     `…/autonomous-grid-feats/<slug>` looks for `…/<repo>-feats/<slug>` first and falls back to the
-    main `…/<repo>` checkout.
+    main `…/<repo>` checkout. `_mirror_candidates` holds the full rule, including the
+    parallel-ticket layout, and `tests/test_sibling_root.py` pins it.
 
     ``marker`` is a directory that must exist under a candidate for it to count as that repository —
     the difference between "found it" and "found a directory with the right name".
@@ -48,14 +95,7 @@ def _sibling_root(
         return root
 
     here = pathlib.Path(__file__).resolve().parent.parent  # the autonomous-grid checkout
-    projects = here.parent
-    candidates = []
-    if projects.name == "autonomous-grid-feats":
-        candidates.append(projects.parent / f"{repo}-feats" / here.name)
-        candidates.append(projects.parent / repo)
-    else:
-        candidates.append(projects / repo)
-    for candidate in candidates:
+    for candidate in _mirror_candidates(here, repo):
         if (candidate / marker).is_dir():
             return candidate
     return None

--- a/tests/test_billing_credits_lockstep.py
+++ b/tests/test_billing_credits_lockstep.py
@@ -1,0 +1,318 @@
+"""The five billing values that cross a repository boundary, pinned (ADR 0042 D-l).
+
+A grid's money is counted in **credits** — a thousandth of a dollar — and four wire values plus one
+sentence carry that unit between three repositories that share no code. Each is hand-duplicated and
+kept in step by editing both sides; this file is what says so out loud.
+
+⚠️ **Not one of the five has a half in THIS repository**, which is why they are pinned here rather
+than beside an implementation. Two run grid-src ↔ grid-apis, one is a bare number nobody sends, and
+the last runs grid-src ↔ the Flutter app. This repository is the hub; the register
+(`docs/agents/lockstep-register.md`) is the prose and this is the executable half of it.
+
+⚠️ **Both sides are compared to a literal written HERE**, never to each other and never to one
+side's own constant. A pin that reads grid-src's spelling and asserts grid-apis matches it is green
+for any pair that agrees — including a pair that agreed on the wrong name, which is the only failure
+this feature can actually produce. The canonical strings below are the third party.
+
+⚠️ **A green continuous-integration run proves nothing about any of this.** Every check here skips
+unless the sibling checkout sits beside this worktree, and in CI none does. Run it locally on a
+machine that has them, and read `CLAUDE.md` § *Cross-repo lockstep* before changing any value.
+
+What each failure costs, because they differ and the differences are the whole design:
+
+* `cost_credits` — a loud 422 from the control plane, and loud **only** because ADR 0042 D-h taught
+  the relay to read the reply's status. Revert that and this becomes a grid serving free in silence.
+* `balance_credits` — the relay's `.get(…, 0.0)` default, and zero is below every threshold, so the
+  grid refuses **every** request. Fail closed on the rename, deliberately.
+* `min_balance_credits` — the relay falls back to its own figure, which must be the credit one.
+* `CREDITS_PER_USD` — nothing degrades. No route is missing, no body refused, no postcondition to
+  check: charges simply run on one scale and top-ups on the other, both answering 200.
+* the refusal sentence — a **disclosure**, not an outage: the app's substring match misses and it
+  renders the relay's raw text, which prints the viewer's exact balance and the grid's threshold
+  into their chat window.
+"""
+from __future__ import annotations
+
+import ast
+import pathlib
+import re
+
+import pytest
+
+from tests.grid_src_repo import app_root, grid_apis_root, grid_src_private_server
+
+# ── the canonical values, written here so neither side can be compared to itself ────────────────
+_COST_FIELD = "cost_credits"
+_BALANCE_FIELD = "balance_credits"
+_MIN_BALANCE_FIELD = "min_balance_credits"
+_CREDITS_PER_USD = 1000
+#: The app lowercases before matching, so the phrase is pinned in the relay's own capitalisation and
+#: lowered for the app's half. Only the sentence's NUMBERS became credits; these bytes did not move.
+_REFUSAL_PHRASE = "Insufficient balance"
+
+#: Where the app's half lives, and the shape of it. The regex accepts either quote style — Dart
+#: formatters move between them freely, and reporting that as drift is a false red on a seam whose
+#: real failure is a disclosure. Applied per LINE, skipping comments, so a `//` note quoting the old
+#: call cannot stand in for a live one.
+_APP_CHAT_SENDER = ("lib", "features", "playground", "logic", "chat_sender.dart")
+_APP_MATCH = re.compile(r"""contains\(\s*(['"])""" + re.escape(_REFUSAL_PHRASE.lower()) + r"""\1\s*\)""")
+
+#: The names the rename replaced. Asserting the new spelling is present is half a pin — a side that
+#: added the new key while keeping the old refuses nothing, and that is exactly the shape ADR 0042
+#: D-c rules out ("accepting both names would make a thousand-fold unit error answer 200").
+_RETIRED = {_COST_FIELD: "cost_usd",
+            _BALANCE_FIELD: "balance",
+            _MIN_BALANCE_FIELD: "min_balance_usd"}
+
+
+_SKIP_NO_SIBLING = "the sibling checkout is not beside this worktree; this pin cannot run here"
+
+
+def _sibling_file(path: pathlib.Path | None, *parts: str) -> pathlib.Path:
+    """A file inside a sibling checkout, skipping only when that REPOSITORY is absent.
+
+    ⚠️ **A resolved checkout missing the file RAISES**, following `tests/grid_apis_routes.py`. The
+    resolver has already proved the marker directory is there, so a file absent from it was renamed
+    or moved — which is drift, and drift is what this file exists to catch. Reporting it as "the
+    sibling is not beside this one" would turn every pin here off with a message blaming a checkout
+    that is sitting right there, and the credit rename would then have no executable proof at all.
+    """
+    if path is None:
+        pytest.skip(_SKIP_NO_SIBLING)
+    target = path.joinpath(*parts)
+    if not target.exists():
+        raise AssertionError(
+            f"the checkout at {path} has no {'/'.join(parts)} — it was renamed or moved, so teach "
+            f"this pin where it went rather than letting it skip")
+    return target
+
+
+def _source(path: pathlib.Path | None, *parts: str) -> ast.Module:
+    """Parse a sibling repository's file, or skip when that repository is not on this machine."""
+    return ast.parse(_sibling_file(path, *parts).read_text())
+
+
+def _named(tree: ast.Module, name: str) -> ast.AST:
+    """The top-level function or class called ``name``, or an assertion naming where to look."""
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)) and node.name == name:
+            return node
+    raise AssertionError(
+        f"{name} is no longer defined at module level in the sibling repository — it was renamed or "
+        f"moved, so teach this pin where it went rather than deleting the pin")
+
+
+def _wire_keys(node: ast.AST) -> set[str]:
+    """The names ``node`` actually uses AS WIRE KEYS: dict-literal keys, and `.get()` lookups.
+
+    ⚠️ **Every other string in the function is deliberately invisible here, and that is the whole
+    difference between this pin and a grep.** Both halves of this seam name their own field in
+    prose — grid-apis' balance endpoint spells `balance_credits` inside its docstring — and the
+    relay names it in log lines and URL fragments. Collecting every literal would let a payload key
+    quietly become a *third* spelling (not the retired one, so the negative check misses it either)
+    while a surviving comment or log message kept the pin green and grid-apis 422'd every report.
+
+    Two shapes cover all five sites because they are the only two ways a JSON field is named in
+    Python: `{"cost_credits": …}` on the way out and `r.json().get("balance_credits", …)` on the
+    way back.
+    """
+    keys: set[str] = set()
+    for inner in ast.walk(node):
+        if isinstance(inner, ast.Dict):
+            keys.update(k.value for k in inner.keys
+                        if isinstance(k, ast.Constant) and isinstance(k.value, str))
+        elif (isinstance(inner, ast.Call) and isinstance(inner.func, ast.Attribute)
+                and inner.func.attr == "get" and inner.args
+                and isinstance(inner.args[0], ast.Constant)
+                and isinstance(inner.args[0].value, str)):
+            keys.add(inner.args[0].value)
+    return keys
+
+
+def _returned_text(node: ast.AST) -> set[str]:
+    """The string literals ``node`` RETURNS, f-string fragments included and docstring excluded.
+
+    Its own reader rather than `_wire_keys`, because the refusal is not a wire key: it is prose the
+    relay hands back in a body. Narrowed to `return` statements so a comment quoting the old phrase
+    cannot stand in for the sentence itself.
+    """
+    return {inner.value
+            for statement in ast.walk(node) if isinstance(statement, ast.Return)
+            for inner in ast.walk(statement.value) if statement.value is not None
+            if isinstance(inner, ast.Constant) and isinstance(inner.value, str)}
+
+
+def _module_number(tree: ast.Module, name: str) -> float:
+    """A module-level numeric constant, asserted to still BE a literal.
+
+    A value computed at import — read from the environment, derived from another constant — is not
+    something a cross-repository pin can compare, and silently reading `None` for it would turn this
+    check off.
+    """
+    for node in tree.body:
+        targets = (node.targets if isinstance(node, ast.Assign)
+                   else [node.target] if isinstance(node, ast.AnnAssign) and node.value is not None
+                   else [])
+        if not any(getattr(t, "id", None) == name for t in targets):
+            continue
+        assert isinstance(node.value, ast.Constant) and isinstance(node.value.value, (int, float)) \
+            and not isinstance(node.value.value, bool), (
+            f"{name} is no longer a plain numeric literal, so the two repositories' copies cannot "
+            f"be compared — ADR 0042 D-a says this is a constant and not a setting, on purpose")
+        return node.value.value
+    raise AssertionError(
+        f"{name} is no longer defined in the sibling repository — it was renamed or moved, so teach "
+        f"this pin where it went rather than deleting it")
+
+
+def _is_required(field: ast.AnnAssign) -> bool:
+    """Whether a pydantic model field has no default — the only shape that REFUSES a body missing it.
+
+    ⚠️ **Declared is not required, and the whole loudness argument rests on the difference.** With
+    pydantic's default `extra='ignore'`, an old relay's surplus `cost_usd` is dropped in silence; it
+    is the *missing required* `cost_credits` that raises. Give the field a default "to be lenient
+    during the rollout" and that same body answers **200** with the cost read as the default — a
+    grid serving free, with D-h's status check seeing nothing wrong.
+
+    Required means either a bare annotation, or a `Field(...)` carrying neither a positional default
+    nor `default=` / `default_factory=`. Any other value is a default.
+    """
+    if field.value is None:
+        return True
+    if isinstance(field.value, ast.Call) and getattr(field.value.func, "id", "") == "Field":
+        return not field.value.args and not any(
+            kw.arg in ("default", "default_factory") for kw in field.value.keywords)
+    return False
+
+
+def _relay() -> ast.Module:
+    return _source(grid_src_private_server(), "relay.py")
+
+
+def _control_plane(module: str) -> ast.Module:
+    return _source(grid_apis_root(), "grid_networks", module)
+
+
+def _speaks(function: str, tree: ast.Module, field: str) -> None:
+    """``function`` names ``field`` and no longer names the value it replaced."""
+    spoken = _wire_keys(_named(tree, function))
+    assert field in spoken, (
+        f"{function} does not name {field!r}; ADR 0042 D-c renames every wire field whose UNIT "
+        f"changed, and the two halves of this seam are hand-duplicated")
+    retired = _RETIRED[field]
+    assert retired not in spoken, (
+        f"{function} still names the retired {retired!r}. Keeping both spellings is the one outcome "
+        f"D-c rules out: it makes a thousand-fold unit error answer 200 instead of refusing")
+
+
+# ── the four wire values ─────────────────────────────────────────────────────────────────────────
+
+def test_the_report_and_the_control_plane_agree_on_the_cost_field():
+    """`POST /v1/grid/internal/usage` — the relay's payload key against the schema's required field.
+
+    ⚠️ Loud only because the relay reads the reply's status (D-h). This pin says the two spellings
+    match; it says nothing about the grid noticing when they do not.
+    """
+    _speaks("_report_usage", _relay(), _COST_FIELD)
+
+    schema = _named(_control_plane("handler.py"), "UsageReportRequest")
+    fields = {t.target.id: t for t in schema.body
+              if isinstance(t, ast.AnnAssign) and isinstance(t.target, ast.Name)}
+    assert _COST_FIELD in fields, (
+        f"grid-apis' UsageReportRequest does not declare {_COST_FIELD!r}, so an old relay's body is "
+        f"accepted rather than refused")
+    assert _is_required(fields[_COST_FIELD]), (
+        f"grid-apis' UsageReportRequest declares {_COST_FIELD!r} with a DEFAULT, so it is optional. "
+        f"An old relay posting `cost_usd` then gets a 200 and is charged the default — the silent "
+        f"free-serving this whole seam exists to close, and the sole reason the rollout is control "
+        f"plane first. Only a REQUIRED field 422s (ADR 0042 D-c: the extra old key is ignored; it "
+        f"is the missing required one that refuses)")
+    assert _RETIRED[_COST_FIELD] not in fields, (
+        "grid-apis' UsageReportRequest still declares the dollar field; accepting both is what D-c "
+        "forbids")
+
+
+def test_the_gate_and_the_control_plane_agree_on_the_balance_field():
+    """`GET /v1/grid/internal/accounts/{sub}/balance` — the read the min-balance gate makes."""
+    _speaks("_fetch_authoritative_balance", _relay(), _BALANCE_FIELD)
+    _speaks("internal_account_balance", _control_plane("handler.py"), _BALANCE_FIELD)
+
+
+def test_the_gate_and_the_control_plane_agree_on_the_minimum_field():
+    """`GET /v1/grid/internal/min-balance` — the threshold that gate compares against."""
+    _speaks("_fetch_min_balance", _relay(), _MIN_BALANCE_FIELD)
+    _speaks("internal_min_balance", _control_plane("handler.py"), _MIN_BALANCE_FIELD)
+
+
+def test_both_repositories_convert_at_the_same_ratio():
+    """`CREDITS_PER_USD` — the only value here whose disagreement is pure arithmetic.
+
+    Nothing on the wire carries it and nothing anywhere would report a mismatch: charges would run
+    on one scale and top-ups on the other, both answering 200. This pin is the whole of the
+    detection, which is why it compares each side to the number written above rather than to the
+    other side.
+    """
+    assert _module_number(_relay(), "CREDITS_PER_USD") == _CREDITS_PER_USD, (
+        "grid-src converts a cost to credits at a different ratio than ADR 0042 D-a states")
+    assert _module_number(_control_plane("store.py"), "CREDITS_PER_USD") == _CREDITS_PER_USD, (
+        "grid-apis turns a dollar top-up into credits at a different ratio than ADR 0042 D-a states")
+
+
+# ── the sentence, which is a contract with a repository written in another language ──────────────
+
+def test_the_refusal_the_app_matches_survives_byte_for_byte():
+    """The 402's phrase — grid-src ↔ autonomous-grid-app, with nothing in this repository between.
+
+    ⚠️ A reword costs a **disclosure**, not an outage: the app's match misses, it falls back to
+    rendering the relay's raw sentence, and that sentence prints the viewer's exact balance and the
+    grid's threshold into their chat window. Only the numbers in it became credits.
+    """
+    detail = _named(_relay(), "_insufficient_balance_detail")
+    # `contains`, not `startsWith` — the app's own predicate. Pinning a prefix would report drift
+    # for a reprefixed sentence the app still matches perfectly well.
+    assert any(_REFUSAL_PHRASE.lower() in text.lower() for text in _returned_text(detail)), (
+        f"grid-src's refusal no longer carries {_REFUSAL_PHRASE!r}; autonomous-grid-app's "
+        f"chat_sender.dart substring-matches it and will render the raw sentence instead")
+
+    dart = _sibling_file(app_root(), *_APP_CHAT_SENDER)
+    matched = [line for line in dart.read_text().splitlines()
+               if not line.lstrip().startswith("//") and _APP_MATCH.search(line)]
+    assert matched, (
+        f"autonomous-grid-app has no live call matching {_REFUSAL_PHRASE.lower()!r} in "
+        f"{'/'.join(_APP_CHAT_SENDER)}. Both halves are outside this repository and no deploy order "
+        f"brings the matched phrase back — see ADR 0042 D-l")
+
+
+# ── the pin's own controls ───────────────────────────────────────────────────────────────────────
+
+def test_an_absent_repository_skips_but_a_moved_file_goes_red():
+    """Absent repository ⇒ skip; everything past that ⇒ red. The register's rule for every pin here.
+
+    ⚠️ The two halves are one test on purpose. Written as "an absent sibling skips" alone, the
+    natural way to satisfy it is to skip on the missing FILE too — which is how a renamed
+    `relay.py` or `handler.py` turns every pin in this file off while reporting that a checkout
+    sitting right there is missing. Both halves are reachable only through the helper, because the
+    derivation finds all four repositories on the machine this was written on.
+    """
+    with pytest.raises(pytest.skip.Exception):
+        _source(None, "relay.py")
+
+    with pytest.raises(AssertionError, match="renamed or moved"):
+        _source(pathlib.Path("/no-such-checkout"), "relay.py")
+
+
+def test_a_field_named_anywhere_but_a_wire_key_does_not_count_as_spoken():
+    """The control for `_wire_keys`, and the difference between this pin and a grep.
+
+    Both halves of this seam name their own field in a docstring, and the relay names it in log
+    lines and URLs too. If any of those counted, a payload key could quietly become a third spelling
+    — not the retired one, so the negative check misses it as well — while the prose kept this file
+    green and grid-apis 422'd every report.
+    """
+    tree = ast.parse(
+        'def f(r):\n'
+        '    """mentions balance_credits."""\n'
+        '    log("balance_credits went out")\n'
+        '    return {"other": r.get("fetched")}\n')
+
+    assert _wire_keys(_named(tree, "f")) == {"other", "fetched"}

--- a/tests/test_grid_apis_routes.py
+++ b/tests/test_grid_apis_routes.py
@@ -1,0 +1,194 @@
+"""The route reader itself, driven against a synthetic module (`billing-activation` issue 01).
+
+`tests/grid_apis_routes.py` is the one derivation every lockstep pin here uses to answer *what
+whole paths does the control plane actually serve?* Until this slice it could answer that for
+**POST only**, and the billing seam sits on three methods — a POST report, two GET reads, and a PUT
+toggle. So it gains a method-generic reader and keeps the POST accessor as a wrapper.
+
+⚠️ **These cases parse a module written out below rather than grid-apis' own.** That is deliberate,
+and it is the only way this file can hold a *negative* case honestly: a reader that answered
+nothing at all would satisfy "a PUT route is not reported for GET" against any real source, and it
+would also satisfy it against a grid-apis that is not beside this worktree. The synthetic module
+carries one route per method, so every negative here has a positive beside it proving the reader
+can produce the other answer.
+
+Two cases at the end DO need the sibling, and say so by skipping: they read whole paths off
+grid-apis itself and compare them to literals written here, because the prefix is the half a
+synthetic module cannot vouch for.
+"""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from tests import grid_apis_routes
+
+#: One route per method, plus the two shapes that have caught this reader out before: an
+#: `async def` handler (not an `ast.FunctionDef`) and a decorator on some *other* object.
+SYNTHETIC_HANDLER = '''
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/v1/grid")
+other = APIRouter(prefix="/nope")
+
+
+@router.post("/internal/usage")
+def report_usage():
+    ...
+
+
+@router.get("/internal/min-balance")
+async def internal_min_balance():
+    ...
+
+
+@router.put("/managed-networks/{network_id}/billing-mode")
+def set_billing_mode():
+    ...
+
+
+@other.put("/somewhere-else")
+def not_ours():
+    ...
+'''
+
+
+@pytest.fixture()
+def tree() -> ast.Module:
+    return ast.parse(SYNTHETIC_HANDLER)
+
+
+def test_a_put_route_is_read_by_the_method_generic_accessor(tree):
+    """The whole reason this slice exists: three of the billing seam's five values are not POSTs."""
+    assert grid_apis_routes.decorated_paths(tree, "put") == [
+        "/managed-networks/{network_id}/billing-mode"
+    ]
+
+
+def test_a_get_route_is_read_even_though_its_handler_is_async(tree):
+    """`async def` is an `ast.AsyncFunctionDef` and is NOT a subclass of `ast.FunctionDef`.
+
+    grid-apis spells many of its routes that way, so matching only the sync kind would make
+    converting one handler look like a deleted route.
+    """
+    assert grid_apis_routes.decorated_paths(tree, "get") == ["/internal/min-balance"]
+
+
+def test_one_methods_routes_are_not_reported_for_another(tree):
+    """The negative, with the two positives above as its control.
+
+    Without them this assertion passes for a reader that answers nothing at all — which is the
+    shape a pin fails *open* in: an empty list reads as "the route is gone" to a caller counting
+    matches, and as "nothing to check" to one that is not.
+    """
+    posts = grid_apis_routes.decorated_paths(tree, "post")
+
+    assert posts == ["/internal/usage"]
+    assert "/internal/min-balance" not in posts
+    assert "/managed-networks/{network_id}/billing-mode" not in posts
+
+
+def test_another_routers_routes_are_not_reported(tree):
+    """Only the module-level `router` this repository's pins name is read.
+
+    grid-apis mounts more than one `APIRouter`, and a path served under a different prefix is a
+    different whole path — reporting it here would make a pin pass against a route no caller of
+    ours can reach.
+
+    The control is in the same assertion rather than a sibling test: `put` has to come back with
+    *our* router's route, or a reader that answers nothing satisfies the exclusion for free.
+    """
+    puts = grid_apis_routes.decorated_paths(tree, "put")
+
+    assert puts == ["/managed-networks/{network_id}/billing-mode"]
+    assert "/somewhere-else" not in puts
+
+
+def test_a_method_the_reader_does_not_know_RAISES(tree):
+    """⚠️ The typo this reader must not answer quietly.
+
+    `decorated_paths(tree, "POST")` — the natural spelling, since that is how a method is written
+    everywhere else — matches no decorator, and an empty list is indistinguishable from *the route
+    was renamed*. A pin fed one reports drift that is not there, or, where it counts nothing,
+    reports agreement it never checked. So an unknown method is a programming error and says so.
+    """
+    with pytest.raises(AssertionError, match="POST"):
+        grid_apis_routes.decorated_paths(tree, "POST")
+
+    with pytest.raises(AssertionError, match="fetch"):
+        grid_apis_routes.decorated_paths(tree, "fetch")
+
+
+def test_the_post_accessor_answers_exactly_what_the_generic_one_does(tree):
+    """The wrapper is the contract with the suites that already use it: same answer, same order."""
+    assert grid_apis_routes.posted_paths(tree) == grid_apis_routes.decorated_paths(tree, "post")
+
+
+def test_a_method_the_reader_does_not_know_RAISES_BEFORE_it_needs_the_sibling(monkeypatch):
+    """⚠️ The guard has to fire where grid-apis is **absent**, which is where CI runs.
+
+    `served_paths` reaches for the sibling worktree, and `handler_tree()` *skips* when it is not
+    there. Validate the method after that call and a typo'd one is reported as "the grid-apis
+    worktree is not beside this one" on every machine that could still have caught it cheaply — a
+    programming error reachable only on a developer's laptop, in a module written to stop that.
+
+    ⚠️ **The absence has to be forced, or this case proves nothing here.** Run on a machine that
+    *has* the sibling — which is the one this feature's worktrees were cut on — the reader raises
+    from either position and the ordering is invisible. So the resolver is patched to answer *no
+    such repository*, with the positive control below proving the patch really produced that state.
+
+    ⚠️ And the failure is caught as a `BaseException`: `pytest.skip` raises one, so a misplaced
+    guard would make this case **skip** rather than fail — the quiet outcome, in the assertion
+    written to stop a quiet outcome.
+    """
+    monkeypatch.setattr(grid_apis_routes, "grid_apis_root", lambda: None)
+
+    with pytest.raises(BaseException) as caught:  # a skip is a BaseException — see the docstring
+        grid_apis_routes.served_paths("POST")
+
+    assert isinstance(caught.value, AssertionError), (
+        f"served_paths reached for grid-apis BEFORE validating the method — it raised "
+        f"{type(caught.value).__name__}, which on a machine without the sibling worktree is a skip, "
+        f"so a typo'd method would never be reported anywhere CI could see it")
+    assert "POST" in str(caught.value)
+
+
+def test_the_forced_absence_really_does_make_the_reader_skip(monkeypatch):
+    """The positive control for the case above: proves the patch produces the CI state.
+
+    Without it that case passes for a resolver patch that did nothing at all, and the ordering it
+    exists to pin would go unchecked while reading as covered.
+    """
+    monkeypatch.setattr(grid_apis_routes, "grid_apis_root", lambda: None)
+
+    with pytest.raises(BaseException) as caught:  # a skip is not an `Exception`
+        grid_apis_routes.served_paths("post")
+
+    assert type(caught.value).__name__ == "Skipped"
+
+
+def test_the_reader_finds_whole_paths_this_CLI_actually_calls_on_GET_and_PUT():
+    """The end-to-end half, and the reason this slice exists: the billing seam is not all POSTs.
+
+    Two paths written out here rather than derived — `remote/control_plane.py` sends both, and
+    comparing a *literal* is the only way this can fail. Deriving the expectation from the same
+    prefix the reader joined on would be true by construction: a repointed `APIRouter(prefix=…)`
+    would move both sides together and the assertion would never notice.
+
+    ⚠️ These are **not** lockstep pins for those two routes and must not be read as ones — nothing
+    here checks a request body or a reply key. What they check is that `served_paths` answers whole,
+    joined paths for a non-POST method at all, which is the property every billing pin will rest on.
+    """
+    assert "/v1/grid/tokens" in grid_apis_routes.served_paths("get")
+    assert "/v1/grid/networks/{network_id}/router/advisors" in grid_apis_routes.served_paths("put")
+
+
+def test_the_post_wrapper_answers_over_the_real_control_plane_too():
+    """`served_post_paths()` is what the two existing pins call, and this slice moved its body.
+
+    Compared against a literal for the same reason as the case above: asserting it equals
+    `served_paths("post")` would be `f() == f()`, since the wrapper is that call.
+    """
+    assert "/v1/grid/auth/sessions/revoke" in grid_apis_routes.served_post_paths()

--- a/tests/test_sibling_root.py
+++ b/tests/test_sibling_root.py
@@ -1,0 +1,68 @@
+"""Where `grid_src_repo` looks for a sibling checkout, for every worktree layout on this machine.
+
+`_sibling_root` decides whether the cross-repo lockstep suites RUN. It fails by returning `None`,
+which reads as "that repository is not on this machine" and skips — so a layout it does not
+understand turns every pin off without a single red test. That is why the candidate list is pinned
+here as data rather than exercised only through the suites that consume it.
+
+The parallel-ticket layout (`<repo>-feats/<feat>_parallel/<ticket>`, cut by the `new-grid-worktree`
+skill's `parallel` mode) is the case that motivated the multi-level mirror: under the old
+single-level derivation `projects.name` was `<feat>_parallel`, not `autonomous-grid-feats`, so every
+ticket worktree fell through to a candidate that cannot exist and skipped.
+"""
+from __future__ import annotations
+
+import pathlib
+
+from tests.grid_src_repo import PARALLEL_SUFFIX, _mirror_candidates
+
+
+def _c(here: str, repo: str = "grid-src") -> list[str]:
+    return [str(p) for p in _mirror_candidates(pathlib.Path(here), repo)]
+
+
+def test_main_checkout_looks_beside_itself() -> None:
+    # Arrange / Act
+    got = _c("/P/autonomous-grid")
+
+    # Assert
+    assert got == ["/P/grid-src"]
+
+
+def test_feature_worktree_mirrors_the_slug_then_falls_back_to_the_main_checkout() -> None:
+    # The pre-existing behaviour, unchanged: `<repo>-feats/<slug>` first, main checkout second.
+    assert _c("/P/autonomous-grid-feats/billing-activation") == [
+        "/P/grid-src-feats/billing-activation",
+        "/P/grid-src",
+    ]
+
+
+def test_parallel_ticket_worktree_mirrors_the_whole_path_below_the_feats_dir() -> None:
+    # The exact mirror comes FIRST: a ticket worktree must read its own ticket's sibling, not the
+    # feature branch it was cut from, or a lockstep test compares against code the other agent has
+    # already moved past.
+    assert _c("/P/autonomous-grid-feats/billing-activation_parallel/t12") == [
+        "/P/grid-src-feats/billing-activation_parallel/t12",
+        "/P/grid-src-feats/billing-activation",
+        "/P/grid-src",
+    ]
+
+
+def test_parallel_fallback_is_the_feature_worktree_not_the_parallel_directory() -> None:
+    # `<feat>_parallel/` holds worktrees; it is not one. The fallback strips the suffix.
+    got = _c("/P/autonomous-grid-feats/billing-activation_parallel/t12")
+    assert f"/P/grid-src-feats/billing-activation{PARALLEL_SUFFIX}" not in got
+
+
+def test_a_nested_directory_that_is_not_parallel_gets_no_feature_fallback() -> None:
+    # Only the `_parallel` convention earns the middle candidate; anything else would be inventing
+    # a checkout out of a directory name.
+    assert _c("/P/autonomous-grid-feats/a/b") == ["/P/grid-src-feats/a/b", "/P/grid-src"]
+
+
+def test_the_repo_name_is_carried_into_every_candidate() -> None:
+    assert _c("/P/autonomous-grid-feats/billing-activation_parallel/t12", "grid-apis") == [
+        "/P/grid-apis-feats/billing-activation_parallel/t12",
+        "/P/grid-apis-feats/billing-activation",
+        "/P/grid-apis",
+    ]


### PR DESCRIPTION
The hub's half of the billing-activation feature: the decision record and the cross-repo pins. The code lands in `autonomous-ai/autonomous-grid-be` (the control plane) and `autonomous-ai/autonomous-grid-cli` (the relay); **this repository gains no billing surface** — prices stay in dollars, so the public CLI has no half of the money seam.

## What lands

- **ADR 0042** — a grid's money is counted in credits. `CREDITS_PER_USD = 1000`.
- **Three amendments**, each written because the first draft asserted something the code then disproved:
  - D-c — the gate fails closed only on the **rename**. A control plane that *refuses* or is unreachable yields `None`, not zero, which was a different and worse path.
  - D-e — the discard is a **choice**, and it is wider than payment.
  - D-f — the fence is closed, and the real fault was **data-dependence** rather than a direction. The earlier text said the credit change inverts the fallback into refusing everyone; that holds only for a member who never topped media up. A member with ≥ 500 media credits was **served free**.
- **`tests/test_billing_credits_lockstep.py`** — pins five values across three repositories: the cost field, the balance field, the minimum field, the conversion ratio, and the 402's phrase.
- **`tests/grid_src_repo.py`** — sibling-checkout derivation that works from a **parallel ticket worktree**, so the lockstep suites keep running when several agents work tickets of one feature at once.

## The parts worth reviewing closely

**The five pinned values are hand-duplicated per repo by design** — the seams are wire-level with no code dependency between the repos, so changing one side alone compiles, passes every suite, and breaks the seam at runtime. The lockstep test is the only thing that notices.

**`CREDITS_PER_USD` is the one value in the register whose whole failure is arithmetic.** No missing route, no 422, no postcondition to check — charges and top-ups simply run on two scales, both answering 200. No deploy order helps, because neither side ever asks the other what the number is.

**Engine prices, price scores and `grid_reference_pricing` stay USD/1M on purpose.** Re-scaling one alone makes every priced engine sort 1000× dear, so the unpriced one wins every request — and that lands in ROUTING, where no money test looks.

## A note for reviewers on what is *not* in this diff

`CLAUDE.md` and `docs/agents/lockstep-register.md` are **gitignored in this repository**. Both carried claims this feature makes false (the balance read "falls back to the media wallet… so the grid serves free"), and both have been corrected — in this worktree and in the main checkout, which is the propagation point for future worktrees. Those corrections cannot appear in this PR. `.scratch/billing-activation/` (the PRD and eleven issues) is gitignored for the same reason.

## Test plan

- [x] `3524 passed, 9 skipped, 7 deselected` — zero failures.
- [x] The cross-repo lockstep suite **genuinely runs** rather than skipping (an absent sibling skips silently): all 7 tests PASSED, read against the merged sibling checkouts of both other repositories.
- [x] `test_the_refusal_the_app_matches_survives_byte_for_byte` passes — the 402's phrase survives this change byte-for-byte.
- [ ] **Follow-up, already written up as issue 11:** `autonomous-grid-app` is retired, and six register rows, two rollout-order groups and one test still pin it as a live contract. That test is green against a checkout of a product nobody ships. It needs the replacement client surveyed before any of them is repointed or deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMobuz7F8yqXTEzfTgVJWu