### PR TITLE
fix(engine): make --ctx-size per-request, not the whole KV pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,8 @@ point it at whichever one you already run. Each prints its own URL when it start
 computer on the same network, so this one needs [remote mode](#working-from-anywhere).
 
 The engine sizes itself to whatever machine it lands on: at load it measures free memory and takes
-the largest context that fits. `--ctx-size N` pins it instead. `--n-predict`, `--parallel`,
+the largest context that fits. `--ctx-size N` pins it instead — N is what one request may use, so
+serving several at once reserves N × the slot count. `--n-predict`, `--parallel`,
 `--temp`, `--flash-attn` and `--endpoint-port` are there too — see `grid join --help`.
 
 ### Stopping, leaving, deleting

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -282,10 +282,15 @@ def _add_engines(sub) -> None:
     tuning.add_argument("--endpoint-port", "--llama-port", type=int, default=8081)
     tuning.add_argument("--heartbeat-interval", type=float, default=15.0)
     tuning.add_argument("--ctx-size", type=int, default=None, metavar="N",
-                        help="Pin the context window to N tokens. Left unset, the engine measures "
-                             "free memory at load and takes the largest window that fits — pinning "
-                             "turns that off, so an N this machine cannot hold fails to start "
-                             "instead of shrinking. N=0 is not 'unset': it demands the model's "
+                        help="Pin EACH REQUEST's context window to N tokens — the same thing vLLM's "
+                             "--max-model-len and SGLang's --context-length mean. Left unset, the "
+                             "engine measures free memory at load and takes the largest window that "
+                             "fits — pinning turns that off, so an N this machine cannot hold fails "
+                             "to start instead of shrinking. Because N is per request, the KV cache "
+                             "reserved is N × the slot count (--parallel, else --max-concurrency): "
+                             "4 slots at --ctx-size 32000 allocate 128000 tokens up front, and "
+                             "llama.cpp reserves every slot's share whether or not it is used. "
+                             "N=0 is not 'unset': it demands the model's "
                              "full trained window and spills weights into system RAM to get it.")
     tuning.add_argument("--n-predict", type=int, default=None)
     tuning.add_argument("--parallel", type=int, default=None)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -458,7 +458,9 @@ The `grid join` flag set is the union of both modes, gated by mode:
 
 - **Both modes:** `--at` / `--serve` / `-m,--model` / `--kind <kind>` (alias `--engine`) / `--name`
   / `--all`, `--advertise-as` (or inline `-m real=pub`), `--endpoint-port` (alias `--llama-port`),
-  the llama tuning flags (`--ctx-size --n-predict --parallel --flash-attn --temp --reasoning-budget`),
+  the llama tuning flags (`--ctx-size --n-predict --parallel --flash-attn --temp --reasoning-budget`
+  — `--ctx-size N` is the window **one request** may use, so a Grid-launched llama-server reserves
+  N × its slot count of KV cache up front),
   `--heartbeat-interval` (seconds between heartbeats, default 15), `--api-key <key>` (overrides the
   env var and the key store, and warns that it is visible in shell history), and the media flags
   `--media` / `--bundle <bundle>` / `--comfyui-port` / `--media-port`.
@@ -474,7 +476,9 @@ The `grid join` flag set is the union of both modes, gated by mode:
   default 1, or 8 when the identity serves only API engines, pinned back to **1** when any of
   them is a `codex` seat: a flat-rate subscription is never hammered four-wide by default).
   Match it to the engine's own batch width — llama.cpp `--parallel`, vLLM `max_num_seqs` — or the
-  extra slots queue behind a batch that was never widened to take them. Finally, `--respawn` (stop
+  extra slots queue behind a batch that was never widened to take them. For a Grid-launched
+  llama-server this is also the slot count (`run_records.effective_parallel`), so raising it
+  multiplies the KV cache an explicit `--ctx-size` reserves. Finally, `--respawn` (stop
   the engine already serving this grid and start a fresh one — see below).
 - **Deprecated:** `--engine-label` — the grid page now derives the engine kind automatically, so it is
   accepted but inert (still matched by `grid leave --engine <label>`); `--pricing-input` /

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -57,7 +57,8 @@ non-interactive shell pass `--all` or `--engine <kind>`.
 | `--advertise-host HOST` | Host other machines should reach a Grid-launched engine on. |
 | `--endpoint-port N` | Built-in llama-server port (default 8081). |
 | `--heartbeat-interval S` | Seconds between heartbeats (default 15). |
-| `--ctx-size / --n-predict / --parallel / --temp / --flash-attn / --reasoning-budget` | Passed to a Grid-launched llama-server. |
+| `--ctx-size N` | Context window **per request** (as vLLM's `--max-model-len`). KV reserved is N × the slot count. |
+| `--n-predict / --parallel / --temp / --flash-attn / --reasoning-budget` | Passed to a Grid-launched llama-server. |
 
 Inspect and stop what's live:
 

--- a/shared/engine/launcher.py
+++ b/shared/engine/launcher.py
@@ -25,6 +25,10 @@ class LlamaProcess:
     proc: subprocess.Popen
     port: int
     log: Path
+    # What the launch actually asked llama.cpp for, carried so a bring-up failure can name the KV
+    # allocation the operator never typed (see `_ctx_hint`). `None` when `--ctx-size` was left unset.
+    ctx_size: int | None = None
+    parallel: int = 1
 
 
 @dataclass(frozen=True)
@@ -247,8 +251,19 @@ def start_llm(
     # Emitted ONLY when the operator asked for one. Left unset, llama.cpp measures free device
     # memory at load and takes the largest window that fits; naming a number here turns that off,
     # which is the whole reason the old hardcoded 128000 broke small machines.
+    #
+    # SCALED BY THE SLOT COUNT, because llama.cpp's `--ctx-size` is not a per-request cap: it is the
+    # whole KV pool, and `--parallel N` statically carves it into N slots holding `ctx/N` each. The
+    # unified KV cache that would instead share one buffer is only on when the slot count is `auto`,
+    # and `--parallel` is always passed below — so the division always applies here. Forwarding the
+    # operator's number raw therefore handed each request `ctx/N` tokens while `remote/serve.py`
+    # advertised the undivided `ctx` to the grid as `context_window`: a window over-promised N-fold,
+    # which the auto-router then routed against. `--ctx-size` means per REQUEST, the same thing
+    # vLLM's `--max-model-len` and SGLang's `--context-length` mean, so the flag reads identically
+    # whichever engine Grid is fronting. The cost model does NOT carry over: those two page the KV
+    # cache and treat the number as a ceiling, while llama.cpp reserves every slot's share up front.
     if ctx_size is not None:
-        cmd.extend(["--ctx-size", str(ctx_size)])
+        cmd.extend(["--ctx-size", str(ctx_size * parallel)])
     if profile.gpu_layers is not None:
         cmd.extend(["--n-gpu-layers", profile.gpu_layers])
     if profile.min_p is not None:
@@ -283,7 +298,24 @@ def start_llm(
         cmd.extend(["--spec-type", "draft-mtp", "--spec-draft-n-max", str(profile.spec_draft_n_max)])
 
     proc = subprocess.Popen(cmd, stdout=log_fh, stderr=log_fh)
-    return LlamaProcess(proc=proc, port=port, log=log)
+    return LlamaProcess(proc=proc, port=port, log=log, ctx_size=ctx_size, parallel=parallel)
+
+
+def _ctx_hint(proc: LlamaProcess) -> str:
+    """The one thing the log tail cannot say: the KV pool asked for is not the number typed.
+
+    `--ctx-size` is per request, so the launch multiplies it by the slot count — an out-of-memory
+    exit after `--ctx-size 32000` is really a 128000-token allocation failing on four slots, and
+    nothing in llama.cpp's own output connects that back to the flag the operator passed. Silent
+    only when there is nothing to explain: no `--ctx-size`, or a single slot where N is N.
+    """
+    if proc.ctx_size is None or proc.parallel <= 1:
+        return ""
+    return (
+        f" --ctx-size {proc.ctx_size} is per request, so the launch asked for "
+        f"{proc.ctx_size * proc.parallel} tokens of KV cache across {proc.parallel} slots; if this "
+        f"ran out of memory, lower --ctx-size or the slot count (--parallel / --max-concurrency)."
+    )
 
 
 def wait_for_models(proc: LlamaProcess, timeout: float = 120.0) -> None:
@@ -293,8 +325,8 @@ def wait_for_models(proc: LlamaProcess, timeout: float = 120.0) -> None:
         rc = proc.proc.poll()
         if rc is not None:
             raise SystemExit(
-                f"llama-server on port {proc.port} exited (rc={rc}) before becoming ready. "
-                f"Last lines of {proc.log}:\n{_log_tail(proc.log)}"
+                f"llama-server on port {proc.port} exited (rc={rc}) before becoming ready."
+                f"{_ctx_hint(proc)} Last lines of {proc.log}:\n{_log_tail(proc.log)}"
             )
         try:
             resp = httpx.get(f"http://localhost:{proc.port}/v1/models", timeout=5.0)

--- a/tests/test_local_cli.py
+++ b/tests/test_local_cli.py
@@ -3611,6 +3611,62 @@ def test_start_llm_passes_through_an_operator_override(monkeypatch, tmp_path):
     assert cmd[cmd.index("--flash-attn") + 1] == "off"
 
 
+def test_start_llm_scales_ctx_size_by_the_slot_count(monkeypatch, tmp_path):
+    """`--ctx-size` is per REQUEST; llama.cpp's `-c` is the whole KV pool, split across slots.
+
+    `--parallel N` statically carves `-c` into N slots of `ctx/N`, and the unified KV cache that
+    would share one buffer instead is only on when the slot count is `auto` — which it never is
+    here, because `--parallel` is always passed. Forwarding the operator's number raw therefore
+    handed each request `ctx/N` tokens while `remote/serve.py` advertised the undivided `ctx` to
+    the grid as `context_window`, over-promising the window N-fold to the auto-router.
+    """
+    cmd = _launch_argv(monkeypatch, tmp_path, ctx_size=32000, parallel=4)
+    assert cmd[cmd.index("--ctx-size") + 1] == "128000"
+    assert cmd[cmd.index("--parallel") + 1] == "4"
+
+
+def test_start_llm_leaves_ctx_size_alone_on_a_single_slot(monkeypatch, tmp_path):
+    """The common case must be untouched: one slot means N is N."""
+    cmd = _launch_argv(monkeypatch, tmp_path, ctx_size=32000, parallel=1)
+    assert cmd[cmd.index("--ctx-size") + 1] == "32000"
+
+
+def test_start_llm_scaling_never_resurrects_an_unset_ctx_size(monkeypatch, tmp_path):
+    """Unset stays unset whatever the slot count — llama.cpp must keep fitting itself to the box."""
+    assert "--ctx-size" not in _launch_argv(monkeypatch, tmp_path, parallel=8)
+
+
+class _DeadProc:
+    pid = 1
+
+    def poll(self):
+        return 1
+
+
+def test_wait_for_models_explains_the_scaled_kv_allocation(monkeypatch, tmp_path):
+    """A dead bring-up must name the allocation the operator never typed.
+
+    llama.cpp's own log says only that it could not allocate 128000 tokens; nothing in it connects
+    that back to the `--ctx-size 32000` that was passed for four slots.
+    """
+    log = tmp_path / "llama.log"
+    log.write_text("ggml_backend_buffer alloc failed\n")
+    proc = launcher.LlamaProcess(proc=_DeadProc(), port=8081, log=log, ctx_size=32000, parallel=4)
+    with pytest.raises(SystemExit, match="128000 tokens of KV cache across 4 slots"):
+        launcher.wait_for_models(proc)
+
+
+def test_wait_for_models_stays_quiet_when_there_is_nothing_to_explain(monkeypatch, tmp_path):
+    """One slot, or no `--ctx-size`, means the number in the log IS the number typed."""
+    log = tmp_path / "llama.log"
+    log.write_text("boom\n")
+    for kwargs in ({"ctx_size": 32000, "parallel": 1}, {"ctx_size": None, "parallel": 4}):
+        proc = launcher.LlamaProcess(proc=_DeadProc(), port=8081, log=log, **kwargs)
+        with pytest.raises(SystemExit) as excinfo:
+            launcher.wait_for_models(proc)
+        assert "KV cache" not in str(excinfo.value)
+
+
 def test_start_llm_pins_gpu_layers_only_on_unified_memory(monkeypatch, tmp_path):
     """Apple Silicon must not let llama.cpp spill layers to "system memory" — it is the same pool."""
     monkeypatch.setattr(launcher, "runtime_profile", lambda: launcher.APPLE_SILICON_RUNTIME)


### PR DESCRIPTION
llama.cpp's `--ctx-size` is not a per-request cap: it is the entire KV pool, and `--parallel N` statically carves it into N slots holding `ctx/N` tokens each. The unified KV cache that would share one buffer instead is only enabled when the slot count is `auto`, and `start_llm` always passes `--parallel` explicitly — so the division always applied.

Forwarding the operator's number raw meant `grid join --max-concurrency 4 --ctx-size 32000` gave each request 8000 tokens, while `remote/serve.py` advertised the undivided 32000 to the grid as `context_window`. The auto-router then ranked against a window four times larger than any single request could use.

Scaling `-c` by the slot count makes the flag mean what every other runtime Grid fronts already means by it: vLLM's `--max-model-len` and SGLang's `--context-length` are both per-sequence caps, with the KV pool sized separately by a memory fraction. `context_window` needs no change — it sends the raw per-request number, which is now the truth rather than an N-fold over-promise.

What does NOT carry over is the cost model. Those two page the KV cache and treat the number as a ceiling; llama.cpp reserves every slot's share up front. So `--max-concurrency 8 --ctx-size 32000` really does allocate 256k of KV and, per this launcher's existing fail-loud policy, refuses to boot rather than shrinking. `LlamaProcess` now carries the launch parameters so `wait_for_models` can say so: llama.cpp's own log reports only that it could not allocate 128000 tokens, and nothing in it connects that back to the 32000 the operator typed.

BEHAVIOR CHANGE: anyone who already compensated by hand — `--ctx-size 128000 --max-concurrency 4` to get 32k per request — now asks for 512k and fails to start.

Refs: ggml-org/llama.cpp#11681 (the division), ggml-org/llama.cpp#24124 (`--kv-unified-per-slot`, the fuller alignment — needs a build-floor check against MIN_LLAMA_SERVER_BUILD before it can be adopted).
